### PR TITLE
Remove `isFieldAnalyseRequired` from code

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -389,8 +389,8 @@ public class BLangPackageBuilder {
         this.typeNodeStack.push(tupleTypeNode);
     }
 
-    void addRecordType(DiagnosticPos pos, Set<Whitespace> ws, boolean isFieldAnalyseRequired, boolean isAnonymous,
-                       boolean hasRestField, boolean isExclusiveTypeDesc) {
+    void addRecordType(DiagnosticPos pos, Set<Whitespace> ws, boolean isAnonymous, boolean hasRestField,
+                       boolean isExclusiveTypeDesc) {
         // If there is an explicitly defined rest field, take it.
         BLangType restFieldType = null;
         if (hasRestField) {
@@ -398,7 +398,6 @@ public class BLangPackageBuilder {
         }
         // Create an anonymous record and add it to the list of records in the current package.
         BLangRecordTypeNode recordTypeNode = populateRecordTypeNode(pos, ws, isAnonymous);
-        recordTypeNode.isFieldAnalyseRequired = isFieldAnalyseRequired;
         recordTypeNode.sealed = isExclusiveTypeDesc && !hasRestField;
         recordTypeNode.restFieldType = restFieldType;
 
@@ -2345,11 +2344,10 @@ public class BLangPackageBuilder {
         startFieldBlockList();
     }
 
-    void addObjectType(DiagnosticPos pos, Set<Whitespace> ws, boolean isFieldAnalyseRequired, boolean isAnonymous,
-                       boolean isAbstract, boolean isClient, boolean isService) {
+    void addObjectType(DiagnosticPos pos, Set<Whitespace> ws, boolean isAnonymous, boolean isAbstract,
+                       boolean isClient, boolean isService) {
         BLangObjectTypeNode objectTypeNode = populateObjectTypeNode(pos, ws, isAnonymous);
         objectTypeNode.addWS(this.objectFieldBlockWs.pop());
-        objectTypeNode.isFieldAnalyseRequired = isFieldAnalyseRequired;
 
         if (isAbstract) {
             objectTypeNode.flagSet.add(Flag.ABSTRACT);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -255,11 +255,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        boolean isFieldAnalyseRequired = (ctx.parent.parent instanceof BallerinaParser.GlobalVariableDefinitionContext
-                || ctx.parent.parent instanceof BallerinaParser.ReturnParameterContext)
-                || ctx.parent.parent.parent.parent instanceof BallerinaParser.TypeDefinitionContext;
-        this.pkgBuilder
-                .addObjectType(getCurrentPos(ctx), getWS(ctx), isFieldAnalyseRequired, false, false, false, true);
+        this.pkgBuilder.addObjectType(getCurrentPos(ctx), getWS(ctx), false, false, false, true);
     }
 
     /**
@@ -493,14 +489,9 @@ public class BLangParserListener extends BallerinaParserBaseListener {
                     && ctx.parent.parent.parent instanceof BallerinaParser.FiniteTypeContext
                     && ctx.parent.parent.parent.getChildCount() > 1);
 
-        boolean isFieldAnalyseRequired =
-                (ctx.parent.parent instanceof BallerinaParser.GlobalVariableDefinitionContext ||
-                        ctx.parent.parent instanceof BallerinaParser.ReturnParameterContext) ||
-                        ctx.parent.parent.parent.parent instanceof BallerinaParser.TypeDefinitionContext;
         boolean isAbstract = ((ObjectTypeNameLabelContext) ctx.parent).ABSTRACT() != null;
         boolean isClient = ((ObjectTypeNameLabelContext) ctx.parent).CLIENT() != null;
-        this.pkgBuilder.addObjectType(getCurrentPos(ctx), getWS(ctx), isFieldAnalyseRequired, isAnonymous, isAbstract,
-                isClient, false);
+        this.pkgBuilder.addObjectType(getCurrentPos(ctx), getWS(ctx), isAnonymous, isAbstract, isClient, false);
     }
 
     /**
@@ -871,13 +862,7 @@ public class BLangParserListener extends BallerinaParserBaseListener {
 
         boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
 
-        boolean isFieldAnalyseRequired =
-                (ctx.parent.parent instanceof BallerinaParser.GlobalVariableDefinitionContext ||
-                        ctx.parent.parent instanceof BallerinaParser.ReturnParameterContext) ||
-                        ctx.parent.parent.parent.parent instanceof BallerinaParser.TypeDefinitionContext;
-
-        this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isFieldAnalyseRequired, isAnonymous, false,
-                                      false);
+        this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isAnonymous, false, false);
     }
 
     @Override
@@ -897,15 +882,9 @@ public class BLangParserListener extends BallerinaParserBaseListener {
 
         boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
 
-        boolean isFieldAnalyseRequired =
-                (ctx.parent.parent instanceof BallerinaParser.GlobalVariableDefinitionContext ||
-                        ctx.parent.parent instanceof BallerinaParser.ReturnParameterContext) ||
-                        ctx.parent.parent.parent.parent instanceof BallerinaParser.TypeDefinitionContext;
-
         boolean hasRestField = ctx.recordRestFieldDefinition() != null;
 
-        this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isFieldAnalyseRequired, isAnonymous,
-                                      hasRestField, true);
+        this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isAnonymous, hasRestField, true);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -311,7 +311,6 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.initFunction = clone(source.initFunction);
         clone.isAnonymous = source.isAnonymous;
         clone.isLocal = source.isLocal;
-        clone.isFieldAnalyseRequired = source.isFieldAnalyseRequired;
         clone.typeRefs = cloneList(source.typeRefs);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -196,12 +196,10 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.Stack;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 import static org.wso2.ballerinalang.compiler.tree.BLangInvokableNode.DEFAULT_WORKER_NAME;
 import static org.wso2.ballerinalang.compiler.util.Constants.MAIN_FUNCTION_NAME;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2324,14 +2324,18 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     public void visit(BLangRecordTypeNode recordTypeNode) {
 
         SymbolEnv recordEnv = SymbolEnv.createTypeEnv(recordTypeNode, recordTypeNode.symbol.scope, env);
-        recordTypeNode.fields.forEach(field -> analyzeNode(field, recordEnv));
+        for (BLangSimpleVariable field : recordTypeNode.fields) {
+            analyzeNode(field, recordEnv);
+        }
     }
 
     @Override
     public void visit(BLangObjectTypeNode objectTypeNode) {
 
         SymbolEnv objectEnv = SymbolEnv.createTypeEnv(objectTypeNode, objectTypeNode.symbol.scope, env);
-        objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
+        for (BLangSimpleVariable field : objectTypeNode.fields) {
+            analyzeNode(field, objectEnv);
+        }
 
         List<BLangFunction> bLangFunctionList = new ArrayList<>(objectTypeNode.functions);
         if (objectTypeNode.initFunction != null) {
@@ -2340,7 +2344,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
         // To ensure the order of the compile errors
         bLangFunctionList.sort(Comparator.comparingInt(o -> o.pos.sLine));
-        bLangFunctionList.forEach(fn -> this.analyzeNode(fn, objectEnv));
+        for (BLangFunction function : bLangFunctionList) {
+            this.analyzeNode(function, objectEnv);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2326,18 +2326,20 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     public void visit(BLangRecordTypeNode recordTypeNode) {
 
         SymbolEnv recordEnv = SymbolEnv.createTypeEnv(recordTypeNode, recordTypeNode.symbol.scope, env);
-        if (recordTypeNode.isFieldAnalyseRequired) {
-            recordTypeNode.fields.forEach(field -> analyzeNode(field, recordEnv));
-        }
+//        if (recordTypeNode.isFieldAnalyseRequired) {
+//            recordTypeNode.fields.forEach(field -> analyzeNode(field, recordEnv));
+//        }
+        recordTypeNode.fields.forEach(field -> analyzeNode(field, recordEnv));
     }
 
     @Override
     public void visit(BLangObjectTypeNode objectTypeNode) {
 
         SymbolEnv objectEnv = SymbolEnv.createTypeEnv(objectTypeNode, objectTypeNode.symbol.scope, env);
-        if (objectTypeNode.isFieldAnalyseRequired) {
-            objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
-        }
+//        if (objectTypeNode.isFieldAnalyseRequired) {
+//            objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
+//        }
+        objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
 
         // To ensure the order of the compile errors
         Stream.concat(objectTypeNode.functions.stream(),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2335,11 +2335,14 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         SymbolEnv objectEnv = SymbolEnv.createTypeEnv(objectTypeNode, objectTypeNode.symbol.scope, env);
         objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
 
+        List<BLangFunction> bLangFunctionList = new ArrayList<>(objectTypeNode.functions);
+        if (objectTypeNode.initFunction != null) {
+            bLangFunctionList.add(objectTypeNode.initFunction);
+        }
+
         // To ensure the order of the compile errors
-        Stream.concat(objectTypeNode.functions.stream(),
-                Optional.ofNullable(objectTypeNode.initFunction).map(Stream::of).orElseGet(Stream::empty))
-                .sorted(Comparator.comparingInt(fn -> fn.pos.sLine))
-                .forEachOrdered(fn -> this.analyzeNode(fn, objectEnv));
+        bLangFunctionList.sort(Comparator.comparingInt(o -> o.pos.sLine));
+        bLangFunctionList.forEach(fn -> this.analyzeNode(fn, objectEnv));
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2343,7 +2343,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
 
         // To ensure the order of the compile errors
-        bLangFunctionList.sort(Comparator.comparingInt(o -> o.pos.sLine));
+        bLangFunctionList.sort(Comparator.comparingInt(function -> function.pos.sLine));
         for (BLangFunction function : bLangFunctionList) {
             this.analyzeNode(function, objectEnv);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2326,9 +2326,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     public void visit(BLangRecordTypeNode recordTypeNode) {
 
         SymbolEnv recordEnv = SymbolEnv.createTypeEnv(recordTypeNode, recordTypeNode.symbol.scope, env);
-//        if (recordTypeNode.isFieldAnalyseRequired) {
-//            recordTypeNode.fields.forEach(field -> analyzeNode(field, recordEnv));
-//        }
         recordTypeNode.fields.forEach(field -> analyzeNode(field, recordEnv));
     }
 
@@ -2336,9 +2333,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     public void visit(BLangObjectTypeNode objectTypeNode) {
 
         SymbolEnv objectEnv = SymbolEnv.createTypeEnv(objectTypeNode, objectTypeNode.symbol.scope, env);
-//        if (objectTypeNode.isFieldAnalyseRequired) {
-//            objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
-//        }
         objectTypeNode.fields.forEach(field -> analyzeNode(field, objectEnv));
 
         // To ensure the order of the compile errors

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangStructureTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangStructureTypeNode.java
@@ -39,7 +39,6 @@ public abstract class BLangStructureTypeNode extends BLangType implements Struct
     public BLangFunction initFunction;
     public boolean isAnonymous;
     public boolean isLocal;
-    public boolean isFieldAnalyseRequired;
     public List<BLangType> typeRefs;
     public BSymbol symbol;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AnonymousObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AnonymousObjectTest.java
@@ -162,4 +162,9 @@ public class AnonymousObjectTest {
                 "no implementation found for the function 'test' of non-abstract object " +
                         "'object { public int age; public string name; function test () returns (); }'", 8, 58);
     }
+
+    @Test(description = "Test Code analyzer execution on Anonymous objects")
+    public void testCodeAnalyzerRunningOnAnonymousObjectsForDeprecatedFunctionAnnotation() {
+        BAssertUtil.validateWarning(compileResult, 0, "usage of construct 'Test()' is deprecated", 218, 17);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousOpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousOpenRecordTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.model.values.BBoolean;
 import org.ballerinalang.model.values.BInteger;
 import org.ballerinalang.model.values.BString;
 import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
@@ -81,5 +82,10 @@ public class AnonymousOpenRecordTest {
 
         returns = BRunUtil.invoke(compileResult, "testAnonRecWithExplicitRestField");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @Test(description = "Test Code analyzer execution on Anonymous records")
+    public void testCodeAnalyzerRunningOnAnonymousRecordsForDeprecatedFunctionAnnotation() {
+        BAssertUtil.validateWarning(compileResult, 0, "usage of construct 'Test()' is deprecated", 69, 17);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/anon_object.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/anon_object.bal
@@ -212,3 +212,12 @@ function testObjectWithSelfReference() returns [int, string] {
     sample.test(10, "Jewell");
     return [sample.age, sample.name];
 }
+
+function testCodeAnalyzerRunningOnAnonymousObjectsForDeprecatedFunctionAnnotation() {
+    object {
+        int b = Test();
+    } obj = new;
+}
+
+@deprecated
+function Test() returns int { return 0;}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/anon_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/anon_record.bal
@@ -63,3 +63,12 @@ function testAnonRecWithExplicitRestField() returns boolean {
     animal["legs"] = 4;
     return animal["legs"] == 4;
 }
+
+function testCodeAnalyzerRunningOnAnonymousRecordsForDeprecatedFunctionAnnotation() {
+    record {
+        int b = Test();
+        } rec = {};
+}
+
+@deprecated
+function Test() returns int { return 0;}


### PR DESCRIPTION
## Purpose
This variable resides in code deciding whether to run code analysis on a particular record or a object. This prevents code analysis running on locally defined anonymous records.

Fixes #22061

## Approach
 As there is no proven usefulness of not running code analysts on certain record/object this variable and related code will be refactored.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
