### PR TITLE
Fix type checking against `error[]` and `any[]`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -570,10 +570,6 @@ public class Types {
         }
 
         if (targetTag == TypeTags.JSON) {
-            if (sourceTag == TypeTags.JSON) {
-                return true;
-            }
-
             if (sourceTag == TypeTags.ARRAY) {
                 return isArrayTypesAssignable((BArrayType) source, target, unresolvedTypes);
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -832,21 +832,22 @@ public class Types {
     }
 
     public boolean isArrayTypesAssignable(BArrayType source, BType target, Set<TypePair> unresolvedTypes) {
+        BType sourceElementType = source.getElementType();
         if (target.tag == TypeTags.ARRAY) {
             // Both types are array types
             BArrayType lhsArrayType = (BArrayType) target;
-            if (source.state == BArrayState.UNSEALED) {
-                return isAssignable(source.eType, lhsArrayType.eType, unresolvedTypes);
+            if (lhsArrayType.state == BArrayState.UNSEALED) {
+                return isAssignable(sourceElementType, lhsArrayType.eType, unresolvedTypes);
             }
             return checkSealedArraySizeEquality(source, lhsArrayType)
-                    && isAssignable(source.eType, lhsArrayType.eType, unresolvedTypes);
+                    && isAssignable(sourceElementType, lhsArrayType.eType, unresolvedTypes);
         }
 
         if (target.tag == TypeTags.UNION) {
-            return isAssignable(source.eType, target, unresolvedTypes);
+            return isAssignable(sourceElementType, target, unresolvedTypes);
         }
 
-        BType sourceElementType = source.getElementType();
+
         // If the target type is a JSON, then element type of the rhs array
         // should only be a JSON supported type.
         if (target.tag == TypeTags.JSON) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -837,9 +837,11 @@ public class Types {
                 return isAssignable(sourceElementType, targetElementType, unresolvedTypes);
             }
 
-            if (targetArrayType.size == source.size) {
-                return isAssignable(sourceElementType, targetElementType, unresolvedTypes);
+            if (targetArrayType.size != source.size) {
+                return false;
             }
+            
+            return isAssignable(sourceElementType, targetElementType, unresolvedTypes);
         } else if (target.tag == TypeTags.JSON) {
             return isAssignable(sourceElementType, target, unresolvedTypes);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -844,14 +844,17 @@ public class Types {
             if (targetArrayType.size == source.size) {
                 return isAssignable(sourceElementType, targetElementType, unresolvedTypes);
             }
-            return false;
-        }
-
-        if ((target.tag == TypeTags.UNION) || (target.tag == TypeTags.JSON)) {
+        } else if (target.tag == TypeTags.JSON) {
             return isAssignable(sourceElementType, target, unresolvedTypes);
+        } else if (target.tag == TypeTags.UNION) {
+            return isAssignable(sourceElementType, target, unresolvedTypes);
+//            for (BType memberType : ((BUnionType) target).getMemberTypes()) {
+//                if (isArrayTypesAssignable(source, memberType, unresolvedTypes)) {
+//                    return true;
+//                }
+//            }
         }
-
-        return (target.tag == TypeTags.ANY) && (sourceElementType.tag != TypeTags.ERROR);
+        return false;
     }
 
     private boolean isFunctionTypeAssignable(BInvokableType source, BInvokableType target,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -837,10 +837,10 @@ public class Types {
             BArrayType lhsArrayType = (BArrayType) target;
             BArrayType rhsArrayType = (BArrayType) source;
             if (lhsArrayType.state == BArrayState.UNSEALED) {
-                return isArrayTypesAssignable(rhsArrayType.eType, lhsArrayType.eType, unresolvedTypes);
+                return isAssignable(rhsArrayType.eType, lhsArrayType.eType, unresolvedTypes);
             }
             return checkSealedArraySizeEquality(rhsArrayType, lhsArrayType)
-                    && isArrayTypesAssignable(rhsArrayType.eType, lhsArrayType.eType, unresolvedTypes);
+                    && isAssignable(rhsArrayType.eType, lhsArrayType.eType, unresolvedTypes);
 
         } else if (source.tag == TypeTags.ARRAY) {
             // Only the right-hand side is an array type

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -832,7 +832,7 @@ public class Types {
                 .allMatch(tupleElemType -> isAssignable(source.eType, tupleElemType, unresolvedTypes));
     }
 
-    public boolean isArrayTypesAssignable(BArrayType source, BType target, Set<TypePair> unresolvedTypes) {
+    private boolean isArrayTypesAssignable(BArrayType source, BType target, Set<TypePair> unresolvedTypes) {
         BType sourceElementType = source.getElementType();
         if (target.tag == TypeTags.ARRAY) {
             BArrayType targetArrayType = (BArrayType) target;
@@ -847,12 +847,11 @@ public class Types {
         } else if (target.tag == TypeTags.JSON) {
             return isAssignable(sourceElementType, target, unresolvedTypes);
         } else if (target.tag == TypeTags.UNION) {
-            return isAssignable(sourceElementType, target, unresolvedTypes);
-//            for (BType memberType : ((BUnionType) target).getMemberTypes()) {
-//                if (isArrayTypesAssignable(source, memberType, unresolvedTypes)) {
-//                    return true;
-//                }
-//            }
+            for (BType memberType : ((BUnionType) target).getMemberTypes()) {
+                if (isArrayTypesAssignable(source, memberType, unresolvedTypes)) {
+                    return true;
+                }
+            }
         }
         return false;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -842,12 +842,6 @@ public class Types {
             }
         } else if (target.tag == TypeTags.JSON) {
             return isAssignable(sourceElementType, target, unresolvedTypes);
-        } else if (target.tag == TypeTags.UNION) {
-            for (BType memberType : ((BUnionType) target).getMemberTypes()) {
-                if (isArrayTypesAssignable(source, memberType, unresolvedTypes)) {
-                    return true;
-                }
-            }
         }
         return false;
     }

--- a/examples/abstract-objects/tests/abstract_objects_test.bal
+++ b/examples/abstract-objects/tests/abstract_objects_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs.push(s[0]);
 }
 

--- a/examples/anonymous-functions/tests/anonymous_functions_test.bal
+++ b/examples/anonymous-functions/tests/anonymous_functions_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + str.toString();

--- a/examples/anonymous-objects/tests/anonymous_objects_test.bal
+++ b/examples/anonymous-objects/tests/anonymous_objects_test.bal
@@ -1,12 +1,12 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs.push(s[0]);
 }
 

--- a/examples/anonymous-records/tests/anonymous_records_test.bal
+++ b/examples/anonymous-records/tests/anonymous_records_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = s[0].toString();
     count += 1;
 }

--- a/examples/any-type/tests/any_type_test.bal
+++ b/examples/any-type/tests/any_type_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = s.length() == 2 ? (s[0].toString() + <string>s[1]) : s[0];
     count += 1;
 }

--- a/examples/anydata-type/tests/anydata_type_test.bal
+++ b/examples/anydata-type/tests/anydata_type_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = s[0];
     count += 1;
 }

--- a/examples/arrays/tests/arrays_test.bal
+++ b/examples/arrays/tests/arrays_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int count = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     if (s.length() == 1) {
         outputs[count] = s[0];
     } else {

--- a/examples/async/tests/async_test.bal
+++ b/examples/async/tests/async_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -9,8 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     lock{
         outputs[counter] = s[0];
         counter += 1;

--- a/examples/byte-type/tests/byte_type_test.bal
+++ b/examples/byte-type/tests/byte_type_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int count = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = s[0];
     count += 1;
 }

--- a/examples/cache/tests/cache_test.bal
+++ b/examples/cache/tests/cache_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + <string>str;

--- a/examples/clone/tests/clone_test.bal
+++ b/examples/clone/tests/clone_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -8,8 +8,8 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
-    foreach any a in s {
+public function mockPrint(any|error... s) {
+    foreach (any|error) a in s {
         outputs[counter] = a;
         counter += 1;
     }

--- a/examples/closures/tests/closures_test.bal
+++ b/examples/closures/tests/closures_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function.
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/compound-assignment-operators/tests/compound_assignment_operators_test.bal
+++ b/examples/compound-assignment-operators/tests/compound_assignment_operators_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function.
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
     	 outputs.push(entry);
     }

--- a/examples/constants/tests/constants_test.bal
+++ b/examples/constants/tests/constants_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 // This is the mock function, which will replace the real function.
@@ -8,7 +8,7 @@ int count = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = s[0];
     count += 1;
 }

--- a/examples/crypto/tests/crypto_test.bal
+++ b/examples/crypto/tests/crypto_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/elvis-operator/tests/elvis_operator_test.bal
+++ b/examples/elvis-operator/tests/elvis_operator_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/equality/tests/equality_test.bal
+++ b/examples/equality/tests/equality_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     if (counter < 6) {
         outputs[counter] = s[0].toString() + s[1].toString() + s[2].toString() + s[3].toString() +
                             s[4].toString();

--- a/examples/error-destructure-binding-pattern/tests/error_destructure_binding_pattern.bal
+++ b/examples/error-destructure-binding-pattern/tests/error_destructure_binding_pattern.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/error-handling/tests/error_handling_test.bal
+++ b/examples/error-handling/tests/error_handling_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs[counter] = entry;
         counter += 1;

--- a/examples/error-match-statement/tests/error_match_statement_test.bal
+++ b/examples/error-match-statement/tests/error_match_statement_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + io:sprintf("%s", str);

--- a/examples/error-typed-binding-pattern/tests/error_typed_binding_pattern.bal
+++ b/examples/error-typed-binding-pattern/tests/error_typed_binding_pattern.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/filepath/tests/filepath_test.bal
+++ b/examples/filepath/tests/filepath_test.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 import ballerina/test;
 import ballerina/system;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -10,7 +10,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/foreach/tests/foreach_test.bal
+++ b/examples/foreach/tests/foreach_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string printString = "";
     foreach var val in s {
         printString += val.toString();

--- a/examples/fork-variable-access/tests/fork_variable_access_test.bal
+++ b/examples/fork-variable-access/tests/fork_variable_access_test.bal
@@ -2,7 +2,7 @@ import ballerina/io;
 import ballerina/runtime;
 import ballerina/test;
 
-string[] outputs = [];
+(string|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -10,7 +10,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outStr = "";
     foreach var str in s {
         outStr = outStr + string.convert(str);

--- a/examples/fork/tests/fork_test.bal
+++ b/examples/fork/tests/fork_test.bal
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outStr = "";
     foreach var str in s {
         outStr = outStr + str.toString();

--- a/examples/function-pointers/tests/function_pointers_test.bal
+++ b/examples/function-pointers/tests/function_pointers_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/functional-iteration/tests/functional_iteration_test.bal
+++ b/examples/functional-iteration/tests/functional_iteration_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach any a in s {
         outputs[counter] = a;
         counter += 1;

--- a/examples/functions-with-defaultable-parameters/tests/functions_with_defaultable_parameters_test.bal
+++ b/examples/functions-with-defaultable-parameters/tests/functions_with_defaultable_parameters_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0].toString() + s[1].toString() + s[2].toString()
                     + s[3].toString() + s[4].toString() + s[5].toString();
     counter += 1;

--- a/examples/functions-with-required-parameters/tests/functions_with_required_parameters_test.bal
+++ b/examples/functions-with-required-parameters/tests/functions_with_required_parameters_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function, which will replace the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/functions-with-rest-parameter/tests/functions_with_rest_parameter_test.bal
+++ b/examples/functions-with-rest-parameter/tests/functions_with_rest_parameter_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + <string>str;

--- a/examples/functions/tests/functions_test.bal
+++ b/examples/functions/tests/functions_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/hello-world-client/tests/hello_world_client_test.bal
+++ b/examples/hello-world-client/tests/hello_world_client_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... msg) {
+public function mockPrint(any|error... msg) {
     outputs[counter] = msg[0];
     counter += 1;
 }

--- a/examples/hello-world-parallel/tests/hello_world_parallel_test.bal
+++ b/examples/hello-world-parallel/tests/hello_world_parallel_test.bal
@@ -1,7 +1,7 @@
 import ballerina/runtime;
 import ballerina/test;
 
-string[] outputs = [];
+(string|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outStr = "";
     foreach var str in s {
         outStr = outStr + str.toString();

--- a/examples/hello-world/tests/hello_world_test.bal
+++ b/examples/hello-world/tests/hello_world_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/http-client-endpoint/tests/http_client_endpoint_test.bal
+++ b/examples/http-client-endpoint/tests/http_client_endpoint_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... a) {
+public function mockPrint(any|error... a) {
     outputs[counter] = a[0];
     counter += 1;
 }

--- a/examples/if-else/tests/if_else_test.bal
+++ b/examples/if-else/tests/if_else_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/immutable-values/tests/immutable_values_test.bal
+++ b/examples/immutable-values/tests/immutable_values_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var v in s {
         outputs[counter] = v;
         counter += 1;

--- a/examples/json-arrays/tests/json_arrays_test.bal
+++ b/examples/json-arrays/tests/json_arrays_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var str in s {
         outputs[counter] = str;
         counter += 1;

--- a/examples/json-objects/tests/json_objects_test.bal
+++ b/examples/json-objects/tests/json_objects_test.bal
@@ -8,8 +8,8 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
-    foreach any sa in s {
+public function mockPrint(any|error... s) {
+    foreach any|error sa in s {
         anydata value = <anydata> sa;
         outputs[counter] = value.clone();
         counter += 1;

--- a/examples/json-record-map-conversion/tests/json_record_map_conversion_test.bal
+++ b/examples/json-record-map-conversion/tests/json_record_map_conversion_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/json-to-xml-conversion/tests/json_to_xml_conversion_test.bal
+++ b/examples/json-to-xml-conversion/tests/json_to_xml_conversion_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/length/tests/length_test.bal
+++ b/examples/length/tests/length_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/local-transactions-with-participants/tests/local_transactions_with_participants_test.bal
+++ b/examples/local-transactions-with-participants/tests/local_transactions_with_participants_test.bal
@@ -1,14 +1,14 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = string.convert(s[0]);
     count += 1;
 }

--- a/examples/local-transactions/tests/local_transactions_test.bal
+++ b/examples/local-transactions/tests/local_transactions_test.bal
@@ -1,14 +1,14 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = string.convert(s[0]);
     count += 1;
 }

--- a/examples/maps/tests/maps_test.bal
+++ b/examples/maps/tests/maps_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/match/tests/match.bal
+++ b/examples/match/tests/match.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/math-functions/tests/math_functions_test.bal
+++ b/examples/math-functions/tests/math_functions_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/modules/tests/modules_test.bal
+++ b/examples/modules/tests/modules_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any output = "";
+(any|error) output = "";
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     output = s[0];
 }
 

--- a/examples/object-assignability/tests/object_assignability_test.bal
+++ b/examples/object-assignability/tests/object_assignability_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function that replaces the real function.
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs.push(s[0]);
 }
 

--- a/examples/object-methods/tests/object_methods_test.bal
+++ b/examples/object-methods/tests/object_methods_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function that replaces the real function.
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs.push(s[0]);
 }
 

--- a/examples/object-type-reference/tests/object_type_reference_test.bal
+++ b/examples/object-type-reference/tests/object_type_reference_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function that replaces the real function.
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs.push(s[0]);
 }
 

--- a/examples/objects/tests/objects_test.bal
+++ b/examples/objects/tests/objects_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function that replaces the real function.
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs.push(s[0]);
 }
 

--- a/examples/optional-field-access/tests/optional_field_access_test.bal
+++ b/examples/optional-field-access/tests/optional_field_access_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var str in s {
     outputs[counter] = str;
     counter += 1;

--- a/examples/optional-type/tests/optional_type_test.bal
+++ b/examples/optional-type/tests/optional_type_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/panic/tests/panic_test.bal
+++ b/examples/panic/tests/panic_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var val in s {
         outputs[counter] = val;
         counter += 1;

--- a/examples/quoted-identifiers/tests/quoted_identifiers_test.bal
+++ b/examples/quoted-identifiers/tests/quoted_identifiers_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that will replace the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/range-expressions/tests/range_expressions_test.bal
+++ b/examples/range-expressions/tests/range_expressions_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/record-destructure-binding-pattern/tests/record_destructure_binding_pattern.bal
+++ b/examples/record-destructure-binding-pattern/tests/record_destructure_binding_pattern.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/record-io/tests/record_io_test.bal
+++ b/examples/record-io/tests/record_io_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/record-iteration/tests/record_iteration_test.bal
+++ b/examples/record-iteration/tests/record_iteration_test.bal
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... args) {
+public function mockPrint(any|error... args) {
     string str = "";
     foreach var s in args {
         str += string.convert(s);

--- a/examples/record-match-statement/tests/record_match_statement_test.bal
+++ b/examples/record-match-statement/tests/record_match_statement_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + str.toString();

--- a/examples/record-optional-fields/tests/record_optional_fields_test.bal
+++ b/examples/record-optional-fields/tests/record_optional_fields_test.bal
@@ -7,7 +7,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = "";
     foreach var v in s {
         outputs[counter] += v.toString();

--- a/examples/record-type-reference/tests/record_type_reference_test.bal
+++ b/examples/record-type-reference/tests/record_type_reference_test.bal
@@ -7,7 +7,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = "";
     foreach var v in s {
         outputs[counter] += v.toString();

--- a/examples/record-typed-binding-pattern/tests/record_typed_binding_pattern.bal
+++ b/examples/record-typed-binding-pattern/tests/record_typed_binding_pattern.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
         foreach var str in s {
             outstr = outstr + str.toString();

--- a/examples/records/tests/records_test.bal
+++ b/examples/records/tests/records_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-string[] outputs = [];
+(string|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0].toString();
     counter += 1;
 }

--- a/examples/string-template/tests/string_template_test.bal
+++ b/examples/string-template/tests/string_template_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/strings/tests/strings_test.bal
+++ b/examples/strings/tests/strings_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-string[] outputs = [];
+(string|error)[] outputs = [];
 int counter = 0;
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
        string outstr = "";
        foreach var str in s {
            outstr = outstr + str.toString();

--- a/examples/table/tests/table_test.bal
+++ b/examples/table/tests/table_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that will replace the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var arg in s {
         outputs[counter] = arg;
         counter += 1;

--- a/examples/task-scheduler-appointment/tests/task_scheduler_appointment_test.bal
+++ b/examples/task-scheduler-appointment/tests/task_scheduler_appointment_test.bal
@@ -1,7 +1,7 @@
 import ballerina/io;
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/task-scheduler-timer/tests/task_scheduler_timer_test.bal
+++ b/examples/task-scheduler-timer/tests/task_scheduler_timer_test.bal
@@ -1,7 +1,7 @@
 import ballerina/io;
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/the-main-function/tests/the_main_function_test.bal
+++ b/examples/the-main-function/tests/the_main_function_test.bal
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var val in s {
         outputs[counter] = val;
         counter += 1;

--- a/examples/time/tests/time_test.bal
+++ b/examples/time/tests/time_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... args) {
+public function mockPrint(any|error... args) {
     string str = "";
     foreach var s in args {
         str += string.convert(s);

--- a/examples/trap/tests/trap_test.bal
+++ b/examples/trap/tests/trap_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + <string>str;

--- a/examples/tuple-destructure-binding-pattern/tests/tuple_destructure_test.bal
+++ b/examples/tuple-destructure-binding-pattern/tests/tuple_destructure_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + io:sprintf("%s", str);

--- a/examples/tuple-match-statement/tests/tuple_match_statement_test.bal
+++ b/examples/tuple-match-statement/tests/tuple_match_statement_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + io:sprintf("%s", str);

--- a/examples/tuple-type/tests/tuple_type_test.bal
+++ b/examples/tuple-type/tests/tuple_type_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/tuple-typed-binding-pattern/tests/tuple_typed_binding_pattern_test.bal
+++ b/examples/tuple-typed-binding-pattern/tests/tuple_typed_binding_pattern_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outstr = "";
     foreach var str in s {
         outstr = outstr + io:sprintf("%s", str);

--- a/examples/type-cast/tests/type_cast_test.bal
+++ b/examples/type-cast/tests/type_cast_test.bal
@@ -1,7 +1,7 @@
 import ballerina/io;
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var elem in s {
         outputs[counter] = elem;
         counter += 1;

--- a/examples/type-guard/tests/type_guard_test.bal
+++ b/examples/type-guard/tests/type_guard_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var value in s {
         outputs[counter] = value;
         counter += 1;

--- a/examples/values/tests/values_test.bal
+++ b/examples/values/tests/values_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 
 // This is the mock function which will replace the real function
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     foreach var entry in s {
         outputs.push(entry);
     }

--- a/examples/var/tests/var_test.bal
+++ b/examples/var/tests/var_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/variables/tests/variables_test.bal
+++ b/examples/variables/tests/variables_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/while/tests/while_test.bal
+++ b/examples/while/tests/while_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/worker-interaction/tests/worker_interaction_test.bal
+++ b/examples/worker-interaction/tests/worker_interaction_test.bal
@@ -1,7 +1,7 @@
 import ballerina/test;
 import ballerina/io;
 
-string[] outputs = [];
+(string|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -9,7 +9,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outStr = "";
     foreach var str in s {
         outStr = outStr + string.convert(str);

--- a/examples/workers/tests/worker_test.bal
+++ b/examples/workers/tests/worker_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-string[] outputs = [];
+(string|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     string outStr = "";
     foreach var str in s {
         outStr = outStr + str.toString();

--- a/examples/xa-transactions/tests/xa_transactions_test.bal
+++ b/examples/xa-transactions/tests/xa_transactions_test.bal
@@ -1,14 +1,14 @@
 import ballerina/test;
 import ballerina/io;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int count = 0;
 
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[count] = string.convert(s[0]);
     count += 1;
 }

--- a/examples/xml-access/tests/xml_access_test.bal
+++ b/examples/xml-access/tests/xml_access_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function that replaces the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/xml-attributes/tests/xml_attributes_test.bal
+++ b/examples/xml-attributes/tests/xml_attributes_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-string[] outputs = [];
+string|error[] outputs = [];
 int counter = 0;
 
 // This is the mock function which will replace the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     if (s[0] is ()) {
         // Cannot convert () to string.
         outputs[counter] = "()";

--- a/examples/xml-functions/tests/xml_functions_test.bal
+++ b/examples/xml-functions/tests/xml_functions_test.bal
@@ -1,13 +1,13 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 @test:Mock {
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/xml-literal/tests/xml_literal_test.bal
+++ b/examples/xml-literal/tests/xml_literal_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function, which will replace the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/xml-namespaces/tests/xml_namespaces_test.bal
+++ b/examples/xml-namespaces/tests/xml_namespaces_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function, which replaces the real function.
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/examples/xml/tests/xml_test.bal
+++ b/examples/xml/tests/xml_test.bal
@@ -1,6 +1,6 @@
 import ballerina/test;
 
-any[] outputs = [];
+(any|error)[] outputs = [];
 int counter = 0;
 
 // This is the mock function, which replaces the real function
@@ -8,7 +8,7 @@ int counter = 0;
     moduleName: "ballerina/io",
     functionName: "println"
 }
-public function mockPrint(any... s) {
+public function mockPrint(any|error... s) {
     outputs[counter] = s[0];
     counter += 1;
 }

--- a/stdlib/http/src/main/ballerina/src/http/resiliency/failover_client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/resiliency/failover_client_endpoint.bal
@@ -308,7 +308,7 @@ function performFailoverAction (string path, Request request, HttpOperation requ
     Response inResponse = new;
     HttpFuture inFuture = new;
     Request failoverRequest = request;
-    error?[] failoverActionErrData = [];
+    ClientError?[] failoverActionErrData = [];
     mime:Entity requestEntity = new;
 
     if (isMultipartRequest(failoverRequest)) {
@@ -512,7 +512,7 @@ function getLastSuceededClientEP(FailoverClient failoverClient) returns Client {
 }
 
 function handleResponseWithErrorCode(Response response, int initialIndex, int noOfEndpoints, int index,
-                                                        error?[] failoverActionErrData) returns [int, ClientError?] {
+                                                        ClientError?[] failoverActionErrData) returns [int, ClientError?] {
 
     ClientError? resultError = ();
     int currentIndex = index;
@@ -555,7 +555,7 @@ function handleResponseWithErrorCode(Response response, int initialIndex, int no
     return [currentIndex, resultError];
 }
 
-function handleError(ClientError err, int initialIndex, int noOfEndpoints, int index, error?[] failoverActionErrData)
+function handleError(ClientError err, int initialIndex, int noOfEndpoints, int index, ClientError?[] failoverActionErrData)
                                                                                         returns [int, ClientError?] {
     ClientError? httpConnectorErr = ();
 

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -237,7 +237,7 @@ public class ErrorTest {
 
     @Test
     public void testErrorNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 22);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 18);
         int i = 0;
         BAssertUtil.validateError(negativeCompileResult, i++,
                                   "incompatible types: expected 'reason one|reason two', found 'string'", 26, 31);
@@ -273,15 +273,8 @@ public class ErrorTest {
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error<string, " +
                         "record {| string message?; error cause?; int i; anydata...; |}>', found 'int'", 122, 73);
-        BAssertUtil.validateError(negativeCompileResult, i++,
-                                  "incompatible types: expected 'any[]', found 'error[]'", 127, 15);
-        BAssertUtil.validateError(negativeCompileResult, i++,
-                                  "incompatible types: expected 'error[]', found 'any[]'", 129, 26);
-        BAssertUtil.validateError(negativeCompileResult, i++,
-                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 147, 19);
-        BAssertUtil.validateError(negativeCompileResult, i,
-                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 148, 11);
     }
+
     @DataProvider(name = "userDefTypeAsReasonTests")
     public Object[][] userDefTypeAsReasonTests() {
         return new Object[][] {

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -237,7 +237,7 @@ public class ErrorTest {
 
     @Test
     public void testErrorNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 18);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 22);
         int i = 0;
         BAssertUtil.validateError(negativeCompileResult, i++,
                                   "incompatible types: expected 'reason one|reason two', found 'string'", 26, 31);
@@ -270,9 +270,17 @@ public class ErrorTest {
                 "error reason is mandatory for direct error constructor", 112, 28);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error', found '(error|int)'", 118, 11);
-        BAssertUtil.validateError(negativeCompileResult, i,
+        BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error<string, " +
                         "record {| string message?; error cause?; int i; anydata...; |}>', found 'int'", 122, 73);
+        BAssertUtil.validateError(negativeCompileResult, i++,
+                                  "incompatible types: expected 'any[]', found 'error[]'", 127, 15);
+        BAssertUtil.validateError(negativeCompileResult, i++,
+                                  "incompatible types: expected 'error[]', found 'any[]'", 129, 26);
+        BAssertUtil.validateError(negativeCompileResult, i++,
+                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 147, 19);
+        BAssertUtil.validateError(negativeCompileResult, i,
+                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 148, 11);
     }
     @DataProvider(name = "userDefTypeAsReasonTests")
     public Object[][] userDefTypeAsReasonTests() {

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -270,11 +270,10 @@ public class ErrorTest {
                 "error reason is mandatory for direct error constructor", 112, 28);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error', found '(error|int)'", 118, 11);
-        BAssertUtil.validateError(negativeCompileResult, i++,
+        BAssertUtil.validateError(negativeCompileResult, i,
                 "incompatible types: expected 'error<string, " +
                         "record {| string message?; error cause?; int i; anydata...; |}>', found 'int'", 122, 73);
     }
-
     @DataProvider(name = "userDefTypeAsReasonTests")
     public Object[][] userDefTypeAsReasonTests() {
         return new Object[][] {

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -121,31 +121,3 @@ function panicOnNonErrorMemberUnion() {
 function errorDefinitionNegative() {
     error<string, record { string message?; error cause?; int i;}> e  = 1;
 }
-
-function assignErrorArrayToAnyTypeArrayViseVersa() {
-    error[] ea = [];
-    any[] j = ea;
-    any[] anyArray = [];
-    error[] errorArray = anyArray;
-}
-
-public const C_ERROR = "CError";
-public const L_ERROR = "LError";
-
-public type Detail record {
-    string message;
-    error cause?;
-};
-
-type CError error<C_ERROR, Detail>;
-type LError error<L_ERROR, Detail>;
-type CLError CError|LError;
-
-function nonAssingableErrorTypeArrayAssign() {
-    CLError? [] err = [];
-    error? [] errs = err;
-    ProcessErrors(errs);
-    err = errs;
-}
-
-function ProcessErrors(CLError?[] errors) {}

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -122,6 +122,13 @@ function errorDefinitionNegative() {
     error<string, record { string message?; error cause?; int i;}> e  = 1;
 }
 
+function assignErrorArrayToAnyTypeArrayViseVersa() {
+    error[] ea = [];
+    any[] j = ea;
+    any[] anyArray = [];
+    error[] errorArray = anyArray;
+}
+
 public const C_ERROR = "CError";
 public const L_ERROR = "LError";
 
@@ -132,13 +139,13 @@ public type Detail record {
 
 type CError error<C_ERROR, Detail>;
 type LError error<L_ERROR, Detail>;
-type MyError CError|LError;
+type CLError CError|LError;
 
 function nonAssingableErrorTypeArrayAssign() {
-    MyError? [] err = [];
+    CLError? [] err = [];
     error? [] errs = err;
     ProcessErrors(errs);
     err = errs;
 }
 
-function ProcessErrors(MyError?[] errors) {}
+function ProcessErrors(CLError?[] errors) {}

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -121,3 +121,24 @@ function panicOnNonErrorMemberUnion() {
 function errorDefinitionNegative() {
     error<string, record { string message?; error cause?; int i;}> e  = 1;
 }
+
+public const C_ERROR = "CError";
+public const L_ERROR = "LError";
+
+public type Detail record {
+    string message;
+    error cause?;
+};
+
+type CError error<C_ERROR, Detail>;
+type LError error<L_ERROR, Detail>;
+type MyError CError|LError;
+
+function nonAssingableErrorTypeArrayAssign() {
+    MyError? [] err = [];
+    error? [] errs = err;
+    ProcessErrors(errs);
+    err = errs;
+}
+
+function ProcessErrors(MyError?[] errors) {}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -237,7 +237,7 @@ public class ErrorTest {
 
     @Test
     public void testErrorNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 22);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 18);
         int i = 0;
         BAssertUtil.validateError(negativeCompileResult, i++,
                                   "incompatible types: expected 'reason one|reason two', found 'string'", 26, 31);
@@ -273,14 +273,6 @@ public class ErrorTest {
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error<string, " +
                         "record {| string message?; error cause?; int i; anydata...; |}>', found 'int'", 122, 73);
-        BAssertUtil.validateError(negativeCompileResult, i++,
-                                  "incompatible types: expected 'any[]', found 'error[]'", 127, 15);
-        BAssertUtil.validateError(negativeCompileResult, i++,
-                                  "incompatible types: expected 'error[]', found 'any[]'", 129, 26);
-        BAssertUtil.validateError(negativeCompileResult, i++,
-                                 "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 147, 19);
-        BAssertUtil.validateError(negativeCompileResult, i,
-                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 148, 11);
     }
 
     @DataProvider(name = "userDefTypeAsReasonTests")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -237,7 +237,7 @@ public class ErrorTest {
 
     @Test
     public void testErrorNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 20);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 22);
         int i = 0;
         BAssertUtil.validateError(negativeCompileResult, i++,
                                   "incompatible types: expected 'reason one|reason two', found 'string'", 26, 31);
@@ -277,6 +277,10 @@ public class ErrorTest {
                                   "incompatible types: expected 'any[]', found 'error[]'", 127, 15);
         BAssertUtil.validateError(negativeCompileResult, i++,
                                   "incompatible types: expected 'error[]', found 'any[]'", 129, 26);
+        BAssertUtil.validateError(negativeCompileResult, i++,
+                                 "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 147, 19);
+        BAssertUtil.validateError(negativeCompileResult, i,
+                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 148, 11);
     }
 
     @DataProvider(name = "userDefTypeAsReasonTests")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -270,7 +270,7 @@ public class ErrorTest {
                 "error reason is mandatory for direct error constructor", 112, 28);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error', found '(error|int)'", 118, 11);
-        BAssertUtil.validateError(negativeCompileResult, i++,
+        BAssertUtil.validateError(negativeCompileResult, i,
                 "incompatible types: expected 'error<string, " +
                         "record {| string message?; error cause?; int i; anydata...; |}>', found 'int'", 122, 73);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -237,7 +237,7 @@ public class ErrorTest {
 
     @Test
     public void testErrorNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 18);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 20);
         int i = 0;
         BAssertUtil.validateError(negativeCompileResult, i++,
                                   "incompatible types: expected 'reason one|reason two', found 'string'", 26, 31);
@@ -270,10 +270,15 @@ public class ErrorTest {
                 "error reason is mandatory for direct error constructor", 112, 28);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error', found '(error|int)'", 118, 11);
-        BAssertUtil.validateError(negativeCompileResult, i,
+        BAssertUtil.validateError(negativeCompileResult, i++,
                 "incompatible types: expected 'error<string, " +
                         "record {| string message?; error cause?; int i; anydata...; |}>', found 'int'", 122, 73);
+        BAssertUtil.validateError(negativeCompileResult, i++,
+                                  "incompatible types: expected 'any[]', found 'error[]'", 127, 15);
+        BAssertUtil.validateError(negativeCompileResult, i++,
+                                  "incompatible types: expected 'error[]', found 'any[]'", 129, 26);
     }
+
     @DataProvider(name = "userDefTypeAsReasonTests")
     public Object[][] userDefTypeAsReasonTests() {
         return new Object[][] {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -271,4 +271,9 @@ public class AssignStmtTest {
     public void testAssignIntArrayToJson() {
         BRunUtil.invoke(result, "testAssignIntArrayToJson");
     }
+
+    @Test()
+    public void testAssignIntOrStringArrayIntOrFloatOrStringUnionArray() {
+        BRunUtil.invoke(result, "testAssignIntOrStringArrayIntOrFloatOrStringUnionArray");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -261,4 +261,9 @@ public class AssignStmtTest {
         BAssertUtil.validateError(result, i++, "unknown type 'X'", 79, 5);
         BAssertUtil.validateError(result, i, "unknown type 'V'", 81, 5);
     }
+
+    @Test()
+    public void testAssignErrorArrayToAnyArray() {
+        BRunUtil.invoke(result, "testAssignErrorArrayToAnyArray");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -266,4 +266,9 @@ public class AssignStmtTest {
     public void testAssignErrorArrayToAnyArray() {
         BRunUtil.invoke(result, "testAssignErrorArrayToAnyArray");
     }
+
+    @Test()
+    public void testAssignIntArrayToJson() {
+        BRunUtil.invoke(result, "testAssignIntArrayToJson");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -219,6 +219,9 @@ public class AssignStmtTest {
                                   "incompatible types: expected '(error|int[])', found 'error[]'", 127, 21);
         BAssertUtil.validateError(resultNegative, i++,
                                   "incompatible types: expected '(int|error[])', found 'error'", 132, 21);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected 'function ((any|error)...) returns ()', found " +
+                                          "'function (any...) returns ()'", 136, 47);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 
@@ -273,5 +276,10 @@ public class AssignStmtTest {
     @Test()
     public void testAssignIntOrStringArrayIntOrFloatOrStringUnionArray() {
         BRunUtil.invoke(result, "testAssignIntOrStringArrayIntOrFloatOrStringUnionArray");
+    }
+
+    @Test()
+    public void assignAnyToUnionWithErrorAndAny() {
+        BRunUtil.invoke(result, "assignAnyToUnionWithErrorAndAny");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -261,8 +261,8 @@ public class AssignStmtTest {
     }
 
     @Test()
-    public void testAssignErrorArrayToAnyArray() {
-        BRunUtil.invoke(result, "testAssignErrorArrayToAnyArray");
+    public void testAssignErrorArrayToAny() {
+        BRunUtil.invoke(result, "testAssignErrorArrayToAny");
     }
 
     @Test()

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -207,6 +207,20 @@ public class AssignStmtTest {
                 "invalid record binding pattern with type 'error'", 92, 9);
         BAssertUtil.validateError(resultNegative, i++,
                 "invalid record variable; expecting a record type but found 'error' in type definition", 92, 20);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected 'any[]', found 'error[]'", 98, 15);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected 'error[]', found 'any[]'", 100, 26);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 118, 19);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected '(CError|LError)?[]', found 'error?[]'", 119, 11);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected '(error|int[])', found 'error[]'", 127, 21);
+        BAssertUtil.validateError(resultNegative, i++,
+                                  "incompatible types: expected '(int|error[])', found 'error'", 132, 21);
+//        BAssertUtil.validateError(resultNegative, i++,
+//                                  "incompatible types: expected '(int|error[])', found 'error'", 132, 21);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -219,8 +219,6 @@ public class AssignStmtTest {
                                   "incompatible types: expected '(error|int[])', found 'error[]'", 127, 21);
         BAssertUtil.validateError(resultNegative, i++,
                                   "incompatible types: expected '(int|error[])', found 'error'", 132, 21);
-//        BAssertUtil.validateError(resultNegative, i++,
-//                                  "incompatible types: expected '(int|error[])', found 'error'", 132, 21);
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -121,31 +121,3 @@ function panicOnNonErrorMemberUnion() {
 function errorDefinitionNegative() {
     error<string, record { string message?; error cause?; int i;}> e  = 1;
 }
-
-function assignErrorArrayToAnyTypeArrayViseVersa() {
-    error[] ea = [];
-    any[] j = ea;
-    any[] anyArray = [];
-    error[] errorArray = anyArray;
-}
-
-public const C_ERROR = "CError";
-public const L_ERROR = "LError";
-
-public type Detail record {
-    string message;
-    error cause?;
-};
-
-type CError error<C_ERROR, Detail>;
-type LError error<L_ERROR, Detail>;
-type CLError CError|LError;
-
-function nonAssingableErrorTypeArrayAssign() {
-    CLError? [] err = [];
-    error? [] errs = err;
-    ProcessErrors(errs);
-    err = errs;
-}
-
-function ProcessErrors(CLError?[] errors) {}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -121,3 +121,10 @@ function panicOnNonErrorMemberUnion() {
 function errorDefinitionNegative() {
     error<string, record { string message?; error cause?; int i;}> e  = 1;
 }
+
+function assignErrorArrayToAnyTypeArrayViseVersa() {
+    error[] ea = [];
+    any[] j = ea;
+    any[] anyArray = [];
+    error[] errorArray = anyArray;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -128,3 +128,24 @@ function assignErrorArrayToAnyTypeArrayViseVersa() {
     any[] anyArray = [];
     error[] errorArray = anyArray;
 }
+
+public const C_ERROR = "CError";
+public const L_ERROR = "LError";
+
+public type Detail record {
+    string message;
+    error cause?;
+};
+
+type CError error<C_ERROR, Detail>;
+type LError error<L_ERROR, Detail>;
+type CLError CError|LError;
+
+function nonAssingableErrorTypeArrayAssign() {
+    CLError? [] err = [];
+    error? [] errs = err;
+    ProcessErrors(errs);
+    err = errs;
+}
+
+function ProcessErrors(CLError?[] errors) {}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt-negative.bal
@@ -91,3 +91,43 @@ public function restActionResultAssignment() {
     map<string> sm = c->foo1();
     var { a: d } = c->foo2();
 }
+
+
+function assignErrorArrayToAnyTypeArrayViseVersa() {
+    error[] ea = [];
+    any[] j = ea;
+    any[] anyArray = [];
+    error[] errorArray = anyArray;
+}
+
+public const C_ERROR = "CError";
+public const L_ERROR = "LError";
+
+public type Detail record {
+    string message;
+    error cause?;
+};
+
+type CError error<C_ERROR, Detail>;
+type LError error<L_ERROR, Detail>;
+type CLError CError|LError;
+
+function nonAssingableErrorTypeArrayAssign() {
+    CLError? [] err = [];
+    error? [] errs = err;
+    ProcessErrors(errs);
+    err = errs;
+}
+
+function ProcessErrors(CLError?[] errors) {}
+
+function assignErrorArrayToUnionWithError() {
+    error e1 = error("E1");
+    error[] x = [e1];
+    error|int[] y = x;
+}
+
+function assignErrorArrayToUnionWithErrorArray() {
+    error e1 = error("E1");
+    int|error[] y = e1;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt-negative.bal
@@ -113,8 +113,8 @@ type LError error<L_ERROR, Detail>;
 type CLError CError|LError;
 
 function nonAssingableErrorTypeArrayAssign() {
-    CLError? [] err = [];
-    error? [] errs = err;
+    CLError?[] err = [];
+    error?[] errs = err;
     ProcessErrors(errs);
     err = errs;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt-negative.bal
@@ -127,7 +127,11 @@ function assignErrorArrayToUnionWithError() {
     error|int[] y = x;
 }
 
-function assignErrorArrayToUnionWithErrorArray() {
+function assignErrorToUnionWithErrorArray() {
     error e1 = error("E1");
     int|error[] y = e1;
+}
+
+function assignFunctionParameterAnyToParameterUnionWithErrorAndAny() {
+    function (any|error...) returns () func = function (any... y) {};
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -112,6 +112,12 @@ function testAssignIntOrStringArrayIntOrFloatOrStringUnionArray() {
     assertEquality(2, arr2[1]);
 }
 
+function assignAnyToUnionWithErrorAndAny() {
+    any x = 4;
+    any|error y = x;
+    assertEquality(4, y);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 type AssertionError error<ASSERTION_ERROR_REASON>;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -103,6 +103,13 @@ function testAssignIntArrayToJson() {
     assertEquality("1 2", jsonToJson.toString());
 }
 
+function testAssignIntOrStringArrayIntOrFloatOrStringUnionArray() {
+    int[]|string[] intOrStringArray = <int[]>[1, 2];
+    (int|float)[]|string[] intOrFloatArray = intOrStringArray;
+    assertEquality(1, intOrFloatArray[0]);
+    assertEquality(2, intOrFloatArray[1]);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 type AssertionError error<ASSERTION_ERROR_REASON>;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -96,6 +96,13 @@ function testAssignErrorArrayToAnyArray() {
     assertEquality(errorMessage, errorArrayBack[0].reason());
 }
 
+function testAssignIntArrayToJson() {
+    int[*] intArray = [1, 2];
+    json jsonObjectOfIntArray = intArray;
+    json jsonToJson = jsonObjectOfIntArray;
+    assertEquality("1 2", jsonToJson.toString());
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 type AssertionError error<ASSERTION_ERROR_REASON>;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -86,3 +86,27 @@ public function restActionResultAssignment() returns [int, int, string, string, 
     var error(r2, failedAttempts = failedAttempts) = c->foo3();
     return [a, b, d, r, r2, <int>failedAttempts];
 }
+
+function testAssignErrorArrayToAnyArray() {
+    string errorMessage = "Test Error";
+    error testError = error("Test Error");
+    error[] errorArray = [testError];
+    any anyArray = errorArray;
+    error[] errorArrayBack = <error[]>anyArray;
+    assertEquality(errorMessage, errorArrayBack[0].reason());
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+type AssertionError error<ASSERTION_ERROR_REASON>;
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic AssertionError(message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -87,27 +87,29 @@ public function restActionResultAssignment() returns [int, int, string, string, 
     return [a, b, d, r, r2, <int>failedAttempts];
 }
 
-function testAssignErrorArrayToAnyArray() {
-    string errorMessage = "Test Error";
-    error testError = error("Test Error");
+function testAssignErrorArrayToAny() {
+    string errorReason = "TestError";
+    error testError = error(errorReason);
     error[] errorArray = [testError];
-    any anyArray = errorArray;
-    error[] errorArrayBack = <error[]>anyArray;
-    assertEquality(errorMessage, errorArrayBack[0].reason());
+    any anyVal = errorArray;
+    error[] errorArrayBack = <error[]>anyVal;
+    assertEquality(errorReason, errorArrayBack[0].reason());
 }
 
 function testAssignIntArrayToJson() {
     int[*] intArray = [1, 2];
-    json jsonObjectOfIntArray = intArray;
-    json jsonToJson = jsonObjectOfIntArray;
-    assertEquality("1 2", jsonToJson.toString());
+    json jsonVar = intArray;
+    assertTrue(jsonVar is int[2]);
+    int[2] arr = <int[2]> jsonVar;
+    assertEquality(1, arr[0]);
+    assertEquality(2, arr[1]);
 }
 
 function testAssignIntOrStringArrayIntOrFloatOrStringUnionArray() {
-    int[]|string[] intOrStringArray = <int[]>[1, 2];
-    (int|float)[]|string[] intOrFloatArray = intOrStringArray;
-    assertEquality(1, intOrFloatArray[0]);
-    assertEquality(2, intOrFloatArray[1]);
+    int[]|string[] arr1 = <int[]>[1, 2];
+    (int|float)[]|string[] arr2 = arr1;
+    assertEquality(1, arr2[0]);
+    assertEquality(2, arr2[1]);
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";
@@ -123,4 +125,8 @@ function assertEquality(any|error expected, any|error actual) {
     }
 
     panic AssertionError(message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}
+
+function assertTrue(any|error actual) {
+    assertEquality(true, actual);
 }


### PR DESCRIPTION
## Purpose
Proper type checking logic is not happening when trying to assign `error[]` to `any[]`.

Fixes #22410

## Approach
Type checking logic is added to filter out error type. Existing code let any type or array to be assigned to `any` type array.

## Samples
```Ballerina
error[] ea = [];
any[] j = ea;
```

```LogTalk
error: .::error_test_negative.bal:127:15: incompatible types: expected 'any[]', found 'error[]'
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
