### PR TITLE
Fix issue of initializing hex literals to decimal type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -344,7 +344,8 @@ public class TypeChecker extends BLangNodeVisitor {
             if (expType.tag == TypeTags.FLOAT) {
                 literalType = symTable.floatType;
                 literalExpr.value = ((Long) literalValue).doubleValue();
-            } else if (expType.tag == TypeTags.DECIMAL) {
+            } else if ((expType.tag == TypeTags.DECIMAL) && !NumericLiteralSupport
+                    .isHexIndicator(literalExpr.originalValue)) {
                 literalType = symTable.decimalType;
                 literalExpr.value = String.valueOf(literalValue);
             } else if (TypeTags.isIntegerTypeTag(expType.tag) || expType.tag == TypeTags.BYTE) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -344,8 +344,8 @@ public class TypeChecker extends BLangNodeVisitor {
             if (expType.tag == TypeTags.FLOAT) {
                 literalType = symTable.floatType;
                 literalExpr.value = ((Long) literalValue).doubleValue();
-            } else if ((expType.tag == TypeTags.DECIMAL) && !NumericLiteralSupport
-                    .isHexIndicator(literalExpr.originalValue)) {
+            } else if (expType.tag == TypeTags.DECIMAL &&
+                    !NumericLiteralSupport.hasHexIndicator(literalExpr.originalValue)) {
                 literalType = symTable.decimalType;
                 literalExpr.value = String.valueOf(literalValue);
             } else if (TypeTags.isIntegerTypeTag(expType.tag) || expType.tag == TypeTags.BYTE) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NumericLiteralSupport.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NumericLiteralSupport.java
@@ -69,6 +69,24 @@ public final class NumericLiteralSupport {
     }
 
     /**
+     * Check input for decimal indicator.
+     *
+     * @param literalValue literal to check
+     * @return true if Hex prefix is present, false otherwise
+     */
+    public static boolean isHexIndicator(String literalValue) {
+        int length = literalValue.length();
+        // There should be at least 3 characters to form hex literal.
+        if (length < 3) {
+            return false;
+        }
+        char firstChar = literalValue.charAt(1);
+        char secondChar = literalValue.charAt(2);
+        return (firstChar == 'x' || secondChar == 'x' || firstChar == 'X' || secondChar == 'X');
+    }
+
+
+    /**
      * Parse BigDecimal using DECIMAL128 math context.
      *
      * @param baseValue value to be parsed

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NumericLiteralSupport.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/NumericLiteralSupport.java
@@ -74,15 +74,16 @@ public final class NumericLiteralSupport {
      * @param literalValue literal to check
      * @return true if Hex prefix is present, false otherwise
      */
-    public static boolean isHexIndicator(String literalValue) {
+    public static boolean hasHexIndicator(String literalValue) {
         int length = literalValue.length();
         // There should be at least 3 characters to form hex literal.
         if (length < 3) {
             return false;
         }
+        // Check whether hex prefix is with positive and negative inputs.
         char firstChar = literalValue.charAt(1);
         char secondChar = literalValue.charAt(2);
-        return (firstChar == 'x' || secondChar == 'x' || firstChar == 'X' || secondChar == 'X');
+        return firstChar == 'x' || secondChar == 'x' || firstChar == 'X' || secondChar == 'X';
     }
 
 

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -58,20 +58,22 @@ public class BDecimalValueNegativeTest {
     @Test
     void testDecimalValueNegativeLiteral() {
         CompileResult negative = BCompileUtil.compile("test-src/types/decimal/decimal_value_negative_literal.bal");
-        Assert.assertEquals(negative.getErrorCount(), 13);
+        Assert.assertEquals(negative.getErrorCount(), 15);
         int i = 0;
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 20, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 21, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 22, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 31);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 30, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 31, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 22, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 23, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 31);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 26, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 23);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 33, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 17);
-        BAssertUtil.validateError(negative, i, "incompatible types: expected 'decimal', found 'float'", 37, 37);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 37);
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -58,22 +58,24 @@ public class BDecimalValueNegativeTest {
     @Test
     void testDecimalValueNegativeLiteral() {
         CompileResult negative = BCompileUtil.compile("test-src/types/decimal/decimal_value_negative_literal.bal");
-        Assert.assertEquals(negative.getErrorCount(), 15);
+        Assert.assertEquals(negative.getErrorCount(), 17);
         int i = 0;
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 20, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 21, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 22, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 23, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 31);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 26, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 33, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 24, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 25, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 26, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 27, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 27, 31);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 28, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 23);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 37);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 38, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 41, 37);
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
@@ -190,37 +190,6 @@ public class BDecimalValueTest {
                             "Invalid decimal value returned.");
     }
 
-    @Test(description = "Test assigning positive hexadecimal literal without power and floating point")
-    public void testHexAssignment1() {
-        BValue[] returns = BRunUtil.invoke(result, "testHexAssignment1");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BDecimal.class);
-        BDecimal value = (BDecimal) returns[0];
-        Assert.assertEquals(value.decimalValue().compareTo(new BigDecimal("74736", MathContext.DECIMAL128)), 0,
-                            "Invalid decimal value returned.");
-    }
-
-    @Test(description = "Test assigning negative hexadecimal literal without power and floating point")
-    public void testHexAssignment7() {
-        BValue[] returns = BRunUtil.invoke(result, "testHexAssignment7");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BDecimal.class);
-        BDecimal value = (BDecimal) returns[0];
-        Assert.assertEquals(value.decimalValue().compareTo(new BigDecimal("-74736", MathContext.DECIMAL128)), 0,
-                            "Invalid decimal value returned.");
-    }
-
-    @Test(description = "Test a complex expression including hexadecimal literals")
-    public void testHexComplexExpression() {
-        BValue[] returns = BRunUtil.invoke(result, "testHexComplexExpression");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BDecimal.class);
-        BDecimal value = (BDecimal) returns[0];
-        Assert.assertEquals(value.decimalValue().compareTo(new BigDecimal("381.1061220240414588528678304239401",
-                                                                          MathContext.DECIMAL128)), 0,
-                            "Invalid decimal value returned.");
-    }
-
     @Test(description = "Test positively signed literal assignment")
     public void testPositivelySignedLiteralAssignment() {
         BValue[] returns = BRunUtil.invoke(result, "testPositivelySignedLiteralAssignment");

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
@@ -126,26 +126,6 @@ function testDiscriminatedDecimalLiterals() returns [decimal, decimal, decimal, 
     return [a, b, c, d];
 }
 
-// Test assigning positive hexadecimal literal without power and floating point.
-function testHexAssignment1() returns decimal {
-    decimal d = 0x123F0;
-    return d;
-}
-
-// Test assigning negative hexadecimal literal without power and floating point.
-function testHexAssignment7() returns decimal {
-    decimal d = -0x123F0;
-    return d;
-}
-
-// Test a complex expression including hexadecimal literals
-function testHexComplexExpression() returns decimal {
-    decimal d1 = -0x123F0;
-    decimal d2 = -200.5;
-    decimal d3 = (-1 * <decimal>0x1A2F.1C2p-2 + d1) / d2;
-    return d3;
-}
-
 // Test positively signed literal assignment
 function testPositivelySignedLiteralAssignment() returns [decimal, decimal, decimal] {
     decimal d1 = +12.23;

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
@@ -21,6 +21,8 @@ function testInvlaidDecimalValue() {
     decimal b = 0x4fp1;
     decimal c = 0x12bc;
     decimal d = -0x12b;
+    decimal e = 0X1abc;
+    decimal f = -0X1ab;
     decimal[] ds1 = [12.3f, 22.4];
     decimal[] ds2 = [0x3ap-1, 0x4bp3];
     int|decimal md1 = 0x33p0;

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
@@ -19,6 +19,8 @@ function testInvlaidDecimalValue() {
     // This is to test a syntax issue.
     decimal a = 12.3f;
     decimal b = 0x4fp1;
+    decimal c = 0x12bc;
+    decimal d = -0x12b;
     decimal[] ds1 = [12.3f, 22.4];
     decimal[] ds2 = [0x3ap-1, 0x4bp3];
     int|decimal md1 = 0x33p0;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -58,22 +58,24 @@ public class BDecimalValueNegativeTest {
     @Test
     void testDecimalValueNegativeLiteral() {
         CompileResult negative = BCompileUtil.compile("test-src/types/decimal/decimal_value_negative_literal.bal");
-        Assert.assertEquals(negative.getErrorCount(), 15);
+        Assert.assertEquals(negative.getErrorCount(), 17);
         int i = 0;
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 20, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 21, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 22, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 23, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 31);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 26, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 33, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 24, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 25, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 26, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 27, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 27, 31);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 28, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 23);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 37);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 38, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 41, 37);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueNegativeTest.java
@@ -58,20 +58,22 @@ public class BDecimalValueNegativeTest {
     @Test
     void testDecimalValueNegativeLiteral() {
         CompileResult negative = BCompileUtil.compile("test-src/types/decimal/decimal_value_negative_literal.bal");
-        Assert.assertEquals(negative.getErrorCount(), 13);
+        Assert.assertEquals(negative.getErrorCount(), 15);
         int i = 0;
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 20, 17);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 21, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 22, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 22);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 23, 31);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 30, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 31, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 22, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'int'", 23, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 24, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 22);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 25, 31);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 26, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 32, 23);
         BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 33, 23);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 17);
-        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 37);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 34, 24);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 35, 23);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 36, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 37, 17);
+        BAssertUtil.validateError(negative, i++, "incompatible types: expected 'decimal', found 'float'", 39, 37);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
@@ -197,36 +197,6 @@ public class BDecimalValueTest {
                 "Invalid decimal value returned.");
     }
 
-    @Test(description = "Test assigning positive hexadecimal literal without power and floating point")
-    public void testHexAssignment1() {
-        BValue[] returns = BRunUtil.invoke(result, "testHexAssignment1");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BDecimal.class);
-        BDecimal value = (BDecimal) returns[0];
-        Assert.assertTrue(value.decimalValue().compareTo(new BigDecimal("74736", MathContext.DECIMAL128)) == 0,
-                "Invalid decimal value returned.");
-    }
-
-    @Test(description = "Test assigning negative hexadecimal literal without power and floating point")
-    public void testHexAssignment7() {
-        BValue[] returns = BRunUtil.invoke(result, "testHexAssignment7");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BDecimal.class);
-        BDecimal value = (BDecimal) returns[0];
-        Assert.assertTrue(value.decimalValue().compareTo(new BigDecimal("-74736", MathContext.DECIMAL128)) == 0,
-                "Invalid decimal value returned.");
-    }
-
-    @Test(description = "Test a complex expression including hexadecimal literals")
-    public void testHexComplexExpression() {
-        BValue[] returns = BRunUtil.invoke(result, "testHexComplexExpression");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertSame(returns[0].getClass(), BDecimal.class);
-        BDecimal value = (BDecimal) returns[0];
-        Assert.assertTrue(value.decimalValue().compareTo(new BigDecimal("381.1061220240414588528678304239401",
-                        MathContext.DECIMAL128)) == 0, "Invalid decimal value returned.");
-    }
-
     @Test(description = "Test positively signed literal assignment")
     public void testPositivelySignedLiteralAssignment() {
         BValue[] returns = BRunUtil.invoke(result, "testPositivelySignedLiteralAssignment");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value.bal
@@ -126,26 +126,6 @@ function testDiscriminatedDecimalLiterals() returns [decimal, decimal, decimal, 
     return [a, b, c, d];
 }
 
-// Test assigning positive hexadecimal literal without power and floating point.
-function testHexAssignment1() returns decimal {
-    decimal d = 0x123F0;
-    return d;
-}
-
-// Test assigning negative hexadecimal literal without power and floating point.
-function testHexAssignment7() returns decimal {
-    decimal d = -0x123F0;
-    return d;
-}
-
-// Test a complex expression including hexadecimal literals
-function testHexComplexExpression() returns decimal {
-    decimal d1 = -0x123F0;
-    decimal d2 = -200.5;
-    decimal d3 = (-1 * <decimal>0x1A2F.1C2p-2 + d1) / d2;
-    return d3;
-}
-
 // Test positively signed literal assignment
 function testPositivelySignedLiteralAssignment() returns [decimal, decimal, decimal] {
     decimal d1 = +12.23;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
@@ -21,6 +21,8 @@ function testInvlaidDecimalValue() {
     decimal b = 0x4fp1;
     decimal c = 0x12bc;
     decimal d = -0x12b;
+    decimal e = 0X1abc;
+    decimal f = -0X1ab;
     decimal[] ds1 = [12.3f, 22.4];
     decimal[] ds2 = [0x3ap-1, 0x4bp3];
     int|decimal md1 = 0x33p0;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/decimal/decimal_value_negative_literal.bal
@@ -19,6 +19,8 @@ function testInvlaidDecimalValue() {
     // This is to test a syntax issue.
     decimal a = 12.3f;
     decimal b = 0x4fp1;
+    decimal c = 0x12bc;
+    decimal d = -0x12b;
     decimal[] ds1 = [12.3f, 22.4];
     decimal[] ds2 = [0x3ap-1, 0x4bp3];
     int|decimal md1 = 0x33p0;


### PR DESCRIPTION
## Purpose
>Hex floating point literals are always float.

Fixes #14775 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
