### PR TITLE
Update xml langlib methods

### DIFF
--- a/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/xml-internal.bal
+++ b/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/xml-internal.bal
@@ -53,10 +53,3 @@ public function getAttribute(xml x, string attributeName, boolean isOptionalAcce
 # + x - The xml value
 # + return - Element name
 public function getElementNameNilLifting(xml x) returns string|error? = external;
-
-# lift getChildren over sequences
-# equivalent to elements(x).map(getChildren)
-#
-# + x - The xml value
-# + return - children of elements lifted over the sequence
-public function children(xml x) returns xml = external;

--- a/langlib/lang.xml/src/main/ballerina/src/lang.xml/xml.bal
+++ b/langlib/lang.xml/src/main/ballerina/src/lang.xml/xml.bal
@@ -183,11 +183,31 @@ public function slice(xml<ItemType> x, int startIndex, int endIndex = x.length()
 # + return - `x` with insignificant parts removed
 public function strip(xml x) returns xml = external;
 
-# Selects the elements from an xml value.
+# Selects elements from an xml value.
+# If `nm` is `()`, selects all elements;
+# otherwise, selects only elements whose expanded name is `nm`.
 #
 # + x - the xml value
-# + return - an xml sequence consisting of all the element items in `x`
-public function elements(xml x) returns xml<Element> = external;
+# + nm - the expanded name of the elements to be selected, or `()` for all elements
+# + return - an xml sequence consisting of all the element items in `x` whose expanded name is `nm`,
+#  or, if `nm` is `()`, all element items in `x`
+public function elements(xml x, string? nm = ()) returns xml<Element> = external;
+
+# Returns the children of elements in an xml value.
+# When `x` is of type Element, it is equivalent to `getChildren`.
+# + x - xml value
+# + return - xml sequence containing the children of each element x concatenated in order
+# This is equivalent to `elements(x).map(getChildren)`.
+public function children(xml x) returns xml = external;
+
+# Selects element children of an xml value
+# + x - the xml value
+# + nm - the expanded name of the elements to be selected, or `()` for all elements
+# + return - an xml sequence consisting of child elements of elements in `x`; if `nm`
+#  is `()`, returns a sequence of all such elements;
+#  otherwise, include only elements whose expanded name is `nm`
+# This is equivalent to `children(x).elements(nm)`.
+public function elementChildren(xml x, string? nm = ()) returns xml<Element> = external;
 
 // Functional programming methods
 

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Children.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Children.java
@@ -57,4 +57,8 @@ public class Children {
         }
         return new XMLSequence();
     }
+
+    public static XMLValue children_bstring(Strand strand, XMLValue xmlVal) {
+        return children(strand, xmlVal);
+    }
 }

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Elements.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Elements.java
@@ -46,8 +46,11 @@ public class Elements {
 
     private static final String OPERATION = "get elements from xml";
 
-    public static XMLValue elements(Strand strand, XMLValue xml) {
+    public static XMLValue elements(Strand strand, XMLValue xml, Object name) {
         try {
+            if (name instanceof  String) {
+                return (XMLValue) xml.elements((String) name);
+            }
             return (XMLValue) xml.elements();
         } catch (Throwable e) {
             BLangExceptionHelper.handleXMLException(OPERATION, e);
@@ -64,7 +67,7 @@ public class Elements {
         }
         return new XMLSequence(list);
     }
-    public static XMLValue elements_bstring(Strand strand, XMLValue xml) {
-        return elements(strand, xml);
+    public static XMLValue elements_bstring(Strand strand, XMLValue xml, Object name) {
+        return elements(strand, xml, name);
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -230,6 +230,21 @@ public class LangLibXMLTest {
     }
 
     @Test
+    public void testChildren() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testChildren");
+    }
+
+    @Test
+    public void testElements() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testElements");
+    }
+
+    @Test
+    public void testElementChildren() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testElementChildren");
+    }
+
+    @Test
     public void testNegativeCases() {
         int i = 0;
         validateError(negativeResult, i++, "incompatible types: expected 'xml:Element', found 'xml'", 21, 12);

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -240,8 +240,18 @@ public class LangLibXMLTest {
     }
 
     @Test
+    public void testElementsNS()  {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testElementsNS");
+    }
+
+    @Test
     public void testElementChildren() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testElementChildren");
+    }
+
+    @Test
+    public void testElementChildrenNS()  {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testElementChildrenNS");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -249,6 +249,25 @@ function testElements() {
     assert(z.toString(), "<RUS>Putin</RUS>");
 }
 
+function testElementsNS() {
+    xmlns "foo" as ns;
+    xml presidents = xml `<Leaders>
+                            <!-- This is a comment -->
+                            <ns:US>Obama</ns:US>
+                            <US>Trump</US>
+                            <RUS>Putin</RUS>
+                          </Leaders>`;
+    xml seq = presidents/*;
+
+    xml usNs = seq.elements("{foo}US");
+    assert(usNs.length(), 1);
+    assert(usNs.toString(), "<ns:US xmlns:ns=\"foo\">Obama</ns:US>");
+
+    xml usNoNs = seq.elements("US");
+    assert(usNoNs.length(), 1);
+    assert(usNoNs.toString(), "<US>Trump</US>");
+}
+
 function testElementChildren() {
     xml letter = xml `<note>
                         <to>Tove</to>
@@ -275,6 +294,26 @@ function testElementChildren() {
                          "<to>Tove</to><to>Irshad</to><from>Jani</from><body>Don't forget me this weekend!</body>");
     assert(z.length(), 4);
     assert(z.toString(), "<to>Tove</to><to>Irshad</to><to>Tove</to><to>Irshad</to>");
+}
+
+function testElementChildrenNS() {
+    xmlns "foo" as ns;
+    xml letter = xml `<note>
+                            <ns:to>Tove</ns:to>
+                            <to>Irshad</to>
+                            <!-- This is a comment -->
+                            <from>Jani</from>
+                            <body>Don't forget me this weekend!</body>
+                          </note>`;
+    xml seq = 'xml:concat(letter, letter);
+
+    xml toNs = seq.elementChildren("{foo}to");
+    assert(toNs.length(), 2);
+    assert(toNs.toString(), "<ns:to xmlns:ns=\"foo\">Tove</ns:to><ns:to xmlns:ns=\"foo\">Tove</ns:to>");
+
+    xml toNoNs = seq.elementChildren("to");
+    assert(toNoNs.length(), 2);
+    assert(toNoNs.toString(), "<to>Irshad</to><to>Irshad</to>");
 }
 
 function assert(anydata actual, anydata expected) {

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -217,3 +217,73 @@ function testGet() returns [xml|error, xml|error, xml|error, xml|error, xml|erro
 
     return [e1, e2, c1, item, item2];
 }
+
+function testChildren() {
+     xml brands = xml `<Brands><!-- Comment --><Apple>IPhone</Apple><Samsung>Galaxy</Samsung><OP>OP7</OP></Brands>`;
+
+     xml p = brands.children(); // equivalent to getChildren()
+     assert(p.length(), 4);
+     assert(p.toString(), "<!-- Comment --><Apple>IPhone</Apple><Samsung>Galaxy</Samsung><OP>OP7</OP>");
+
+     xml seq = brands/*;
+     xml q = seq.children();
+     assert(q.length(), 3);
+     assert(q.toString(), "IPhoneGalaxyOP7");
+}
+
+function testElements() {
+    xml presidents = xml `<Leaders>
+                            <!-- This is a comment -->
+                            <US>Obama</US>
+                            <US>Trump</US>
+                            <RUS>Putin</RUS>
+                          </Leaders>`;
+    xml seq = presidents/*;
+
+    xml y = seq.elements();
+    assert(y.length(), 3);
+    assert(y.toString(), "<US>Obama</US><US>Trump</US><RUS>Putin</RUS>");
+
+    xml z = seq.elements("RUS");
+    assert(z.length(), 1);
+    assert(z.toString(), "<RUS>Putin</RUS>");
+}
+
+function testElementChildren() {
+    xml letter = xml `<note>
+                        <to>Tove</to>
+                        <to>Irshad</to>
+                        <!-- This is a comment -->
+                        <from>Jani</from>
+                        <body>Don't forget me this weekend!</body>
+                      </note>`;
+
+    xml p = letter.elementChildren();
+    xml q = letter.elementChildren("to");
+
+    assert(p.length(), 4);
+    assert(p.toString(), "<to>Tove</to><to>Irshad</to><from>Jani</from><body>Don't forget me this weekend!</body>");
+    assert(q.length(), 2);
+    assert(q.toString(), "<to>Tove</to><to>Irshad</to>");
+
+    xml seq = 'xml:concat(letter, letter);
+    xml y = seq.elementChildren();
+    xml z = seq.elementChildren("to");
+
+    assert(y.length(), 8);
+    assert(y.toString(), "<to>Tove</to><to>Irshad</to><from>Jani</from><body>Don't forget me this weekend!</body>" +
+                         "<to>Tove</to><to>Irshad</to><from>Jani</from><body>Don't forget me this weekend!</body>");
+    assert(z.length(), 4);
+    assert(z.toString(), "<to>Tove</to><to>Irshad</to><to>Tove</to><to>Irshad</to>");
+}
+
+function assert(anydata actual, anydata expected) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}


### PR DESCRIPTION
## Purpose
$title
Modifies `elements()` method to support querying elements by name
Adds `elementChildren()` method
Adds `children()` method

Fixes #22509

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
