### PR TITLE
Fix Invalid reference warning for functions passed as arguments

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
@@ -360,7 +360,7 @@ public class DocumentationAnalyzer extends BLangNodeVisitor {
             case BACKTICK_CONTENT:
             case FUNCTION:
                 tag = SymTag.FUNCTION;
-                // Check if function is available as parameter to a function
+                // Check if the function is available as a parameter
                 if (documentableNode.getKind() == NodeKind.FUNCTION) {
                     BLangFunction funcNode = (BLangFunction) documentableNode;
                     SymbolEnv tempEnv = SymbolEnv.createFunctionEnv(funcNode, funcNode.symbol.scope, this.env);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DocumentationAnalyzer.java
@@ -21,6 +21,7 @@ import org.antlr.v4.runtime.ANTLRInputStream;
 import org.antlr.v4.runtime.CommonTokenStream;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.model.elements.Flag;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.DocReferenceErrorType;
 import org.ballerinalang.model.tree.DocumentableNode;
 import org.ballerinalang.model.tree.DocumentationReferenceType;
@@ -359,6 +360,18 @@ public class DocumentationAnalyzer extends BLangNodeVisitor {
             case BACKTICK_CONTENT:
             case FUNCTION:
                 tag = SymTag.FUNCTION;
+                // Check if function is available as parameter to a function
+                if (documentableNode.getKind() == NodeKind.FUNCTION) {
+                    BLangFunction funcNode = (BLangFunction) documentableNode;
+                    SymbolEnv tempEnv = SymbolEnv.createFunctionEnv(funcNode, funcNode.symbol.scope, this.env);
+                    BSymbol symbol = resolveFullyQualifiedSymbol(reference.pos, tempEnv, reference.qualifier,
+                            reference.typeName, reference.identifier, tag);
+                    if (symbol != symTable.notFoundSymbol) {
+                        if (symbol.kind == SymbolKind.FUNCTION) {
+                            return DocReferenceErrorType.NO_ERROR;
+                        }
+                    }
+                }
                 break;
         }
 


### PR DESCRIPTION
## Purpose
> Fixes a warning appearing when a function that is passed as a argument is referred to in documentation.

Fixes #21527 

@dulvinw Please review.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
