### PR TITLE
Fix direct return of byte binary operation in a lambda

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -4039,7 +4039,7 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private void checkByteTypeIncompatibleOperations(BLangBinaryExpr binaryExpr) {
-        if (binaryExpr.parent == null || binaryExpr.parent.type == null) {
+        if (binaryExpr.expectedType == null) {
             return;
         }
 
@@ -4049,7 +4049,7 @@ public class Desugar extends BLangNodeVisitor {
             return;
         }
 
-        int resultTypeTag = binaryExpr.type.tag;
+        int resultTypeTag = binaryExpr.expectedType.tag;
         if (resultTypeTag == TypeTags.INT) {
             if (rhsExprTypeTag == TypeTags.BYTE) {
                 binaryExpr.rhsExpr = addConversionExprIfRequired(binaryExpr.rhsExpr, symTable.intType);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -792,4 +792,34 @@ public class BByteValueTest {
         BInteger bInteger = (BInteger) returns[0];
         Assert.assertEquals(bInteger.intValue(), expected, "Invalid byte value returned.");
     }
+
+    @Test(description = "Test byte value return as int in lambda 1")
+    public void testByteReturnAsIntInLambda1() {
+        BValue[] returns = BRunUtil.invoke(result, "testByteReturnAsIntInLambda1");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BInteger.class);
+        BInteger intValue = (BInteger) returns[0];
+        Assert.assertEquals(intValue.intValue(), 0, "Invalid int value returned.");
+    }
+
+    @Test(description = "Test byte value return as int in lambda 2")
+    public void testByteReturnAsIntInLambda2() {
+        BValue[] returns = BRunUtil.invoke(result, "testByteReturnAsIntInLambda2");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BBoolean.class);
+        BBoolean booleanVal = (BBoolean) returns[0];
+        Assert.assertTrue(booleanVal.booleanValue());
+    }
+
+    @Test(description = "Test byte value return as int in lambda 3")
+    public void testByteReturnAsIntInLambda3() {
+        long a = 233;
+        long b = 245;
+        BValue[] returns = BRunUtil.invoke(result, "testByteReturnAsIntInLambda3", new BValue[]{new BByte(a),
+                new BByte(b)});
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertSame(returns[0].getClass(), BInteger.class);
+        BInteger intValue = (BInteger) returns[0];
+        Assert.assertEquals(intValue.intValue(), (a - b), "Invalid int value returned.");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -793,33 +793,10 @@ public class BByteValueTest {
         Assert.assertEquals(bInteger.intValue(), expected, "Invalid byte value returned.");
     }
 
-    @Test(description = "Test byte value return as int in lambda 1")
-    public void testByteReturnAsIntInLambda1() {
-        BValue[] returns = BRunUtil.invoke(result, "testByteReturnAsIntInLambda1");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BInteger.class);
-        BInteger intValue = (BInteger) returns[0];
-        Assert.assertEquals(intValue.intValue(), 0, "Invalid int value returned.");
-    }
-
-    @Test(description = "Test byte value return as int in lambda 2")
-    public void testByteReturnAsIntInLambda2() {
-        BValue[] returns = BRunUtil.invoke(result, "testByteReturnAsIntInLambda2");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BBoolean.class);
-        BBoolean booleanVal = (BBoolean) returns[0];
-        Assert.assertTrue(booleanVal.booleanValue());
-    }
-
-    @Test(description = "Test byte value return as int in lambda 3")
-    public void testByteReturnAsIntInLambda3() {
-        long a = 233;
-        long b = 245;
-        BValue[] returns = BRunUtil.invoke(result, "testByteReturnAsIntInLambda3", new BValue[]{new BByte(a),
-                new BByte(b)});
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BInteger.class);
-        BInteger intValue = (BInteger) returns[0];
-        Assert.assertEquals(intValue.intValue(), (a - b), "Invalid int value returned.");
+    @Test(description = "Test byte value return as int in lambda")
+    public void testByteReturnAsIntInLambda() {
+        BRunUtil.invoke(result, "testByteReturnAsIntInLambda1");
+        BRunUtil.invoke(result, "testByteReturnAsIntInLambda2");
+        BRunUtil.invoke(result, "testByteReturnAsIntInLambda3");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -301,16 +301,16 @@ function testBitwiseOperatorPrecedence6(int a, int b, int c) returns int {
     return d;
 }
 
-public function testByteReturnAsIntInLambda1() returns int {
+public function testByteReturnAsIntInLambda1() {
     var fn = function () returns int {
         byte a = 255;
         return a - a;
     };
 
-    return fn();
+    assert(0, fn());
 }
 
-public function testByteReturnAsIntInLambda2() returns boolean {
+public function testByteReturnAsIntInLambda2() {
     var fn1 = function () returns int {
         byte a = 255;
         return a - a;
@@ -322,10 +322,32 @@ public function testByteReturnAsIntInLambda2() returns boolean {
         return res;
     };
 
-    return fn1() == fn2();
+    assertTrue(fn1() == fn2(), "fn1() == fn2()");
 }
 
-public function testByteReturnAsIntInLambda3(byte a, byte b) returns int {
+public function testByteReturnAsIntInLambda3() {
+    byte a = 255;
+    byte b = 255;
+
     var fn = function (byte a, byte b) returns int { return a - b; };
-    return fn(a, b);
+    assert(a - b, fn(a, b));
+}
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}
+
+function assertTrue(boolean result, string condition) {
+    if (!result) {
+        string reason = "condition [" + condition + "] evaluated to 'false'";
+        error e = error(reason);
+        panic e;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte-value.bal
@@ -300,3 +300,32 @@ function testBitwiseOperatorPrecedence6(int a, int b, int c) returns int {
     int d = b >> c & ~a;
     return d;
 }
+
+public function testByteReturnAsIntInLambda1() returns int {
+    var fn = function () returns int {
+        byte a = 255;
+        return a - a;
+    };
+
+    return fn();
+}
+
+public function testByteReturnAsIntInLambda2() returns boolean {
+    var fn1 = function () returns int {
+        byte a = 255;
+        return a - a;
+    };
+
+    var fn2 = function () returns int {
+        byte a = 255;
+        int res = a - a;
+        return res;
+    };
+
+    return fn1() == fn2();
+}
+
+public function testByteReturnAsIntInLambda3(byte a, byte b) returns int {
+    var fn = function (byte a, byte b) returns int { return a - b; };
+    return fn(a, b);
+}


### PR DESCRIPTION
## Purpose
This PR fixes the issue of direct return of byte binary operation in a lambda.

An example :

```ballerina
public function main() {
    var fn = function () returns int {
        byte a = 255;
        return a - a;
    };
}
```
Fixes #22168

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
