### PR TITLE
[1.2.x] Fixes issue in handling error for streams with query expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2810,7 +2810,7 @@ public class Desugar extends BLangNodeVisitor {
         return function.symbol;
     }
 
-    private BInvokableSymbol getLangLibIteratorInvokableSymbol(BVarSymbol collectionSymbol) {
+    BInvokableSymbol getLangLibIteratorInvokableSymbol(BVarSymbol collectionSymbol) {
         return (BInvokableSymbol) symResolver.lookupLangLibMethod(collectionSymbol.type,
                 names.fromString(BLangCompilerConstants.ITERABLE_COLLECTION_ITERATOR_FUNC));
     }
@@ -2868,7 +2868,7 @@ public class Desugar extends BLangNodeVisitor {
         whileNode.body = foreach.body;
 
         // Note - $result$ = $iterator$.next(); < this should go after initial assignment of `item`
-        BLangAssignment resultAssignment = getIteratorNextAssignment(foreach, iteratorSymbol, resultSymbol);
+        BLangAssignment resultAssignment = getIteratorNextAssignment(foreach.pos, iteratorSymbol, resultSymbol);
         VariableDefinitionNode variableDefinitionNode = foreach.variableDefinitionNode;
 
         // Generate $result$.value
@@ -3841,7 +3841,7 @@ public class Desugar extends BLangNodeVisitor {
         throw new IllegalStateException("None object type '" + type.toString() + "' found in object init context");
     }
 
-    private BLangErrorType getErrorTypeNode() {
+    BLangErrorType getErrorTypeNode() {
         BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
         errorTypeNode.type = symTable.errorType;
         return errorTypeNode;
@@ -4762,7 +4762,7 @@ public class Desugar extends BLangNodeVisitor {
     // private functions
 
     // Foreach desugar helper method.
-    private BLangSimpleVariableDef getIteratorVariableDefinition(DiagnosticPos pos, BVarSymbol collectionSymbol,
+    BLangSimpleVariableDef getIteratorVariableDefinition(DiagnosticPos pos, BVarSymbol collectionSymbol,
                                                                  BInvokableSymbol iteratorInvokableSymbol,
                                                                  boolean isIteratorFuncFromLangLib) {
 
@@ -4789,35 +4789,35 @@ public class Desugar extends BLangNodeVisitor {
     private BLangSimpleVariableDef getIteratorNextVariableDefinition(BLangForeach foreach,
                                                                      BVarSymbol iteratorSymbol,
                                                                      BVarSymbol resultSymbol) {
-        BLangInvocation nextInvocation = createIteratorNextInvocation(foreach, iteratorSymbol);
+        BLangInvocation nextInvocation = createIteratorNextInvocation(foreach.pos, iteratorSymbol);
         BLangSimpleVariable resultVariable = ASTBuilderUtil.createVariable(foreach.pos, "$result$",
                 foreach.nillableResultType, nextInvocation, resultSymbol);
         return ASTBuilderUtil.createVariableDef(foreach.pos, resultVariable);
     }
 
     // Foreach desugar helper method.
-    private BLangAssignment getIteratorNextAssignment(BLangForeach foreach,
+    BLangAssignment getIteratorNextAssignment(DiagnosticPos pos,
                                                       BVarSymbol iteratorSymbol, BVarSymbol resultSymbol) {
-        BLangSimpleVarRef resultReferenceInAssignment = ASTBuilderUtil.createVariableRef(foreach.pos, resultSymbol);
+        BLangSimpleVarRef resultReferenceInAssignment = ASTBuilderUtil.createVariableRef(pos, resultSymbol);
 
         // Note - $iterator$.next();
-        BLangInvocation nextInvocation = createIteratorNextInvocation(foreach, iteratorSymbol);
+        BLangInvocation nextInvocation = createIteratorNextInvocation(pos, iteratorSymbol);
 
         // we are inside the while loop. hence the iterator cannot be nil. hence remove nil from iterator's type
         nextInvocation.expr.type = types.getSafeType(nextInvocation.expr.type, true, false);
 
-        return ASTBuilderUtil.createAssignmentStmt(foreach.pos, resultReferenceInAssignment, nextInvocation, false);
+        return ASTBuilderUtil.createAssignmentStmt(pos, resultReferenceInAssignment, nextInvocation, false);
     }
 
-    private BLangInvocation createIteratorNextInvocation(BLangForeach foreach, BVarSymbol iteratorSymbol) {
-        BLangIdentifier nextIdentifier = ASTBuilderUtil.createIdentifier(foreach.pos, "next");
-        BLangSimpleVarRef iteratorReferenceInNext = ASTBuilderUtil.createVariableRef(foreach.pos, iteratorSymbol);
+    BLangInvocation createIteratorNextInvocation(DiagnosticPos pos, BVarSymbol iteratorSymbol) {
+        BLangIdentifier nextIdentifier = ASTBuilderUtil.createIdentifier(pos, "next");
+        BLangSimpleVarRef iteratorReferenceInNext = ASTBuilderUtil.createVariableRef(pos, iteratorSymbol);
         BInvokableSymbol nextFuncSymbol = getNextFunc((BObjectType) iteratorSymbol.type).symbol;
         BLangInvocation nextInvocation = (BLangInvocation) TreeBuilder.createInvocationNode();
-        nextInvocation.pos = foreach.pos;
+        nextInvocation.pos = pos;
         nextInvocation.name = nextIdentifier;
         nextInvocation.expr = iteratorReferenceInNext;
-        nextInvocation.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(foreach.pos, iteratorSymbol));
+        nextInvocation.requiredArgs = Lists.of(ASTBuilderUtil.createVariableRef(pos, iteratorSymbol));
         nextInvocation.argExprs = nextInvocation.requiredArgs;
         nextInvocation.symbol = nextFuncSymbol;
         nextInvocation.type = nextFuncSymbol.retType;
@@ -5639,7 +5639,7 @@ public class Desugar extends BLangNodeVisitor {
         return new BAttachedFunction(Names.INIT_FUNCTION_SUFFIX, initFuncSymbol, bInvokableType);
     }
 
-    private BLangErrorType createErrorTypeNode(BErrorType errorType) {
+    BLangErrorType createErrorTypeNode(BErrorType errorType) {
         BLangErrorType errorTypeNode = (BLangErrorType) TreeBuilder.createErrorTypeNode();
         errorTypeNode.type = errorType;
         return errorTypeNode;
@@ -6128,7 +6128,7 @@ public class Desugar extends BLangNodeVisitor {
         accessExprStack.push(expr);
     }
 
-    private BLangValueType getNillTypeNode() {
+    BLangValueType getNillTypeNode() {
         BLangValueType nillTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         nillTypeNode.typeKind = TypeKind.NIL;
         nillTypeNode.type = symTable.nilType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2796,7 +2796,7 @@ public class Desugar extends BLangNodeVisitor {
         return blockNode;
     }
 
-    private BInvokableSymbol getIterableObjectIteratorInvokableSymbol(BVarSymbol collectionSymbol) {
+    public BInvokableSymbol getIterableObjectIteratorInvokableSymbol(BVarSymbol collectionSymbol) {
         BObjectTypeSymbol typeSymbol = (BObjectTypeSymbol) collectionSymbol.type.tsymbol;
         // We know for sure at this point, the object symbol should have the __iterator method
         BAttachedFunction iteratorFunc = null;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -251,6 +251,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil.createBlockStmt;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -131,7 +131,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         BLangLiteral nillLiteral = ASTBuilderUtil.createLiteral(fromClause.pos, symTable.nilType,
                 null);
         BVarSymbol outputArrayVarSymbol = new BVarSymbol(0, new Name("$outputDataArray$"),
-                env.scope.owner.pkgID, outputArrayType, env.scope.owner);
+                env.scope.owner.pkgID, outputUnionType, env.scope.owner);
         BLangSimpleVariable outputArrayVariable =
                 ASTBuilderUtil.createVariable(pos, "$outputDataArray$", outputUnionType,
                         nillLiteral, outputArrayVarSymbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -113,8 +113,8 @@ public class QueryDesugar extends BLangNodeVisitor {
     //                                        select person;
     //
     // changes as,
-    //    Employee[]|error? outputDataArray = ();
-    //    Employee[] $tempDataArray$ = [];
+    //    Person[]|error? outputDataArray = ();
+    //    Person[] $tempDataArray$ = [];
     //
     //    Person[] $data$ = personList;
     //    abstract object {public function next() returns record {|Person value;|}? $iterator$ = $data$.iterator();
@@ -195,8 +195,8 @@ public class QueryDesugar extends BLangNodeVisitor {
         bodyBlock.addStatement(tempVarAssignment);
         buildWhereClauseBlock(whereClauseList, letClauseList, leafElseBlock, bodyBlock, selectClause.pos);
 
-        // if ($result$ is()){
-        //    break;
+        // if (outputDataArray is ()) {
+        //     outputDataArray = tempDataArray;
         // }
         BLangBlockStmt nullCheckIfBody = ASTBuilderUtil.createBlockStmt(fromClause.pos);
         BLangAssignment outputAssignment = ASTBuilderUtil

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -218,7 +218,7 @@ public class QueryDesugar extends BLangNodeVisitor {
         List<BLangWhereClause> whereClauseList = queryAction.whereClauseList;
         DiagnosticPos pos = fromClause.pos;
 
-        BLangForeach leafForeach = buildFromClauseBlock(fromClauseList);
+//        BLangBlockStmt leafElseBlock = buildFromClauseBlockStmt(fromClauseList, outputVarRef);
         BLangBlockStmt foreachBody = ASTBuilderUtil.createBlockStmt(pos);
         buildWhereClauseBlock(whereClauseList, letClauseList, null, null, doClause.pos);
         foreachBody.addStatement(doClause.body);
@@ -341,8 +341,22 @@ public class QueryDesugar extends BLangNodeVisitor {
             elseBody.stmts.add(0, (BLangStatement) variableDefinitionNode);
             erroCheckIf.elseStmt = elseBody;
 
+//            if($outputDataArray$ is error) {
+//                break;
+//            }
+            BLangBlockStmt outputErrorCheckIfBody = ASTBuilderUtil.createBlockStmt(fromClause.pos);
+            BLangTypeTestExpr isOutputErrorTest =
+                    ASTBuilderUtil.createTypeTestExpr(fromClause.pos, outputVarRef, desugar.getErrorTypeNode());
+            isErrorTest.type = symTable.booleanType;
+            outputErrorCheckIfBody.addStatement(TreeBuilder.createBreakNode());
+            BLangIf outputErrorCheckIf = (BLangIf) TreeBuilder.createIfElseStatementNode();
+            outputErrorCheckIf.pos = fromClause.pos;
+            outputErrorCheckIf.expr = isOutputErrorTest;
+            outputErrorCheckIf.body = outputErrorCheckIfBody;
+
             BLangBlockStmt whileBody = ASTBuilderUtil.createBlockStmt(fromClause.pos);
             whileBody.addStatement(nullCheckIf);
+            whileBody.addStatement(outputErrorCheckIf);
             whileBody.addStatement(resultAssignment);
 
             whileNode.body = whileBody;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -39,7 +39,6 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangWhereClause;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2842,24 +2842,22 @@ public class TypeChecker extends BLangNodeVisitor {
 
         Map<Boolean, List<BType>> resultTypeMap = types.getAllTypes(targetType).stream()
                 .collect(Collectors.groupingBy(memberType -> (types.isAssignable(memberType, symTable.errorType) ||
-                        (types.isAssignable(memberType, symTable.errorType)))));
+                        (types.isAssignable(memberType, symTable.nilType)))));
         for (BType type : resultTypeMap.get(false)) {
-            if (type.tag != symTable.nilType.tag) {
-                BType selectType;
-                switch (type.tag) {
-                    case TypeTags.ARRAY:
-                        selectType = checkExpr(selectExp, env, ((BArrayType) type).eType);
-                        enclosedTypeTag = TypeTags.ARRAY;
-                        break;
-                    case TypeTags.STREAM:
-                        selectType = checkExpr(selectExp, env, ((BStreamType) type).constraint);
-                        break;
-                    default:
-                        selectType = checkExpr(selectExp, env, type);
-                }
-                if (selectType != symTable.semanticError) {
-                    assignableSelectTypes.add(selectType);
-                }
+            BType selectType;
+            switch (type.tag) {
+                case TypeTags.ARRAY:
+                    selectType = checkExpr(selectExp, env, ((BArrayType) type).eType);
+                    enclosedTypeTag = TypeTags.ARRAY;
+                    break;
+                case TypeTags.STREAM:
+                    selectType = checkExpr(selectExp, env, ((BStreamType) type).constraint);
+                    break;
+                default:
+                    selectType = checkExpr(selectExp, env, type);
+            }
+            if (selectType != symTable.semanticError) {
+                assignableSelectTypes.add(selectType);
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -167,7 +167,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;
@@ -2826,12 +2825,32 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         BType expSelectType = expType;
+        BType selectType = null;
         if (expType.tag == TypeTags.ARRAY) {
             expSelectType = ((BArrayType) expType).eType;
+            selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
+            resultType = selectType == symTable.semanticError ? selectType : new BArrayType(selectType);
+        } else if (expType.tag == TypeTags.UNION) {
+            Set<BType> memTypes = ((BUnionType) expType).getMemberTypes();
+
+            LinkedHashSet<BType> nilRemovedSet = new LinkedHashSet<>();
+            for (BType bType : memTypes) {
+                if (bType.tag != symTable.nilType.tag && bType.tag != symTable.errorType.tag) {
+                    nilRemovedSet.add(bType);
+                }
+            }
+            expSelectType = nilRemovedSet.size() == 1 ? nilRemovedSet.iterator().next() :
+                    BUnionType.create(null, nilRemovedSet);
+            if(expSelectType.tag == TypeTags.ARRAY ) {
+                selectType = checkExpr(selectClause.expression, whereEnv, ((BArrayType)expSelectType).eType);
+            } else {
+                selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
+            }
+            BType actualType = BUnionType.create(null, new BArrayType(selectType), symTable.errorType, symTable.nilType);
+            resultType = types.checkType(queryExpr.pos, actualType, expType,
+                    DiagnosticCode.INCOMPATIBLE_TYPES);
         }
 
-        BType selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
-        resultType = selectType == symTable.semanticError ? selectType : new BArrayType(selectType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2854,7 +2854,8 @@ public class TypeChecker extends BLangNodeVisitor {
                 actualType = BUnionType.create(null, actualType, errorType);
             }
         }
-        resultType = types.checkType(queryExpr.pos, actualType, expType, DiagnosticCode.INCOMPATIBLE_TYPES);
+        resultType = selectType == symTable.semanticError ? selectType :
+                types.checkType(queryExpr.pos, actualType, expType, DiagnosticCode.INCOMPATIBLE_TYPES);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -27,6 +27,7 @@ import org.ballerinalang.model.elements.TableColumnFlag;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
+import org.ballerinalang.model.tree.expressions.ExpressionNode;
 import org.ballerinalang.model.tree.expressions.NamedArgNode;
 import org.ballerinalang.model.tree.expressions.RecordLiteralNode;
 import org.ballerinalang.model.types.TypeKind;
@@ -2811,7 +2812,9 @@ public class TypeChecker extends BLangNodeVisitor {
         List<? extends FromClauseNode> fromClauseList = queryExpr.fromClauseList;
         List<? extends WhereClauseNode> whereClauseList = queryExpr.whereClauseList;
         List<? extends LetClauseNode> letClauseList = queryExpr.letClausesList;
+        ExpressionNode collectionNode = fromClauseList.get(0).getCollection();
         SymbolEnv parentEnv = env;
+        BErrorType errorType = null;
         for (FromClauseNode fromClause : fromClauseList) {
             parentEnv = typeCheckFromClause((BLangFromClause) fromClause, parentEnv);
         }
@@ -2838,17 +2841,20 @@ public class TypeChecker extends BLangNodeVisitor {
             }
             expSelectType = nilRemovedSet.size() == 1 ? nilRemovedSet.iterator().next() :
                     BUnionType.create(null, nilRemovedSet);
-            if(expSelectType.tag == TypeTags.ARRAY ) {
-                expSelectType = ((BArrayType)expSelectType).eType;
+            if (expSelectType.tag == TypeTags.ARRAY) {
+                expSelectType = ((BArrayType) expSelectType).eType;
             }
         }
         BType selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
         BType actualType = new BArrayType(selectType);
-        if (expType.tag == TypeTags.UNION) {
-            actualType = BUnionType.create(null, new BArrayType(selectType), symTable.errorType,
-                    symTable.nilType);
+        if ((collectionNode instanceof BLangSimpleVarRef) &&
+                (((BLangSimpleVarRef) collectionNode).type instanceof BStreamType)) {
+            errorType = (BErrorType) ((BStreamType) ((BLangSimpleVarRef) collectionNode).type).error;
+            if (errorType != null) {
+                actualType = BUnionType.create(null, actualType, errorType);
+            }
         }
-        resultType = selectType == symTable.semanticError ? selectType : actualType;
+        resultType = types.checkType(queryExpr.pos, actualType, expType, DiagnosticCode.INCOMPATIBLE_TYPES);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2849,6 +2849,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 switch (type.tag) {
                     case TypeTags.ARRAY:
                         selectType = checkExpr(selectExp, env, ((BArrayType) type).eType);
+                        enclosedTypeTag = TypeTags.ARRAY;
                         break;
                     case TypeTags.STREAM:
                         selectType = checkExpr(selectExp, env, ((BStreamType) type).constraint);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2855,6 +2855,7 @@ public class TypeChecker extends BLangNodeVisitor {
                     break;
                 default:
                     selectType = checkExpr(selectExp, env, type);
+                    enclosedTypeTag = TypeTags.ARRAY;
             }
             if (selectType != symTable.semanticError) {
                 assignableSelectTypes.add(selectType);
@@ -2868,6 +2869,9 @@ public class TypeChecker extends BLangNodeVisitor {
             }
         } else if (assignableSelectTypes.size() > 1) {
             dlog.error(selectExp.pos, DiagnosticCode.AMBIGUOUS_TYPES, assignableSelectTypes);
+            return actualType;
+        } else {
+            return actualType;
         }
 
         BType nextMethodReturnType = null;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -168,6 +168,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2827,8 +2827,7 @@ public class TypeChecker extends BLangNodeVisitor {
             whereEnv = typeCheckWhereClause((BLangWhereClause) whereClauseNode, selectClause, parentEnv);
         }
 
-        BType lhsType = expType.tag == TypeTags.NONE ? collectionNode.type : expType;
-        BType actualType = findAssignableType(whereEnv, selectClause.expression,  collectionNode.type, lhsType);
+        BType actualType = findAssignableType(whereEnv, selectClause.expression,  collectionNode.type, expType);
         if (actualType != symTable.semanticError) {
             resultType = types.checkType(queryExpr.pos, actualType, expType, DiagnosticCode.INCOMPATIBLE_TYPES);
         } else {
@@ -2838,23 +2837,21 @@ public class TypeChecker extends BLangNodeVisitor {
 
     private BType findAssignableType(SymbolEnv env, BLangExpression selectExp, BType collectionType, BType targetType) {
         List<BType> assignableSelectTypes = new ArrayList<>();
-
+        int enclosedTypeTag = targetType.tag == TypeTags.NONE ? collectionType.tag : expType.tag;
         BType actualType = symTable.semanticError;
-        int enclosedTypeTag = TypeTags.NONE;
-        Map<Boolean, List<BType>> resultTypeMap = types.getAllTypes(targetType).stream()
-                .collect(Collectors.groupingBy(memberType -> types.isAssignable(memberType, symTable.errorType)));
 
+        Map<Boolean, List<BType>> resultTypeMap = types.getAllTypes(targetType).stream()
+                .collect(Collectors.groupingBy(memberType -> (types.isAssignable(memberType, symTable.errorType) ||
+                        (types.isAssignable(memberType, symTable.errorType)))));
         for (BType type : resultTypeMap.get(false)) {
             if (type.tag != symTable.nilType.tag) {
                 BType selectType;
                 switch (type.tag) {
                     case TypeTags.ARRAY:
                         selectType = checkExpr(selectExp, env, ((BArrayType) type).eType);
-                        enclosedTypeTag = TypeTags.ARRAY;
                         break;
                     case TypeTags.STREAM:
                         selectType = checkExpr(selectExp, env, ((BStreamType) type).constraint);
-                        enclosedTypeTag = TypeTags.ARRAY;
                         break;
                     default:
                         selectType = checkExpr(selectExp, env, type);
@@ -2867,7 +2864,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
         if (assignableSelectTypes.size() == 1) {
             actualType = assignableSelectTypes.get(0);
-            if (targetType.tag == TypeTags.ARRAY || enclosedTypeTag == TypeTags.ARRAY) {
+            if (enclosedTypeTag == TypeTags.ARRAY) {
                 actualType = new BArrayType(assignableSelectTypes.get(0));
             }
         } else if (assignableSelectTypes.size() > 1) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2825,11 +2825,8 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         BType expSelectType = expType;
-        BType selectType = null;
         if (expType.tag == TypeTags.ARRAY) {
             expSelectType = ((BArrayType) expType).eType;
-            selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
-            resultType = selectType == symTable.semanticError ? selectType : new BArrayType(selectType);
         } else if (expType.tag == TypeTags.UNION) {
             Set<BType> memTypes = ((BUnionType) expType).getMemberTypes();
 
@@ -2842,15 +2839,16 @@ public class TypeChecker extends BLangNodeVisitor {
             expSelectType = nilRemovedSet.size() == 1 ? nilRemovedSet.iterator().next() :
                     BUnionType.create(null, nilRemovedSet);
             if(expSelectType.tag == TypeTags.ARRAY ) {
-                selectType = checkExpr(selectClause.expression, whereEnv, ((BArrayType)expSelectType).eType);
-            } else {
-                selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
+                expSelectType = ((BArrayType)expSelectType).eType;
             }
-            BType actualType = BUnionType.create(null, new BArrayType(selectType), symTable.errorType, symTable.nilType);
-            resultType = types.checkType(queryExpr.pos, actualType, expType,
-                    DiagnosticCode.INCOMPATIBLE_TYPES);
         }
-
+        BType selectType = checkExpr(selectClause.expression, whereEnv, expSelectType);
+        BType actualType = new BArrayType(selectType);
+        if (expType.tag == TypeTags.UNION) {
+            actualType = BUnionType.create(null, new BArrayType(selectType), symTable.errorType,
+                    symTable.nilType);
+        }
+        resultType = selectType == symTable.semanticError ? selectType : actualType;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -168,7 +168,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-
 import javax.xml.XMLConstants;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;
@@ -2815,7 +2814,6 @@ public class TypeChecker extends BLangNodeVisitor {
         List<? extends LetClauseNode> letClauseList = queryExpr.letClausesList;
         ExpressionNode collectionNode = fromClauseList.get(0).getCollection();
         SymbolEnv parentEnv = env;
-        BErrorType errorType = null;
         for (FromClauseNode fromClause : fromClauseList) {
             parentEnv = typeCheckFromClause((BLangFromClause) fromClause, parentEnv);
         }
@@ -2850,7 +2848,7 @@ public class TypeChecker extends BLangNodeVisitor {
         BType actualType = new BArrayType(selectType);
         if ((collectionNode instanceof BLangSimpleVarRef) &&
                 (((BLangSimpleVarRef) collectionNode).type instanceof BStreamType)) {
-            errorType = (BErrorType) ((BStreamType) ((BLangSimpleVarRef) collectionNode).type).error;
+            BErrorType errorType = (BErrorType) ((BStreamType) ((BLangSimpleVarRef) collectionNode).type).error;
             if (errorType != null) {
                 actualType = BUnionType.create(null, actualType, errorType);
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1288,7 +1288,7 @@ public class Types {
         return null;
     }
 
-    private BType getResultTypeOfNextInvocation(BObjectType iteratorType) {
+    public BType getResultTypeOfNextInvocation(BObjectType iteratorType) {
         BAttachedFunction nextFunc = getNextFunc(iteratorType);
         return Objects.requireNonNull(nextFunc).type.retType;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.query;
+
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.model.values.BValueArray;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * TestCases for query expression with iterable objects.
+ *
+ * @since 1.2.1
+ */
+public class QueryExpressionIterableObjectTest {
+
+    private CompileResult program;
+
+    @BeforeClass
+    public void setup() {
+        program = BCompileUtil.compile("test-src/query/query-exp-iterable-objects.bal");
+    }
+
+    @Test
+    public void testIterableObject() {
+        BValue[] returns = BRunUtil.invoke(program, "testIterableObject");
+
+        BValueArray arr = (BValueArray) returns[0];
+        Assert.assertEquals(arr.size(), 7);
+        int i = 0;
+        Assert.assertEquals(arr.getInt(i++), 12);
+        Assert.assertEquals(arr.getInt(i++), 34);
+        Assert.assertEquals(arr.getInt(i++), 56);
+        Assert.assertEquals(arr.getInt(i++), 34);
+        Assert.assertEquals(arr.getInt(i++), 78);
+        Assert.assertEquals(arr.getInt(i++), 21);
+        Assert.assertEquals(arr.getInt(i), 90);
+
+    }
+
+    @Test
+    public void testNestedIterableObject() {
+        BValue[] returns = BRunUtil.invoke(program, "testNestedIterableObject");
+
+        BValueArray arr = (BValueArray) returns[0];
+        Assert.assertEquals(arr.size(), 14);
+        int i = 0;
+        Assert.assertEquals(arr.getInt(i++), 12);
+        Assert.assertEquals(arr.getInt(i++), 34);
+        Assert.assertEquals(arr.getInt(i++), 56);
+        Assert.assertEquals(arr.getInt(i++), 34);
+        Assert.assertEquals(arr.getInt(i++), 78);
+        Assert.assertEquals(arr.getInt(i++), 21);
+        Assert.assertEquals(arr.getInt(i++), 90);
+        Assert.assertEquals(arr.getInt(i++), 12);
+        Assert.assertEquals(arr.getInt(i++), 34);
+        Assert.assertEquals(arr.getInt(i++), 56);
+        Assert.assertEquals(arr.getInt(i++), 34);
+        Assert.assertEquals(arr.getInt(i++), 78);
+        Assert.assertEquals(arr.getInt(i++), 21);
+        Assert.assertEquals(arr.getInt(i), 90);
+
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.query;
 
+import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.model.values.BValueArray;
 import org.ballerinalang.test.util.BCompileUtil;
@@ -79,5 +80,13 @@ public class QueryExpressionIterableObjectTest {
         Assert.assertEquals(arr.getInt(i++), 21);
         Assert.assertEquals(arr.getInt(i), 90);
 
+    }
+
+    @Test
+    public void testIterableWithError() {
+        BValue[] returnValues = BRunUtil.invoke(program, "testIterableWithError");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues.length, 1, "Expected events are not received");
+        Assert.assertTrue(returnValues[0] instanceof BError, "Expected BErrorType type value");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
@@ -238,4 +238,16 @@ public class QueryExpressionWithVarTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
         Assert.assertEquals(person3.get("teacherId").stringValue(), "TER1200");
     }
+
+    @Test(description = "Use a stream with query expression")
+    public void testQueryWithStream() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryWithStream");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues.length, 1, "Expected events are not received");
+        Assert.assertTrue(returnValues[0] instanceof BValueArray, "Expected BValueArray type value");
+
+        Assert.assertEquals(((BValueArray) returnValues[0]).getInt(0), 1);
+        Assert.assertEquals(((BValueArray) returnValues[0]).getInt(1), 3);
+        Assert.assertEquals(((BValueArray) returnValues[0]).getInt(2), 5);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -59,7 +59,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test simple select clause - record variable definition statement ")
+//    @Test(description = "Test simple select clause - record variable definition statement ")
     public void testSimpleSelectQueryWithRecordVariable() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariable");
         Assert.assertNotNull(returnValues);
@@ -75,7 +75,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test simple select clause - record variable definition statement v2 ")
+//    @Test(description = "Test simple select clause - record variable definition statement v2 ")
     public void testSimpleSelectQueryWithRecordVariableV2() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV2");
         Assert.assertNotNull(returnValues);
@@ -91,7 +91,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test simple select clause - record variable definition statement v3 ")
+//    @Test(description = "Test simple select clause - record variable definition statement v3 ")
     public void testSimpleSelectQueryWithRecordVariableV3() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV3");
         Assert.assertNotNull(returnValues);
@@ -106,7 +106,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(person2.get("lastName").stringValue(), "Fonseka");
     }
 
-    @Test(description = "Test simple select clause with a where clause")
+//    @Test(description = "Test simple select clause with a where clause")
     public void testSimpleSelectQueryWithWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithWhereClause");
         Assert.assertNotNull(returnValues);
@@ -122,7 +122,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test Query expression for primitive types ")
+//    @Test(description = "Test Query expression for primitive types ")
     public void testQueryExpressionForPrimitiveType() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionForPrimitiveType");
         Assert.assertNotNull(returnValues);
@@ -134,7 +134,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getInt(1), 25);
     }
 
-    @Test(description = "Test Query expression with select expression ")
+//    @Test(description = "Test Query expression with select expression ")
     public void testQueryExpressionWithSelectExpression() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionWithSelectExpression");
         Assert.assertNotNull(returnValues);
@@ -147,7 +147,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(2), "3");
     }
 
-    @Test(description = "Test filtering null values from query expression")
+//    @Test(description = "Test filtering null values from query expression")
     public void testFilteringNullElements() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFilteringNullElements");
         Assert.assertNotNull(returnValues);
@@ -163,7 +163,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 30);
     }
 
-    @Test(description = "Test filtering map with from query expression")
+//    @Test(description = "Test filtering map with from query expression")
     public void testMapWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testMapWithArity");
         Assert.assertNotNull(returnValues);
@@ -171,7 +171,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(0), "1A");
     }
 
-    @Test(description = "Test selecting values in a JSON array from query expression")
+//    @Test(description = "Test selecting values in a JSON array from query expression")
     public void testJSONArrayWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testJSONArrayWithArity");
         Assert.assertNotNull(returnValues);
@@ -180,7 +180,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(1), "tom");
     }
 
-    @Test(description = "Test filtering values in a tuple from query expression")
+//    @Test(description = "Test filtering values in a tuple from query expression")
     public void testArrayWithTuple() {
         BValue[] returnValues = BRunUtil.invoke(result, "testArrayWithTuple");
         Assert.assertNotNull(returnValues);
@@ -188,7 +188,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(returnValues[0].stringValue(), "[\"C\"]");
     }
 
-    @Test(description = "Test from clause with a stream")
+//    @Test(description = "Test from clause with a stream")
     public void testFromClauseWithStream() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFromClauseWithStream");
         Assert.assertNotNull(returnValues);
@@ -200,7 +200,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person.get("age")).intValue(), 40);
     }
 
-    @Test(description = "Test let clause with a stream")
+//    @Test(description = "Test let clause with a stream")
     public void testSimpleSelectQueryWithLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithLetClause");
         Assert.assertNotNull(returnValues);
@@ -218,7 +218,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("company").stringValue(), "WSO2");
     }
 
-    @Test(description = "Use function return value in let clause")
+//    @Test(description = "Use function return value in let clause")
     public void testFunctionCallInVarDeclLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFunctionCallInVarDeclLetClause");
         Assert.assertNotNull(returnValues);
@@ -236,7 +236,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("age").stringValue(), "60");
     }
 
-    @Test(description = "Use value set in let with where clause")
+//    @Test(description = "Use value set in let with where clause")
     public void testUseOfLetInWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testUseOfLetInWhereClause");
         Assert.assertNotNull(returnValues);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.query;
 
+import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BMap;
 import org.ballerinalang.model.values.BValue;
@@ -28,6 +29,7 @@ import org.ballerinalang.test.util.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 
 /**
  * This contains methods to test simple query expression with from, where and select clauses.
@@ -43,7 +45,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         result = BCompileUtil.compile("test-src/query/simple-query-with-defined-type.bal");
     }
 
-    @Test(description = "Test simple select clause - simple variable definition statement ")
+//    @Test(description = "Test simple select clause - simple variable definition statement ")
     public void testSimpleSelectQueryWithSimpleVariable() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithSimpleVariable");
         Assert.assertNotNull(returnValues);
@@ -59,7 +61,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test simple select clause - record variable definition statement ")
+//    @Test(description = "Test simple select clause - record variable definition statement ")
     public void testSimpleSelectQueryWithRecordVariable() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariable");
         Assert.assertNotNull(returnValues);
@@ -75,7 +77,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test simple select clause - record variable definition statement v2 ")
+//    @Test(description = "Test simple select clause - record variable definition statement v2 ")
     public void testSimpleSelectQueryWithRecordVariableV2() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV2");
         Assert.assertNotNull(returnValues);
@@ -91,7 +93,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test simple select clause - record variable definition statement v3 ")
+//    @Test(description = "Test simple select clause - record variable definition statement v3 ")
     public void testSimpleSelectQueryWithRecordVariableV3() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV3");
         Assert.assertNotNull(returnValues);
@@ -106,7 +108,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(person2.get("lastName").stringValue(), "Fonseka");
     }
 
-    @Test(description = "Test simple select clause with a where clause")
+//    @Test(description = "Test simple select clause with a where clause")
     public void testSimpleSelectQueryWithWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithWhereClause");
         Assert.assertNotNull(returnValues);
@@ -122,7 +124,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 33);
     }
 
-    @Test(description = "Test Query expression for primitive types ")
+//    @Test(description = "Test Query expression for primitive types ")
     public void testQueryExpressionForPrimitiveType() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionForPrimitiveType");
         Assert.assertNotNull(returnValues);
@@ -134,7 +136,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getInt(1), 25);
     }
 
-    @Test(description = "Test Query expression with select expression ")
+//    @Test(description = "Test Query expression with select expression ")
     public void testQueryExpressionWithSelectExpression() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionWithSelectExpression");
         Assert.assertNotNull(returnValues);
@@ -147,7 +149,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(2), "3");
     }
 
-    @Test(description = "Test filtering null values from query expression")
+//    @Test(description = "Test filtering null values from query expression")
     public void testFilteringNullElements() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFilteringNullElements");
         Assert.assertNotNull(returnValues);
@@ -163,7 +165,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 30);
     }
 
-    @Test(description = "Test filtering map with from query expression")
+//    @Test(description = "Test filtering map with from query expression")
     public void testMapWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testMapWithArity");
         Assert.assertNotNull(returnValues);
@@ -171,7 +173,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(0), "1A");
     }
 
-    @Test(description = "Test selecting values in a JSON array from query expression")
+//    @Test(description = "Test selecting values in a JSON array from query expression")
     public void testJSONArrayWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testJSONArrayWithArity");
         Assert.assertNotNull(returnValues);
@@ -180,7 +182,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(1), "tom");
     }
 
-    @Test(description = "Test filtering values in a tuple from query expression")
+//    @Test(description = "Test filtering values in a tuple from query expression")
     public void testArrayWithTuple() {
         BValue[] returnValues = BRunUtil.invoke(result, "testArrayWithTuple");
         Assert.assertNotNull(returnValues);
@@ -188,7 +190,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(returnValues[0].stringValue(), "[\"C\"]");
     }
 
-    @Test(description = "Test from clause with a stream")
+//    @Test(description = "Test from clause with a stream")
     public void testFromClauseWithStream() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFromClauseWithStream");
         Assert.assertNotNull(returnValues);
@@ -200,7 +202,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person.get("age")).intValue(), 40);
     }
 
-    @Test(description = "Test let clause with a stream")
+//    @Test(description = "Test let clause with a stream")
     public void testSimpleSelectQueryWithLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithLetClause");
         Assert.assertNotNull(returnValues);
@@ -218,7 +220,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("company").stringValue(), "WSO2");
     }
 
-    @Test(description = "Use function return value in let clause")
+//    @Test(description = "Use function return value in let clause")
     public void testFunctionCallInVarDeclLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFunctionCallInVarDeclLetClause");
         Assert.assertNotNull(returnValues);
@@ -236,7 +238,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("age").stringValue(), "60");
     }
 
-    @Test(description = "Use value set in let with where clause")
+//    @Test(description = "Use value set in let with where clause")
     public void testUseOfLetInWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testUseOfLetInWhereClause");
         Assert.assertNotNull(returnValues);
@@ -247,6 +249,26 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee.get("firstName").stringValue(), "Ranjan");
         Assert.assertEquals(employee.get("lastName").stringValue(), "Fonseka");
         Assert.assertEquals(employee.get("age").stringValue(), "44");
+    }
+
+    @Test(description = "Use a stream with query expression")
+    public void testQueryWithStream() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryWithStream");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues.length, 1, "Expected events are not received");
+        Assert.assertTrue(returnValues[0] instanceof BValueArray, "Expected BValueArray type value");
+
+        Assert.assertEquals(((BValueArray) returnValues[0]).getInt(0), 1);
+        Assert.assertEquals(((BValueArray) returnValues[0]).getInt(1), 3);
+        Assert.assertEquals(((BValueArray) returnValues[0]).getInt(2), 5);
+    }
+
+    @Test(description = "Query a stream with error")
+    public void testQueryStreamWithError() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryStreamWithError");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues.length, 1, "Expected events are not received");
+        Assert.assertTrue(returnValues[0] instanceof BError, "Expected BErrorType type value");
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -59,7 +59,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test simple select clause - record variable definition statement ")
+    @Test(description = "Test simple select clause - record variable definition statement ")
     public void testSimpleSelectQueryWithRecordVariable() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariable");
         Assert.assertNotNull(returnValues);
@@ -75,7 +75,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test simple select clause - record variable definition statement v2 ")
+    @Test(description = "Test simple select clause - record variable definition statement v2 ")
     public void testSimpleSelectQueryWithRecordVariableV2() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV2");
         Assert.assertNotNull(returnValues);
@@ -91,7 +91,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test simple select clause - record variable definition statement v3 ")
+    @Test(description = "Test simple select clause - record variable definition statement v3 ")
     public void testSimpleSelectQueryWithRecordVariableV3() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV3");
         Assert.assertNotNull(returnValues);
@@ -106,7 +106,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(person2.get("lastName").stringValue(), "Fonseka");
     }
 
-//    @Test(description = "Test simple select clause with a where clause")
+    @Test(description = "Test simple select clause with a where clause")
     public void testSimpleSelectQueryWithWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithWhereClause");
         Assert.assertNotNull(returnValues);
@@ -122,7 +122,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test Query expression for primitive types ")
+    @Test(description = "Test Query expression for primitive types ")
     public void testQueryExpressionForPrimitiveType() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionForPrimitiveType");
         Assert.assertNotNull(returnValues);
@@ -134,7 +134,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getInt(1), 25);
     }
 
-//    @Test(description = "Test Query expression with select expression ")
+    @Test(description = "Test Query expression with select expression ")
     public void testQueryExpressionWithSelectExpression() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionWithSelectExpression");
         Assert.assertNotNull(returnValues);
@@ -147,7 +147,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(2), "3");
     }
 
-//    @Test(description = "Test filtering null values from query expression")
+    @Test(description = "Test filtering null values from query expression")
     public void testFilteringNullElements() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFilteringNullElements");
         Assert.assertNotNull(returnValues);
@@ -163,7 +163,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 30);
     }
 
-//    @Test(description = "Test filtering map with from query expression")
+    @Test(description = "Test filtering map with from query expression")
     public void testMapWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testMapWithArity");
         Assert.assertNotNull(returnValues);
@@ -171,7 +171,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(0), "1A");
     }
 
-//    @Test(description = "Test selecting values in a JSON array from query expression")
+    @Test(description = "Test selecting values in a JSON array from query expression")
     public void testJSONArrayWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testJSONArrayWithArity");
         Assert.assertNotNull(returnValues);
@@ -180,7 +180,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(1), "tom");
     }
 
-//    @Test(description = "Test filtering values in a tuple from query expression")
+    @Test(description = "Test filtering values in a tuple from query expression")
     public void testArrayWithTuple() {
         BValue[] returnValues = BRunUtil.invoke(result, "testArrayWithTuple");
         Assert.assertNotNull(returnValues);
@@ -188,7 +188,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(returnValues[0].stringValue(), "[\"C\"]");
     }
 
-//    @Test(description = "Test from clause with a stream")
+    @Test(description = "Test from clause with a stream")
     public void testFromClauseWithStream() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFromClauseWithStream");
         Assert.assertNotNull(returnValues);
@@ -200,7 +200,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person.get("age")).intValue(), 40);
     }
 
-//    @Test(description = "Test let clause with a stream")
+    @Test(description = "Test let clause with a stream")
     public void testSimpleSelectQueryWithLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithLetClause");
         Assert.assertNotNull(returnValues);
@@ -218,7 +218,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("company").stringValue(), "WSO2");
     }
 
-//    @Test(description = "Use function return value in let clause")
+    @Test(description = "Use function return value in let clause")
     public void testFunctionCallInVarDeclLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFunctionCallInVarDeclLetClause");
         Assert.assertNotNull(returnValues);
@@ -236,7 +236,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("age").stringValue(), "60");
     }
 
-//    @Test(description = "Use value set in let with where clause")
+    @Test(description = "Use value set in let with where clause")
     public void testUseOfLetInWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testUseOfLetInWhereClause");
         Assert.assertNotNull(returnValues);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -29,7 +29,6 @@ import org.ballerinalang.test.util.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 
 /**
  * This contains methods to test simple query expression with from, where and select clauses.
@@ -45,7 +44,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         result = BCompileUtil.compile("test-src/query/simple-query-with-defined-type.bal");
     }
 
-//    @Test(description = "Test simple select clause - simple variable definition statement ")
+    @Test(description = "Test simple select clause - simple variable definition statement ")
     public void testSimpleSelectQueryWithSimpleVariable() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithSimpleVariable");
         Assert.assertNotNull(returnValues);
@@ -61,7 +60,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test simple select clause - record variable definition statement ")
+    @Test(description = "Test simple select clause - record variable definition statement ")
     public void testSimpleSelectQueryWithRecordVariable() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariable");
         Assert.assertNotNull(returnValues);
@@ -77,7 +76,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test simple select clause - record variable definition statement v2 ")
+    @Test(description = "Test simple select clause - record variable definition statement v2 ")
     public void testSimpleSelectQueryWithRecordVariableV2() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV2");
         Assert.assertNotNull(returnValues);
@@ -93,7 +92,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person3.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test simple select clause - record variable definition statement v3 ")
+    @Test(description = "Test simple select clause - record variable definition statement v3 ")
     public void testSimpleSelectQueryWithRecordVariableV3() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithRecordVariableV3");
         Assert.assertNotNull(returnValues);
@@ -108,7 +107,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(person2.get("lastName").stringValue(), "Fonseka");
     }
 
-//    @Test(description = "Test simple select clause with a where clause")
+    @Test(description = "Test simple select clause with a where clause")
     public void testSimpleSelectQueryWithWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithWhereClause");
         Assert.assertNotNull(returnValues);
@@ -124,7 +123,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 33);
     }
 
-//    @Test(description = "Test Query expression for primitive types ")
+    @Test(description = "Test Query expression for primitive types ")
     public void testQueryExpressionForPrimitiveType() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionForPrimitiveType");
         Assert.assertNotNull(returnValues);
@@ -136,7 +135,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getInt(1), 25);
     }
 
-//    @Test(description = "Test Query expression with select expression ")
+    @Test(description = "Test Query expression with select expression ")
     public void testQueryExpressionWithSelectExpression() {
         BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionWithSelectExpression");
         Assert.assertNotNull(returnValues);
@@ -149,7 +148,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(2), "3");
     }
 
-//    @Test(description = "Test filtering null values from query expression")
+    @Test(description = "Test filtering null values from query expression")
     public void testFilteringNullElements() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFilteringNullElements");
         Assert.assertNotNull(returnValues);
@@ -165,7 +164,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person2.get("age")).intValue(), 30);
     }
 
-//    @Test(description = "Test filtering map with from query expression")
+    @Test(description = "Test filtering map with from query expression")
     public void testMapWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testMapWithArity");
         Assert.assertNotNull(returnValues);
@@ -173,7 +172,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(0), "1A");
     }
 
-//    @Test(description = "Test selecting values in a JSON array from query expression")
+    @Test(description = "Test selecting values in a JSON array from query expression")
     public void testJSONArrayWithArity() {
         BValue[] returnValues = BRunUtil.invoke(result, "testJSONArrayWithArity");
         Assert.assertNotNull(returnValues);
@@ -182,7 +181,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BValueArray) returnValues[0]).getString(1), "tom");
     }
 
-//    @Test(description = "Test filtering values in a tuple from query expression")
+    @Test(description = "Test filtering values in a tuple from query expression")
     public void testArrayWithTuple() {
         BValue[] returnValues = BRunUtil.invoke(result, "testArrayWithTuple");
         Assert.assertNotNull(returnValues);
@@ -190,7 +189,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(returnValues[0].stringValue(), "[\"C\"]");
     }
 
-//    @Test(description = "Test from clause with a stream")
+    @Test(description = "Test from clause with a stream")
     public void testFromClauseWithStream() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFromClauseWithStream");
         Assert.assertNotNull(returnValues);
@@ -202,7 +201,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(((BInteger) person.get("age")).intValue(), 40);
     }
 
-//    @Test(description = "Test let clause with a stream")
+    @Test(description = "Test let clause with a stream")
     public void testSimpleSelectQueryWithLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleSelectQueryWithLetClause");
         Assert.assertNotNull(returnValues);
@@ -220,7 +219,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("company").stringValue(), "WSO2");
     }
 
-//    @Test(description = "Use function return value in let clause")
+    @Test(description = "Use function return value in let clause")
     public void testFunctionCallInVarDeclLetClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testFunctionCallInVarDeclLetClause");
         Assert.assertNotNull(returnValues);
@@ -238,7 +237,7 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
         Assert.assertEquals(employee2.get("age").stringValue(), "60");
     }
 
-//    @Test(description = "Use value set in let with where clause")
+    @Test(description = "Use value set in let with where clause")
     public void testUseOfLetInWhereClause() {
         BValue[] returnValues = BRunUtil.invoke(result, "testUseOfLetInWhereClause");
         Assert.assertNotNull(returnValues);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
@@ -59,3 +59,37 @@ public function testNestedIterableObject() returns int[] {
 
     return integers;
 }
+
+type IterableWithError object {
+    public function __iterator() returns abstract object {
+
+        public function next() returns record {|int value;|}|error?;
+    } {
+        object {
+            int[] integers = [12, 34, 56, 34, 78];
+            int cursorIndex = 0;
+            public function next() returns record {|int value;|}|error? {
+                self.cursorIndex += 1;
+                if (self.cursorIndex == 3) {
+                    return error("Custom error thrown.");
+                }
+                else if (self.cursorIndex <= 5) {
+                    return {
+                        value: self.integers[self.cursorIndex - 1]
+                    };
+                } else {
+                    return ();
+                }
+            }
+        } sample = new;
+        return sample;
+    }
+};
+
+public function testIterableWithError() returns int[]|error {
+    IterableWithError p = new IterableWithError();
+    int[]|error integers = from var item in p
+                     select item;
+
+    return integers;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
@@ -1,0 +1,61 @@
+type Iterable object {
+    public function __iterator() returns abstract object {
+
+        public function next() returns record {|int value;|}?;
+    } {
+        object {
+            int[] integers = [12, 34, 56, 34, 78, 21, 90];
+            int cursorIndex = 0;
+            public function next() returns record {|int value;|}? {
+                self.cursorIndex += 1;
+                if (self.cursorIndex <= 7) {
+                    return {
+                        value: self.integers[self.cursorIndex - 1]
+                    };
+                } else {
+                    return ();
+                }
+            }
+        } sample = new;
+        return sample;
+    }
+};
+
+public function testIterableObject() returns int[] {
+    Iterable p = new Iterable();
+    int[] integers = from var item in p
+                     select item;
+
+    return integers;
+}
+
+type AnotherIterable object {
+    public function __iterator() returns abstract object {
+
+        public function next() returns record {|Iterable value;|}?;
+    } {
+        object {
+            int cursorIndex = 0;
+            public function next() returns record {|Iterable value;|}? {
+                self.cursorIndex += 1;
+                if (self.cursorIndex <= 2) {
+                    return {
+                        value: new Iterable()
+                    };
+                } else {
+                    return ();
+                }
+            }
+        } sample = new;
+        return sample;
+    }
+};
+
+public function testNestedIterableObject() returns int[] {
+    AnotherIterable p = new AnotherIterable();
+    int[] integers = from var itr in p
+                     from var item in itr
+                     select item;
+
+    return integers;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -1,4 +1,3 @@
-import ballerina/io;
 type Person record {|
    string firstName;
    string lastName;
@@ -17,42 +16,239 @@ type Employee record {|
    string company;
 |};
 
-function testSimpleSelectQueryWithSimpleVariable() returns   Person[]{
+function testSimpleSelectQueryWithSimpleVariable() returns Person[]{
 
-     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
-         Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
-         Person p3 = {firstName: "John", lastName: "David", age: 33};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
-         Person[] personList = [p1, p2, p3];
+    Person[] personList = [p1, p2, p3];
 
-          Person[] outputFromQuery = from Person person in personList
-                                  select person;
+    Person[] outputPersonList =
+            from var person in personList
+            select {
+                   firstName: person.firstName,
+                   lastName: person.lastName,
+                   age: person.age
+            };
 
-         //Person[]|error? outputList = ();
-         //Person[] tempList = [];
-         //var iteratorObj = personList.iterator();
-         //
-         //record {|Person value;|}|error? nextVal = iteratorObj.next();
-         //while (true) {
-         //    if (nextVal is ()) {
-         //        break;
-         //    } else if (nextVal is error) {
-         //        outputList = nextVal;
-         //        break;
-         //    } else {
-         //        var value = nextVal.value;
-         //        tempList[tempList.length()] = value;
-         //    }
-         //    nextVal = iteratorObj.next();
-         //}
-         //
-         //if (outputList is ()) {
-         //    outputList = tempList;
-         //}
-         //io:println(outputList);
-         //
-         //return outputList;
+    return  outputPersonList;
+}
 
-     io:println(outputFromQuery);
-    return outputFromQuery;
+function testSimpleSelectQueryWithRecordVariable() returns Person[]{
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName:"John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+
+    Person[] outputPersonList =
+            from var { firstName: nm1, lastName: nm2, age: a } in personList
+            select {
+                   firstName: nm1,
+                   lastName: nm2,
+                   age: a
+            };
+
+    return  outputPersonList;
+}
+
+function testSimpleSelectQueryWithRecordVariableV2() returns Person[]{
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName:"John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+
+    Person[] outputPersonList =
+            from var { firstName, lastName, age } in personList
+            select {
+                   firstName: firstName,
+                   lastName: lastName,
+                   age: age
+            };
+
+    return  outputPersonList;
+}
+
+function testSimpleSelectQueryWithRecordVariableV3() returns Teacher[]{
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName:"John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+
+    Teacher[] outputPersonList =
+            from var { firstName, lastName, age } in personList
+            select {
+                   firstName,
+                   lastName
+            };
+
+    return  outputPersonList;
+}
+
+function testSimpleSelectQueryWithWhereClause() returns Person[]{
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName:"John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+
+    Person[] outputPersonList =
+            from var person in personList
+            where person.age >= 30
+            select {
+                   firstName: person.firstName,
+                   lastName: person.lastName,
+                   age: person.age
+            };
+    return  outputPersonList;
+}
+
+function testQueryExpressionForPrimitiveType() returns int[]{
+
+    int[] intList = [12, 13, 14, 15, 20, 21, 25];
+
+    int[] outputIntList =
+            from var value in intList
+            where value > 20
+            select value;
+
+    return  outputIntList;
+}
+
+function testQueryExpressionWithSelectExpression() returns string[]{
+
+    int[] intList = [1, 2, 3];
+
+    string[] stringOutput =
+            from var value in intList
+            select value.toString();
+
+    return  stringOutput;
+}
+
+function testFilteringNullElements() returns Person[] {
+
+    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
+    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+
+    Person?[] personList = [p1,  (), p2];
+
+    Person[] outputPersonList =
+                     from var person in personList
+                     where (person is Person)
+                     select {
+                         firstName: person.firstName,
+                         lastName: person.lastName,
+                         age: person.age
+                         };
+    return outputPersonList;
+}
+
+function testMapWithArity () returns string[] {
+    map<any> m = {a:"1A", b:"2B", c:"3C", d:"4D"};
+    string[] val = from var v in m
+                   where <string> v == "1A"
+                   select <string> v;
+    return val;
+}
+
+function testJSONArrayWithArity() returns string[] {
+    json[] jdata = [{ name : "bob", age : 10}, { name : "tom", age : 16}];
+    string[] val = from var v in jdata
+                   select <string> v.name;
+    return val;
+}
+
+function testArrayWithTuple() returns string[] {
+    [int, string][] arr = [[1, "A"], [2, "B"], [3, "C"]];
+    string[] val = from var [i, v] in arr
+                   where i == 3
+                   select v;
+    return val;
+}
+
+function testFromClauseWithStream() returns Person[]{
+    Person p1 = {firstName: "Alex", lastName: "George", age: 30};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 40};
+    Person p3 = {firstName: "John", lastName: "David", age: 50};
+
+    Person[] personList = [p1, p2, p3];
+    stream<Person> streamedPersons = personList.toStream();
+
+    Person[] outputPersonList =
+            from var person in streamedPersons
+            where person.age == 40
+            select person;
+    return  outputPersonList;
+}
+
+function testSimpleSelectQueryWithLetClause() returns Employee[] {
+
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
+
+    Person[] personList = [p1, p2, p3];
+
+    Employee[] outputPersonList =
+            from var person in personList
+            let string depName = "HR", string companyName = "WSO2"
+            where person.age >= 30
+            select {
+                   firstName: person.firstName,
+                   lastName: person.lastName,
+                   department: depName,
+                   company: companyName
+            };
+    return  outputPersonList;
+}
+
+function testFunctionCallInVarDeclLetClause() returns Person[]{
+
+   Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+   Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+
+   Person[] personList = [p1, p2];
+
+    var outputPersonList =
+            from Person person in personList
+            let int twiceAge = mutiplyBy2(person.age)
+            select {
+                   firstName: person.firstName,
+                   lastName: person.lastName,
+                   age: twiceAge
+            };
+
+    return  outputPersonList;
+}
+
+function testUseOfLetInWhereClause() returns Person[]{
+
+   Person p1 = {firstName: "Alex", lastName: "George", age: 18};
+   Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 22};
+
+   Person[] personList = [p1, p2];
+
+    var outputPersonList =
+            from var person in personList
+            let int twiceAge = mutiplyBy2(person.age)
+            where twiceAge > 40
+            select {
+                   firstName: person.firstName,
+                   lastName: person.lastName,
+                   age: twiceAge
+            };
+
+    return  outputPersonList;
+}
+
+function mutiplyBy2 (int k) returns int {
+    return k * 2;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -1,3 +1,4 @@
+import ballerina/io;
 type Person record {|
    string firstName;
    string lastName;
@@ -16,239 +17,42 @@ type Employee record {|
    string company;
 |};
 
-function testSimpleSelectQueryWithSimpleVariable() returns Person[]{
+function testSimpleSelectQueryWithSimpleVariable() returns   Person[]{
 
-    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
-    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName: "John", lastName: "David", age: 33};
+     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+         Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+         Person p3 = {firstName: "John", lastName: "David", age: 33};
 
-    Person[] personList = [p1, p2, p3];
+         Person[] personList = [p1, p2, p3];
 
-    Person[] outputPersonList =
-            from var person in personList
-            select {
-                   firstName: person.firstName,
-                   lastName: person.lastName,
-                   age: person.age
-            };
+          Person[] outputFromQuery = from Person person in personList
+                                  select person;
 
-    return  outputPersonList;
-}
+         //Person[]|error? outputList = ();
+         //Person[] tempList = [];
+         //var iteratorObj = personList.iterator();
+         //
+         //record {|Person value;|}|error? nextVal = iteratorObj.next();
+         //while (true) {
+         //    if (nextVal is ()) {
+         //        break;
+         //    } else if (nextVal is error) {
+         //        outputList = nextVal;
+         //        break;
+         //    } else {
+         //        var value = nextVal.value;
+         //        tempList[tempList.length()] = value;
+         //    }
+         //    nextVal = iteratorObj.next();
+         //}
+         //
+         //if (outputList is ()) {
+         //    outputList = tempList;
+         //}
+         //io:println(outputList);
+         //
+         //return outputList;
 
-function testSimpleSelectQueryWithRecordVariable() returns Person[]{
-
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
-
-    Person[] personList = [p1, p2, p3];
-
-    Person[] outputPersonList =
-            from var { firstName: nm1, lastName: nm2, age: a } in personList
-            select {
-                   firstName: nm1,
-                   lastName: nm2,
-                   age: a
-            };
-
-    return  outputPersonList;
-}
-
-function testSimpleSelectQueryWithRecordVariableV2() returns Person[]{
-
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
-
-    Person[] personList = [p1, p2, p3];
-
-    Person[] outputPersonList =
-            from var { firstName, lastName, age } in personList
-            select {
-                   firstName: firstName,
-                   lastName: lastName,
-                   age: age
-            };
-
-    return  outputPersonList;
-}
-
-function testSimpleSelectQueryWithRecordVariableV3() returns Teacher[]{
-
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
-
-    Person[] personList = [p1, p2, p3];
-
-    Teacher[] outputPersonList =
-            from var { firstName, lastName, age } in personList
-            select {
-                   firstName,
-                   lastName
-            };
-
-    return  outputPersonList;
-}
-
-function testSimpleSelectQueryWithWhereClause() returns Person[]{
-
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
-
-    Person[] personList = [p1, p2, p3];
-
-    Person[] outputPersonList =
-            from var person in personList
-            where person.age >= 30
-            select {
-                   firstName: person.firstName,
-                   lastName: person.lastName,
-                   age: person.age
-            };
-    return  outputPersonList;
-}
-
-function testQueryExpressionForPrimitiveType() returns int[]{
-
-    int[] intList = [12, 13, 14, 15, 20, 21, 25];
-
-    int[] outputIntList =
-            from var value in intList
-            where value > 20
-            select value;
-
-    return  outputIntList;
-}
-
-function testQueryExpressionWithSelectExpression() returns string[]{
-
-    int[] intList = [1, 2, 3];
-
-    string[] stringOutput =
-            from var value in intList
-            select value.toString();
-
-    return  stringOutput;
-}
-
-function testFilteringNullElements() returns Person[] {
-
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-
-    Person?[] personList = [p1,  (), p2];
-
-    Person[] outputPersonList =
-                     from var person in personList
-                     where (person is Person)
-                     select {
-                         firstName: person.firstName,
-                         lastName: person.lastName,
-                         age: person.age
-                         };
-    return outputPersonList;
-}
-
-function testMapWithArity () returns string[] {
-    map<any> m = {a:"1A", b:"2B", c:"3C", d:"4D"};
-    string[] val = from var v in m
-                   where <string> v == "1A"
-                   select <string> v;
-    return val;
-}
-
-function testJSONArrayWithArity() returns string[] {
-    json[] jdata = [{ name : "bob", age : 10}, { name : "tom", age : 16}];
-    string[] val = from var v in jdata
-                   select <string> v.name;
-    return val;
-}
-
-function testArrayWithTuple() returns string[] {
-    [int, string][] arr = [[1, "A"], [2, "B"], [3, "C"]];
-    string[] val = from var [i, v] in arr
-                   where i == 3
-                   select v;
-    return val;
-}
-
-function testFromClauseWithStream() returns Person[]{
-    Person p1 = {firstName: "Alex", lastName: "George", age: 30};
-    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 40};
-    Person p3 = {firstName: "John", lastName: "David", age: 50};
-
-    Person[] personList = [p1, p2, p3];
-    stream<Person> streamedPersons = personList.toStream();
-
-    Person[] outputPersonList =
-            from var person in streamedPersons
-            where person.age == 40
-            select person;
-    return  outputPersonList;
-}
-
-function testSimpleSelectQueryWithLetClause() returns Employee[] {
-
-    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
-    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName: "John", lastName: "David", age: 33};
-
-    Person[] personList = [p1, p2, p3];
-
-    Employee[] outputPersonList =
-            from var person in personList
-            let string depName = "HR", string companyName = "WSO2"
-            where person.age >= 30
-            select {
-                   firstName: person.firstName,
-                   lastName: person.lastName,
-                   department: depName,
-                   company: companyName
-            };
-    return  outputPersonList;
-}
-
-function testFunctionCallInVarDeclLetClause() returns Person[]{
-
-   Person p1 = {firstName: "Alex", lastName: "George", age: 23};
-   Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
-
-   Person[] personList = [p1, p2];
-
-    var outputPersonList =
-            from Person person in personList
-            let int twiceAge = mutiplyBy2(person.age)
-            select {
-                   firstName: person.firstName,
-                   lastName: person.lastName,
-                   age: twiceAge
-            };
-
-    return  outputPersonList;
-}
-
-function testUseOfLetInWhereClause() returns Person[]{
-
-   Person p1 = {firstName: "Alex", lastName: "George", age: 18};
-   Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 22};
-
-   Person[] personList = [p1, p2];
-
-    var outputPersonList =
-            from var person in personList
-            let int twiceAge = mutiplyBy2(person.age)
-            where twiceAge > 40
-            select {
-                   firstName: person.firstName,
-                   lastName: person.lastName,
-                   age: twiceAge
-            };
-
-    return  outputPersonList;
-}
-
-function mutiplyBy2 (int k) returns int {
-    return k * 2;
+     io:println(outputFromQuery);
+    return outputFromQuery;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -1,22 +1,45 @@
 type Person record {|
-   string firstName;
-   string lastName;
-   int age;
+    string firstName;
+    string lastName;
+    int age;
 |};
 
 type Teacher record {|
-   string firstName;
-   string lastName;
+    string firstName;
+    string lastName;
 |};
 
 type Employee record {|
-   string firstName;
-   string lastName;
-   string department;
-   string company;
+    string firstName;
+    string lastName;
+    string department;
+    string company;
 |};
 
-function testSimpleSelectQueryWithSimpleVariable() returns Person[]{
+type NumberGenerator object {
+    int i = 0;
+    public function next() returns record {|int value;|}|error? {
+        //closes the stream after 5 events
+        if (self.i == 5) {
+            return ();
+        }
+        self.i += 1;
+        return {value: self.i};
+    }
+};
+
+type NumberGeneratorWithError object {
+    int i = 0;
+    public function next() returns record {|int value;|}|error? {
+        if (self.i == 3) {
+            return error("Custom error thrown explicitly.");
+        }
+        self.i += 1;
+        return {value: self.i};
+    }
+};
+
+function testSimpleSelectQueryWithSimpleVariable() returns Person[] {
 
     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
@@ -32,14 +55,14 @@ function testSimpleSelectQueryWithSimpleVariable() returns Person[]{
                    age: person.age
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithRecordVariable() returns Person[]{
+function testSimpleSelectQueryWithRecordVariable() returns Person[] {
 
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -51,14 +74,14 @@ function testSimpleSelectQueryWithRecordVariable() returns Person[]{
                    age: a
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithRecordVariableV2() returns Person[]{
+function testSimpleSelectQueryWithRecordVariableV2() returns Person[] {
 
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -70,14 +93,14 @@ function testSimpleSelectQueryWithRecordVariableV2() returns Person[]{
                    age: age
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithRecordVariableV3() returns Teacher[]{
+function testSimpleSelectQueryWithRecordVariableV3() returns Teacher[] {
 
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -88,14 +111,14 @@ function testSimpleSelectQueryWithRecordVariableV3() returns Teacher[]{
                    lastName
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithWhereClause() returns Person[]{
+function testSimpleSelectQueryWithWhereClause() returns Person[] {
 
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -107,10 +130,10 @@ function testSimpleSelectQueryWithWhereClause() returns Person[]{
                    lastName: person.lastName,
                    age: person.age
             };
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testQueryExpressionForPrimitiveType() returns int[]{
+function testQueryExpressionForPrimitiveType() returns int[] {
 
     int[] intList = [12, 13, 14, 15, 20, 21, 25];
 
@@ -119,10 +142,10 @@ function testQueryExpressionForPrimitiveType() returns int[]{
             where value > 20
             select value;
 
-    return  outputIntList;
+    return outputIntList;
 }
 
-function testQueryExpressionWithSelectExpression() returns string[]{
+function testQueryExpressionWithSelectExpression() returns string[] {
 
     int[] intList = [1, 2, 3];
 
@@ -130,15 +153,15 @@ function testQueryExpressionWithSelectExpression() returns string[]{
             from var value in intList
             select value.toString();
 
-    return  stringOutput;
+    return stringOutput;
 }
 
 function testFilteringNullElements() returns Person[] {
 
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
 
-    Person?[] personList = [p1,  (), p2];
+    Person?[] personList = [p1, (), p2];
 
     Person[] outputPersonList =
                      from var person in personList
@@ -151,8 +174,8 @@ function testFilteringNullElements() returns Person[] {
     return outputPersonList;
 }
 
-function testMapWithArity () returns string[] {
-    map<any> m = {a:"1A", b:"2B", c:"3C", d:"4D"};
+function testMapWithArity() returns string[] {
+    map<any> m = {a: "1A", b: "2B", c: "3C", d: "4D"};
     string[] val = from var v in m
                    where <string> v == "1A"
                    select <string> v;
@@ -160,7 +183,7 @@ function testMapWithArity () returns string[] {
 }
 
 function testJSONArrayWithArity() returns string[] {
-    json[] jdata = [{ name : "bob", age : 10}, { name : "tom", age : 16}];
+    json[] jdata = [{name: "bob", age: 10}, {name: "tom", age: 16}];
     string[] val = from var v in jdata
                    select <string> v.name;
     return val;
@@ -174,7 +197,7 @@ function testArrayWithTuple() returns string[] {
     return val;
 }
 
-function testFromClauseWithStream() returns Person[]{
+function testFromClauseWithStream() returns Person[] {
     Person p1 = {firstName: "Alex", lastName: "George", age: 30};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 40};
     Person p3 = {firstName: "John", lastName: "David", age: 50};
@@ -186,7 +209,7 @@ function testFromClauseWithStream() returns Person[]{
             from var person in streamedPersons
             where person.age == 40
             select person;
-    return  outputPersonList;
+    return outputPersonList;
 }
 
 function testSimpleSelectQueryWithLetClause() returns Employee[] {
@@ -207,15 +230,15 @@ function testSimpleSelectQueryWithLetClause() returns Employee[] {
                    department: depName,
                    company: companyName
             };
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testFunctionCallInVarDeclLetClause() returns Person[]{
+function testFunctionCallInVarDeclLetClause() returns Person[] {
 
-   Person p1 = {firstName: "Alex", lastName: "George", age: 23};
-   Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
 
-   Person[] personList = [p1, p2];
+    Person[] personList = [p1, p2];
 
     var outputPersonList =
             from Person person in personList
@@ -226,15 +249,15 @@ function testFunctionCallInVarDeclLetClause() returns Person[]{
                    age: twiceAge
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testUseOfLetInWhereClause() returns Person[]{
+function testUseOfLetInWhereClause() returns Person[] {
 
-   Person p1 = {firstName: "Alex", lastName: "George", age: 18};
-   Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 22};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 18};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 22};
 
-   Person[] personList = [p1, p2];
+    Person[] personList = [p1, p2];
 
     var outputPersonList =
             from var person in personList
@@ -246,9 +269,29 @@ function testUseOfLetInWhereClause() returns Person[]{
                    age: twiceAge
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function mutiplyBy2 (int k) returns int {
+function mutiplyBy2(int k) returns int {
     return k * 2;
+}
+
+public function testQueryWithStream() returns int[]|error {
+    NumberGenerator numGen = new;
+    var numberStream = new stream<int, error>(numGen);
+
+    int[]|error oddNumberList = from int num in numberStream
+                                 where (num % 2 == 1)
+                                 select num;
+    return oddNumberList;
+}
+
+public function testQueryStreamWithError() returns int[]|error {
+    NumberGeneratorWithError numGen = new;
+    var numberStream = new stream<int, error>(numGen);
+
+    int[]|error oddNumberList = from int num in numberStream
+                                where (num % 2 == 1)
+                                select num;
+    return oddNumberList;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
@@ -1,18 +1,29 @@
 type Person record {|
-   string firstName;
-   string lastName;
-   int age;
+    string firstName;
+    string lastName;
+    int age;
 |};
 
 type Teacher record {|
-   string firstName;
-   string lastName;
-   int age;
-   string teacherId;
+    string firstName;
+    string lastName;
+    int age;
+    string teacherId;
 |};
 
+type NumberGenerator object {
+    int i = 0;
+    public function next() returns record {|int value;|}|error? {
+        //closes the stream after 5 events
+        if (self.i == 5) {
+            return ();
+        }
+        self.i += 1;
+        return {value: self.i};
+    }
+};
 
-function testSimpleSelectQueryWithSimpleVariable() returns Person[]{
+function testSimpleSelectQueryWithSimpleVariable() returns Person[] {
     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
     Person p3 = {firstName: "John", lastName: "David", age: 33};
@@ -27,13 +38,13 @@ function testSimpleSelectQueryWithSimpleVariable() returns Person[]{
                    age: person.age
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithRecordVariable() returns Person[]{
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+function testSimpleSelectQueryWithRecordVariable() returns Person[] {
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -45,13 +56,13 @@ function testSimpleSelectQueryWithRecordVariable() returns Person[]{
                    age: a
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithRecordVariableV2() returns Person[]{
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+function testSimpleSelectQueryWithRecordVariableV2() returns Person[] {
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -63,13 +74,13 @@ function testSimpleSelectQueryWithRecordVariableV2() returns Person[]{
                    age: age
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithRecordVariableV3() returns Person[]{
-    Teacher p1 = {firstName:"Alex", lastName: "George", age: 23, teacherId: "XYZ01"};
-    Teacher p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30, teacherId: "ABC01"};
-    Teacher p3 = {firstName:"John", lastName: "David", age: 33, teacherId: "ABC10"};
+function testSimpleSelectQueryWithRecordVariableV3() returns Person[] {
+    Teacher p1 = {firstName: "Alex", lastName: "George", age: 23, teacherId: "XYZ01"};
+    Teacher p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30, teacherId: "ABC01"};
+    Teacher p3 = {firstName: "John", lastName: "David", age: 33, teacherId: "ABC10"};
 
     Teacher[] teacherList = [p1, p2, p3];
 
@@ -81,13 +92,13 @@ function testSimpleSelectQueryWithRecordVariableV3() returns Person[]{
                    age: age
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithWhereClause() returns Person[]{
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
-    Person p3 = {firstName:"John", lastName: "David", age: 33};
+function testSimpleSelectQueryWithWhereClause() returns Person[] {
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
+    Person p3 = {firstName: "John", lastName: "David", age: 33};
 
     Person[] personList = [p1, p2, p3];
 
@@ -99,10 +110,10 @@ function testSimpleSelectQueryWithWhereClause() returns Person[]{
                    lastName: person.lastName,
                    age: person.age
             };
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testQueryExpressionForPrimitiveType() returns int[]{
+function testQueryExpressionForPrimitiveType() returns int[] {
 
     int[] intList = [12, 13, 14, 15, 20, 21, 25];
 
@@ -111,10 +122,10 @@ function testQueryExpressionForPrimitiveType() returns int[]{
             where value > 20
             select value;
 
-    return  outputIntList;
+    return outputIntList;
 }
 
-function testQueryExpressionWithSelectExpression() returns string[]{
+function testQueryExpressionWithSelectExpression() returns string[] {
 
     int[] intList = [1, 2, 3];
 
@@ -122,15 +133,15 @@ function testQueryExpressionWithSelectExpression() returns string[]{
             from var value in intList
             select value.toString();
 
-    return  stringOutput;
+    return stringOutput;
 }
 
 function testFilteringNullElements() returns Person[] {
 
-    Person p1 = {firstName:"Alex", lastName: "George", age: 23};
-    Person p2 = {firstName:"Ranjan", lastName: "Fonseka", age: 30};
+    Person p1 = {firstName: "Alex", lastName: "George", age: 23};
+    Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
 
-    Person?[] personList = [p1,  (), p2];
+    Person?[] personList = [p1, (), p2];
 
     var outputPersonList =
                      from var person in personList
@@ -143,8 +154,8 @@ function testFilteringNullElements() returns Person[] {
     return outputPersonList;
 }
 
-function testMapWithArity () returns string[] {
-    map<any> m = {a:"1A", b:"2B", c:"3C", d:"4D"};
+function testMapWithArity() returns string[] {
+    map<any> m = {a: "1A", b: "2B", c: "3C", d: "4D"};
     var val = from var v in m
                    where <string> v == "1A"
                    select <string>v;
@@ -152,7 +163,7 @@ function testMapWithArity () returns string[] {
 }
 
 function testJSONArrayWithArity() returns string[] {
-    json[] jdata = [{ name : "bob", age : 10}, { name : "tom", age : 16}];
+    json[] jdata = [{name: "bob", age: 10}, {name: "tom", age: 16}];
     var val = from var v in jdata
                    select <string> v.name;
     return val;
@@ -166,7 +177,7 @@ function testArrayWithTuple() returns string[] {
     return val;
 }
 
-function testQueryExpressionWithVarType() returns Teacher[]{
+function testQueryExpressionWithVarType() returns Teacher[] {
 
     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
@@ -183,10 +194,10 @@ function testQueryExpressionWithVarType() returns Teacher[]{
                    teacherId: "TER1200"
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testSimpleSelectQueryWithSpreadOperator() returns Person[]{
+function testSimpleSelectQueryWithSpreadOperator() returns Person[] {
     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
     Person p3 = {firstName: "John", lastName: "David", age: 33};
@@ -199,10 +210,10 @@ function testSimpleSelectQueryWithSpreadOperator() returns Person[]{
                    ...person
             };
 
-    return  outputPersonList;
+    return outputPersonList;
 }
 
-function testQueryExpressionWithSpreadOperatorV2() returns Teacher[]{
+function testQueryExpressionWithSpreadOperatorV2() returns Teacher[] {
 
     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};
@@ -217,5 +228,15 @@ function testQueryExpressionWithSpreadOperatorV2() returns Teacher[]{
                    teacherId: "TER1200"
             };
 
-    return  outputPersonList;
+    return outputPersonList;
+}
+
+public function testQueryWithStream() returns int[]|error {
+    NumberGenerator numGen = new;
+    var numberStream = new stream<int, error>(numGen);
+
+    var oddNumberList = from var num in numberStream
+                        where (num % 2 == 1)
+                        select num;
+    return oddNumberList;
 }


### PR DESCRIPTION
## Purpose
> At the moment, the query expression is desugared to foreach statements. Hence, limitation to handle error for streams with query expressions.

Fixes #21757

## Approach
> Desugar query expression into while statements, and handle errors within the while statement.

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
