### PR TITLE
Populate caller remote IP and introduce function to get remote hostname

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/completion/resource/completionAvoidRemoteFunctions.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/resource/completionAvoidRemoteFunctions.json
@@ -28,7 +28,7 @@
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key=value for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `==` operator).  \n  \n"
+          "value": "**Package:** _ballerina/lang.value_  \n  \nPerforms a minimal conversion of a value to a string.\nThe conversion is minimal in particular in the sense\nthat the conversion applied to a value that is already\na string does nothing.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe result of `toString(v)` is as follows:  \n  \n- if `v` is a string, then returns `v`  \n- if `v` is `()`, then returns an empty string  \n- if `v` is boolean, then the string `true` or `false`  \n- if `v` is an int, then return `v` represented as a decimal string  \n- if `v` is a float or decimal, then return `v` represented as a decimal string,  \n  with a decimal point only if necessary, but without any suffix indicating the type of `v`;  \n  return `NaN`, `Infinity` for positive infinity, and `-Infinity` for negative infinity  \n- if `v` is a list, then returns the results toString on each member of the list  \n  separated by a space character  \n- if `v` is a map, then returns key\u003dvalue for each member separated by a space character  \n- if `v` is xml, then returns `v` in XML format (as if it occurred within an XML element)  \n- if `v` is table, TBD  \n- if `v` is an error, then a string consisting of the following in order  \n    1. the string `error`  \n    2. a space character  \n    3. the reason string  \n    4. if the detail record is non-empty  \n        1. a space character  \n        2. the result of calling toString on the detail record  \n- if `v` is an object, then  \n    - if `v` provides a `toString` method with a string return type and no required methods,  \n      then the result of calling that method on `v`  \n    - otherwise, `object` followed by some implementation-dependent string  \n- if `v` is any other behavioral type, then the identifier for the behavioral type  \n  (`function`, `future`, `service`, `typedesc` or `handle`)  \n  followed by some implementation-dependent string  \n  \nNote that `toString` may produce the same string for two Ballerina values  \nthat are not equal (in the sense of the `\u003d\u003d` operator).  \n  \n"
         }
       },
       "sortText": "120",
@@ -41,6 +41,20 @@
       "detail": "http:Remote",
       "sortText": "130",
       "insertText": "remoteAddress",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getRemoteHostName()((string|()))",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/http_  \n  \nGets the hostname from the remote address. This method may trigger a DNS reverse lookup if the address was created\nwith a literal IP address.\n  \n  \n  \n**Returns** `(string|())`   \n- The hostname of the address or `nil` if it is unresolved  \n  \n"
+        }
+      },
+      "sortText": "120",
+      "insertText": "getRemoteHostName()",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/stdlib/http/src/main/ballerina/src/http/http_connection.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_connection.bal
@@ -172,11 +172,24 @@ public type Caller client object {
         response.statusCode = STATUS_ACCEPTED;
         return self->respond(response);
     }
+
+    # Gets the hostname from the remote address. This method may trigger a DNS reverse lookup if the address was created
+    # with a literal IP address.
+    #
+    # + return - The hostname of the address or `nil` if it is unresolved
+    public function getRemoteHostName() returns string? {
+        return java:toString(nativeGetRemoteHostName(self));
+    }
 };
 
 function nativeRespond(Caller caller, Response response) returns ListenerError? = @java:Method {
     class: "org.ballerinalang.net.http.nativeimpl.connection.Respond",
     name: "nativeRespond"
+} external;
+
+function nativeGetRemoteHostName(Caller caller) returns handle = @java:Method {
+    class: "org.ballerinalang.net.http.nativeimpl.connection.getRemoteHostName",
+    name: "nativeGetRemoteHostName"
 } external;
 
 

--- a/stdlib/http/src/main/ballerina/src/http/http_connection.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_connection.bal
@@ -188,7 +188,7 @@ function nativeRespond(Caller caller, Response response) returns ListenerError? 
 } external;
 
 function nativeGetRemoteHostName(Caller caller) returns handle = @java:Method {
-    class: "org.ballerinalang.net.http.nativeimpl.connection.getRemoteHostName",
+    class: "org.ballerinalang.net.http.nativeimpl.connection.GetRemoteHostName",
     name: "nativeGetRemoteHostName"
 } external;
 

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -174,7 +174,7 @@ function externDetach(Listener listenerObj, service s) returns error? = @java:Me
 
 # Presents a read-only view of the remote address.
 #
-# + host - The remote host name/IP
+# + host - The remote host IP
 # + port - The remote port
 public type Remote record {|
     string host = "";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -416,6 +416,7 @@ public class HttpConstants {
     public static final String REMOTE_STRUCT_FIELD = "remoteAddress";
     public static final String REMOTE_HOST_FIELD = "host";
     public static final String REMOTE_PORT_FIELD = "port";
+    public static final String REMOTE_SOCKET_ADDRESS = "remoteSocketAddress";
 
     //Local struct field names
     public static final String LOCAL_STRUCT_INDEX = "localAddress";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -729,7 +729,9 @@ public class HttpUtil {
         Object remoteSocketAddress = inboundMsg.getProperty(HttpConstants.REMOTE_ADDRESS);
         if (remoteSocketAddress instanceof InetSocketAddress) {
             InetSocketAddress inetSocketAddress = (InetSocketAddress) remoteSocketAddress;
+            String remoteHost = inetSocketAddress.getHostString();
             long remotePort = inetSocketAddress.getPort();
+            remote.put(HttpConstants.REMOTE_HOST_FIELD, remoteHost);
             remote.put(HttpConstants.REMOTE_PORT_FIELD, remotePort);
         }
         httpCaller.set(HttpConstants.REMOTE_STRUCT_FIELD, remote);
@@ -746,6 +748,7 @@ public class HttpUtil {
         httpCaller.set(HttpConstants.SERVICE_ENDPOINT_PROTOCOL_FIELD, inboundMsg.getProperty(HttpConstants.PROTOCOL));
         httpCaller.set(HttpConstants.SERVICE_ENDPOINT_CONFIG_FIELD, config);
         httpCaller.addNativeData(HttpConstants.HTTP_SERVICE, httpResource.getParentService());
+        httpCaller.addNativeData(HttpConstants.REMOTE_SOCKET_ADDRESS, remoteSocketAddress);
     }
 
     /**

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/GetRemoteHostName.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/GetRemoteHostName.java
@@ -29,7 +29,7 @@ import java.net.InetSocketAddress;
  *
  * @since 1.1.5
  */
-public class getRemoteHostName {
+public class GetRemoteHostName {
 
     public static Object nativeGetRemoteHostName(ObjectValue caller) {
         Object remoteSocketAddress = caller.getNativeData(HttpConstants.REMOTE_SOCKET_ADDRESS);

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/getRemoteHostName.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/getRemoteHostName.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.net.http.nativeimpl.connection;
+
+import org.ballerinalang.jvm.values.ObjectValue;
+import org.ballerinalang.net.http.HttpConstants;
+
+import java.net.InetSocketAddress;
+
+/**
+ * Extern function to get the hostname from the remote address. This method may trigger DNS reverse lookup if the
+ * address was created with a literal IP address.
+ *
+ * @since 1.1.5
+ */
+public class getRemoteHostName {
+
+    public static Object nativeGetRemoteHostName(ObjectValue caller) {
+        Object remoteSocketAddress = caller.getNativeData(HttpConstants.REMOTE_SOCKET_ADDRESS);
+        if (remoteSocketAddress instanceof InetSocketAddress) {
+            return ((InetSocketAddress) remoteSocketAddress).getHostName();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
## Purpose
> $Title

Fixes #22283

## Samples
```ballerina
string? remoteHostName = caller.getRemoteHostName();
```

Definition : 
```ballerina
# Gets the hostname from the remote address. This method may trigger DNS reverse lookup if the address was created
# with a literal IP address.
#
# + return - the hostname part of the address or nil if it is unresolved
public function getRemoteHostName() returns string? {}
```
