### PR TITLE
Limit descriptions to one sentence

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
@@ -100,6 +100,14 @@ public class Writer {
                 return defaultValue;
             });
 
+            handlebars.registerHelper("editDescription", (Helper<String>) (description, options) -> {
+                //remove anything with <pre> tag
+                String newDescription = description.replaceAll("<pre>(.|\\n)*?<\\/pre>","");
+                // select only the first sentence
+                newDescription = newDescription.replaceAll("\\.(.|\\n)*",".");
+                return newDescription;
+            });
+
             handlebars.registerHelper("equals", (arg1, options) -> {
                 CharSequence result;
                 Object param0 = options.param(0);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
@@ -102,9 +102,9 @@ public class Writer {
 
             handlebars.registerHelper("editDescription", (Helper<String>) (description, options) -> {
                 //remove anything with <pre> tag
-                String newDescription = description.replaceAll("<pre>(.|\\n)*?<\\/pre>","");
+                String newDescription = description.replaceAll("<pre>(.|\\n)*?<\\/pre>", "");
                 // select only the first sentence
-                newDescription = newDescription.replaceAll("\\.(.|\\n)*",".");
+                newDescription = newDescription.replaceAll("\\.(.|\\n)*", ".");
                 return newDescription;
             });
 

--- a/misc/docerina/src/main/resources/template/html/module.hbs
+++ b/misc/docerina/src/main/resources/template/html/module.hbs
@@ -58,7 +58,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{#if isAnonymous}}Anonymous record{{else}}{{{ description }}}{{/if}}
+                                {{#if isAnonymous}}Anonymous record{{else}}{{{ editDescription description }}}{{/if}}
                             </td>
                         </tr>
                     {{/each}}
@@ -84,7 +84,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}
@@ -110,7 +110,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}
@@ -136,7 +136,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}
@@ -163,7 +163,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}
@@ -190,7 +190,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}
@@ -212,7 +212,7 @@
                         <tr>
                             <td class="module-title truncate annotations" id="{{name}}" title="{{name}}"><a
                                     class="annotations" href="annotations.html#{{name}}">{{name}}</a></td>
-                            <td class="module-desc">{{{ description }}}</td>
+                            <td class="module-desc">{{{ editDescription description }}}</td>
                         </tr>
                     {{/each}}
                 </table>
@@ -237,7 +237,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}
@@ -263,7 +263,7 @@
                                 {{#if isDeprecated}}
                                     <span class="stab">Deprecated</span>
                                 {{/if}}
-                                {{{ description }}}
+                                {{{ editDescription description }}}
                             </td>
                         </tr>
                     {{/each}}


### PR DESCRIPTION
## Purpose
> Limits descriptions in tables in Module page to the first sentence.


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
