### PR TITLE
Refactor record, tuple and error var desugar logic

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1185,25 +1185,25 @@ public class Desugar extends BLangNodeVisitor {
     @Override
     public void visit(BLangTupleVariable varNode) {
         //  case 1:
-        //  (string, int) (a, b) = (tuple)
+        //  [string, int] (a, b) = (tuple)
         //
         //  any[] x = (tuple);
         //  string a = x[0];
         //  int b = x[1];
         //
         //  case 2:
-        //  ((string, float) int)) ((a, b), c)) = (tuple)
+        //  [[string, float], int] [[a, b], c] = (tuple)
         //
         //  any[] x = (tuple);
         //  string a = x[0][0];
         //  float b = x[0][1];
         //  int c = x[1];
 
-        //create tuple destruct block stmt
+        // Create tuple destruct block stmt
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
 
-        //create a simple var for the array 'any[] x = (tuple)' based on the dimension for x
-        String name = "tuple";
+        // Create a simple var for the array 'any[] x = (tuple)' based on the dimension for x
+        String name = "$tuple$";
         final BLangSimpleVariable tuple =
                 ASTBuilderUtil.createVariable(varNode.pos, name, symTable.arrayAllType, null,
                                               new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
@@ -1212,11 +1212,11 @@ public class Desugar extends BLangNodeVisitor {
         final BLangSimpleVariableDef variableDef = ASTBuilderUtil.createVariableDefStmt(varNode.pos, blockStmt);
         variableDef.var = tuple;
 
-        //create the variable definition statements using the root block stmt created
+        // Create the variable definition statements using the root block stmt created
         createVarDefStmts(varNode, blockStmt, tuple.symbol, null);
         createRestFieldVarDefStmts(varNode, blockStmt, tuple.symbol);
 
-        //finally rewrite the populated block statement
+        // Finally rewrite the populated block statement
         result = rewrite(blockStmt, env);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -800,6 +800,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             symTable.errorOrNilType = BUnionType.create(null, symTable.errorType, symTable.nilType);
             symTable.anyOrErrorType = BUnionType.create(null, symTable.anyType, symTable.errorType);
             symTable.mapAllType = new BMapType(TypeTags.MAP, symTable.anyOrErrorType, null);
+            symTable.arrayAllType = new BArrayType(symTable.anyOrErrorType);
             return;
         }
         throw new IllegalStateException("built-in error not found ?");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -142,6 +142,7 @@ public class SymbolTable {
     public BFiniteType trueType;
     public BObjectType intRangeType;
     public BMapType mapAllType;
+    public BArrayType arrayAllType;
 
     // builtin subtypes
     public final BIntSubType signed32IntType = new BIntSubType(TypeTags.SIGNED32_INT, Names.SIGNED32);


### PR DESCRIPTION
## Purpose
> This PR refactors the desugar logic for record, error and tuple variables. Previously, the desugar logic for these variables were in the visit() methods of their respective definition nodes (e.g., BLangRecordVariableDef). Since these variables can be used in both expressions and statements, this had the side effect of having to include the definitions statements in expressions (e.g., Let expression). With this PR, that desugar logic is moved to the visit() methods of the variables themselves so that they can be used in both expression and statement contexts without any issue. This is a precursor to fixing #22701.