### PR TITLE
Removing the API Docs Link in the Crypto BBE Comments

### DIFF
--- a/examples/crypto/crypto.bal
+++ b/examples/crypto/crypto.bal
@@ -9,8 +9,7 @@ public function main() returns error? {
     string input = "Hello Ballerina!";
     byte[] inputArr = input.toBytes();
 
-    // Hashing input value using [MD5 hashing algorithm](#https://ballerina.io/v1-2/learn/api-docs/ballerina/crypto/functions.html#hashMd5) 
-    // and printing hash value using Hex encoding.
+    // Hashing input value using MD5 hashing algorithm, and printing hash value using Hex encoding.
     byte[] output = crypto:hashMd5(inputArr);
     io:println("Hex encoded hash with MD5: " + output.toBase16());
 

--- a/examples/crypto/crypto.description
+++ b/examples/crypto/crypto.description
@@ -1,4 +1,4 @@
 // The `crypto` stdlib provides functions usable to perform different cryptographic operations such as hashing,
 // HMAC generation, checksum generation and digitally signing data.
 
-For more information on the underlying module, see [The Crypto Module](#https://ballerina.io/learn/api-docs/ballerina/crypto/).
+For more information on the underlying module, see [The Crypto Module](https://ballerina.io/learn/api-docs/ballerina/crypto/).


### PR DESCRIPTION
## Purpose
This is to remove the APIDocs Link in the Crypto BBE Comments.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
