### PR TITLE
Add lock statement suport and block statement support for incremental parser

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaLexer.java
@@ -661,6 +661,8 @@ public class BallerinaLexer {
                 return getSyntaxToken(SyntaxKind.TYPEOF_KEYWORD);
             case LexerTerminals.IS:
                 return getSyntaxToken(SyntaxKind.IS_KEYWORD);
+            case LexerTerminals.LOCK:
+                return getSyntaxToken(SyntaxKind.LOCK_KEYWORD);
             default:
                 return getIdentifierToken(tokenText);
         }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -2742,6 +2742,10 @@ public class BallerinaParser {
                 // If the statement starts with an identifier, it could be a var-decl-stmt
                 // with a user defined type, or some statement starts with an expression
                 return parseStatementStartsWithIdentifier(getAnnotations(annots));
+            case LOCK_KEYWORD:
+                return parseLockStatement();
+            case OPEN_BRACE_TOKEN:
+                return parseBlockNode();
             default:
                 // If the next token in the token stream does not match to any of the statements and
                 // if it is not the end of statement, then try to fix it and continue.
@@ -5739,6 +5743,35 @@ public class BallerinaParser {
             case OPEN_PAREN_TOKEN:
             default:
                 return false;
+        }
+    }
+
+    /**
+     * Parse lock statement.
+     * <code>lock-stmt := lock block-stmt ;</code>
+     *
+     * @return Lock statement
+     */
+    private STNode parseLockStatement() {
+        startContext(ParserRuleContext.LOCK_STMT);
+        STNode lockKeyword = parseLockKeyword();
+        STNode blockStatement = parseBlockNode();
+        endContext();
+        return STNodeFactory.createLockStatementNode(lockKeyword, blockStatement);
+    }
+
+    /**
+     * Parse lock-keyword.
+     *
+     * @return lock-keyword node
+     */
+    private STNode parseLockKeyword() {
+        STToken token = peek();
+        if (token.kind == SyntaxKind.LOCK_KEYWORD) {
+            return consume();
+        } else {
+            Solution sol = recover(token, ParserRuleContext.LOCK_KEYWORD);
+            return sol.recoveredNode;
         }
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -2651,6 +2651,7 @@ public class BallerinaParser {
             case RETURN_KEYWORD:
             case TYPE_KEYWORD:
             case OPEN_PAREN_TOKEN: // nil type descriptor '()'
+            case LOCK_KEYWORD:
                 break;
             default:
                 if (isValidLHSExpression(tokenKind)) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
@@ -72,7 +72,7 @@ public class BallerinaParserErrorHandler {
             ParserRuleContext.WHILE_BLOCK, ParserRuleContext.CALL_STMT, ParserRuleContext.PANIC_STMT,
             ParserRuleContext.CONTINUE_STATEMENT, ParserRuleContext.BREAK_STATEMENT, ParserRuleContext.RETURN_STMT,
             ParserRuleContext.COMPOUND_ASSIGNMENT_STMT, ParserRuleContext.LOCAL_TYPE_DEFINITION_STMT,
-            ParserRuleContext.EXPRESSION_STATEMENT };
+            ParserRuleContext.EXPRESSION_STATEMENT, ParserRuleContext.LOCK_STMT };
 
     private static final ParserRuleContext[] VAR_DECL_RHS =
             { ParserRuleContext.SEMICOLON, ParserRuleContext.ASSIGN_OP };
@@ -787,6 +787,9 @@ public class BallerinaParserErrorHandler {
                 case AS_KEYWORD:
                     hasMatch = nextToken.kind == SyntaxKind.AS_KEYWORD;
                     break;
+                case LOCK_KEYWORD:
+                    hasMatch = nextToken.kind == SyntaxKind.LOCK_KEYWORD;
+                    break;
                 case BOOLEAN_LITERAL:
                     hasMatch = nextToken.kind == SyntaxKind.TRUE_KEYWORD || nextToken.kind == SyntaxKind.FALSE_KEYWORD;
                     break;
@@ -951,6 +954,7 @@ public class BallerinaParserErrorHandler {
                 case VARIABLE_REF:
                 case TYPE_REFERENCE:
                 case ANNOT_REFERENCE:
+                case LOCK_STMT:
                 default:
                     // Stay at the same place
                     skipRule = true;
@@ -1348,6 +1352,7 @@ public class BallerinaParserErrorHandler {
             case MAPPING_CONSTRUCTOR:
             case LOCAL_TYPE_DEFINITION_STMT:
             case EXPRESSION_STATEMENT:
+            case LOCK_STMT:
                 startContext(currentCtx);
                 break;
             default:
@@ -1699,6 +1704,10 @@ public class BallerinaParserErrorHandler {
                 return getNextRuleForDecimalIntegerLiteral();
             case EXPRESSION_STATEMENT:
                 return ParserRuleContext.EXPRESSION_STATEMENT_START;
+            case LOCK_STMT:
+                return ParserRuleContext.LOCK_KEYWORD;
+            case LOCK_KEYWORD:
+                return ParserRuleContext.BLOCK_STMT;
 
             case OBJECT_FUNC_OR_FIELD:
             case OBJECT_METHOD_START:
@@ -1910,6 +1919,9 @@ public class BallerinaParserErrorHandler {
                     return ParserRuleContext.ELSE_BLOCK;
                 } else if (parentCtx == ParserRuleContext.WHILE_BLOCK) {
                     endContext(); // end while-block
+                    return ParserRuleContext.STATEMENT;
+                } else if (parentCtx == ParserRuleContext.LOCK_STMT) {
+                    endContext();
                     return ParserRuleContext.STATEMENT;
                 }
                 return ParserRuleContext.STATEMENT;
@@ -2198,6 +2210,7 @@ public class BallerinaParserErrorHandler {
             case LOCAL_TYPE_DEFINITION_STMT:
             case STMT_START_WITH_IDENTIFIER:
             case EXPRESSION_STATEMENT:
+            case LOCK_STMT:
                 return true;
             default:
                 return false;
@@ -2478,6 +2491,8 @@ public class BallerinaParserErrorHandler {
                 return SyntaxKind.PLUS_TOKEN;
             case UNARY_EXPRESSION:
                 return SyntaxKind.PLUS_TOKEN;
+            case LOCK_KEYWORD:
+                return SyntaxKind.LOCK_KEYWORD;
 
             // TODO:
             case COMP_UNIT:
@@ -2539,6 +2554,7 @@ public class BallerinaParserErrorHandler {
             case STMT_START_WITH_IDENTIFIER:
             case IS_EXPRESSION:
             case LOCAL_TYPE_DEFINITION_STMT:
+            case LOCK_STMT:
             default:
                 break;
         }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
@@ -72,7 +72,7 @@ public class BallerinaParserErrorHandler {
             ParserRuleContext.WHILE_BLOCK, ParserRuleContext.CALL_STMT, ParserRuleContext.PANIC_STMT,
             ParserRuleContext.CONTINUE_STATEMENT, ParserRuleContext.BREAK_STATEMENT, ParserRuleContext.RETURN_STMT,
             ParserRuleContext.COMPOUND_ASSIGNMENT_STMT, ParserRuleContext.LOCAL_TYPE_DEFINITION_STMT,
-            ParserRuleContext.EXPRESSION_STATEMENT, ParserRuleContext.LOCK_STMT };
+            ParserRuleContext.EXPRESSION_STATEMENT, ParserRuleContext.LOCK_STMT, ParserRuleContext.BLOCK_STMT };
 
     private static final ParserRuleContext[] VAR_DECL_RHS =
             { ParserRuleContext.SEMICOLON, ParserRuleContext.ASSIGN_OP };

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/LexerTerminals.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/LexerTerminals.java
@@ -57,6 +57,7 @@ public class LexerTerminals {
     public static final String FINAL = "final";
     public static final String TYPEOF = "typeof";
     public static final String IS = "is";
+    public static final String LOCK = "lock";
 
     // Types
     public static final String INT = "int";

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/ParserRuleContext.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/ParserRuleContext.java
@@ -127,6 +127,7 @@ public enum ParserRuleContext {
     STMT_START_WITH_EXPR_RHS("stmt-start-with-expr-rhs"),
     EXPRESSION_STATEMENT("expression-statement"),
     EXPRESSION_STATEMENT_START("expression-statement-start"),
+    LOCK_STMT("lock-stmt"),
 
     // Keywords
     RETURNS_KEYWORD("returns"),
@@ -158,6 +159,7 @@ public enum ParserRuleContext {
     CONST_KEYWORD("const"),
     TYPEOF_KEYWORD("typeof"),
     IS_KEYWORD("is"),
+    LOCK_KEYWORD("lock"),
 
     // Syntax tokens
     OPEN_PARENTHESIS("("),

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STLockStatementNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STLockStatementNode.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.internal.parser.tree;
+
+import io.ballerinalang.compiler.syntax.tree.LockStatementNode;
+import io.ballerinalang.compiler.syntax.tree.Node;
+import io.ballerinalang.compiler.syntax.tree.NonTerminalNode;
+import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
+
+/**
+ * This is a generated internal syntax tree node.
+ *
+ * @since 1.3.0
+ */
+public class STLockStatementNode extends STStatementNode {
+    public final STNode lockKeyword;
+    public final STNode blockStatement;
+
+    STLockStatementNode(
+            STNode lockKeyword,
+            STNode blockStatement) {
+        super(SyntaxKind.LOCK_STATEMENT);
+        this.lockKeyword = lockKeyword;
+        this.blockStatement = blockStatement;
+
+        addChildren(
+                lockKeyword,
+                blockStatement);
+    }
+
+    public Node createFacade(int position, NonTerminalNode parent) {
+        return new LockStatementNode(this, position, parent);
+    }
+}

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
@@ -312,6 +312,15 @@ public class STNodeFactory extends STAbstractNodeFactory {
                 semicolonToken);
     }
 
+    public static STNode createLockStatementNode(
+            STNode lockKeyword,
+            STNode blockStatement) {
+
+        return new STLockStatementNode(
+                lockKeyword,
+                blockStatement);
+    }
+
     public static STNode createBinaryExpressionNode(
             SyntaxKind kind,
             STNode lhsExpr,

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/LockStatementNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/LockStatementNode.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.syntax.tree;
+
+import io.ballerinalang.compiler.internal.parser.tree.STNode;
+
+/**
+ * This is a generated syntax tree node.
+ *
+ * @since 1.3.0
+ */
+public class LockStatementNode extends StatementNode {
+
+    public LockStatementNode(STNode internalNode, int position, NonTerminalNode parent) {
+        super(internalNode, position, parent);
+    }
+
+    public Token lockKeyword() {
+        return childInBucket(0);
+    }
+
+    public StatementNode blockStatement() {
+        return childInBucket(1);
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(NodeTransformer<T> visitor) {
+        return visitor.transform(this);
+    }
+
+    @Override
+    protected String[] childNames() {
+        return new String[]{
+                "lockKeyword",
+                "blockStatement"};
+    }
+
+    public LockStatementNode modify(
+            Token lockKeyword,
+            StatementNode blockStatement) {
+        if (checkForReferenceEquality(
+                lockKeyword,
+                blockStatement)) {
+            return this;
+        }
+
+        return NodeFactory.createLockStatementNode(
+                lockKeyword,
+                blockStatement);
+    }
+}

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
@@ -19,7 +19,6 @@ package io.ballerinalang.compiler.syntax.tree;
 
 import io.ballerinalang.compiler.internal.parser.tree.STNode;
 import io.ballerinalang.compiler.internal.parser.tree.STNodeFactory;
-
 import java.util.Objects;
 
 /**
@@ -404,6 +403,18 @@ public abstract class NodeFactory extends AbstractNodeFactory {
                 typeDescriptor.internalNode(),
                 semicolonToken.internalNode());
         return stLocalTypeDefinitionStatementNode.createUnlinkedFacade();
+    }
+
+    public static LockStatementNode createLockStatementNode(
+            Token lockKeyword,
+            StatementNode blockStatement) {
+        Objects.requireNonNull(lockKeyword, "lockKeyword must not be null");
+        Objects.requireNonNull(blockStatement, "blockStatement must not be null");
+
+        STNode stLockStatementNode = STNodeFactory.createLockStatementNode(
+                lockKeyword.internalNode(),
+                blockStatement.internalNode());
+        return stLockStatementNode.createUnlinkedFacade();
     }
 
     public static BinaryExpressionNode createBinaryExpressionNode(

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeTransformer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeTransformer.java
@@ -120,6 +120,10 @@ public abstract class NodeTransformer<T> {
         return transformSyntaxNode(localTypeDefinitionStatementNode);
     }
 
+    public T transform(LockStatementNode lockStatementNode) {
+        return transformSyntaxNode(lockStatementNode);
+    }
+
     public T transform(BinaryExpressionNode binaryExpressionNode) {
         return transformSyntaxNode(binaryExpressionNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeVisitor.java
@@ -119,6 +119,10 @@ public abstract class NodeVisitor {
         visitSyntaxNode(localTypeDefinitionStatementNode);
     }
 
+    public void visit(LockStatementNode lockStatementNode) {
+        visitSyntaxNode(lockStatementNode);
+    }
+
     public void visit(BinaryExpressionNode binaryExpressionNode) {
         visitSyntaxNode(binaryExpressionNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/SyntaxKind.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/SyntaxKind.java
@@ -57,6 +57,7 @@ public enum SyntaxKind {
     BREAK_KEYWORD(212,"break"),
     TYPEOF_KEYWORD(213,"typeof"),
     IS_KEYWORD(214, "is"),
+    LOCK_KEYWORD(214, "lock"),
 
     // Separators
     OPEN_BRACE_TOKEN(500, "{"),
@@ -138,6 +139,7 @@ public enum SyntaxKind {
     COMPOUND_ASSIGNMENT_STATEMENT(1211),
     LOCAL_TYPE_DEFINITION_STATEMENT(1212),
     ACTION_STATEMENT(1213),
+    LOCK_STATEMENT(1214),
 
     // Expressions
     BINARY_EXPRESSION(1300),

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
@@ -305,6 +305,15 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
     }
 
     @Override
+    public Node transform(LockStatementNode lockStatementNode) {
+        Token lockKeyword = modifyToken(lockStatementNode.lockKeyword());
+        StatementNode blockStatement = modifyNode(lockStatementNode.blockStatement());
+        return lockStatementNode.modify(
+                lockKeyword,
+                blockStatement);
+    }
+
+    @Override
     public Node transform(BinaryExpressionNode binaryExpressionNode) {
         Node lhsExpr = modifyNode(binaryExpressionNode.lhsExpr());
         Token operator = modifyToken(binaryExpressionNode.operator());

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
@@ -357,6 +357,8 @@ public class ParserTestUtils {
                 return SyntaxKind.ANNOTATION_KEYWORD;
             case "IS_KEYWORD":
                 return SyntaxKind.IS_KEYWORD;
+            case "LOCK_KEYWORD":
+                return SyntaxKind.LOCK_KEYWORD;
 
             // Operators
             case "PLUS_TOKEN":
@@ -521,6 +523,8 @@ public class ParserTestUtils {
                 return SyntaxKind.LOCAL_TYPE_DEFINITION_STATEMENT;
             case "ACTION_STATEMENT":
                 return SyntaxKind.ACTION_STATEMENT;
+            case "LOCK_STATEMENT":
+                return SyntaxKind.LOCK_STATEMENT;
 
             // Others
             case "SIMPLE_TYPE":

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/BlockStatement.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/BlockStatement.java
@@ -64,4 +64,9 @@ public class BlockStatement extends AbstractStatementTest {
         "block-stmt/block_stmt_assert_06.json");
     }
 
+    @Test
+    public void testMissingCloseBrace() {
+        testFile("block-stmt/block_stmt_source_07.bal",
+        "block-stmt/block_stmt_assert_07.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/BlockStatement.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/BlockStatement.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerinalang.compiler.parser.test.syntax.statements;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test parsing object type definitions.
+ */
+public class BlockStatement extends AbstractStatementTest {
+
+    // Valid syntax tests
+
+    @Test
+    public void testComplexBlockStmt() {
+        testFile("block-stmt/block_stmt_source_01.bal",
+        "block-stmt/block_stmt_assert_01.json");
+    }
+
+    @Test
+    public void testEmptyBlockStmt() {
+        testFile("block-stmt/block_stmt_source_02.bal",
+        "block-stmt/block_stmt_assert_02.json");
+    }
+
+    @Test
+    public void testBlockStmtWithFieldsOnly() {
+        testFile("block-stmt/block_stmt_source_03.bal",
+        "block-stmt/block_stmt_assert_03.json");
+    }
+
+    // Recovery tests
+
+    @Test
+    public void testBlockStmtWithExtraTokens() {
+        testFile("block-stmt/block_stmt_source_04.bal",
+        "block-stmt/block_stmt_assert_04.json");
+    }
+
+    @Test
+    public void testBlockStmtWithMissingEqual() {
+        testFile("block-stmt/block_stmt_source_05.bal",
+        "block-stmt/block_stmt_assert_05.json");
+    }
+
+    @Test
+    public void testNestedObjectRecovery() {
+        testFile("block-stmt/block_stmt_source_06.bal",
+        "block-stmt/block_stmt_assert_06.json");
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/LockStatement.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/LockStatement.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerinalang.compiler.parser.test.syntax.statements;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test parsing object type definitions.
+ */
+public class LockStatement extends AbstractStatementTest {
+
+    // Valid syntax tests
+
+   @Test
+    public void testComplexLockStmt() {
+        testFile("lock-stmt/lock_stmt_source_01.bal",
+        "lock-stmt/lock_stmt_assert_01.json");
+    }
+
+    @Test
+    public void testEmptyLockStmt() {
+        testFile("lock-stmt/lock_stmt_source_02.bal",
+        "lock-stmt/lock_stmt_assert_02.json");
+    }
+
+    @Test
+    public void testLockStmtWithFieldsOnly() {
+        testFile("lock-stmt/lock_stmt_source_03.bal",
+        "lock-stmt/lock_stmt_assert_03.json");
+    }
+
+    // Recovery tests
+
+    @Test
+    public void testLockStmtWithExtraTokens() {
+        testFile("lock-stmt/lock_stmt_source_04.bal",
+        "lock-stmt/lock_stmt_assert_04.json");
+    }
+
+    @Test
+    public void testLockStmtWithMissingEqual() {
+        testFile("lock-stmt/lock_stmt_source_05.bal",
+        "lock-stmt/lock_stmt_assert_05.json");
+    }
+
+    @Test
+    public void testNestedObjectRecovery() {
+        testFile("lock-stmt/lock_stmt_source_06.bal",
+        "lock-stmt/lock_stmt_assert_06.json");
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/LockStatement.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/LockStatement.java
@@ -64,4 +64,9 @@ public class LockStatement extends AbstractStatementTest {
         "lock-stmt/lock_stmt_assert_06.json");
     }
 
+    @Test
+    public void testMissingCloseBrace() {
+        testFile("lock-stmt/lock_stmt_source_07.bal",
+        "lock-stmt/lock_stmt_assert_07.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_01.json
@@ -1,0 +1,495 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "BLOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": [
+                                        {
+                                            "kind": "INVALID",
+                                            "children": [
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "A"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "int"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "age"
+                                                },
+                                                {
+                                                    "kind": "EQUAL_TOKEN"
+                                                },
+                                                {
+                                                    "kind": "BINARY_EXPRESSION",
+                                                    "children": [
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "10"
+                                                        },
+                                                        {
+                                                            "kind": "ASTERISK_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "string"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "name"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "int"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "status"
+                                                },
+                                                {
+                                                    "kind": "EQUAL_TOKEN"
+                                                },
+                                                {
+                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                    "value": "0"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "float"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "score"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "INVALID",
+                                            "children": [
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "B"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_TYPE_DEFINITION_STATEMENT",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "TYPE_KEYWORD"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "typeN"
+                                                },
+                                                {
+                                                    "kind": "OBJECT_TYPE_DESCRIPTOR",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "OBJECT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "OPEN_BRACE_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "TYPE_REFERENCE",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "ASTERISK_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "A"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "OBJECT_FIELD",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "SIMPLE_TYPE",
+                                                                            "value": "int"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "age"
+                                                                        },
+                                                                        {
+                                                                            "kind": "EQUAL_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "BINARY_EXPRESSION",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                                    "value": "10"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "ASTERISK_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                                    "value": "2"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "OBJECT_FIELD",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "SIMPLE_TYPE",
+                                                                            "value": "string"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "name"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "OBJECT_FIELD",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "PUBLIC_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SIMPLE_TYPE",
+                                                                            "value": "int"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "status"
+                                                                        },
+                                                                        {
+                                                                            "kind": "EQUAL_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                            "value": "0"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "OBJECT_FIELD",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "PRIVATE_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SIMPLE_TYPE",
+                                                                            "value": "float"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "score"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "FUNCTION_DEFINITION",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "PUBLIC_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "FUNCTION_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "__init"
+                                                                        },
+                                                                        {
+                                                                            "kind": "OPEN_PAREN_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "LIST",
+                                                                            "children": []
+                                                                        },
+                                                                        {
+                                                                            "kind": "CLOSE_PAREN_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "BLOCK_STATEMENT",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "OPEN_BRACE_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                },
+                                                                                {
+                                                                                    "kind": "CLOSE_BRACE_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "TYPE_REFERENCE",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "ASTERISK_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "B"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "FUNCTION_DEFINITION",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "FUNCTION_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "getName"
+                                                                        },
+                                                                        {
+                                                                            "kind": "OPEN_PAREN_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "LIST",
+                                                                            "children": []
+                                                                        },
+                                                                        {
+                                                                            "kind": "CLOSE_PAREN_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "BLOCK_STATEMENT",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "OPEN_BRACE_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                },
+                                                                                {
+                                                                                    "kind": "CLOSE_BRACE_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "CLOSE_BRACE_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_01.json
@@ -49,18 +49,6 @@
                                     "kind": "LIST",
                                     "children": [
                                         {
-                                            "kind": "INVALID",
-                                            "children": [
-                                                {
-                                                    "kind": "IDENTIFIER_TOKEN",
-                                                    "value": "A"
-                                                },
-                                                {
-                                                    "kind": "SEMICOLON_TOKEN"
-                                                }
-                                            ]
-                                        },
-                                        {
                                             "kind": "LOCAL_VAR_DECL",
                                             "children": [
                                                 {
@@ -160,18 +148,6 @@
                                                 {
                                                     "kind": "IDENTIFIER_TOKEN",
                                                     "value": "score"
-                                                },
-                                                {
-                                                    "kind": "SEMICOLON_TOKEN"
-                                                }
-                                            ]
-                                        },
-                                        {
-                                            "kind": "INVALID",
-                                            "children": [
-                                                {
-                                                    "kind": "IDENTIFIER_TOKEN",
-                                                    "value": "B"
                                                 },
                                                 {
                                                     "kind": "SEMICOLON_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_02.json
@@ -1,0 +1,65 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "BLOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": []
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_03.json
@@ -1,0 +1,172 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "BLOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": [
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "int"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "age"
+                                                },
+                                                {
+                                                    "kind": "EQUAL_TOKEN"
+                                                },
+                                                {
+                                                    "kind": "BINARY_EXPRESSION",
+                                                    "children": [
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "10"
+                                                        },
+                                                        {
+                                                            "kind": "ASTERISK_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "string"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "name"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "int"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "status"
+                                                },
+                                                {
+                                                    "kind": "EQUAL_TOKEN"
+                                                },
+                                                {
+                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                    "value": "0"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "float"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "score"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_04.json
@@ -1,0 +1,118 @@
+{
+            "kind": "FUNCTION_DEFINITION",
+            "children": [
+                {
+                    "kind": "METADATA",
+                    "children": [
+                        {
+                            "kind": "LIST",
+                            "children": []
+                        }
+                    ]
+                },
+                {
+                    "kind": "PUBLIC_KEYWORD"
+                },
+                {
+                    "kind": "FUNCTION_KEYWORD"
+                },
+                {
+                    "kind": "IDENTIFIER_TOKEN",
+                    "value": "foo"
+                },
+                {
+                    "kind": "OPEN_PAREN_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": []
+                },
+                {
+                    "kind": "CLOSE_PAREN_TOKEN"
+                },
+                {
+                    "kind": "BLOCK_STATEMENT",
+                    "children": [
+                        {
+                            "kind": "OPEN_BRACE_TOKEN"
+                        },
+                        {
+                            "kind": "LIST",
+                            "children": [
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "INVALID",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "A"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "a"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "b"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "CLOSE_BRACE_TOKEN"
+                        }
+                    ]
+                }
+            ]
+        }

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_05.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_05.json
@@ -1,0 +1,94 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "BLOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": [
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "int"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "b"
+                                                },
+                                                {
+                                                    "kind": "EQUAL_TOKEN",
+                                                    "isMissing": true
+                                                },
+                                                {
+                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                    "value": "7"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_06.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_06.json
@@ -1,0 +1,199 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "BLOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": [
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "SIMPLE_TYPE",
+                                                    "value": "int"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "a"
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN"
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "LOCAL_VAR_DECL",
+                                            "children": [
+                                                {
+                                                    "kind": "LIST",
+                                                    "children": []
+                                                },
+                                                {
+                                                    "kind": "OBJECT_TYPE_DESCRIPTOR",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "OBJECT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "OPEN_BRACE_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "OBJECT_FIELD",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "SIMPLE_TYPE",
+                                                                            "value": "int"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "a"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN",
+                                                                            "isMissing": true
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "FUNCTION_DEFINITION",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "METADATA",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "FUNCTION_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "isMissing": true
+                                                                        },
+                                                                        {
+                                                                            "kind": "OPEN_PAREN_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "LIST",
+                                                                            "children": []
+                                                                        },
+                                                                        {
+                                                                            "kind": "CLOSE_PAREN_TOKEN"
+                                                                        },
+                                                                        {
+                                                                            "kind": "BLOCK_STATEMENT",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "OPEN_BRACE_TOKEN",
+                                                                                    "isMissing": true
+                                                                                },
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                },
+                                                                                {
+                                                                                    "kind": "CLOSE_BRACE_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "CLOSE_BRACE_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "isMissing": true
+                                                },
+                                                {
+                                                    "kind": "SEMICOLON_TOKEN",
+                                                    "isMissing": true
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_assert_07.json
@@ -1,0 +1,67 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "BLOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": []
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN",
+                                    "isMissing": true
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN",
+                    "isMissing": true
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_01.bal
@@ -1,0 +1,29 @@
+public function foo() {
+    {
+
+        *A;
+
+        int age = 10 * 2;
+        string name;
+        int status = 0;
+        float score;
+        
+        *B;
+
+        type typeN object {
+            *A;
+            int age = 10 * 2;
+            string name;
+            public int status = 0;
+            private float score;
+
+            public function __init() {
+            }
+
+            *B;
+
+            function getName() {
+            }
+        };
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_01.bal
@@ -1,15 +1,10 @@
 public function foo() {
     {
-
-        *A;
-
         int age = 10 * 2;
         string name;
         int status = 0;
         float score;
         
-        *B;
-
         type typeN object {
             *A;
             int age = 10 * 2;

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_02.bal
@@ -1,0 +1,5 @@
+public function foo() {
+    {
+
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_03.bal
@@ -1,0 +1,8 @@
+public function foo() {
+    {
+        int age = 10 * 2;
+        string name;
+        int status = 0;
+        float score;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_04.bal
@@ -1,0 +1,7 @@
+public function foo() {
+    {
+        A;
+        +int a;
+        int b;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_05.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_05.bal
@@ -1,0 +1,5 @@
+public function foo() {
+    {
+        int b 7;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_06.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_06.bal
@@ -1,0 +1,12 @@
+public function foo() {
+    {
+        int a;
+        
+        object {
+            int a
+            
+            function () 
+            }
+        }
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_07.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/block-stmt/block_stmt_source_07.bal
@@ -1,0 +1,3 @@
+public function foo() {
+    {
+

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_01.json
@@ -55,18 +55,6 @@
                                             "kind": "LIST",
                                             "children": [
                                                 {
-                                                    "kind": "INVALID",
-                                                    "children": [
-                                                        {
-                                                            "kind": "IDENTIFIER_TOKEN",
-                                                            "value": "A"
-                                                        },
-                                                        {
-                                                            "kind": "SEMICOLON_TOKEN"
-                                                        }
-                                                    ]
-                                                },
-                                                {
                                                     "kind": "LOCAL_VAR_DECL",
                                                     "children": [
                                                         {
@@ -166,18 +154,6 @@
                                                         {
                                                             "kind": "IDENTIFIER_TOKEN",
                                                             "value": "score"
-                                                        },
-                                                        {
-                                                            "kind": "SEMICOLON_TOKEN"
-                                                        }
-                                                    ]
-                                                },
-                                                {
-                                                    "kind": "INVALID",
-                                                    "children": [
-                                                        {
-                                                            "kind": "IDENTIFIER_TOKEN",
-                                                            "value": "B"
                                                         },
                                                         {
                                                             "kind": "SEMICOLON_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_01.json
@@ -1,0 +1,503 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "INVALID",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "A"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "age"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "BINARY_EXPRESSION",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                    "value": "10"
+                                                                },
+                                                                {
+                                                                    "kind": "ASTERISK_TOKEN"
+                                                                },
+                                                                {
+                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                    "value": "2"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "string"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "name"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "status"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "0"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "float"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "score"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "INVALID",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "B"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_TYPE_DEFINITION_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "TYPE_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "typeN"
+                                                        },
+                                                        {
+                                                            "kind": "OBJECT_TYPE_DESCRIPTOR",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "LIST",
+                                                                    "children": []
+                                                                },
+                                                                {
+                                                                    "kind": "OBJECT_KEYWORD"
+                                                                },
+                                                                {
+                                                                    "kind": "OPEN_BRACE_TOKEN"
+                                                                },
+                                                                {
+                                                                    "kind": "LIST",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "TYPE_REFERENCE",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "ASTERISK_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "A"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "OBJECT_FIELD",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SIMPLE_TYPE",
+                                                                                    "value": "int"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "age"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "EQUAL_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "BINARY_EXPRESSION",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                                            "value": "10"
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "ASTERISK_TOKEN"
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                                            "value": "2"
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "OBJECT_FIELD",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SIMPLE_TYPE",
+                                                                                    "value": "string"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "name"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "OBJECT_FIELD",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "PUBLIC_KEYWORD"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SIMPLE_TYPE",
+                                                                                    "value": "int"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "status"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "EQUAL_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                                    "value": "0"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "OBJECT_FIELD",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "PRIVATE_KEYWORD"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SIMPLE_TYPE",
+                                                                                    "value": "float"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "score"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "FUNCTION_DEFINITION",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "PUBLIC_KEYWORD"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "FUNCTION_KEYWORD"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "__init"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "OPEN_PAREN_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                },
+                                                                                {
+                                                                                    "kind": "CLOSE_PAREN_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "BLOCK_STATEMENT",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "OPEN_BRACE_TOKEN"
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "CLOSE_BRACE_TOKEN"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "TYPE_REFERENCE",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "ASTERISK_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "B"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN"
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "FUNCTION_DEFINITION",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "FUNCTION_KEYWORD"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "getName"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "OPEN_PAREN_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                },
+                                                                                {
+                                                                                    "kind": "CLOSE_PAREN_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "BLOCK_STATEMENT",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "OPEN_BRACE_TOKEN"
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "CLOSE_BRACE_TOKEN"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "CLOSE_BRACE_TOKEN"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_02.json
@@ -1,0 +1,73 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": []
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_03.json
@@ -1,0 +1,180 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "age"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "BINARY_EXPRESSION",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                    "value": "10"
+                                                                },
+                                                                {
+                                                                    "kind": "ASTERISK_TOKEN"
+                                                                },
+                                                                {
+                                                                    "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                    "value": "2"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "string"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "name"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "status"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "0"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "float"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "score"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_04.json
@@ -1,0 +1,126 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "INVALID",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "A"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "a"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "b"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_05.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_05.json
@@ -1,0 +1,102 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "b"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN",
+                                                            "isMissing": true
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "7"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_06.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_06.json
@@ -1,0 +1,207 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "SIMPLE_TYPE",
+                                                            "value": "int"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "a"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "OBJECT_TYPE_DESCRIPTOR",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "LIST",
+                                                                    "children": []
+                                                                },
+                                                                {
+                                                                    "kind": "OBJECT_KEYWORD"
+                                                                },
+                                                                {
+                                                                    "kind": "OPEN_BRACE_TOKEN"
+                                                                },
+                                                                {
+                                                                    "kind": "LIST",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "OBJECT_FIELD",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SIMPLE_TYPE",
+                                                                                    "value": "int"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "value": "a"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "SEMICOLON_TOKEN",
+                                                                                    "isMissing": true
+                                                                                }
+                                                                            ]
+                                                                        },
+                                                                        {
+                                                                            "kind": "FUNCTION_DEFINITION",
+                                                                            "children": [
+                                                                                {
+                                                                                    "kind": "METADATA",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        }
+                                                                                    ]
+                                                                                },
+                                                                                {
+                                                                                    "kind": "FUNCTION_KEYWORD"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "IDENTIFIER_TOKEN",
+                                                                                    "isMissing": true
+                                                                                },
+                                                                                {
+                                                                                    "kind": "OPEN_PAREN_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "LIST",
+                                                                                    "children": []
+                                                                                },
+                                                                                {
+                                                                                    "kind": "CLOSE_PAREN_TOKEN"
+                                                                                },
+                                                                                {
+                                                                                    "kind": "BLOCK_STATEMENT",
+                                                                                    "children": [
+                                                                                        {
+                                                                                            "kind": "OPEN_BRACE_TOKEN",
+                                                                                            "isMissing": true
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "LIST",
+                                                                                            "children": []
+                                                                                        },
+                                                                                        {
+                                                                                            "kind": "CLOSE_BRACE_TOKEN"
+                                                                                        }
+                                                                                    ]
+                                                                                }
+                                                                            ]
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "CLOSE_BRACE_TOKEN"
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "isMissing": true
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN",
+                                                            "isMissing": true
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_assert_07.json
@@ -1,0 +1,75 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "BLOCK_STATEMENT",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "LOCK_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "LOCK_KEYWORD"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": []
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN",
+                                            "isMissing": true
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN",
+                    "isMissing": true
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_01.bal
@@ -1,0 +1,29 @@
+public function foo() {
+    lock {
+
+        *A;
+
+        int age = 10 * 2;
+        string name;
+        int status = 0;
+        float score;
+        
+        *B;
+
+        type typeN object {
+            *A;
+            int age = 10 * 2;
+            string name;
+            public int status = 0;
+            private float score;
+
+            public function __init() {
+            }
+
+            *B;
+
+            function getName() {
+            }
+        };
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_01.bal
@@ -1,15 +1,11 @@
 public function foo() {
     lock {
 
-        *A;
-
         int age = 10 * 2;
         string name;
         int status = 0;
         float score;
         
-        *B;
-
         type typeN object {
             *A;
             int age = 10 * 2;

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_02.bal
@@ -1,0 +1,5 @@
+public function foo() {
+    lock {
+
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_03.bal
@@ -1,0 +1,8 @@
+public function foo() {
+    lock {
+        int age = 10 * 2;
+        string name;
+        int status = 0;
+        float score;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_04.bal
@@ -1,0 +1,7 @@
+public function foo() {
+    lock {
+        A;
+        +int a;
+        int b;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_05.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_05.bal
@@ -1,0 +1,5 @@
+public function foo() {
+    lock {
+        int b 7;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_06.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_06.bal
@@ -1,0 +1,12 @@
+public function foo() {
+    lock {
+        int a;
+        
+        object {
+            int a
+            
+            function () 
+            }
+        }
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_07.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/lock-stmt/lock_stmt_source_07.bal
@@ -1,0 +1,2 @@
+public function foo() {
+    lock {

--- a/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
+++ b/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
@@ -530,6 +530,21 @@
             ]
         },
         {
+            "name": "LockStatementNode",
+            "base": "StatementNode",
+            "kind": "LOCK_STATEMENT",
+            "attributes": [
+                {
+                    "name": "lockKeyword",
+                    "type": "Token"
+                },
+                {
+                    "name": "blockStatement",
+                    "type": "StatementNode"
+                }
+            ]
+        },
+        {
             "name": "ExpressionNode",
             "base": "Node",
             "isAbstract": true


### PR DESCRIPTION
Add block statement and lock statement support for incremental parser.

<code>lock-stmt := lock block-stmt</code>
<code>sequence-stmt := statement*</code>
<code>block-stmt := { sequence-stmt }</code>

https://ballerina.io/spec/lang/2020R1/#lock-stmt

closes: #22486
closes: #22780

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
