### PR TITLE
Add initial functional constructor impl

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BallerinaXMLSerializer.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BallerinaXMLSerializer.java
@@ -136,7 +136,10 @@ public class BallerinaXMLSerializer extends OutputStream {
     }
 
     private void writeXMLText(XMLText xmlValue) throws XMLStreamException {
-        xmlStreamWriter.writeCharacters(xmlValue.getTextValue());
+        String textValue = xmlValue.getTextValue();
+        if (!textValue.isEmpty()) {
+            xmlStreamWriter.writeCharacters(textValue);
+        }
     }
 
     private void writeElement(XMLItem xmlValue) throws XMLStreamException {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/XMLFactory.java
@@ -164,11 +164,11 @@ public class XMLFactory {
         // Add all the items in the first sequence
         if (firstSeq.getNodeType() == XMLNodeType.SEQUENCE) {
             concatenatedList.addAll(((XMLSequence) firstSeq).getChildrenList());
-        } else {
+        } else if (!firstSeq.isEmpty()) {
             concatenatedList.add(firstSeq);
         }
 
-        // When last item fo left seq and first item of right seq are both text nodes merge them into single consecutive
+        // When last item of left seq and first item of right seq are both text nodes merge them into single consecutive
         // text node.
         if (!concatenatedList.isEmpty()) {
             int lastIndexOFLeftChildren = concatenatedList.size() - 1;
@@ -195,7 +195,7 @@ public class XMLFactory {
         // Add all the items in the second sequence
         if (secondSeq.getNodeType() == XMLNodeType.SEQUENCE) {
             concatenatedList.addAll(((XMLSequence) secondSeq).getChildrenList());
-        } else {
+        } else if (!secondSeq.isEmpty()) {
             concatenatedList.add(secondSeq);
         }
 

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/XMLSequence.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/XMLSequence.java
@@ -64,7 +64,9 @@ public final class XMLSequence extends XMLValue {
 
     public XMLSequence(BXML child) {
         this.children = new ArrayList<>();
-        this.children.add(child);
+        if (!child.isEmpty()) {
+            this.children.add(child);
+        }
     }
 
     public List<BXML> getChildrenList() {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/XMLText.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/XMLText.java
@@ -45,10 +45,7 @@ public class XMLText extends XMLNonElementItem {
 
     @Override
     public boolean isEmpty() {
-        if (getNodeType() == XMLNodeType.TEXT) {
-            return data.isEmpty();
-        }
-        return false;
+        return data.isEmpty();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
@@ -53,6 +53,7 @@ public enum SymbolKind {
     OTHER,
 
     ERROR_CONSTRUCTOR,
+    FUNCTIONAL_CONSTRUCTOR,
 
     INVOKABLE_TYPE
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -459,7 +459,7 @@ public class BIRPackageSymbolEnter {
     }
 
     private void defineErrorConstructor(Scope scope, BTypeSymbol typeDefSymbol) {
-        BConstructorSymbol symbol = new BConstructorSymbol(SymTag.CONSTRUCTOR, typeDefSymbol.flags, typeDefSymbol.name,
+        BConstructorSymbol symbol = new BConstructorSymbol(typeDefSymbol.flags, typeDefSymbol.name,
                 typeDefSymbol.pkgID, typeDefSymbol.type, typeDefSymbol.owner);
         symbol.kind = SymbolKind.ERROR_CONSTRUCTOR;
         symbol.scope = new Scope(symbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
@@ -152,6 +152,7 @@ public class CompilerDriver {
             symbolTable.langValueModuleSymbol = pkgLoader.loadPackageSymbol(VALUE, null, null);
             symbolTable.langXmlModuleSymbol = pkgLoader.loadPackageSymbol(XML, null, null);
             symbolTable.langBooleanModuleSymbol = pkgLoader.loadPackageSymbol(BOOLEAN, null, null);
+            symResolver.loadFunctionalConstructors();
             return;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -46,6 +46,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
@@ -3555,6 +3556,13 @@ public class Desugar extends BLangNodeVisitor {
 
         if (iExpr.symbol != null && iExpr.symbol.kind == SymbolKind.ERROR_CONSTRUCTOR) {
             result = rewriteErrorConstructor(iExpr);
+        } else if (iExpr.symbol.kind == SymbolKind.FUNCTIONAL_CONSTRUCTOR) {
+            String name = ((BConstructorSymbol) iExpr.symbol).name.value;
+
+            String internalMethodName = name.substring(0, 1).toLowerCase() + name.substring(1) + "Ctor";
+            BSymbol bSymbol = symResolver.lookupLangLibMethodInModule(
+                    symTable.langInternalModuleSymbol, names.fromString(internalMethodName));
+            iExpr.symbol = bSymbol;
         }
 
         if (!enclLocks.isEmpty()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -817,7 +817,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     private void defineErrorConstructorSymbol(DiagnosticPos pos, BTypeSymbol typeDefSymbol) {
         BErrorType errorType = (BErrorType) typeDefSymbol.type;
-        BConstructorSymbol symbol = new BConstructorSymbol(SymTag.CONSTRUCTOR, typeDefSymbol.flags, typeDefSymbol.name,
+        BConstructorSymbol symbol = new BConstructorSymbol(typeDefSymbol.flags, typeDefSymbol.name,
                 typeDefSymbol.pkgID, errorType, typeDefSymbol.owner);
         symbol.kind = SymbolKind.ERROR_CONSTRUCTOR;
         symbol.scope = new Scope(symbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1331,14 +1331,6 @@ public class SymbolResolver extends BLangNodeVisitor {
             return;
         }
 
-        ScopeEntry entry = xmlModuleSymbol.scope.lookup(names.fromString("Element"));
-        while (entry.symbol != null && entry.symbol != symTable.notFoundSymbol) {
-            if (entry.symbol.tag == SymTag.CONSTRUCTOR) {
-                return;
-            }
-            entry = entry.next;
-        }
-
         BConstructorSymbol elementCtor =
                 FunctionalConstructorBuilder.newConstructor("Element", xmlModuleSymbol, symTable.xmlElementType)
                     .addParam("name", symTable.stringType)

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope.ScopeEntry;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
@@ -78,6 +79,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.FunctionalConstructorBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -1321,5 +1323,49 @@ public class SymbolResolver extends BLangNodeVisitor {
                 && env.enclInvokable.symbol.receiverSymbol != null
                 && env.enclInvokable.symbol.receiverSymbol.type.tsymbol == symbol.owner
                 || isMemberAllowed(env.enclEnv, symbol));
+    }
+
+    public void loadFunctionalConstructors() {
+        BPackageSymbol xmlModuleSymbol = symTable.langXmlModuleSymbol;
+        if (xmlModuleSymbol == null) {
+            return;
+        }
+
+        ScopeEntry entry = xmlModuleSymbol.scope.lookup(names.fromString("Element"));
+        while (entry.symbol != null && entry.symbol != symTable.notFoundSymbol) {
+            if (entry.symbol.tag == SymTag.CONSTRUCTOR) {
+                return;
+            }
+            entry = entry.next;
+        }
+
+        BConstructorSymbol elementCtor =
+                FunctionalConstructorBuilder.newConstructor("Element", xmlModuleSymbol, symTable.xmlElementType)
+                    .addParam("name", symTable.stringType)
+                    .addDefaultableParam("attributes", symTable.mapStringType)
+                    .addDefaultableParam("children", symTable.xmlType)
+                    .build();
+        xmlModuleSymbol.scope.define(elementCtor.name, elementCtor);
+
+        BConstructorSymbol piCtor =
+                FunctionalConstructorBuilder.newConstructor("ProcessingInstruction",
+                        xmlModuleSymbol,
+                        symTable.xmlPIType)
+                    .addParam("target", symTable.stringType)
+                    .addDefaultableParam("content", symTable.stringType)
+                    .build();
+        xmlModuleSymbol.scope.define(piCtor.name, piCtor);
+
+        BConstructorSymbol commentCtor =
+                FunctionalConstructorBuilder.newConstructor("Comment", xmlModuleSymbol, symTable.xmlCommentType)
+                    .addDefaultableParam("comment", symTable.stringType)
+                    .build();
+        xmlModuleSymbol.scope.define(commentCtor.name, commentCtor);
+
+        BConstructorSymbol textCtor =
+                FunctionalConstructorBuilder.newConstructor("Text", xmlModuleSymbol, symTable.xmlTextType)
+                    .addDefaultableParam("characters", symTable.stringType)
+                    .build();
+        xmlModuleSymbol.scope.define(textCtor.name, textCtor);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -3464,7 +3464,8 @@ public class TypeChecker extends BLangNodeVisitor {
     }
 
     private boolean isNotFunction(BSymbol funcSymbol) {
-        if ((funcSymbol.tag & SymTag.FUNCTION) == SymTag.FUNCTION) {
+        if ((funcSymbol.tag & SymTag.FUNCTION) == SymTag.FUNCTION
+                || (funcSymbol.tag & SymTag.CONSTRUCTOR) == SymTag.CONSTRUCTOR) {
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConstructorSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BConstructorSymbol.java
@@ -27,13 +27,11 @@ import org.wso2.ballerinalang.compiler.util.Name;
  */
 public class BConstructorSymbol extends BInvokableSymbol implements ConstructorSymbol {
 
-    public BConstructorSymbol(int tag,
-                              int flags,
+    public BConstructorSymbol(int flags,
                               Name name,
                               PackageID pkgID,
                               BType type,
                               BSymbol owner) {
-        super(tag, flags, name, pkgID, type, owner);
-        this.tag = tag;
+        super(SymTag.CONSTRUCTOR, flags, name, pkgID, type, owner);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/FunctionalConstructorBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/FunctionalConstructorBuilder.java
@@ -72,7 +72,7 @@ public class FunctionalConstructorBuilder {
     }
 
     public BConstructorSymbol build() {
-        List<BType> paramTypes = new ArrayList<>();
+        List<BType> paramTypes = new ArrayList<>(params.size());
         for (BVarSymbol param : params) {
             paramTypes.add(param.type);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/FunctionalConstructorBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/FunctionalConstructorBuilder.java
@@ -1,0 +1,93 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.ballerinalang.compiler.util;
+
+
+import org.ballerinalang.model.symbols.SymbolKind;
+import org.wso2.ballerinalang.compiler.semantics.model.Scope;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.util.Flags;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Build functional constructor symbol.
+ *
+ * @since 1.3.0
+ */
+public class FunctionalConstructorBuilder {
+    private ArrayList<BVarSymbol> params;
+    private String name;
+    private BPackageSymbol langlibPkg;
+    private BType constructedType;
+
+    private FunctionalConstructorBuilder(String name, BPackageSymbol langlibPkg, BType constructedType) {
+        this.name = name;
+        this.langlibPkg = langlibPkg;
+        this.constructedType = constructedType;
+        this.params = new ArrayList<>();
+    }
+
+    public static FunctionalConstructorBuilder newConstructor(String name,
+                                                              BPackageSymbol langlibModule,
+                                                              BType constructedType) {
+        return new FunctionalConstructorBuilder(name, langlibModule, constructedType);
+    }
+
+    private FunctionalConstructorBuilder addParam(String name, BType type, boolean isDefaultable) {
+        BVarSymbol paramSymbol = new BVarSymbol(0, new Name(name), langlibPkg.pkgID, type, null);
+        paramSymbol.defaultableParam = isDefaultable;
+        params.add(paramSymbol);
+        return this;
+    }
+
+    public FunctionalConstructorBuilder addParam(String name, BType type) {
+        return addParam(name, type, false);
+    }
+
+    public FunctionalConstructorBuilder addDefaultableParam(String name, BType type) {
+        return addParam(name, type, true);
+    }
+
+    public BConstructorSymbol build() {
+        List<BType> paramTypes = new ArrayList<>();
+        for (BVarSymbol param : params) {
+            paramTypes.add(param.type);
+        }
+
+        BInvokableTypeSymbol invokableTSymbol = new BInvokableTypeSymbol(SymTag.CONSTRUCTOR, Flags.PUBLIC,
+                langlibPkg.pkgID, constructedType, langlibPkg);
+        invokableTSymbol.params = params;
+        invokableTSymbol.returnType = constructedType;
+        BInvokableType invokableType = new BInvokableType(paramTypes, constructedType, invokableTSymbol);
+        BConstructorSymbol symbol = new BConstructorSymbol(Flags.PUBLIC, new Name(name),
+                langlibPkg.pkgID, invokableType, langlibPkg);
+        symbol.params = params;
+        symbol.kind = SymbolKind.FUNCTIONAL_CONSTRUCTOR;
+        symbol.scope = new Scope(symbol);
+        symbol.retType = constructedType;
+        return symbol;
+    }
+}

--- a/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/xml-internal.bal
+++ b/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/xml-internal.bal
@@ -56,27 +56,27 @@ public function getElementNameNilLifting(xml x) returns string|error? = external
 
 # Functional constructor for xml:Element subtype.
 #
-# + name - name of element
-# + attributeMap - optional attribute map
-# + children - optional children
-# + return - constructed Element value
+# + name - Name of element
+# + attributeMap - Optional attribute map
+# + children - Optional children
+# + return - Constructed Element value
 public function elementCtor(string name, map<string> attributeMap = {}, xml children = textCtor()) returns xml = external;
 
 # Functional constructor for xml:ProcessingInstruction subtype.
 #
-# + target - target potion
-# + content - content potion
-# + return - constructed ProcessingInstruction value
+# + target - Target potion
+# + content - Content potion
+# + return - Constructed ProcessingInstruction value
 public function processingInstructionCtor(string target, string content = "") returns xml = external;
 
 # Functional constructor for xml:Comment subtype.
 #
-# + content - comment content
-# + return - constructed Comment value
+# + content - Comment content
+# + return - Constructed Comment value
 public function commentCtor(string content = "") returns xml = external;
 
 # Functional constructor for xml:Text subtype.
 #
-# + charactors - text content
-# + return - constructed Text value
+# + charactors - Text content
+# + return - Constructed Text value
 public function textCtor(string charactors = "") returns xml = external;

--- a/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/xml-internal.bal
+++ b/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/xml-internal.bal
@@ -53,3 +53,30 @@ public function getAttribute(xml x, string attributeName, boolean isOptionalAcce
 # + x - The xml value
 # + return - Element name
 public function getElementNameNilLifting(xml x) returns string|error? = external;
+
+# Functional constructor for xml:Element subtype.
+#
+# + name - name of element
+# + attributeMap - optional attribute map
+# + children - optional children
+# + return - constructed Element value
+public function elementCtor(string name, map<string> attributeMap = {}, xml children = textCtor()) returns xml = external;
+
+# Functional constructor for xml:ProcessingInstruction subtype.
+#
+# + target - target potion
+# + content - content potion
+# + return - constructed ProcessingInstruction value
+public function processingInstructionCtor(string target, string content = "") returns xml = external;
+
+# Functional constructor for xml:Comment subtype.
+#
+# + content - comment content
+# + return - constructed Comment value
+public function commentCtor(string content = "") returns xml = external;
+
+# Functional constructor for xml:Text subtype.
+#
+# + charactors - text content
+# + return - constructed Text value
+public function textCtor(string charactors = "") returns xml = external;

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/CommentCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/CommentCtor.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.internal;
+
+import org.ballerinalang.jvm.XMLFactory;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.XMLValue;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * XML Comment constructor function.
+ *
+ * @since 1.3.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.__internal", functionName = "commentCtor",
+        args = {
+                @Argument(name = "content", type = TypeKind.STRING)
+        },
+        returnType = {@ReturnType(type = TypeKind.XML)}
+)
+public class CommentCtor {
+
+    public static XMLValue commentCtor(Strand strand, String content) {
+        if (content == null) {
+            content = "";
+        }
+        return XMLFactory.createXMLComment(content);
+    }
+}

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/CommentCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/CommentCtor.java
@@ -29,7 +29,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
 /**
  * XML Comment constructor function.
  *
- * @since 1.3.0
+ * @since 2.0.0
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "lang.__internal", functionName = "commentCtor",
@@ -41,9 +41,6 @@ import org.ballerinalang.natives.annotations.ReturnType;
 public class CommentCtor {
 
     public static XMLValue commentCtor(Strand strand, String content) {
-        if (content == null) {
-            content = "";
-        }
         return XMLFactory.createXMLComment(content);
     }
 }

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ElementCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ElementCtor.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.internal;
+
+import org.ballerinalang.jvm.XMLFactory;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.jvm.values.XMLItem;
+import org.ballerinalang.jvm.values.XMLQName;
+import org.ballerinalang.jvm.values.XMLValue;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * XML Element constructor function.
+ *
+ * @since 1.3.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.__internal", functionName = "elementCtor",
+        args = {
+                @Argument(name = "name", type = TypeKind.STRING),
+                @Argument(name = "attributeMap", type = TypeKind.MAP),
+                @Argument(name = "children", type = TypeKind.XML)
+        },
+        returnType = {@ReturnType(type = TypeKind.XML)}
+)
+public class ElementCtor {
+
+    public static XMLValue elementCtor(Strand strand, String name, MapValue<String, String> attributeMap,
+                                       XMLValue children) {
+        XMLItem xmlElement = (XMLItem) XMLFactory.createXMLElement(new XMLQName(name), (String) null);
+        if (children != null) {
+            xmlElement.setChildren(children);
+        }
+        if (attributeMap != null) {
+            xmlElement.setAttributes(attributeMap);
+        }
+        return xmlElement;
+    }
+}

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ElementCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ElementCtor.java
@@ -32,7 +32,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
 /**
  * XML Element constructor function.
  *
- * @since 1.3.0
+ * @since 2.0.0
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "lang.__internal", functionName = "elementCtor",
@@ -48,12 +48,8 @@ public class ElementCtor {
     public static XMLValue elementCtor(Strand strand, String name, MapValue<String, String> attributeMap,
                                        XMLValue children) {
         XMLItem xmlElement = (XMLItem) XMLFactory.createXMLElement(new XMLQName(name), (String) null);
-        if (children != null) {
-            xmlElement.setChildren(children);
-        }
-        if (attributeMap != null) {
-            xmlElement.setAttributes(attributeMap);
-        }
+        xmlElement.setChildren(children);
+        xmlElement.setAttributes(attributeMap);
         return xmlElement;
     }
 }

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ProcessingInstructionCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ProcessingInstructionCtor.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.internal;
+
+import org.ballerinalang.jvm.XMLFactory;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.XMLValue;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * XML Processing Instruction constructor function.
+ *
+ * @since 1.3.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.__internal", functionName = "processingInstructionCtor",
+        args = {
+                @Argument(name = "target", type = TypeKind.STRING),
+                @Argument(name = "content", type = TypeKind.STRING)
+        },
+        returnType = {@ReturnType(type = TypeKind.XML)}
+)
+public class ProcessingInstructionCtor {
+
+    public static XMLValue processingInstructionCtor(Strand strand, String target, String content) {
+        if (content == null) {
+            content = "";
+        }
+        return XMLFactory.createXMLProcessingInstruction(target, content);
+    }
+}

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ProcessingInstructionCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/ProcessingInstructionCtor.java
@@ -29,7 +29,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
 /**
  * XML Processing Instruction constructor function.
  *
- * @since 1.3.0
+ * @since 2.0.0
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "lang.__internal", functionName = "processingInstructionCtor",
@@ -42,9 +42,6 @@ import org.ballerinalang.natives.annotations.ReturnType;
 public class ProcessingInstructionCtor {
 
     public static XMLValue processingInstructionCtor(Strand strand, String target, String content) {
-        if (content == null) {
-            content = "";
-        }
         return XMLFactory.createXMLProcessingInstruction(target, content);
     }
 }

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/TextCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/TextCtor.java
@@ -29,7 +29,7 @@ import org.ballerinalang.natives.annotations.ReturnType;
 /**
  * XML Text constructor function.
  *
- * @since 1.3.0
+ * @since 2.0.0
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "lang.__internal", functionName = "textCtor",

--- a/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/TextCtor.java
+++ b/langlib/lang.__internal/src/main/java/org/ballerinalang/langlib/internal/TextCtor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.internal;
+
+import org.ballerinalang.jvm.XMLFactory;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.values.XMLValue;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.Argument;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+/**
+ * XML Text constructor function.
+ *
+ * @since 1.3.0
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.__internal", functionName = "textCtor",
+        args = {
+                @Argument(name = "charactors", type = TypeKind.STRING)
+        },
+        returnType = {@ReturnType(type = TypeKind.XML)}
+)
+public class TextCtor {
+
+    public static XMLValue textCtor(Strand strand, String charactors) {
+        return XMLFactory.createXMLText(charactors);
+    }
+}

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibXMLTest.java
@@ -266,6 +266,16 @@ public class LangLibXMLTest {
     }
 
     @Test
+    public void testXMLFunctionalCtor() {
+        BRunUtil.invoke(compileResult, "testXMLFunctionalCtor");
+        BRunUtil.invoke(compileResult, "testXMLFunctionalConstructorWithAttributes");
+        BRunUtil.invoke(compileResult, "testXMLFunctionalConstructorWithAChild");
+        BRunUtil.invoke(compileResult, "testXMLCommentCtor");
+        BRunUtil.invoke(compileResult, "testXMLPICtor");
+        BRunUtil.invoke(compileResult, "testXMLTextCtor");
+    }
+
+    @Test
     public void testNegativeCases() {
         int i = 0;
         validateError(negativeResult, i++, "incompatible types: expected 'xml:Element', found 'xml'", 21, 12);

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -378,3 +378,51 @@ function assert(anydata actual, anydata expected) {
         panic e;
     }
 }
+
+function testXMLFunctionalCtor() {
+    'xml:Element x = 'xml:Element("hello");
+    'xml:Element y = xml `<hello></hello>`;
+    assertValueEquality(y, x);
+}
+
+function testXMLFunctionalConstructorWithAttributes() {
+    'xml:Element x = 'xml:Element("element", { "attr": "attrVal", "two": "Val2"});
+    'xml:Element y = xml `<element attr="attrVal" two="Val2"/>`;
+    assertValueEquality(y, x);
+}
+
+function testXMLFunctionalConstructorWithAChild() {
+    'xml:Element x = 'xml:Element("element", {attr: "hello"}, 'xml:Element("child"));
+    'xml:Element y = xml `<element attr="hello"><child/></element>`;
+    assertValueEquality(y, x);
+}
+
+function testXMLCommentCtor() {
+    'xml:Comment x = 'xml:Comment("comment content");
+    'xml:Comment y = xml `<!--comment content-->`;
+    assertValueEquality(y, x);
+}
+
+function testXMLPICtor() {
+    'xml:ProcessingInstruction x = 'xml:ProcessingInstruction("DONOT", "print this");
+    'xml:ProcessingInstruction y = xml `<?DONOT print this?>`;
+    assertValueEquality(y, x);
+}
+
+function testXMLTextCtor() {
+    'xml:Text x = 'xml:Text("this is a charactor sequence");
+    'xml:Text y = xml `this is a charactor sequence`;
+    assertValueEquality(y, x);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertValueEquality(anydata|error expected, anydata|error actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}
+


### PR DESCRIPTION
## Purpose
Add initial support for functionally constructable syntax support.
This PR add the constructors and relevant symbols for them.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/22635

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
