### PR TITLE
[1.2.x] Narrow type bound to union type parameters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -278,7 +278,6 @@ public class TypeParamAnalyzer {
             updateTypeParamAndBoundType(pos, env, expType, actualType);
 
             // If type param discovered before, now type check with actual type. It has to be matched.
-
             if (checkContravariance) {
                 types.checkType(pos, getMatchingBoundType(expType, env, new HashSet<>()), actualType,
                                 DiagnosticCode.INCOMPATIBLE_TYPES);
@@ -299,6 +298,10 @@ public class TypeParamAnalyzer {
                     findTypeParamInTupleForArray(pos, (BArrayType) expType, (BTupleType) actualType, env, resolvedTypes,
                                                  result);
                 }
+                if (actualType.tag == TypeTags.UNION) {
+                    findTypeParamInUnionForArray(pos, (BArrayType) expType, (BUnionType) actualType, env, resolvedTypes,
+                                                 result);
+                }
                 return;
             case TypeTags.TABLE:
                 if (actualType.tag == TypeTags.TABLE) {
@@ -314,6 +317,10 @@ public class TypeParamAnalyzer {
                 if (actualType.tag == TypeTags.RECORD) {
                     findTypeParamInMapForRecord(pos, (BMapType) expType, (BRecordType) actualType, env, resolvedTypes,
                                                 result);
+                }
+                if (actualType.tag == TypeTags.UNION) {
+                    findTypeParamInUnionForMap(pos, (BMapType) expType, (BUnionType) actualType, env, resolvedTypes,
+                                               result);
                 }
                 return;
             case TypeTags.STREAM:
@@ -405,6 +412,34 @@ public class TypeParamAnalyzer {
         }
         BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
         findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
+    }
+
+    private void findTypeParamInUnionForArray(DiagnosticPos pos, BArrayType expType, BUnionType actualType,
+                                              SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
+        for (BType type : actualType.getMemberTypes()) {
+            if (type.tag == TypeTags.ARRAY) {
+                tupleTypes.add(((BArrayType) type).eType);
+            } else {
+                tupleTypes.add(type);
+            }
+        }
+        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
+        findTypeParam(pos, expType.eType, tupleElementType, env, resolvedTypes, result);
+    }
+
+    private void findTypeParamInUnionForMap(DiagnosticPos pos, BMapType expType, BUnionType actualType,
+                                            SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+        LinkedHashSet<BType> tupleTypes = new LinkedHashSet<>();
+        for (BType type : actualType.getMemberTypes()) {
+            if (type.tag == TypeTags.MAP) {
+                tupleTypes.add(((BMapType) type).constraint);
+            } else {
+                tupleTypes.add(type);
+            }
+        }
+        BUnionType tupleElementType = BUnionType.create(null, tupleTypes);
+        findTypeParam(pos, expType.constraint, tupleElementType, env, resolvedTypes, result);
     }
 
     private void findTypeParamInRecord(DiagnosticPos pos, BRecordType expType, BRecordType actualType, SymbolEnv env,

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -67,13 +67,9 @@ public class TypeParamTest {
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'int', found 'float'", 119, 21);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 122, 31);
         BAssertUtil.validateError(result, err++, "incompatible types: expected 'byte', found 'int'", 125, 26);
-
-        // Disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/22137
-        // BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'int'", 130,
-        // 14);
-        // BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'float'", 131,
-        //                           24);
-
+        BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'boolean'", 130,
+                                  14);
+        BAssertUtil.validateError(result, err++, "incompatible types: expected '(int|string)', found 'float'", 131, 24);
         Assert.assertEquals(result.getErrorCount(), err);
     }
 
@@ -111,4 +107,11 @@ public class TypeParamTest {
         Assert.assertEquals(ret2[0].stringValue(), "100");
     }
 
+    @Test(description = "Tests for type narrowing for union return parameters")
+    public void testTypeNarrowingForUnionReturnParameters() {
+        CompileResult result = BCompileUtil.compile("test-src/type-param/type_param_narrowing_for_union_return.bal");
+        BRunUtil.invoke(result, "testSimpleUnionReturnParameterNarrowing");
+        BRunUtil.invoke(result, "testUnionOfMapsReturnParameterNarrowing");
+        Assert.assertEquals(result.getErrorCount(), 0);
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -1,0 +1,21 @@
+function testSimpleUnionReturnParameterNarrowing() {
+    int[]|float[] arr = <int[]>[1, 2];
+    [int, (int|float)][] y = arr.enumerate();
+    assertTrue(true);
+}
+
+function testUnionOfMapsReturnParameterNarrowing() {
+    map<int>|map<float> m = <map<int>>{"1": 1};
+    int|float x = m.get("1");
+    assertTrue(true);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertTrue(any|error actual) {
+    if actual is boolean && actual {
+        return;
+    }
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected 'true', found '" + actual.toString () + "'");
+}


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues.

Fixes #16828
Fixes #22137

## Approach
Add logic to TypeParamAnalyser. Union and union with arrays will be flattened and merged as a union again.

## Samples
> Provide high-level details about the samples related to this feature.
#### Case 1
```Ballerina
int[]|Person[] arr = <int[]>[1, 2];
[int, int][] y = arr.enumerate();
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
