### PR TITLE
Prioritise filed-level docs over object/record def-level docs

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -284,8 +284,8 @@ public class Generator {
         for (BLangSimpleVariable param : allFields) {
             if (param.getFlags().contains(Flag.PUBLIC)) {
                 String name = param.getName().value;
-                String desc = fieldAnnotation(node, param);
-                desc = desc.isEmpty() ? findDescFromList(name, documentation, param) : desc;
+                String desc = findDescFromList(name, documentation, param);
+                desc = desc.isEmpty() ? fieldAnnotation(node, param) : desc;
 
                 String defaultValue = EMPTY_STRING;
                 if (null != param.getInitialExpression()) {
@@ -307,16 +307,19 @@ public class Generator {
         }
         Map<String, BLangMarkdownParameterDocumentation> parameterDocumentations = documentation
                 .getParameterDocumentations();
-        BLangMarkdownParameterDocumentation parameter = parameterDocumentations.get(name);
-        if (parameter != null) {
-            return BallerinaDocUtils.mdToHtml(parameter.getParameterDocumentation());
+
+        // Get field documentation from field decl documentation (priority)
+        BLangMarkdownDocumentation paramDocAttach = param.getMarkdownDocumentationAttachment();
+        if (paramDocAttach != null) {
+            return BallerinaDocUtils.mdToHtml(paramDocAttach.getDocumentation());
         } else {
-            // Get field-level documentation
-            BLangMarkdownDocumentation paramDocAttach = param.getMarkdownDocumentationAttachment();
-            if (paramDocAttach == null) {
+            // Get field documentation from object/record def documentation
+            BLangMarkdownParameterDocumentation parameter = parameterDocumentations.get(name);
+            if (parameter != null) {
+                return BallerinaDocUtils.mdToHtml(parameter.getParameterDocumentation());
+            } else {
                 return EMPTY_STRING;
             }
-            return BallerinaDocUtils.mdToHtml(paramDocAttach.getDocumentation());
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/FieldLevelDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/FieldLevelDocsTest.java
@@ -58,6 +58,8 @@ public class FieldLevelDocsTest {
     private Object studentObj;
     // Object with field-level documentation
     private Object teacherObj;
+    // object with both module-level & field-level documentation
+    private Object employeeObj;
 
     private static final String PARAGRAPH_OPEN_TAG = "<p>";
     private static final String PARAGRAPH_CLOSE_TAG = "</p>";
@@ -100,6 +102,8 @@ public class FieldLevelDocsTest {
                 studentObj = obj;
             } else if ("Teacher".equals(objName)) {
                 teacherObj = obj;
+            } else if ("Employee".equals(objName)) {
+                employeeObj = obj;
             }
         }
     }
@@ -155,7 +159,7 @@ public class FieldLevelDocsTest {
     }
 
 
-    @Test(description = "Test records with both module-level & field-level field docs. module-level is the priority")
+    @Test(description = "Test records with both module-level & field-level field docs. field-level is the priority")
     public void testRecordWithModuleLevelAndFieldLevelFieldDocs() {
         DefaultableVariable numberField = null;
         DefaultableVariable streetField = null;
@@ -175,9 +179,9 @@ public class FieldLevelDocsTest {
             }
         }
 
-        testDescription(numberField, formatHtmlDescription("number of the apartment"));
-        testDescription(streetField, formatHtmlDescription("street of the apartment"));
-        testDescription(countryCodeField, formatHtmlDescription("country code of the apartment"));
+        testDescription(numberField, formatHtmlDescription("apartment no"));
+        testDescription(streetField, formatHtmlDescription("apartment street"));
+        testDescription(countryCodeField, formatHtmlDescription("apartment country-code"));
     }
 
     @Test(description = "Test object with module-level field docs")
@@ -220,6 +224,27 @@ public class FieldLevelDocsTest {
 
         testDescription(nameField, formatHtmlDescription("Teacher name"));
         testDescription(ageField, formatHtmlDescription("Teacher age"));
+    }
+
+    @Test(description = "Test object with both module-level & field-level field docs. field-level is the priority")
+    public void testObjWithModuleLevelAndFieldLevelFieldDocs() {
+        DefaultableVariable empNoField = null;
+        DefaultableVariable ageField = null;
+
+        List<DefaultableVariable> fields = employeeObj.fields;
+
+        for (DefaultableVariable field : fields) {
+            String fieldName = field.name;
+
+            if ("empNo".equals(fieldName)) {
+                empNoField = field;
+            } else if ("age".equals(fieldName)) {
+                ageField = field;
+            }
+        }
+
+        testDescription(empNoField, formatHtmlDescription("funny number"));
+        testDescription(ageField, formatHtmlDescription("funny age"));
     }
 
     @Test(description = "Test documentation of objects with markdown styles")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/documentation/record_object_fields_project/src/test_module/main.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/documentation/record_object_fields_project/src/test_module/main.bal
@@ -60,6 +60,18 @@ public type Teacher object {
     public int age = 15;
 };
 
+
+# Employee object
+#
+# + empNo - employee number
+# + age - employee age
+public type Employee object {
+    # funny number
+    public string empNo = "E100546";
+    # funny age
+    public int age = 15;
+};
+
 # Prints `Hello World`.
 public function main() {
     io:println("Hello World!");


### PR DESCRIPTION
## Purpose
> Give priority to the field decl level docs over record/object def level in docerina documentation & added unit tests for this use-case.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/22402

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
