### PR TITLE
Refactor and move all old Observability logic to Compiler Back-end Desugar phase

### DIFF
--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
@@ -327,7 +327,6 @@ const string ANNOTATION_UTILS = "org/ballerinalang/jvm/AnnotationUtils";
 const string ANNOTATION_MAP_NAME = "$annotation_data";
 const string DEFAULTABLE_ARGS_ANOT_NAME = "DefaultableArgs";
 const string DEFAULTABLE_ARGS_ANOT_FIELD = "args";
-const string OBSERVABLE_ANOTATION = "ballerina/observe/Observable";
 
 // types related constants
 const string TYPES_ERROR =  "typeError";

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/bir;
 import ballerina/io;
 import ballerina/jvm;
 import ballerina/stringutils;
@@ -33,32 +32,12 @@ function emitReportErrorInvocation(jvm:MethodVisitor mv, int strandIndex, int er
 }
 
 function emitStartObservationInvocation(jvm:MethodVisitor mv, int strandIndex, string serviceOrConnectorName,
-                                        string resourceOrActionName, string observationStartMethod,
-                                        map<string> tags = {}) {
+                                        string resourceOrActionName, string observationStartMethod) {
     mv.visitVarInsn(ALOAD, strandIndex);
     mv.visitLdcInsn(cleanUpServiceName(serviceOrConnectorName));
     mv.visitLdcInsn(resourceOrActionName);
-
-    if (tags.length() > 0) {
-        mv.visitTypeInsn(NEW, "java/util/HashMap");
-        mv.visitInsn(DUP);
-        mv.visitLdcInsn(tags.length());
-        mv.visitInsn(L2I);
-        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "(I)V", false);
-        foreach var [key, value] in tags.entries() {
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn(key);
-            mv.visitLdcInsn(value);
-            mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put",
-                io:sprintf("(L%s;L%s;)L%s;", OBJECT, OBJECT, OBJECT), true);
-            mv.visitInsn(POP);
-        }
-    } else {
-        mv.visitMethodInsn(INVOKESTATIC, "java/util/Collections", "emptyMap",
-            io:sprintf("()L%s;", MAP), false);
-    }
     mv.visitMethodInsn(INVOKESTATIC, OBSERVE_UTILS, observationStartMethod,
-        io:sprintf("(L%s;L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE, MAP), false);
+        io:sprintf("(L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE), false);
 }
 
 function cleanUpServiceName(string serviceName) returns string {
@@ -74,27 +53,4 @@ function getFullQualifiedRemoteFunctionName(string moduleOrg, string moduleName,
         return funcName;
     }
     return moduleOrg + "/" + moduleName + "/" + funcName;
-}
-
-function isFunctionObserved(bir:Function func) returns boolean {
-    boolean isObserved = false;
-    string funcName = cleanupFunctionName(<@untainted> func.name.value);
-    if (funcName != "__init" && funcName != "$__init$") {
-        boolean isRemote = (func.flags & bir:REMOTE) == bir:REMOTE;
-        if (isRemote) {
-            isObserved = true;
-        } else {
-            foreach var attachment in func.annotAttachments {
-                if (attachment is bir:AnnotationAttachment) {
-                    string annotationFQN = attachment.moduleId.org + "/" + attachment.moduleId.name + "/"
-                        + attachment.annotTagRef.value;
-                    if (annotationFQN == OBSERVABLE_ANOTATION) {
-                        isObserved = true;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-    return isObserved;
 }

--- a/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
+++ b/compiler/ballerina-backend-jvm-old/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
@@ -511,6 +511,7 @@ type TerminatorGenerator object {
         string cleanMethodName = cleanupFunctionName(methodName);
         boolean useBString = isBStringFunc(methodLookupName);
         string methodDesc = lookupJavaMethodDescription(lookupKey, useBString);
+
         self.mv.visitMethodInsn(INVOKESTATIC, jvmClass, cleanupFunctionName(methodName), methodDesc, false);
     }
 
@@ -796,7 +797,7 @@ type TerminatorGenerator object {
 
         } else {
             self.mv.visitMethodInsn(INVOKEVIRTUAL, FUNCTION_POINTER, "call", io:sprintf("(L%s;)L%s;", OBJECT, OBJECT), false);
-            // store result
+            // store reult
             bir:BType? lhsType = fpCall.lhsOp?.typeValue;
             if (lhsType is bir:BType) {
                 addUnboxInsn(self.mv, lhsType);

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_constants.bal
@@ -324,7 +324,6 @@ const string ANNOTATION_UTILS = "org/ballerinalang/jvm/AnnotationUtils";
 const string ANNOTATION_MAP_NAME = "$annotation_data";
 const string DEFAULTABLE_ARGS_ANOT_NAME = "DefaultableArgs";
 const string DEFAULTABLE_ARGS_ANOT_FIELD = "args";
-const string OBSERVABLE_ANOTATION = "ballerina/observe/Observable";
 
 // types related constants
 const string TYPES_ERROR =  "typeError";

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_method_gen.bal
@@ -100,10 +100,11 @@ function genJMethodForBFunc(bir:Function func,
     jvm:Label? tryStart = ();
     boolean isObserved = false;
     boolean isWorker = (func.flags & bir:WORKER) == bir:WORKER;
-    if ((isService || isWorker) && funcName != "__init" && funcName != "$__init$") {
+    boolean isRemote = (func.flags & bir:REMOTE) == bir:REMOTE;
+    if ((isService || isRemote || isWorker) && funcName != "__init" && funcName != "$__init$") {
         // create try catch block to start and stop observability.
         isObserved = true;
-        tryStart = labelGen.getLabel("observe-try-start");
+        tryStart = labelGen.getLabel("try-start");
         mv.visitLabel(<jvm:Label>tryStart);
     }
 
@@ -257,14 +258,13 @@ function genJMethodForBFunc(bir:Function func,
     jvm:Label methodEndLabel = new;
     // generate the try catch finally to stop observing if an error occurs.
     if (isObserved) {
-        jvm:Label tryEnd = labelGen.getLabel("observe-try-end");
-        jvm:Label tryCatch = labelGen.getLabel("observe-try-handler");
-        jvm:Label tryCatchFinally = labelGen.getLabel("observe-try-catch-finally");
-        jvm:Label tryFinally = labelGen.getLabel("observe-try-finally");
-
+        jvm:Label tryEnd = labelGen.getLabel("try-end");
+        jvm:Label tryCatch = labelGen.getLabel("try-handler");
         // visitTryCatchBlock visited at the end since order of the error table matters.
         mv.visitTryCatchBlock(<jvm:Label>tryStart, tryEnd, tryCatch, ERROR_VALUE);
+        jvm:Label tryFinally = labelGen.getLabel("try-finally");
         mv.visitTryCatchBlock(<jvm:Label>tryStart, tryEnd, tryFinally, ());
+        jvm:Label tryCatchFinally = labelGen.getLabel("try-catch-finally");
         mv.visitTryCatchBlock(tryCatch, tryCatchFinally, tryFinally, ());
 
         bir:VariableDcl catchVarDcl = { typeValue: "any", name: { value: "$_catch_$" } };
@@ -274,16 +274,22 @@ function genJMethodForBFunc(bir:Function func,
 
         // Try-To-Finally
         mv.visitLabel(tryEnd);
+        // emitStopObservationInvocation(mv, localVarOffset);
+        jvm:Label tryBlock1 = labelGen.getLabel("try-block-1");
+        mv.visitLabel(tryBlock1);
         mv.visitJumpInsn(GOTO, methodEndLabel);
 
         // Catch Block
         mv.visitLabel(tryCatch);
         mv.visitVarInsn(ASTORE, catchVarIndex);
+        jvm:Label tryBlock2 = labelGen.getLabel("try-block-2");
+        mv.visitLabel(tryBlock2);
         emitReportErrorInvocation(mv, localVarOffset, catchVarIndex);
-
         mv.visitLabel(tryCatchFinally);
         emitStopObservationInvocation(mv, localVarOffset);
-        // Re-throw caught error value
+        jvm:Label tryBlock3 = labelGen.getLabel("try-block-3");
+        mv.visitLabel(tryBlock3);
+        // re-throw caught error value
         mv.visitVarInsn(ALOAD, catchVarIndex);
         mv.visitInsn(ATHROW);
 
@@ -291,6 +297,8 @@ function genJMethodForBFunc(bir:Function func,
         mv.visitLabel(tryFinally);
         mv.visitVarInsn(ASTORE, throwableVarIndex);
         emitStopObservationInvocation(mv, localVarOffset);
+        jvm:Label tryBlock4 = labelGen.getLabel("try-block-4");
+        mv.visitLabel(tryBlock4);
         mv.visitVarInsn(ALOAD, throwableVarIndex);
         mv.visitInsn(ATHROW);
     }
@@ -682,9 +690,9 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
             caseIndex += 1;
         }
 
+        string serviceOrConnectorName = serviceName;
         if (isObserved && j == 0) {
             string observationStartMethod = isService ? "startResourceObservation" : "startCallableObservation";
-            string serviceOrConnectorName = serviceName;
             if !isService && attachedType is bir:BObjectType {
                 // add module org and module name to remote spans.
                 serviceOrConnectorName = getFullQualifiedRemoteFunctionName(
@@ -756,7 +764,7 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
                     instGen.generateNewXMLQNameIns(<bir:NewXMLQName> inst, useBString);
                 } else {
                     instGen.generateNewStringXMLQNameIns(<bir:NewStringXMLQName> inst);
-                }
+                } 
             } else if (insKind <= bir:INS_KIND_NEW_TABLE) {
                 if (insKind == bir:INS_KIND_XML_SEQ_STORE) {
                     instGen.generateXMLStoreIns(<bir:XMLAccess> inst);
@@ -786,7 +794,7 @@ function generateBasicBlocks(jvm:MethodVisitor mv, bir:BasicBlock?[] basicBlocks
                     instGen.generateNewTypedescIns(<bir:NewTypeDesc> inst);
                 } else {
                     instGen.generateNegateIns(<bir:UnaryOp> inst);
-                }
+                } 
             } else if (insKind == bir:INS_KIND_PLATFORM) {
                 instGen.generatePlatformIns(<JInstruction>inst);
             } else {
@@ -2528,7 +2536,7 @@ function scheduleStopMethod(jvm:MethodVisitor mv, string initClass, string stopF
 
 function generateJavaCompatibilityCheck(jvm:MethodVisitor mv) {
     mv.visitLdcInsn(getJavaVersion());
-    mv.visitMethodInsn(INVOKESTATIC, COMPATIBILITY_CHECKER, "verifyJavaCompatibility",
+    mv.visitMethodInsn(INVOKESTATIC, COMPATIBILITY_CHECKER, "verifyJavaCompatibility", 
                         io:sprintf("(L%s;)V", STRING_VALUE), false);
 }
 

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_observability_gen.bal
@@ -14,7 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/bir;
 import ballerina/io;
 import ballerina/jvm;
 import ballerina/stringutils;
@@ -33,32 +32,12 @@ function emitReportErrorInvocation(jvm:MethodVisitor mv, int strandIndex, int er
 }
 
 function emitStartObservationInvocation(jvm:MethodVisitor mv, int strandIndex, string serviceOrConnectorName,
-                                        string resourceOrActionName, string observationStartMethod,
-                                        map<string> tags = {}) {
+                                        string resourceOrActionName, string observationStartMethod) {
     mv.visitVarInsn(ALOAD, strandIndex);
     mv.visitLdcInsn(cleanUpServiceName(serviceOrConnectorName));
     mv.visitLdcInsn(resourceOrActionName);
-
-    if (tags.length() > 0) {
-        mv.visitTypeInsn(NEW, "java/util/HashMap");
-        mv.visitInsn(DUP);
-        mv.visitLdcInsn(tags.length());
-        mv.visitInsn(L2I);
-        mv.visitMethodInsn(INVOKESPECIAL, "java/util/HashMap", "<init>", "(I)V", false);
-        foreach var [key, value] in tags.entries() {
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn(key);
-            mv.visitLdcInsn(value);
-            mv.visitMethodInsn(INVOKEINTERFACE, "java/util/Map", "put",
-                io:sprintf("(L%s;L%s;)L%s;", OBJECT, OBJECT, OBJECT), true);
-            mv.visitInsn(POP);
-        }
-    } else {
-        mv.visitMethodInsn(INVOKESTATIC, "java/util/Collections", "emptyMap",
-            io:sprintf("()L%s;", MAP), false);
-    }
     mv.visitMethodInsn(INVOKESTATIC, OBSERVE_UTILS, observationStartMethod,
-        io:sprintf("(L%s;L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE, MAP), false);
+        io:sprintf("(L%s;L%s;L%s;)V", STRAND, STRING_VALUE, STRING_VALUE), false);
 }
 
 function cleanUpServiceName(string serviceName) returns string {
@@ -82,27 +61,4 @@ function getFullQualifiedRemoteFunctionName(string moduleOrg, string moduleName,
         return funcName;
     }
     return moduleOrg + "/" + moduleName + "/" + funcName;
-}
-
-function isFunctionObserved(bir:Function func) returns boolean {
-    boolean isObserved = false;
-    string funcName = cleanupFunctionName(<@untainted> func.name.value);
-    if (funcName != "__init" && funcName != "$__init$") {
-        boolean isRemote = (func.flags & bir:REMOTE) == bir:REMOTE;
-        if (isRemote) {
-            isObserved = true;
-        } else {
-            foreach var attachment in func.annotAttachments {
-                if (attachment is bir:AnnotationAttachment) {
-                    string annotationFQN = attachment.moduleId.org + "/" + attachment.moduleId.name + "/"
-                        + attachment.annotTagRef.value;
-                    if (annotationFQN == OBSERVABLE_ANOTATION) {
-                        isObserved = true;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-    return isObserved;
 }

--- a/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
+++ b/compiler/ballerina-backend-jvm/src/main/ballerina/src/compiler_backend_jvm/jvm_terminator_gen.bal
@@ -508,7 +508,7 @@ type TerminatorGenerator object {
         string jvmClass = lookupFullQualifiedClassName(lookupKey);
         string cleanMethodName = cleanupFunctionName(methodName);
         boolean useBString = IS_BSTRING && orgName == "ballerina" &&
-                             (moduleName == "lang.string" || moduleName == "lang.error" || moduleName == "lang.value"
+                             (moduleName == "lang.string" || moduleName == "lang.error" || moduleName == "lang.value" 
                              || moduleName == "lang.map") && !cleanMethodName.endsWith("_");
         if (useBString) {
             cleanMethodName = nameOfBStringFunc(cleanMethodName);
@@ -796,7 +796,7 @@ type TerminatorGenerator object {
 
         } else {
             self.mv.visitMethodInsn(INVOKEVIRTUAL, FUNCTION_POINTER, "call", io:sprintf("(L%s;)L%s;", OBJECT, OBJECT), false);
-            // store result
+            // store reult
             bir:BType? lhsType = fpCall.lhsOp?.typeValue;
             if (lhsType is bir:BType) {
                 addUnboxInsn(self.mv, lhsType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -135,7 +135,6 @@ public class JvmConstants {
     public static final String ANNOTATION_MAP_NAME = "$annotation_data";
     public static final String DEFAULTABLE_ARGS_ANOT_NAME = "DefaultableArgs";
     public static final String DEFAULTABLE_ARGS_ANOT_FIELD = "args";
-    public static final String OBSERVABLE_ANNOTATION = "ballerina/observe/Observable";
 
     // types related constants
     public static final String TYPES_ERROR = "typeError";
@@ -186,6 +185,11 @@ public class JvmConstants {
     // observability related constants
     public static final String OBSERVER_CONTEXT = "org/ballerinalang/jvm/observability/ObserverContext";
     public static final String OBSERVE_UTILS = "org/ballerinalang/jvm/observability/ObserveUtils";
+    public static final String START_RESOURCE_OBSERVATION_METHOD = "startResourceObservation";
+    public static final String START_CALLABLE_OBSERVATION_METHOD = "startCallableObservation";
+    public static final String REPORT_ERROR_METHOD = "reportError";
+    public static final String STOP_OBSERVATION_METHOD = "stopObservation";
+    public static final String OBSERVABLE_ANNOTATION = "ballerina/observe/Observable";
 
     // visibility flags
     public static final int BAL_PUBLIC = 1;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -17,49 +17,27 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen;
 
-import org.ballerinalang.model.elements.Flag;
-import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.JIMethodCall;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunctionParameter;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRPackage;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.ConstantLoad;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.FieldAccess;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewStructure;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.TypeCast;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.TypeTest;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.UnaryOP;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
-import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarScope;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
-import static org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBSERVABLE_ANNOTATION;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBSERVE_UTILS;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupFunctionName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getBasicBlock;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFunction;
@@ -67,7 +45,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFuncti
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getVariableDcl;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.nextId;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.nextVarId;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.symbolTable;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.TerminatorGenerator.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Branch;
@@ -264,195 +241,5 @@ public class JvmDesugarPhase {
             index += 1;
         }
         func.localVars = updatedLocalVars;
-    }
-
-    public static void rewriteObservableFunctionInvocations(BIRPackage pkg) {
-        for (BIRFunction func : pkg.functions) {
-            rewriteObservableFunctionInvocations(func.basicBlocks, func.localVars, pkg);
-        }
-        for (BIRTypeDefinition typeDef : pkg.typeDefs) {
-            for (BIRFunction attachedFunc : typeDef.attachedFuncs) {
-                rewriteObservableFunctionInvocations(attachedFunc.basicBlocks, attachedFunc.localVars, pkg);
-            }
-        }
-    }
-
-    public static void rewriteObservableFunctionInvocations(List<BIRBasicBlock> basicBlocks,
-                                                            List<BIRVariableDcl> scopeVarList, BIRPackage pkg) {
-        int i = 0;
-        while (i < basicBlocks.size()) {
-            BIRBasicBlock currentBB = basicBlocks.get(i);
-            BIRTerminator currentTerminator = currentBB.terminator;
-            if (currentTerminator.kind == InstructionKind.CALL) {
-                BIRTerminator.Call callIns = (BIRTerminator.Call) currentTerminator;
-                boolean isRemote = callIns.calleeFlags.contains(Flag.REMOTE);
-                boolean isObservableAnnotationPresent = false;
-                for (BIRNode.BIRAnnotationAttachment annot : callIns.calleeAnnotAttachments) {
-                    if (OBSERVABLE_ANNOTATION.equals(annot.packageID.orgName.value + "/"
-                            + annot.packageID.name.value + "/" + annot.annotTagRef.value)) {
-                        isObservableAnnotationPresent = true;
-                        break;
-                    }
-                }
-                if (isRemote || isObservableAnnotationPresent) {
-                    DiagnosticPos desugaredInsPosition = callIns.pos;
-                    String action;
-                    if (callIns.name.value.contains(".")) {
-                        String[] split = callIns.name.value.split("\\.");
-                        action = split[1];
-                    } else {
-                        action = callIns.name.value;
-                    }
-                    String connectorName;
-                    if (callIns.isVirtual) {
-                        BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
-                        connectorName = getPackageName(selfArg.type.tsymbol.pkgID.orgName,
-                                selfArg.type.tsymbol.pkgID.name) + selfArg.type.tsymbol.name.value;
-                    } else {
-                        connectorName = "";
-                    }
-
-                    boolean isErrorCheckRequired = false;
-                    if (callIns.lhsOp.variableDcl.type instanceof BUnionType) {
-                        BUnionType returnUnionType = (BUnionType) callIns.lhsOp.variableDcl.type;
-                        isErrorCheckRequired = returnUnionType.getMemberTypes().stream()
-                                .anyMatch(type -> type instanceof BErrorType);
-                    } else if (callIns.lhsOp.variableDcl.type instanceof BErrorType) {
-                        isErrorCheckRequired = true;
-                    }
-
-                    BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(basicBlocks, i + 1, "desugaredBB");
-                    BIRBasicBlock errorCheckBranchBB = null;
-                    BIRBasicBlock errorReportBB = null;
-                    if (isErrorCheckRequired) {
-                        errorCheckBranchBB = insertAndGetNextBasicBlock(basicBlocks, i + 2, "desugaredBB");
-                        errorReportBB = insertAndGetNextBasicBlock(basicBlocks, i + 3, "desugaredBB");
-                    }
-                    BIRBasicBlock observeEndBB = insertAndGetNextBasicBlock(basicBlocks,
-                            i + (isErrorCheckRequired ? 4 : 2), "desugaredBB");
-
-                    newCurrentBB.instructions = currentBB.instructions;
-                    newCurrentBB.terminator = currentBB.terminator;
-                    currentBB.instructions = new ArrayList<>(0);
-                    currentBB.terminator = null;
-
-                    {
-                        BIROperand connectorNameOperand = generateConstantOperand(
-                                String.format("%s_connector", currentBB.id.value), connectorName, scopeVarList,
-                                currentBB, desugaredInsPosition);
-                        BIROperand actionNameOperand = generateConstantOperand(
-                                String.format("%s_action", currentBB.id.value), action, scopeVarList, currentBB,
-                                desugaredInsPosition);
-                        Map<String, String> tags = new HashMap<>();
-                        tags.put("source.invocation_fqn", String.format("%s:%s:%s:%s:%d:%d", pkg.org.value,
-                                pkg.name.value, pkg.version.value, callIns.pos.src.cUnitName, callIns.pos.sLine,
-                                callIns.pos.sCol));
-                        if (isRemote) {
-                            tags.put("source.remote", "true");
-                        }
-                        BIROperand tagsMapOperand = generateMapOperand(String.format("%s_tags", currentBB.id.value),
-                                tags, scopeVarList, currentBB, desugaredInsPosition);
-
-                        JIMethodCall observeStartCallTerminator = new JIMethodCall(desugaredInsPosition);
-                        observeStartCallTerminator.invocationType = INVOKESTATIC;
-                        observeStartCallTerminator.jClassName = OBSERVE_UTILS;
-                        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;L%s;L%s;)V", STRING_VALUE,
-                                STRING_VALUE, MAP_VALUE);
-                        observeStartCallTerminator.name = "startCallableObservation";
-                        observeStartCallTerminator.args = Arrays.asList(connectorNameOperand, actionNameOperand,
-                                tagsMapOperand);
-                        currentBB.terminator = observeStartCallTerminator;
-                    }
-
-                    if (isErrorCheckRequired) {
-                        BIRVariableDcl isErrorVariableDcl = new BIRVariableDcl(symbolTable.booleanType,
-                                new Name(String.format("$_%s_is_error_$", errorCheckBranchBB.id.value)),
-                                VarScope.FUNCTION, VarKind.TEMP);
-                        scopeVarList.add(isErrorVariableDcl);
-                        BIROperand isErrorOperand = new BIROperand(isErrorVariableDcl);
-                        TypeTest errorTypeTestInstruction = new TypeTest(desugaredInsPosition, symbolTable.errorType,
-                                isErrorOperand, callIns.lhsOp);
-                        errorCheckBranchBB.instructions.add(errorTypeTestInstruction);
-                        errorCheckBranchBB.terminator = new Branch(desugaredInsPosition, isErrorOperand, errorReportBB,
-                                observeEndBB);
-
-                        BIRVariableDcl castedErrorVariableDcl = new BIRVariableDcl(symbolTable.errorType,
-                                new Name(String.format("$_%s_casted_error_$", errorReportBB.id.value)),
-                                VarScope.FUNCTION, VarKind.TEMP);
-                        scopeVarList.add(castedErrorVariableDcl);
-                        BIROperand castedErrorOperand = new BIROperand(castedErrorVariableDcl);
-                        TypeCast errorCastInstruction = new TypeCast(desugaredInsPosition, castedErrorOperand,
-                                callIns.lhsOp, symbolTable.errorType, false);
-                        errorReportBB.instructions.add(errorCastInstruction);
-
-                        JIMethodCall reportErrorCallTerminator = new JIMethodCall(desugaredInsPosition);
-                        reportErrorCallTerminator.invocationType = INVOKESTATIC;
-                        reportErrorCallTerminator.jClassName = OBSERVE_UTILS;
-                        reportErrorCallTerminator.jMethodVMSig = String.format("(L%s;)V", ERROR_VALUE);
-                        reportErrorCallTerminator.name = "reportError";
-                        reportErrorCallTerminator.args = Collections.singletonList(castedErrorOperand);
-                        errorReportBB.terminator = reportErrorCallTerminator;
-                    }
-
-                    JIMethodCall observeEndCallTerminator = new JIMethodCall(desugaredInsPosition);
-                    observeEndCallTerminator.invocationType = INVOKESTATIC;
-                    observeEndCallTerminator.jClassName = OBSERVE_UTILS;
-                    observeEndCallTerminator.jMethodVMSig = "()V";
-                    observeEndCallTerminator.name = "stopObservation";
-                    observeEndCallTerminator.args = Collections.emptyList();
-                    observeEndBB.terminator = observeEndCallTerminator;
-
-                    observeEndBB.terminator.thenBB = newCurrentBB.terminator.thenBB;
-                    if (isErrorCheckRequired) {
-                        errorReportBB.terminator.thenBB = observeEndBB;
-                        newCurrentBB.terminator.thenBB = errorCheckBranchBB;
-                    } else {
-                        newCurrentBB.terminator.thenBB = observeEndBB;
-                    }
-                    currentBB.terminator.thenBB = newCurrentBB; // Current BB now contains observe start call
-                    i += (isErrorCheckRequired ? 4 : 2);
-                }
-            }
-            i++;
-        }
-    }
-
-    public static BIROperand generateConstantOperand(String uniqueId, String constantValue,
-                                                     List<BIRVariableDcl> scopeVarList, BIRBasicBlock basicBlock,
-                                                     DiagnosticPos desugaredInsPosition) {
-        BIRVariableDcl variableDcl = new BIRVariableDcl(symbolTable.stringType,
-                new Name(String.format("$_%s_const_$", uniqueId)), VarScope.FUNCTION, VarKind.TEMP);
-        scopeVarList.add(variableDcl);
-        BIROperand operand = new BIROperand(variableDcl);
-        ConstantLoad instruction = new ConstantLoad(desugaredInsPosition, constantValue, symbolTable.stringType,
-                operand);
-        basicBlock.instructions.add(instruction);
-        return operand;
-    }
-
-    public static BIROperand generateMapOperand(String uniqueId, Map<String, String> map,
-                                                List<BIRVariableDcl> scopeVarList, BIRBasicBlock basicBlock,
-                                                DiagnosticPos desugaredInsPosition) {
-        BIRVariableDcl variableDcl = new BIRVariableDcl(symbolTable.mapType,
-                new Name(String.format("$_%s_map_$", uniqueId)), VarScope.FUNCTION, VarKind.TEMP);
-        scopeVarList.add(variableDcl);
-        BIROperand tagsMapOperand = new BIROperand(variableDcl);
-
-        NewStructure bMapNewInstruction = new NewStructure(desugaredInsPosition,
-                new BMapType(TypeTags.MAP, symbolTable.stringType, null), tagsMapOperand);
-        basicBlock.instructions.add(bMapNewInstruction);
-
-        int entryIndex = 0;
-        for (Map.Entry<String, String> tagEntry: map.entrySet()) {
-            BIROperand keyOperand = generateConstantOperand(String.format("%s_map_%d_key", uniqueId, entryIndex),
-                    tagEntry.getKey(), scopeVarList, basicBlock, desugaredInsPosition);
-            BIROperand valueOperand = generateConstantOperand(String.format("%s_map_%d_value", uniqueId,
-                    entryIndex), tagEntry.getValue(), scopeVarList, basicBlock, desugaredInsPosition);
-            FieldAccess fieldAccessIns = new FieldAccess(desugaredInsPosition,
-                    InstructionKind.MAP_STORE, tagsMapOperand, keyOperand, valueOperand);
-            basicBlock.instructions.add(fieldAccessIns);
-            entryIndex++;
-        }
-        return tagsMapOperand;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
@@ -151,7 +151,7 @@ public class JvmErrorGen {
                             THROWABLE, ERROR_VALUE), false);
                     generateVarStore(this.mv, retVarDcl, this.currentPackageName, retIndex);
                     Return term = catchIns.term;
-                    termGen.genReturnTerm(term, retIndex, func, false, -1);
+                    termGen.genReturnTerm(term, retIndex, func, -1);
                     this.mv.visitJumpInsn(GOTO, jumpLabel);
                 }
                 if (!exeptionExist) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -290,8 +290,7 @@ public class JvmMethodGen {
         @Nilable Label tryStart = null;
         boolean isObserved = false;
         boolean isWorker = (func.flags & Flags.WORKER) == Flags.WORKER;
-        if ((isWorker || "main".equals(funcName))
-                && !"__init".equals(funcName) && !"$__init$".equals(funcName)) {
+        if (isWorker) {
             // create try catch block to start and stop observability.
             isObserved = true;
             tryStart = labelGen.getLabel("observe-try-start");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -289,10 +289,8 @@ public class JvmMethodGen {
 
         @Nilable Label tryStart = null;
         boolean isObserved = false;
-        boolean isWorker = (func.flags & Flags.WORKER) == Flags.WORKER;
-        if (isWorker) {
+        if (isObserved) {
             // create try catch block to start and stop observability.
-            isObserved = true;
             tryStart = labelGen.getLabel("observe-try-start");
             mv.visitLabel(tryStart);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -17,8 +17,28 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen;
 
+import org.ballerinalang.model.elements.Flag;
 import org.objectweb.asm.MethodVisitor;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator;
+import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
+import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
+import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
+import org.wso2.ballerinalang.compiler.bir.model.VarKind;
+import org.wso2.ballerinalang.compiler.bir.model.VarScope;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
+import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.objectweb.asm.Opcodes.ALOAD;
@@ -32,8 +52,13 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VAL
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBSERVABLE_ANNOTATION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBSERVE_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.insertAndGetNextBasicBlock;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getVariableDcl;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.symbolTable;
 
 /**
  * BIR observability model to JVM byte code generation class.
@@ -91,5 +116,195 @@ class JvmObservabilityGen {
             return funcName;
         }
         return moduleOrg + "/" + moduleName + "/" + funcName;
+    }
+
+    public static void rewriteObservableFunctions(BIRNode.BIRPackage pkg) {
+        for (BIRNode.BIRFunction func : pkg.functions) {
+            rewriteObservableFunctionInvocations(func.basicBlocks, func.localVars, pkg);
+        }
+        for (BIRNode.BIRTypeDefinition typeDef : pkg.typeDefs) {
+            for (BIRNode.BIRFunction attachedFunc : typeDef.attachedFuncs) {
+                rewriteObservableFunctionInvocations(attachedFunc.basicBlocks, attachedFunc.localVars, pkg);
+            }
+        }
+    }
+
+    public static void rewriteObservableFunctionInvocations(List<BIRNode.BIRBasicBlock> basicBlocks,
+                                                            List<BIRNode.BIRVariableDcl> scopeVarList, BIRNode.BIRPackage pkg) {
+        int i = 0;
+        while (i < basicBlocks.size()) {
+            BIRNode.BIRBasicBlock currentBB = basicBlocks.get(i);
+            BIRTerminator currentTerminator = currentBB.terminator;
+            if (currentTerminator.kind == InstructionKind.CALL) {
+                BIRTerminator.Call callIns = (BIRTerminator.Call) currentTerminator;
+                boolean isRemote = callIns.calleeFlags.contains(Flag.REMOTE);
+                boolean isObservableAnnotationPresent = false;
+                for (BIRNode.BIRAnnotationAttachment annot : callIns.calleeAnnotAttachments) {
+                    if (OBSERVABLE_ANNOTATION.equals(annot.packageID.orgName.value + "/"
+                            + annot.packageID.name.value + "/" + annot.annotTagRef.value)) {
+                        isObservableAnnotationPresent = true;
+                        break;
+                    }
+                }
+                if (isRemote || isObservableAnnotationPresent) {
+                    DiagnosticPos desugaredInsPosition = callIns.pos;
+                    String action;
+                    if (callIns.name.value.contains(".")) {
+                        String[] split = callIns.name.value.split("\\.");
+                        action = split[1];
+                    } else {
+                        action = callIns.name.value;
+                    }
+                    String connectorName;
+                    if (callIns.isVirtual) {
+                        BIRNode.BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
+                        connectorName = getPackageName(selfArg.type.tsymbol.pkgID.orgName,
+                                selfArg.type.tsymbol.pkgID.name) + selfArg.type.tsymbol.name.value;
+                    } else {
+                        connectorName = "";
+                    }
+
+                    boolean isErrorCheckRequired = false;
+                    if (callIns.lhsOp.variableDcl.type instanceof BUnionType) {
+                        BUnionType returnUnionType = (BUnionType) callIns.lhsOp.variableDcl.type;
+                        isErrorCheckRequired = returnUnionType.getMemberTypes().stream()
+                                .anyMatch(type -> type instanceof BErrorType);
+                    } else if (callIns.lhsOp.variableDcl.type instanceof BErrorType) {
+                        isErrorCheckRequired = true;
+                    }
+
+                    BIRNode.BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(basicBlocks, i + 1, "desugaredBB");
+                    BIRNode.BIRBasicBlock errorCheckBranchBB = null;
+                    BIRNode.BIRBasicBlock errorReportBB = null;
+                    if (isErrorCheckRequired) {
+                        errorCheckBranchBB = insertAndGetNextBasicBlock(basicBlocks, i + 2, "desugaredBB");
+                        errorReportBB = insertAndGetNextBasicBlock(basicBlocks, i + 3, "desugaredBB");
+                    }
+                    BIRNode.BIRBasicBlock observeEndBB = insertAndGetNextBasicBlock(basicBlocks,
+                            i + (isErrorCheckRequired ? 4 : 2), "desugaredBB");
+
+                    newCurrentBB.instructions = currentBB.instructions;
+                    newCurrentBB.terminator = currentBB.terminator;
+                    currentBB.instructions = new ArrayList<>(0);
+                    currentBB.terminator = null;
+
+                    {
+                        BIROperand connectorNameOperand = generateConstantOperand(
+                                String.format("%s_connector", currentBB.id.value), connectorName, scopeVarList,
+                                currentBB, desugaredInsPosition);
+                        BIROperand actionNameOperand = generateConstantOperand(
+                                String.format("%s_action", currentBB.id.value), action, scopeVarList, currentBB,
+                                desugaredInsPosition);
+                        Map<String, String> tags = new HashMap<>();
+                        tags.put("source.invocation_fqn", String.format("%s:%s:%s:%s:%d:%d", pkg.org.value,
+                                pkg.name.value, pkg.version.value, callIns.pos.src.cUnitName, callIns.pos.sLine,
+                                callIns.pos.sCol));
+                        if (isRemote) {
+                            tags.put("source.remote", "true");
+                        }
+                        BIROperand tagsMapOperand = generateMapOperand(String.format("%s_tags", currentBB.id.value),
+                                tags, scopeVarList, currentBB, desugaredInsPosition);
+
+                        InteropMethodGen.JIMethodCall observeStartCallTerminator = new InteropMethodGen.JIMethodCall(desugaredInsPosition);
+                        observeStartCallTerminator.invocationType = INVOKESTATIC;
+                        observeStartCallTerminator.jClassName = OBSERVE_UTILS;
+                        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;L%s;L%s;)V", STRING_VALUE,
+                                STRING_VALUE, MAP_VALUE);
+                        observeStartCallTerminator.name = "startCallableObservation";
+                        observeStartCallTerminator.args = Arrays.asList(connectorNameOperand, actionNameOperand,
+                                tagsMapOperand);
+                        currentBB.terminator = observeStartCallTerminator;
+                    }
+
+                    if (isErrorCheckRequired) {
+                        BIRNode.BIRVariableDcl isErrorVariableDcl = new BIRNode.BIRVariableDcl(symbolTable.booleanType,
+                                new Name(String.format("$_%s_is_error_$", errorCheckBranchBB.id.value)),
+                                VarScope.FUNCTION, VarKind.TEMP);
+                        scopeVarList.add(isErrorVariableDcl);
+                        BIROperand isErrorOperand = new BIROperand(isErrorVariableDcl);
+                        BIRNonTerminator.TypeTest errorTypeTestInstruction = new BIRNonTerminator.TypeTest(desugaredInsPosition, symbolTable.errorType,
+                                isErrorOperand, callIns.lhsOp);
+                        errorCheckBranchBB.instructions.add(errorTypeTestInstruction);
+                        errorCheckBranchBB.terminator = new BIRTerminator.Branch(desugaredInsPosition, isErrorOperand, errorReportBB,
+                                observeEndBB);
+
+                        BIRNode.BIRVariableDcl castedErrorVariableDcl = new BIRNode.BIRVariableDcl(symbolTable.errorType,
+                                new Name(String.format("$_%s_casted_error_$", errorReportBB.id.value)),
+                                VarScope.FUNCTION, VarKind.TEMP);
+                        scopeVarList.add(castedErrorVariableDcl);
+                        BIROperand castedErrorOperand = new BIROperand(castedErrorVariableDcl);
+                        BIRNonTerminator.TypeCast errorCastInstruction = new BIRNonTerminator.TypeCast(desugaredInsPosition, castedErrorOperand,
+                                callIns.lhsOp, symbolTable.errorType, false);
+                        errorReportBB.instructions.add(errorCastInstruction);
+
+                        InteropMethodGen.JIMethodCall reportErrorCallTerminator = new InteropMethodGen.JIMethodCall(desugaredInsPosition);
+                        reportErrorCallTerminator.invocationType = INVOKESTATIC;
+                        reportErrorCallTerminator.jClassName = OBSERVE_UTILS;
+                        reportErrorCallTerminator.jMethodVMSig = String.format("(L%s;)V", ERROR_VALUE);
+                        reportErrorCallTerminator.name = "reportError";
+                        reportErrorCallTerminator.args = Collections.singletonList(castedErrorOperand);
+                        errorReportBB.terminator = reportErrorCallTerminator;
+                    }
+
+                    InteropMethodGen.JIMethodCall observeEndCallTerminator = new InteropMethodGen.JIMethodCall(desugaredInsPosition);
+                    observeEndCallTerminator.invocationType = INVOKESTATIC;
+                    observeEndCallTerminator.jClassName = OBSERVE_UTILS;
+                    observeEndCallTerminator.jMethodVMSig = "()V";
+                    observeEndCallTerminator.name = "stopObservation";
+                    observeEndCallTerminator.args = Collections.emptyList();
+                    observeEndBB.terminator = observeEndCallTerminator;
+
+                    observeEndBB.terminator.thenBB = newCurrentBB.terminator.thenBB;
+                    if (isErrorCheckRequired) {
+                        errorReportBB.terminator.thenBB = observeEndBB;
+                        newCurrentBB.terminator.thenBB = errorCheckBranchBB;
+                    } else {
+                        newCurrentBB.terminator.thenBB = observeEndBB;
+                    }
+                    currentBB.terminator.thenBB = newCurrentBB; // Current BB now contains observe start call
+                    i += (isErrorCheckRequired ? 4 : 2);
+                }
+            }
+            i++;
+        }
+    }
+
+    public static BIROperand generateConstantOperand(String uniqueId, String constantValue,
+                                                     List<BIRNode.BIRVariableDcl> scopeVarList, BIRNode.BIRBasicBlock basicBlock,
+                                                     DiagnosticPos desugaredInsPosition) {
+        BIRNode.BIRVariableDcl variableDcl = new BIRNode.BIRVariableDcl(symbolTable.stringType,
+                new Name(String.format("$_%s_const_$", uniqueId)), VarScope.FUNCTION, VarKind.TEMP);
+        scopeVarList.add(variableDcl);
+        BIROperand operand = new BIROperand(variableDcl);
+        BIRNonTerminator.ConstantLoad instruction = new BIRNonTerminator.ConstantLoad(desugaredInsPosition, constantValue, symbolTable.stringType,
+                operand);
+        basicBlock.instructions.add(instruction);
+        return operand;
+    }
+
+    public static BIROperand generateMapOperand(String uniqueId, Map<String, String> map,
+                                                List<BIRNode.BIRVariableDcl> scopeVarList, BIRNode.BIRBasicBlock basicBlock,
+                                                DiagnosticPos desugaredInsPosition) {
+        BIRNode.BIRVariableDcl variableDcl = new BIRNode.BIRVariableDcl(symbolTable.mapType,
+                new Name(String.format("$_%s_map_$", uniqueId)), VarScope.FUNCTION, VarKind.TEMP);
+        scopeVarList.add(variableDcl);
+        BIROperand tagsMapOperand = new BIROperand(variableDcl);
+
+        BIRNonTerminator.NewStructure bMapNewInstruction = new BIRNonTerminator.NewStructure(desugaredInsPosition,
+                new BMapType(TypeTags.MAP, symbolTable.stringType, null), tagsMapOperand);
+        basicBlock.instructions.add(bMapNewInstruction);
+
+        int entryIndex = 0;
+        for (Map.Entry<String, String> tagEntry: map.entrySet()) {
+            BIROperand keyOperand = generateConstantOperand(String.format("%s_map_%d_key", uniqueId, entryIndex),
+                    tagEntry.getKey(), scopeVarList, basicBlock, desugaredInsPosition);
+            BIROperand valueOperand = generateConstantOperand(String.format("%s_map_%d_value", uniqueId,
+                    entryIndex), tagEntry.getValue(), scopeVarList, basicBlock, desugaredInsPosition);
+            BIRNonTerminator.FieldAccess fieldAccessIns = new BIRNonTerminator.FieldAccess(desugaredInsPosition,
+                    InstructionKind.MAP_STORE, tagsMapOperand, keyOperand, valueOperand);
+            basicBlock.instructions.add(fieldAccessIns);
+            entryIndex++;
+        }
+        return tagsMapOperand;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -19,8 +19,13 @@ package org.wso2.ballerinalang.compiler.bir.codegen;
 
 import org.ballerinalang.model.elements.Flag;
 import org.objectweb.asm.MethodVisitor;
-import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.JIMethodCall;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationAttachment;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRPackage;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
@@ -29,6 +34,7 @@ import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -118,28 +124,82 @@ class JvmObservabilityGen {
         return moduleOrg + "/" + moduleName + "/" + funcName;
     }
 
-    public static void rewriteObservableFunctions(BIRNode.BIRPackage pkg) {
-        for (BIRNode.BIRFunction func : pkg.functions) {
+    public static void rewriteObservableFunctions(BIRPackage pkg) {
+        for (BIRFunction func : pkg.functions) {
             rewriteObservableFunctionInvocations(func.basicBlocks, func.localVars, pkg);
         }
-        for (BIRNode.BIRTypeDefinition typeDef : pkg.typeDefs) {
-            for (BIRNode.BIRFunction attachedFunc : typeDef.attachedFuncs) {
-                rewriteObservableFunctionInvocations(attachedFunc.basicBlocks, attachedFunc.localVars, pkg);
+        for (BIRTypeDefinition typeDef : pkg.typeDefs) {
+            boolean isService = typeDef.type instanceof BServiceType;
+            for (BIRFunction func : typeDef.attachedFuncs) {
+                if (isService && !func.name.value.startsWith("$")) {
+                    Map<String, String> tags = new HashMap<>();
+                    tags.put("source.service", "true");
+                    rewriteObservableFunctionBody(func, pkg, true, cleanUpServiceName(typeDef.name.value), tags);
+                }
+                rewriteObservableFunctionInvocations(func.basicBlocks, func.localVars, pkg);
             }
         }
     }
 
-    public static void rewriteObservableFunctionInvocations(List<BIRNode.BIRBasicBlock> basicBlocks,
-                                                            List<BIRNode.BIRVariableDcl> scopeVarList, BIRNode.BIRPackage pkg) {
+    private static void rewriteObservableFunctionBody(BIRFunction func, BIRPackage pkg, boolean isResourceObservation,
+                                                      String serviceName, Map<String, String> additionalTags) {
+        DiagnosticPos desugaredInsPosition = func.pos;
+        // Injecting observe start call at the start of the function
+        {
+            BIRBasicBlock startBB = func.basicBlocks.get(0);
+            BIRBasicBlock newStartBB = insertAndGetNextBasicBlock(func.basicBlocks, 1, "desugaredBB");
+            swapBasicBlockContent(startBB, newStartBB);
+
+            injectObserveStartCall(startBB, func.localVars, pkg, desugaredInsPosition, isResourceObservation,
+                    serviceName, func.name.value, additionalTags);
+            startBB.terminator.thenBB = newStartBB;
+        }
+        // Injecting error report call and observe end call at the start of the function
+        boolean isErrorCheckRequired = isErrorAssignable(func.returnVariable);
+        BIROperand returnValOperand = new BIROperand(func.returnVariable);
+        int i = 1;
+        while (i < func.basicBlocks.size()) {
+            BIRBasicBlock currentBB = func.basicBlocks.get(i);
+            BIRTerminator currentTerminator = currentBB.terminator;
+            if (currentTerminator.kind == InstructionKind.RETURN) {
+                if (isErrorCheckRequired) {
+                    BIRBasicBlock errorReportBB = insertAndGetNextBasicBlock(func.basicBlocks, i + 1, "desugaredBB");
+                    BIRBasicBlock observeEndBB = insertAndGetNextBasicBlock(func.basicBlocks, i + 2, "desugaredBB");
+                    BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(func.basicBlocks, i + 3, "desugaredBB");
+                    swapBasicBlockContent(currentBB, newCurrentBB);
+
+                    injectCheckAndReportErrorCalls(currentBB, errorReportBB, observeEndBB, func.localVars,
+                            desugaredInsPosition, returnValOperand);
+                    injectObserveEndCall(observeEndBB, desugaredInsPosition);
+
+                    observeEndBB.terminator.thenBB = newCurrentBB;
+                    errorReportBB.terminator.thenBB = observeEndBB;
+                    i += 3;
+                } else {
+                    BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(func.basicBlocks, i + 1, "desugaredBB");
+                    swapBasicBlockContent(currentBB, newCurrentBB);
+
+                    injectObserveEndCall(currentBB, desugaredInsPosition);
+
+                    currentBB.terminator.thenBB = newCurrentBB;
+                    i += 1;
+                }
+            }
+            i++;
+        }
+    }
+
+    private static void rewriteObservableFunctionInvocations(List<BIRBasicBlock> basicBlocks,
+                                                             List<BIRVariableDcl> scopeVarList, BIRPackage pkg) {
         int i = 0;
         while (i < basicBlocks.size()) {
-            BIRNode.BIRBasicBlock currentBB = basicBlocks.get(i);
+            BIRBasicBlock currentBB = basicBlocks.get(i);
             BIRTerminator currentTerminator = currentBB.terminator;
             if (currentTerminator.kind == InstructionKind.CALL) {
                 BIRTerminator.Call callIns = (BIRTerminator.Call) currentTerminator;
                 boolean isRemote = callIns.calleeFlags.contains(Flag.REMOTE);
                 boolean isObservableAnnotationPresent = false;
-                for (BIRNode.BIRAnnotationAttachment annot : callIns.calleeAnnotAttachments) {
+                for (BIRAnnotationAttachment annot : callIns.calleeAnnotAttachments) {
                     if (OBSERVABLE_ANNOTATION.equals(annot.packageID.orgName.value + "/"
                             + annot.packageID.name.value + "/" + annot.annotTagRef.value)) {
                         isObservableAnnotationPresent = true;
@@ -148,6 +208,10 @@ class JvmObservabilityGen {
                 }
                 if (isRemote || isObservableAnnotationPresent) {
                     DiagnosticPos desugaredInsPosition = callIns.pos;
+                    Map<String, String> tags = new HashMap<>();
+                    if (isRemote) {
+                        tags.put("source.remote", "true");
+                    }
                     String action;
                     if (callIns.name.value.contains(".")) {
                         String[] split = callIns.name.value.split("\\.");
@@ -157,154 +221,178 @@ class JvmObservabilityGen {
                     }
                     String connectorName;
                     if (callIns.isVirtual) {
-                        BIRNode.BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
+                        BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
                         connectorName = getPackageName(selfArg.type.tsymbol.pkgID.orgName,
                                 selfArg.type.tsymbol.pkgID.name) + selfArg.type.tsymbol.name.value;
                     } else {
                         connectorName = "";
                     }
-
-                    boolean isErrorCheckRequired = false;
-                    if (callIns.lhsOp.variableDcl.type instanceof BUnionType) {
-                        BUnionType returnUnionType = (BUnionType) callIns.lhsOp.variableDcl.type;
-                        isErrorCheckRequired = returnUnionType.getMemberTypes().stream()
-                                .anyMatch(type -> type instanceof BErrorType);
-                    } else if (callIns.lhsOp.variableDcl.type instanceof BErrorType) {
-                        isErrorCheckRequired = true;
-                    }
-
-                    BIRNode.BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(basicBlocks, i + 1, "desugaredBB");
-                    BIRNode.BIRBasicBlock errorCheckBranchBB = null;
-                    BIRNode.BIRBasicBlock errorReportBB = null;
-                    if (isErrorCheckRequired) {
-                        errorCheckBranchBB = insertAndGetNextBasicBlock(basicBlocks, i + 2, "desugaredBB");
-                        errorReportBB = insertAndGetNextBasicBlock(basicBlocks, i + 3, "desugaredBB");
-                    }
-                    BIRNode.BIRBasicBlock observeEndBB = insertAndGetNextBasicBlock(basicBlocks,
-                            i + (isErrorCheckRequired ? 4 : 2), "desugaredBB");
-
-                    newCurrentBB.instructions = currentBB.instructions;
-                    newCurrentBB.terminator = currentBB.terminator;
-                    currentBB.instructions = new ArrayList<>(0);
-                    currentBB.terminator = null;
-
-                    {
-                        BIROperand connectorNameOperand = generateConstantOperand(
-                                String.format("%s_connector", currentBB.id.value), connectorName, scopeVarList,
-                                currentBB, desugaredInsPosition);
-                        BIROperand actionNameOperand = generateConstantOperand(
-                                String.format("%s_action", currentBB.id.value), action, scopeVarList, currentBB,
-                                desugaredInsPosition);
-                        Map<String, String> tags = new HashMap<>();
-                        tags.put("source.invocation_fqn", String.format("%s:%s:%s:%s:%d:%d", pkg.org.value,
-                                pkg.name.value, pkg.version.value, callIns.pos.src.cUnitName, callIns.pos.sLine,
-                                callIns.pos.sCol));
-                        if (isRemote) {
-                            tags.put("source.remote", "true");
-                        }
-                        BIROperand tagsMapOperand = generateMapOperand(String.format("%s_tags", currentBB.id.value),
-                                tags, scopeVarList, currentBB, desugaredInsPosition);
-
-                        InteropMethodGen.JIMethodCall observeStartCallTerminator = new InteropMethodGen.JIMethodCall(desugaredInsPosition);
-                        observeStartCallTerminator.invocationType = INVOKESTATIC;
-                        observeStartCallTerminator.jClassName = OBSERVE_UTILS;
-                        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;L%s;L%s;)V", STRING_VALUE,
-                                STRING_VALUE, MAP_VALUE);
-                        observeStartCallTerminator.name = "startCallableObservation";
-                        observeStartCallTerminator.args = Arrays.asList(connectorNameOperand, actionNameOperand,
-                                tagsMapOperand);
-                        currentBB.terminator = observeStartCallTerminator;
-                    }
+                    boolean isErrorCheckRequired = isErrorAssignable(callIns.lhsOp.variableDcl);
 
                     if (isErrorCheckRequired) {
-                        BIRNode.BIRVariableDcl isErrorVariableDcl = new BIRNode.BIRVariableDcl(symbolTable.booleanType,
-                                new Name(String.format("$_%s_is_error_$", errorCheckBranchBB.id.value)),
-                                VarScope.FUNCTION, VarKind.TEMP);
-                        scopeVarList.add(isErrorVariableDcl);
-                        BIROperand isErrorOperand = new BIROperand(isErrorVariableDcl);
-                        BIRNonTerminator.TypeTest errorTypeTestInstruction = new BIRNonTerminator.TypeTest(desugaredInsPosition, symbolTable.errorType,
-                                isErrorOperand, callIns.lhsOp);
-                        errorCheckBranchBB.instructions.add(errorTypeTestInstruction);
-                        errorCheckBranchBB.terminator = new BIRTerminator.Branch(desugaredInsPosition, isErrorOperand, errorReportBB,
-                                observeEndBB);
+                        BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(basicBlocks, i + 1, "desugaredBB");
+                        BIRBasicBlock errorCheckBranchBB = insertAndGetNextBasicBlock(basicBlocks, i + 2, "desugaredBB");
+                        BIRBasicBlock errorReportBB = insertAndGetNextBasicBlock(basicBlocks, i + 3, "desugaredBB");
+                        BIRBasicBlock observeEndBB = insertAndGetNextBasicBlock(basicBlocks, i + 4, "desugaredBB");
+                        swapBasicBlockContent(currentBB, newCurrentBB);
 
-                        BIRNode.BIRVariableDcl castedErrorVariableDcl = new BIRNode.BIRVariableDcl(symbolTable.errorType,
-                                new Name(String.format("$_%s_casted_error_$", errorReportBB.id.value)),
-                                VarScope.FUNCTION, VarKind.TEMP);
-                        scopeVarList.add(castedErrorVariableDcl);
-                        BIROperand castedErrorOperand = new BIROperand(castedErrorVariableDcl);
-                        BIRNonTerminator.TypeCast errorCastInstruction = new BIRNonTerminator.TypeCast(desugaredInsPosition, castedErrorOperand,
-                                callIns.lhsOp, symbolTable.errorType, false);
-                        errorReportBB.instructions.add(errorCastInstruction);
+                        injectObserveStartCall(currentBB, scopeVarList, pkg, desugaredInsPosition, false, connectorName,
+                                action, tags);
+                        injectCheckAndReportErrorCalls(errorCheckBranchBB, errorReportBB, observeEndBB, scopeVarList,
+                                desugaredInsPosition, callIns.lhsOp);
+                        injectObserveEndCall(observeEndBB, desugaredInsPosition);
 
-                        InteropMethodGen.JIMethodCall reportErrorCallTerminator = new InteropMethodGen.JIMethodCall(desugaredInsPosition);
-                        reportErrorCallTerminator.invocationType = INVOKESTATIC;
-                        reportErrorCallTerminator.jClassName = OBSERVE_UTILS;
-                        reportErrorCallTerminator.jMethodVMSig = String.format("(L%s;)V", ERROR_VALUE);
-                        reportErrorCallTerminator.name = "reportError";
-                        reportErrorCallTerminator.args = Collections.singletonList(castedErrorOperand);
-                        errorReportBB.terminator = reportErrorCallTerminator;
-                    }
-
-                    InteropMethodGen.JIMethodCall observeEndCallTerminator = new InteropMethodGen.JIMethodCall(desugaredInsPosition);
-                    observeEndCallTerminator.invocationType = INVOKESTATIC;
-                    observeEndCallTerminator.jClassName = OBSERVE_UTILS;
-                    observeEndCallTerminator.jMethodVMSig = "()V";
-                    observeEndCallTerminator.name = "stopObservation";
-                    observeEndCallTerminator.args = Collections.emptyList();
-                    observeEndBB.terminator = observeEndCallTerminator;
-
-                    observeEndBB.terminator.thenBB = newCurrentBB.terminator.thenBB;
-                    if (isErrorCheckRequired) {
+                        observeEndBB.terminator.thenBB = newCurrentBB.terminator.thenBB;
                         errorReportBB.terminator.thenBB = observeEndBB;
                         newCurrentBB.terminator.thenBB = errorCheckBranchBB;
+                        currentBB.terminator.thenBB = newCurrentBB; // Current BB now contains observe start call
+                        i += 4;
                     } else {
+                        BIRBasicBlock newCurrentBB = insertAndGetNextBasicBlock(basicBlocks, i + 1, "desugaredBB");
+                        BIRBasicBlock observeEndBB = insertAndGetNextBasicBlock(basicBlocks, i + 2, "desugaredBB");
+                        swapBasicBlockContent(currentBB, newCurrentBB);
+
+                        injectObserveStartCall(currentBB, scopeVarList, pkg, desugaredInsPosition, false, connectorName,
+                                action, tags);
+                        injectObserveEndCall(observeEndBB, desugaredInsPosition);
+
+                        observeEndBB.terminator.thenBB = newCurrentBB.terminator.thenBB;
                         newCurrentBB.terminator.thenBB = observeEndBB;
+                        currentBB.terminator.thenBB = newCurrentBB; // Current BB now contains observe start call
+                        i += 2;
                     }
-                    currentBB.terminator.thenBB = newCurrentBB; // Current BB now contains observe start call
-                    i += (isErrorCheckRequired ? 4 : 2);
                 }
             }
             i++;
         }
     }
 
-    public static BIROperand generateConstantOperand(String uniqueId, String constantValue,
-                                                     List<BIRNode.BIRVariableDcl> scopeVarList, BIRNode.BIRBasicBlock basicBlock,
-                                                     DiagnosticPos desugaredInsPosition) {
-        BIRNode.BIRVariableDcl variableDcl = new BIRNode.BIRVariableDcl(symbolTable.stringType,
+    private static void injectObserveStartCall(BIRBasicBlock observeStartBB, List<BIRVariableDcl> scopeVarList,
+                                               BIRPackage pkg, DiagnosticPos pos, boolean isResourceObservation,
+                                               String serviceOrConnector, String resourceOrAction,
+                                               Map<String, String> additionalTags) {
+        BIROperand connectorNameOperand = generateConstantOperand(
+                String.format("%s_service_or_connector", observeStartBB.id.value), serviceOrConnector, scopeVarList,
+                observeStartBB, pos);
+        BIROperand actionNameOperand = generateConstantOperand( String.format("%s_resource_or_action",
+                observeStartBB.id.value), resourceOrAction, scopeVarList, observeStartBB, pos);
+        Map<String, String> tags = new HashMap<>();
+        tags.put("source.invocation_fqn", String.format("%s:%s:%s:%s:%d:%d", pkg.org.value, pkg.name.value,
+                pkg.version.value, pos.src.cUnitName, pos.sLine, pos.sCol));
+        tags.putAll(additionalTags);
+        BIROperand tagsMapOperand = generateMapOperand(String.format("%s_tags", observeStartBB.id.value), tags,
+                scopeVarList, observeStartBB, pos);
+
+        JIMethodCall observeStartCallTerminator = new JIMethodCall(pos);
+        observeStartCallTerminator.invocationType = INVOKESTATIC;
+        observeStartCallTerminator.jClassName = OBSERVE_UTILS;
+        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;L%s;L%s;)V", STRING_VALUE, STRING_VALUE,
+                MAP_VALUE);
+        observeStartCallTerminator.name = isResourceObservation
+                ? "startResourceObservation" : "startCallableObservation";
+        observeStartCallTerminator.args = Arrays.asList(connectorNameOperand, actionNameOperand, tagsMapOperand);
+        observeStartBB.terminator = observeStartCallTerminator;
+    }
+
+    private static void injectCheckAndReportErrorCalls(BIRBasicBlock errorCheckBranchBB, BIRBasicBlock errorReportBB,
+                                                       BIRBasicBlock observeEndBB, List<BIRVariableDcl> scopeVarList,
+                                                       DiagnosticPos pos, BIROperand returnValueOperand) {
+        BIRVariableDcl isErrorVariableDcl = new BIRVariableDcl(symbolTable.booleanType,
+                new Name(String.format("$_%s_is_error_$", errorCheckBranchBB.id.value)), VarScope.FUNCTION,
+                VarKind.TEMP);
+        scopeVarList.add(isErrorVariableDcl);
+        BIROperand isErrorOperand = new BIROperand(isErrorVariableDcl);
+        BIRNonTerminator.TypeTest errorTypeTestInstruction = new BIRNonTerminator.TypeTest(pos, symbolTable.errorType,
+                isErrorOperand, returnValueOperand);
+        errorCheckBranchBB.instructions.add(errorTypeTestInstruction);
+        errorCheckBranchBB.terminator = new BIRTerminator.Branch(pos, isErrorOperand, errorReportBB, observeEndBB);
+
+        BIRVariableDcl castedErrorVariableDcl = new BIRVariableDcl(symbolTable.errorType,
+                new Name(String.format("$_%s_casted_error_$", errorReportBB.id.value)), VarScope.FUNCTION,
+                VarKind.TEMP);
+        scopeVarList.add(castedErrorVariableDcl);
+        BIROperand castedErrorOperand = new BIROperand(castedErrorVariableDcl);
+        BIRNonTerminator.TypeCast errorCastInstruction = new BIRNonTerminator.TypeCast(pos, castedErrorOperand, returnValueOperand, symbolTable.errorType,
+                false);
+        errorReportBB.instructions.add(errorCastInstruction);
+
+        JIMethodCall reportErrorCallTerminator = new JIMethodCall(pos);
+        reportErrorCallTerminator.invocationType = INVOKESTATIC;
+        reportErrorCallTerminator.jClassName = OBSERVE_UTILS;
+        reportErrorCallTerminator.jMethodVMSig = String.format("(L%s;)V", ERROR_VALUE);
+        reportErrorCallTerminator.name = "reportError";
+        reportErrorCallTerminator.args = Collections.singletonList(castedErrorOperand);
+        errorReportBB.terminator = reportErrorCallTerminator;
+    }
+
+    private static void injectObserveEndCall(BIRBasicBlock observeEndBB, DiagnosticPos pos) {
+        JIMethodCall observeEndCallTerminator = new JIMethodCall(pos);
+        observeEndCallTerminator.invocationType = INVOKESTATIC;
+        observeEndCallTerminator.jClassName = OBSERVE_UTILS;
+        observeEndCallTerminator.jMethodVMSig = "()V";
+        observeEndCallTerminator.name = "stopObservation";
+        observeEndCallTerminator.args = Collections.emptyList();
+        observeEndBB.terminator = observeEndCallTerminator;
+    }
+
+    private static BIROperand generateConstantOperand(String uniqueId, String constantValue,
+                                                      List<BIRVariableDcl> scopeVarList, BIRBasicBlock basicBlock,
+                                                      DiagnosticPos pos) {
+        BIRVariableDcl variableDcl = new BIRVariableDcl(symbolTable.stringType,
                 new Name(String.format("$_%s_const_$", uniqueId)), VarScope.FUNCTION, VarKind.TEMP);
         scopeVarList.add(variableDcl);
         BIROperand operand = new BIROperand(variableDcl);
-        BIRNonTerminator.ConstantLoad instruction = new BIRNonTerminator.ConstantLoad(desugaredInsPosition, constantValue, symbolTable.stringType,
+        BIRNonTerminator.ConstantLoad instruction = new BIRNonTerminator.ConstantLoad(pos, constantValue, symbolTable.stringType,
                 operand);
         basicBlock.instructions.add(instruction);
         return operand;
     }
 
-    public static BIROperand generateMapOperand(String uniqueId, Map<String, String> map,
-                                                List<BIRNode.BIRVariableDcl> scopeVarList, BIRNode.BIRBasicBlock basicBlock,
-                                                DiagnosticPos desugaredInsPosition) {
-        BIRNode.BIRVariableDcl variableDcl = new BIRNode.BIRVariableDcl(symbolTable.mapType,
+    private static BIROperand generateMapOperand(String uniqueId, Map<String, String> map,
+                                                 List<BIRVariableDcl> scopeVarList, BIRBasicBlock basicBlock,
+                                                 DiagnosticPos pos) {
+        BIRVariableDcl variableDcl = new BIRVariableDcl(symbolTable.mapType,
                 new Name(String.format("$_%s_map_$", uniqueId)), VarScope.FUNCTION, VarKind.TEMP);
         scopeVarList.add(variableDcl);
         BIROperand tagsMapOperand = new BIROperand(variableDcl);
 
-        BIRNonTerminator.NewStructure bMapNewInstruction = new BIRNonTerminator.NewStructure(desugaredInsPosition,
+        BIRNonTerminator.NewStructure bMapNewInstruction = new BIRNonTerminator.NewStructure(pos,
                 new BMapType(TypeTags.MAP, symbolTable.stringType, null), tagsMapOperand);
         basicBlock.instructions.add(bMapNewInstruction);
 
         int entryIndex = 0;
         for (Map.Entry<String, String> tagEntry: map.entrySet()) {
             BIROperand keyOperand = generateConstantOperand(String.format("%s_map_%d_key", uniqueId, entryIndex),
-                    tagEntry.getKey(), scopeVarList, basicBlock, desugaredInsPosition);
+                    tagEntry.getKey(), scopeVarList, basicBlock, pos);
             BIROperand valueOperand = generateConstantOperand(String.format("%s_map_%d_value", uniqueId,
-                    entryIndex), tagEntry.getValue(), scopeVarList, basicBlock, desugaredInsPosition);
-            BIRNonTerminator.FieldAccess fieldAccessIns = new BIRNonTerminator.FieldAccess(desugaredInsPosition,
+                    entryIndex), tagEntry.getValue(), scopeVarList, basicBlock, pos);
+            BIRNonTerminator.FieldAccess fieldAccessIns = new BIRNonTerminator.FieldAccess(pos,
                     InstructionKind.MAP_STORE, tagsMapOperand, keyOperand, valueOperand);
             basicBlock.instructions.add(fieldAccessIns);
             entryIndex++;
         }
         return tagsMapOperand;
+    }
+
+    private static void swapBasicBlockContent(BIRBasicBlock firstBB, BIRBasicBlock secondBB) {
+        List<BIRNonTerminator> firstBBInstructions = firstBB.instructions;
+        firstBB.instructions = secondBB.instructions;
+        secondBB.instructions = firstBBInstructions;
+
+        BIRTerminator firstBBTerminator = firstBB.terminator;
+        firstBB.terminator = secondBB.terminator;
+        secondBB.terminator = firstBBTerminator;
+    }
+
+    private static boolean isErrorAssignable(BIRVariableDcl variableDcl) {
+        boolean isErrorAssignable = false;
+        if (variableDcl.type instanceof BUnionType) {
+            BUnionType returnUnionType = (BUnionType) variableDcl.type;
+            isErrorAssignable = returnUnionType.getMemberTypes().stream()
+                    .anyMatch(type -> type instanceof BErrorType);
+        } else if (variableDcl.type instanceof BErrorType) {
+            isErrorAssignable = true;
+        }
+        return isErrorAssignable;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -39,6 +39,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -134,6 +135,10 @@ class JvmObservabilityGen {
             if ("main".equals(func.name.value)) {
                 Map<String, String> tags = new HashMap<>();
                 tags.put("source.entry_point.main", "true");
+                rewriteObservableFunctionBody(func, pkg, false, func.workerName.value, tags);
+            } else if ((func.flags & Flags.WORKER) == Flags.WORKER) {
+                Map<String, String> tags = new HashMap<>();
+                tags.put("worker", func.workerName.value);
                 rewriteObservableFunctionBody(func, pkg, false, func.workerName.value, tags);
             }
             rewriteObservableFunctionInvocations(func.basicBlocks, func.localVars, pkg);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -276,7 +276,7 @@ public class JvmPackageGen {
         // Desugar the record init function
         rewriteRecordInits(module.typeDefs);
 
-        // Desugar Call Terminators to include Observe start and end calls surrounding them
+        // Desugar BIR to include the observations
         rewriteObservableFunctions(module);
 
         // generate object/record value classes
@@ -326,8 +326,7 @@ public class JvmPackageGen {
             cw.visitSource(v.sourceFileName, null);
             // generate methods
             for (BIRFunction func : v.functions) {
-                String workerName = getFunction(func).workerName == null ? null : func.workerName.value;
-                generateMethod(getFunction(func), cw, module, null, workerName);
+                generateMethod(getFunction(func), cw, module, null);
             }
             // generate lambdas created during generating methods
             for (Map.Entry<String, BIRInstruction> l : lambdas.entrySet()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -85,7 +85,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_ST
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CREATOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.addDefaultableBooleanVarsToSignature;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.rewriteObservableFunctionInvocations;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.rewriteRecordInits;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.isBString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.addInitAndTypeInitInstructions;
@@ -108,6 +107,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMainFu
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMethodDesc;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getTypeDef;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.isExternFunc;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmObservabilityGen.rewriteObservableFunctions;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.TerminatorGenerator.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.generateCreateTypesMethod;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.generateUserDefinedTypeFields;
@@ -277,7 +277,7 @@ public class JvmPackageGen {
         rewriteRecordInits(module.typeDefs);
 
         // Desugar Call Terminators to include Observe start and end calls surrounding them
-        rewriteObservableFunctionInvocations(module);
+        rewriteObservableFunctions(module);
 
         // generate object/record value classes
         ObjectGenerator objGen = new ObjectGenerator(module);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -327,7 +327,7 @@ public class JvmPackageGen {
             // generate methods
             for (BIRFunction func : v.functions) {
                 String workerName = getFunction(func).workerName == null ? null : func.workerName.value;
-                generateMethod(getFunction(func), cw, module, null, false, workerName);
+                generateMethod(getFunction(func), cw, module, null, workerName);
             }
             // generate lambdas created during generating methods
             for (Map.Entry<String, BIRInstruction> l : lambdas.entrySet()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -133,7 +133,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMethod
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getVariableDcl;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.isExternFunc;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.loadDefaultValue;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmObservabilityGen.emitStopObservationInvocation;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.BIRFunctionWrapper;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.birFunctionMap;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.currentClass;
@@ -275,8 +274,7 @@ public class JvmTerminatorGen {
         }
 
         void genTerminator(BIRTerminator terminator, BIRFunction func, String funcName,
-                           int localVarOffset, int returnVarRefIndex, @Nilable BType attachedType,
-                           boolean isObserved /* = false */) {
+                           int localVarOffset, int returnVarRefIndex, @Nilable BType attachedType) {
 
             switch (terminator.kind) {
                 case LOCK:
@@ -298,8 +296,7 @@ public class JvmTerminatorGen {
                     this.genBranchTerm((BIRTerminator.Branch) terminator, funcName);
                     return;
                 case RETURN:
-                    this.genReturnTerm((BIRTerminator.Return) terminator, returnVarRefIndex, func, isObserved,
-                            localVarOffset);
+                    this.genReturnTerm((BIRTerminator.Return) terminator, returnVarRefIndex, func, localVarOffset);
                     return;
                 case PANIC:
                     this.errorGen.genPanic((BIRTerminator.Panic) terminator);
@@ -1181,11 +1178,8 @@ public class JvmTerminatorGen {
         }
 
         public void genReturnTerm(BIRTerminator.Return returnIns, int returnVarRefIndex, BIRFunction func,
-                                  boolean isObserved /* = false */, int localVarOffset /* = -1 */) {
+                                  int localVarOffset /* = -1 */) {
 
-            if (isObserved) {
-                emitStopObservationInvocation(this.mv);
-            }
             BType bType = func.type.retType;
             if (bType.tag == TypeTags.NIL) {
                 this.mv.visitVarInsn(ALOAD, returnVarRefIndex);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -299,14 +299,14 @@ class JvmValueGen {
             }
         }
 
-        private void createObjectMethods(ClassWriter cw, @Nilable List<BIRFunction> attachedFuncs, boolean isService,
+        private void createObjectMethods(ClassWriter cw, @Nilable List<BIRFunction> attachedFuncs,
                                          String className, String typeName) {
 
             for (BIRFunction func : attachedFuncs) {
                 if (func == null) {
                     continue;
                 }
-                generateMethod(func, cw, this.module, this.currentObjectType, isService, typeName);
+                generateMethod(func, cw, this.module, this.currentObjectType, typeName);
             }
         }
 
@@ -561,7 +561,7 @@ class JvmValueGen {
                 if (func == null) {
                     continue;
                 }
-                generateMethod(func, cw, this.module, null, false, "");
+                generateMethod(func, cw, this.module, null, "");
             }
         }
 
@@ -1196,7 +1196,7 @@ class JvmValueGen {
 
             @Nilable List<BIRFunction> attachedFuncs = typeDef.attachedFuncs;
             if (attachedFuncs != null) {
-                this.createObjectMethods(cw, attachedFuncs, isService, className, typeDef.name.value);
+                this.createObjectMethods(cw, attachedFuncs, className, typeDef.name.value);
             }
 
             this.createObjectInit(cw, fields, className);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -300,13 +300,13 @@ class JvmValueGen {
         }
 
         private void createObjectMethods(ClassWriter cw, @Nilable List<BIRFunction> attachedFuncs,
-                                         String className, String typeName) {
+                                         String className) {
 
             for (BIRFunction func : attachedFuncs) {
                 if (func == null) {
                     continue;
                 }
-                generateMethod(func, cw, this.module, this.currentObjectType, typeName);
+                generateMethod(func, cw, this.module, this.currentObjectType);
             }
         }
 
@@ -561,7 +561,7 @@ class JvmValueGen {
                 if (func == null) {
                     continue;
                 }
-                generateMethod(func, cw, this.module, null, "");
+                generateMethod(func, cw, this.module, null);
             }
         }
 
@@ -1196,7 +1196,7 @@ class JvmValueGen {
 
             @Nilable List<BIRFunction> attachedFuncs = typeDef.attachedFuncs;
             if (attachedFuncs != null) {
-                this.createObjectMethods(cw, attachedFuncs, className, typeDef.name.value);
+                this.createObjectMethods(cw, attachedFuncs, className);
             }
 
             this.createObjectInit(cw, fields, className);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
@@ -77,7 +77,7 @@ public class ExternalMethodGen {
         if (extFuncWrapper instanceof JFieldFunctionWrapper) {
             genJFieldForInteropField((JFieldFunctionWrapper) extFuncWrapper, cw, birModule);
         } else {
-            genJMethodForBFunc(birFunc, cw, birModule, "", attachedType);
+            genJMethodForBFunc(birFunc, cw, birModule, attachedType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
@@ -77,7 +77,7 @@ public class ExternalMethodGen {
         if (extFuncWrapper instanceof JFieldFunctionWrapper) {
             genJFieldForInteropField((JFieldFunctionWrapper) extFuncWrapper, cw, birModule);
         } else {
-            genJMethodForBFunc(birFunc, cw, birModule, false, "", attachedType);
+            genJMethodForBFunc(birFunc, cw, birModule, "", attachedType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -191,7 +191,7 @@ public class InteropMethodGen {
 
             @Nilable List<BIRBasicBlock> basicBlocks = birFunc.parameters.get(birFuncParam);
             generateBasicBlocks(mv, basicBlocks, labelGen, errorGen, instGen, termGen, birFunc, -1, -1,
-                    strandParamIndex, true, birModule, currentPackageName, null, false, false, null);
+                    strandParamIndex, true, birModule, currentPackageName, null, false, null);
             mv.visitLabel(paramNextLabel);
 
             birFuncParamIndex += 1;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -191,7 +191,7 @@ public class InteropMethodGen {
 
             @Nilable List<BIRBasicBlock> basicBlocks = birFunc.parameters.get(birFuncParam);
             generateBasicBlocks(mv, basicBlocks, labelGen, errorGen, instGen, termGen, birFunc, -1, -1,
-                    strandParamIndex, true, birModule, currentPackageName, null, false, null);
+                    strandParamIndex, true, birModule, currentPackageName, null);
             mv.visitLabel(paramNextLabel);
 
             birFuncParamIndex += 1;
@@ -281,7 +281,7 @@ public class InteropMethodGen {
         Label retLabel = labelGen.getLabel("return_lable");
         mv.visitLabel(retLabel);
         mv.visitLineNumber(birFunc.pos.sLine, retLabel);
-        termGen.genReturnTerm(new BIRTerminator.Return(birFunc.pos), returnVarRefIndex, birFunc, false, -1);
+        termGen.genReturnTerm(new BIRTerminator.Return(birFunc.pos), returnVarRefIndex, birFunc, -1);
         mv.visitMaxs(200, 400);
         mv.visitEnd();
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
@@ -121,9 +121,8 @@ public class MetricsTestCase extends BaseTest {
                 "service=\"metricsTest\",http_status_code_group=\"2xx\"," +
                 "source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:49:24\",source_remote=\"true\"," +
                 "action=\"respond\",resource=\"getProduct\",connector_name=\"ballerina/http/Caller\",}", regexNumber);
-        expectedMetrics.put("response_time_seconds_value{" +
-                "service=\"metricsTest\",connector_name=\"http\"," +
-                "source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:39:5\",source_service=\"true\"," +
+        expectedMetrics.put("response_time_seconds_value{service=\"metricsTest\",connector_name=\"http\"," +
+                "source_entry_point_resource=\"true\",source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:39:5\"," +
                 "protocol=\"http\",resource=\"getProduct\",http_url=\"/test\",http_method=\"GET\",}", regexNumber);
         expectedMetrics.put("response_time_seconds_value{" +
                 "service=\"metricsTest\",source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:43:24\"," +
@@ -138,9 +137,8 @@ public class MetricsTestCase extends BaseTest {
                 "service=\"metricsTest\",http_status_code_group=\"2xx\"," +
                 "source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:49:24\",source_remote=\"true\"," +
                 "action=\"respond\",resource=\"getProduct\",connector_name=\"ballerina/http/Caller\",}", regexNumber);
-        expectedMetrics.put("response_time_nanoseconds_total_value{" +
-                "service=\"metricsTest\",connector_name=\"http\"," +
-                "source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:39:5\",source_service=\"true\"," +
+        expectedMetrics.put("response_time_nanoseconds_total_value{service=\"metricsTest\",connector_name=\"http\"," +
+                "source_entry_point_resource=\"true\",source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:39:5\"," +
                 "protocol=\"http\",resource=\"getProduct\",http_url=\"/test\",http_method=\"GET\",}", regexNumber);
         expectedMetrics.put("response_time_nanoseconds_total_value{" +
                 "service=\"metricsTest\",source_invocation_fqn=\"_anon:.:0.0.0:metrics_test.bal:43:24\"," +


### PR DESCRIPTION
## Purpose
> Since all the newer Observability instrumentation had been added to the desugar phase, all the remaining logic from old implementation were also moved to the compiler back-end desugar phase.

## Approach
> The logic related to Observability were removed from the Byte-code generation phase. Additional logic to recognize and instrument functions related to service resources, main method and workers were added in the compiler back-end desugar phase. Moreover, since the Ballerina based Jvm Back-end will be removed in the future completely, changes done to it previously, were reverted as well.