### PR TITLE
Add type cast action and separate function/method calls and actions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
@@ -494,6 +494,10 @@ public class TreeBuilder {
         return new BLangInvocation();
     }
 
+    public static InvocationNode createRemoteMethodCall() {
+        return new BLangInvocation.BLangActionInvocation();
+    }
+
     public static FieldBasedAccessNode createFieldBasedAccessNode() {
         return new BLangFieldBasedAccess();
     }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
@@ -494,7 +494,7 @@ public class TreeBuilder {
         return new BLangInvocation();
     }
 
-    public static InvocationNode createRemoteMethodCall() {
+    public static InvocationNode createActionInvocation() {
         return new BLangInvocation.BLangActionInvocation();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/ActionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/ActionNode.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/ActionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/ActionNode.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.model.tree;
+
+/**
+ * Interface used for marking nodes as actions.
+ *
+ * @since 1.3.0
+ */
+public interface ActionNode extends Node {
+}

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/InvocationNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/InvocationNode.java
@@ -41,7 +41,5 @@ public interface InvocationNode extends VariableReferenceNode, AnnotatableNode {
 
     boolean isIterableOperation();
 
-    boolean isActionInvocation();
-    
     boolean isAsync();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WaitExpressionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WaitExpressionNode.java
@@ -17,12 +17,14 @@
 */
 package org.ballerinalang.model.tree.expressions;
 
+import org.ballerinalang.model.tree.ActionNode;
+
 /**
  * This represents the wait expression node.
- * 
+ *
  * @since 0.965
  */
-public interface WaitExpressionNode extends ExpressionNode {
+public interface WaitExpressionNode extends ExpressionNode, ActionNode {
 
     ExpressionNode getExpression();
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WaitForAllExpressionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WaitForAllExpressionNode.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.model.tree.expressions;
 
+import org.ballerinalang.model.tree.ActionNode;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangWaitForAllExpr;
@@ -28,7 +29,7 @@ import java.util.List;
  *
  * @since 0.985
  */
-public interface WaitForAllExpressionNode extends ExpressionNode {
+public interface WaitForAllExpressionNode extends ExpressionNode, ActionNode {
 
     List<BLangWaitForAllExpr.BLangWaitKeyValue> getKeyValuePairs();
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WorkerFlushExpressionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WorkerFlushExpressionNode.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.model.tree.expressions;
 
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.IdentifierNode;
 
 /**
@@ -24,6 +25,6 @@ import org.ballerinalang.model.tree.IdentifierNode;
  *
  * @since 0.985
  */
-public interface WorkerFlushExpressionNode extends ExpressionNode {
+public interface WorkerFlushExpressionNode extends ExpressionNode, ActionNode {
     IdentifierNode getWorkerName();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WorkerSendSyncExpressionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/WorkerSendSyncExpressionNode.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.model.tree.expressions;
 
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.IdentifierNode;
 
 /**
@@ -24,7 +25,7 @@ import org.ballerinalang.model.tree.IdentifierNode;
  *
  * @since 0.985
  */
-public interface WorkerSendSyncExpressionNode extends ExpressionNode {
+public interface WorkerSendSyncExpressionNode extends ExpressionNode, ActionNode {
     ExpressionNode getExpression();
 
     IdentifierNode getWorkerName();

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/QueryActionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/QueryActionNode.java
@@ -21,6 +21,7 @@ import org.ballerinalang.model.clauses.DoClauseNode;
 import org.ballerinalang.model.clauses.FromClauseNode;
 import org.ballerinalang.model.clauses.LetClauseNode;
 import org.ballerinalang.model.clauses.WhereClauseNode;
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLetClause;
 
@@ -31,7 +32,7 @@ import java.util.List;
  *
  * @since 1.2.0
  */
-public interface QueryActionNode extends ExpressionNode {
+public interface QueryActionNode extends ExpressionNode, ActionNode {
 
     List<? extends FromClauseNode> getFromClauseNodes();
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/WorkerReceiveNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/WorkerReceiveNode.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.model.tree.statements;
 
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
 
@@ -25,7 +26,7 @@ import org.ballerinalang.model.tree.expressions.ExpressionNode;
  *
  * @since 0.94
  */
-public interface WorkerReceiveNode extends ExpressionNode {
+public interface WorkerReceiveNode extends ExpressionNode, ActionNode {
 
     ExpressionNode getKeyExpression();
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/WorkerSendNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/statements/WorkerSendNode.java
@@ -17,6 +17,7 @@
 */
 package org.ballerinalang.model.tree.statements;
 
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
 
@@ -25,7 +26,7 @@ import org.ballerinalang.model.tree.expressions.ExpressionNode;
  *
  * @since 0.94
  */
-public interface WorkerSendNode extends StatementNode {
+public interface WorkerSendNode extends StatementNode, ActionNode {
 
     ExpressionNode getExpression();
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -499,6 +499,10 @@ public enum DiagnosticCode {
 
     ILLEGAL_FUNCTION_CHANGE_LIST_SIZE("illegal.function.change.list.size"),
     ILLEGAL_FUNCTION_CHANGE_TUPLE_SHAPE("illegal.function.change.tuple.shape"),
+
+    INVALID_WAIT_MAPPING_CONSTRUCTORS("invalid.wait.future.expr.mapping.constructors"),
+    INVALID_WAIT_ACTIONS("invalid.wait.future.expr.actions"),
+    INVALID_SEND_EXPR("invalid.send.expr"),
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -177,6 +177,7 @@ public enum DiagnosticCode {
 
     ENDPOINT_NOT_SUPPORT_REGISTRATION("endpoint.not.support.registration"),
     INVALID_ACTION_INVOCATION_SYNTAX("invalid.action.invocation.syntax"),
+    INVALID_METHOD_INVOCATION_SYNTAX("invalid.method.invocation.syntax"),
     INVALID_INIT_INVOCATION("invalid.init.invocation"),
     INVALID_RESOURCE_FUNCTION_INVOCATION("invalid.resource.function.invocation"),
     INVALID_ACTION_INVOCATION("invalid.action.invocation"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -454,6 +454,7 @@ public enum DiagnosticCode {
     INVALID_ERROR_CONSTRUCTOR_DETAIL("invalid.error.detail.rec.does.not.match"),
     INDIRECT_ERROR_CTOR_REASON_NOT_ALLOWED("invalid.error.reason.argument.to.indirect.error.constructor"),
     INDIRECT_ERROR_CTOR_NOT_ALLOWED_ON_NON_CONST_REASON("invalid.indirect.error.constructor.invocation"),
+    INVALID_FUNCTIONAL_CONSTRUCTOR_INVOCATION("invalid.functional.constructor.invocation"),
 
     // Seal inbuilt function related codes
     INCOMPATIBLE_STAMP_TYPE("incompatible.stamp.type"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.bir;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.BlockNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
@@ -960,6 +961,11 @@ public class BIRGen extends BLangNodeVisitor {
             return;
         }
         createCall(invocationExpr, false);
+    }
+
+    @Override
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocation) {
+        createCall(actionInvocation, false);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -20,7 +20,6 @@ package org.wso2.ballerinalang.compiler.bir;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.symbols.SymbolKind;
-import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.BlockNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -1312,6 +1312,9 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangInvocation.BLangActionInvocation aIExpr) {
+        aIExpr.expr = rewriteExpr(aIExpr.expr);
+        aIExpr.requiredArgs = rewriteExprs(aIExpr.requiredArgs);
+        aIExpr.restArgs = rewriteExprs(aIExpr.restArgs);
         result = aIExpr;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -275,6 +275,14 @@ public class ConstantPropagation extends BLangNodeVisitor {
     }
 
     @Override
+    public void visit(BLangInvocation.BLangActionInvocation remoteMethodCallNode) {
+        remoteMethodCallNode.expr = rewrite(remoteMethodCallNode.expr);
+        rewrite(remoteMethodCallNode.requiredArgs);
+        rewrite(remoteMethodCallNode.restArgs);
+        result = remoteMethodCallNode;
+    }
+
+    @Override
     public void visit(BLangNamedArgsExpression namedArgsExpression) {
         namedArgsExpression.expr = rewrite(namedArgsExpression.expr);
         result = namedArgsExpression;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -275,11 +275,11 @@ public class ConstantPropagation extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangInvocation.BLangActionInvocation remoteMethodCallNode) {
-        remoteMethodCallNode.expr = rewrite(remoteMethodCallNode.expr);
-        rewrite(remoteMethodCallNode.requiredArgs);
-        rewrite(remoteMethodCallNode.restArgs);
-        result = remoteMethodCallNode;
+    public void visit(BLangInvocation.BLangActionInvocation actionInv) {
+        actionInv.expr = rewrite(actionInv.expr);
+        rewrite(actionInv.requiredArgs);
+        rewrite(actionInv.restArgs);
+        result = actionInv;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3597,7 +3597,7 @@ public class Desugar extends BLangNodeVisitor {
                     argExprs.add(0, iExpr.expr);
                     BLangAttachedFunctionInvocation attachedFunctionInvocation =
                             new BLangAttachedFunctionInvocation(iExpr.pos, argExprs, iExpr.restArgs, iExpr.symbol,
-                                                                iExpr.type, iExpr.expr, iExpr.async);
+                                                                iExpr.type, iExpr.expr, false);
                     attachedFunctionInvocation.name = iExpr.name;
                     attachedFunctionInvocation.annAttachments = iExpr.annAttachments;
                     result = genIExpr = attachedFunctionInvocation;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3563,58 +3563,58 @@ public class Desugar extends BLangNodeVisitor {
         rewriteInvocation(actionInvocation, actionInvocation.async);
     }
 
-    private void rewriteInvocation(BLangInvocation actionInvocation, boolean async) {
-        BLangInvocation invRef = actionInvocation;
+    private void rewriteInvocation(BLangInvocation invocation, boolean async) {
+        BLangInvocation invRef = invocation;
 
         if (!enclLocks.isEmpty()) {
             BLangLockStmt lock = enclLocks.peek();
-            lock.lockVariables.addAll(((BInvokableSymbol) actionInvocation.symbol).dependentGlobalVars);
+            lock.lockVariables.addAll(((BInvokableSymbol) invocation.symbol).dependentGlobalVars);
         }
 
         // Reorder the arguments to match the original function signature.
-        reorderArguments(actionInvocation);
+        reorderArguments(invocation);
 
-        actionInvocation.requiredArgs = rewriteExprs(actionInvocation.requiredArgs);
-        fixNonRestArgTypeCastInTypeParamInvocation(actionInvocation);
+        invocation.requiredArgs = rewriteExprs(invocation.requiredArgs);
+        fixNonRestArgTypeCastInTypeParamInvocation(invocation);
 
-        actionInvocation.restArgs = rewriteExprs(actionInvocation.restArgs);
+        invocation.restArgs = rewriteExprs(invocation.restArgs);
 
-        annotationDesugar.defineStatementAnnotations(actionInvocation.annAttachments, actionInvocation.pos, actionInvocation.symbol.pkgID,
-                                                     actionInvocation.symbol.owner, env);
+        annotationDesugar.defineStatementAnnotations(invocation.annAttachments, invocation.pos,
+                                                     invocation.symbol.pkgID, invocation.symbol.owner, env);
 
-        if (actionInvocation.functionPointerInvocation) {
-            visitFunctionPointerInvocation(actionInvocation);
+        if (invocation.functionPointerInvocation) {
+            visitFunctionPointerInvocation(invocation);
             return;
         }
-        actionInvocation.expr = rewriteExpr(actionInvocation.expr);
+        invocation.expr = rewriteExpr(invocation.expr);
         result = invRef;
 
-        if (actionInvocation.expr == null) {
-            fixTypeCastInTypeParamInvocation(actionInvocation, invRef);
-            if (actionInvocation.exprSymbol == null) {
+        if (invocation.expr == null) {
+            fixTypeCastInTypeParamInvocation(invocation, invRef);
+            if (invocation.exprSymbol == null) {
                 return;
             }
-            actionInvocation.expr = ASTBuilderUtil.createVariableRef(actionInvocation.pos, actionInvocation.exprSymbol);
-            actionInvocation.expr = rewriteExpr(actionInvocation.expr);
+            invocation.expr = ASTBuilderUtil.createVariableRef(invocation.pos, invocation.exprSymbol);
+            invocation.expr = rewriteExpr(invocation.expr);
         }
-        switch (actionInvocation.expr.type.tag) {
+        switch (invocation.expr.type.tag) {
             case TypeTags.OBJECT:
             case TypeTags.RECORD:
-                if (!actionInvocation.langLibInvocation) {
-                    List<BLangExpression> argExprs = new ArrayList<>(actionInvocation.requiredArgs);
-                    argExprs.add(0, actionInvocation.expr);
+                if (!invocation.langLibInvocation) {
+                    List<BLangExpression> argExprs = new ArrayList<>(invocation.requiredArgs);
+                    argExprs.add(0, invocation.expr);
                     BLangAttachedFunctionInvocation attachedFunctionInvocation =
-                            new BLangAttachedFunctionInvocation(actionInvocation.pos, argExprs, actionInvocation.restArgs,
-                                                                actionInvocation.symbol, actionInvocation.type, actionInvocation.expr,
+                            new BLangAttachedFunctionInvocation(invocation.pos, argExprs, invocation.restArgs,
+                                                                invocation.symbol, invocation.type, invocation.expr,
                                                                 async);
-                    attachedFunctionInvocation.name = actionInvocation.name;
-                    attachedFunctionInvocation.annAttachments = actionInvocation.annAttachments;
+                    attachedFunctionInvocation.name = invocation.name;
+                    attachedFunctionInvocation.annAttachments = invocation.annAttachments;
                     result = invRef = attachedFunctionInvocation;
                 }
                 break;
         }
 
-        fixTypeCastInTypeParamInvocation(actionInvocation, invRef);
+        fixTypeCastInTypeParamInvocation(invocation, invRef);
     }
 
     private void fixNonRestArgTypeCastInTypeParamInvocation(BLangInvocation iExpr) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3598,7 +3598,6 @@ public class Desugar extends BLangNodeVisitor {
                     BLangAttachedFunctionInvocation attachedFunctionInvocation =
                             new BLangAttachedFunctionInvocation(iExpr.pos, argExprs, iExpr.restArgs, iExpr.symbol,
                                                                 iExpr.type, iExpr.expr, iExpr.async);
-                    attachedFunctionInvocation.actionInvocation = iExpr.actionInvocation;
                     attachedFunctionInvocation.name = iExpr.name;
                     attachedFunctionInvocation.annAttachments = iExpr.annAttachments;
                     result = genIExpr = attachedFunctionInvocation;
@@ -3607,6 +3606,58 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         fixTypeCastInTypeParamInvocation(iExpr, genIExpr);
+    }
+
+    @Override
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocation) {
+        BLangInvocation genIExpr = actionInvocation;
+
+        // Reorder the arguments to match the original function signature.
+        reorderArguments(actionInvocation);
+
+        actionInvocation.requiredArgs = rewriteExprs(actionInvocation.requiredArgs);
+        fixNonRestArgTypeCastInTypeParamInvocation(actionInvocation);
+
+        actionInvocation.restArgs = rewriteExprs(actionInvocation.restArgs);
+
+        annotationDesugar.defineStatementAnnotations(actionInvocation.annAttachments, actionInvocation.pos,
+                                                     actionInvocation.symbol.pkgID, actionInvocation.symbol.owner, env);
+
+        if (actionInvocation.functionPointerInvocation) {
+            visitFunctionPointerInvocation(actionInvocation);
+            return;
+        }
+        actionInvocation.expr = rewriteExpr(actionInvocation.expr);
+        result = genIExpr;
+
+        if (actionInvocation.expr == null) {
+            fixTypeCastInTypeParamInvocation(actionInvocation, genIExpr);
+            if (actionInvocation.exprSymbol == null) {
+                return;
+            }
+            actionInvocation.expr = ASTBuilderUtil.createVariableRef(actionInvocation.pos, actionInvocation.exprSymbol);
+            actionInvocation.expr = rewriteExpr(actionInvocation.expr);
+        }
+
+        switch (actionInvocation.expr.type.tag) {
+            case TypeTags.OBJECT:
+            case TypeTags.RECORD:
+                if (!actionInvocation.langLibInvocation) {
+                    List<BLangExpression> argExprs = new ArrayList<>(actionInvocation.requiredArgs);
+                    argExprs.add(0, actionInvocation.expr);
+                    BLangAttachedFunctionInvocation attachedFunctionInvocation =
+                            new BLangAttachedFunctionInvocation(actionInvocation.pos, argExprs,
+                                                                actionInvocation.restArgs, actionInvocation.symbol,
+                                                                actionInvocation.type, actionInvocation.expr,
+                                                                actionInvocation.async);
+                    attachedFunctionInvocation.name = actionInvocation.name;
+                    attachedFunctionInvocation.annAttachments = actionInvocation.annAttachments;
+                    result = genIExpr = attachedFunctionInvocation;
+                }
+                break;
+        }
+
+        fixTypeCastInTypeParamInvocation(actionInvocation, genIExpr);
     }
 
     private void fixNonRestArgTypeCastInTypeParamInvocation(BLangInvocation iExpr) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1654,8 +1654,16 @@ public class BLangPackageBuilder {
         this.exprNodeStack.push(varRef);
     }
 
-    void createFunctionInvocation(DiagnosticPos pos, Set<Whitespace> ws, boolean argsAvailable) {
-        BLangInvocation invocationNode = (BLangInvocation) TreeBuilder.createInvocationNode();
+    void createFunctionInvocation(DiagnosticPos pos, Set<Whitespace> ws, boolean argsAvailable,
+                                  boolean remoteMethodCall) {
+        BLangInvocation invocationNode;
+
+        if (remoteMethodCall) {
+            invocationNode = (BLangInvocation) TreeBuilder.createRemoteMethodCall();
+        } else {
+            invocationNode = (BLangInvocation) TreeBuilder.createInvocationNode();
+        }
+
         invocationNode.pos = pos;
         invocationNode.addWS(ws);
         if (argsAvailable) {
@@ -1715,7 +1723,6 @@ public class BLangPackageBuilder {
 
     void createActionInvocationNode(DiagnosticPos pos, Set<Whitespace> ws, boolean async, int numAnnotations) {
         BLangInvocation invocationExpr = (BLangInvocation) exprNodeStack.pop();
-        invocationExpr.actionInvocation = true;
         invocationExpr.pos = pos;
         invocationExpr.addWS(ws);
         invocationExpr.async = async;
@@ -3194,6 +3201,7 @@ public class BLangPackageBuilder {
         workerReceiveExpr.pos = pos;
         workerReceiveExpr.addWS(ws);
         //if there are two expressions, this is a channel receive and the top expression is the key
+        // TODO: Not needed?
         if (hasKey) {
             workerReceiveExpr.keyExpr = (BLangExpression) exprNodeStack.pop();
             workerReceiveExpr.isChannel = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1656,10 +1656,10 @@ public class BLangPackageBuilder {
     }
 
     void createFunctionInvocation(DiagnosticPos pos, Set<Whitespace> ws, boolean argsAvailable,
-                                  boolean remoteMethodCall) {
+                                  boolean actionInvocation) {
         BLangInvocation invocationNode;
 
-        if (remoteMethodCall) {
+        if (actionInvocation) {
             invocationNode = (BLangInvocation) TreeBuilder.createActionInvocation();
         } else {
             invocationNode = (BLangInvocation) TreeBuilder.createInvocationNode();
@@ -1732,12 +1732,14 @@ public class BLangPackageBuilder {
         addExpressionNode(invocationNode);
     }
 
-    void createActionInvocationNode(DiagnosticPos pos, Set<Whitespace> ws, boolean async, int numAnnotations) {
+    void createActionInvocationNode(DiagnosticPos pos, Set<Whitespace> ws, boolean async, boolean remoteMethodCall,
+                                    int numAnnotations) {
         BLangInvocation.BLangActionInvocation actionInvocation =
                 (BLangInvocation.BLangActionInvocation) exprNodeStack.pop();
         actionInvocation.pos = pos;
         actionInvocation.addWS(ws);
         actionInvocation.async = async;
+        actionInvocation.remoteMethodCall = remoteMethodCall;
 
         actionInvocation.expr = (BLangExpression) exprNodeStack.pop();
         attachAnnotations(actionInvocation, numAnnotations, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -2094,7 +2094,8 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         }
 
         boolean argsAvailable = ctx.invocationArgList() != null;
-        this.pkgBuilder.createFunctionInvocation(getCurrentPos(ctx), getWS(ctx), argsAvailable);
+        boolean remoteMethodCall = ctx.parent instanceof BallerinaParser.ActionInvocationContext;
+        this.pkgBuilder.createFunctionInvocation(getCurrentPos(ctx), getWS(ctx), argsAvailable, remoteMethodCall);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -18,6 +18,7 @@
 package org.wso2.ballerinalang.compiler.parser;
 
 import org.antlr.v4.runtime.ParserRuleContext;
+import org.antlr.v4.runtime.RuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
@@ -2058,8 +2059,10 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         boolean argsAvailable = ctx.invocation().invocationArgList() != null;
         BallerinaParser.AnyIdentifierNameContext identifierContext = ctx.invocation().anyIdentifierName();
         String invocation = identifierContext.getText();
+        BallerinaParser.VariableReferenceExpressionContext varRefCtx = getParentVarRefExprContext(ctx);
+        int annots = varRefCtx != null ? varRefCtx.annotationAttachment().size() : 0;
         this.pkgBuilder.createInvocationNode(getCurrentPos(ctx), getWS(ctx), invocation, argsAvailable,
-                getCurrentPos(identifierContext));
+                                             getCurrentPos(identifierContext), isAsync(ctx), annots);
     }
 
     @Override
@@ -2081,8 +2084,10 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         boolean argsAvailable = invocation.invocationArgList() != null;
         BallerinaParser.AnyIdentifierNameContext identifierContext = invocation.anyIdentifierName();
         String invocationText = identifierContext.getText();
+        BallerinaParser.VariableReferenceExpressionContext varRefCtx = getParentVarRefExprContext(ctx);
+        int annots = varRefCtx != null ? varRefCtx.annotationAttachment().size() : 0;
         this.pkgBuilder.createInvocationNode(getCurrentPos(invocation), getWS(invocation), invocationText,
-                argsAvailable, getCurrentPos(identifierContext));
+                                             argsAvailable, getCurrentPos(identifierContext), isAsync(ctx), annots);
         this.pkgBuilder.createGroupExpression(getCurrentPos(node), getWS(ctx));
     }
 
@@ -2094,8 +2099,21 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         }
 
         boolean argsAvailable = ctx.invocationArgList() != null;
-        boolean remoteMethodCall = ctx.parent instanceof BallerinaParser.ActionInvocationContext;
-        this.pkgBuilder.createFunctionInvocation(getCurrentPos(ctx), getWS(ctx), argsAvailable, remoteMethodCall);
+        boolean actionInvocation = ctx.parent instanceof BallerinaParser.ActionInvocationContext || isAsync(ctx);
+        this.pkgBuilder.createFunctionInvocation(getCurrentPos(ctx), getWS(ctx), argsAvailable, actionInvocation);
+    }
+
+    private boolean isAsync(RuleContext ctx) {
+        BallerinaParser.VariableReferenceExpressionContext parent = getParentVarRefExprContext(ctx);
+        return parent != null && parent.START() != null;
+    }
+
+    private BallerinaParser.VariableReferenceExpressionContext getParentVarRefExprContext(RuleContext ctx) {
+        RuleContext parent = ctx.parent;
+        while (parent != null && !(parent instanceof BallerinaParser.VariableReferenceExpressionContext)) {
+            parent = parent.parent;
+        }
+        return (BallerinaParser.VariableReferenceExpressionContext) parent;
     }
 
     @Override
@@ -2188,8 +2206,10 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         boolean argsAvailable = ctx.invocation().invocationArgList() != null;
         BallerinaParser.AnyIdentifierNameContext identifierContext = ctx.invocation().anyIdentifierName();
         String invocation = identifierContext.getText();
+        BallerinaParser.VariableReferenceExpressionContext varRefCtx = getParentVarRefExprContext(ctx);
+        int annots = varRefCtx != null ? varRefCtx.annotationAttachment().size() : 0;
         this.pkgBuilder.createInvocationNode(getCurrentPos(ctx), getWS(ctx), invocation, argsAvailable,
-                getCurrentPos(identifierContext));
+                                             getCurrentPos(identifierContext), isAsync(ctx), annots);
     }
 
     @Override
@@ -2203,9 +2223,12 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         boolean argsAvailable = invocation.invocationArgList() != null;
         BallerinaParser.AnyIdentifierNameContext identifierContext = invocation.anyIdentifierName();
         String invocationText = identifierContext.getText();
+        BallerinaParser.VariableReferenceExpressionContext varRefCtx = getParentVarRefExprContext(ctx);
+        int annots = varRefCtx != null ? varRefCtx.annotationAttachment().size() : 0;
         this.pkgBuilder.createGroupExpression(getCurrentPos(groupExpression), getWS(groupExpression));
         this.pkgBuilder.createInvocationNode(getCurrentPos(invocation), getWS(invocation),
-                invocationText, argsAvailable, getCurrentPos(identifierContext));
+                                             invocationText, argsAvailable, getCurrentPos(identifierContext),
+                                             isAsync(ctx), annots);
     }
 
     @Override
@@ -2217,8 +2240,10 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         boolean argsAvailable = ctx.invocation().invocationArgList() != null;
         BallerinaParser.AnyIdentifierNameContext identifierContext = ctx.invocation().anyIdentifierName();
         String invocation = identifierContext.getText();
+        BallerinaParser.VariableReferenceExpressionContext varRefCtx = getParentVarRefExprContext(ctx);
+        int annots = varRefCtx != null ? varRefCtx.annotationAttachment().size() : 0;
         this.pkgBuilder.createInvocationNode(getCurrentPos(ctx), getWS(ctx), invocation, argsAvailable,
-                getCurrentPos(identifierContext));
+                                             getCurrentPos(identifierContext), isAsync(ctx), annots);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -2571,8 +2571,8 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
         int numAnnotations = ctx.annotationAttachment().size();
-        this.pkgBuilder.createActionInvocationNode(getCurrentPos(ctx), getWS(ctx), ctx.START() != null,
-                numAnnotations);
+        this.pkgBuilder.createActionInvocationNode(getCurrentPos(ctx), getWS(ctx), ctx.START() != null, true,
+                                                   numAnnotations);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -893,7 +893,7 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.name = source.name;
         clone.argExprs = cloneList(source.argExprs);
         clone.functionPointerInvocation = source.functionPointerInvocation;
-        clone.actionInvocation = source.actionInvocation;
+//        clone.actionInvocation = source.actionInvocation;
         clone.langLibInvocation = source.langLibInvocation;
         clone.async = source.async;
         clone.flagSet = cloneSet(source.flagSet, Flag.class);
@@ -914,9 +914,21 @@ public class NodeCloner extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
+    public void visit(BLangInvocation.BLangActionInvocation source) {
+        BLangInvocation.BLangActionInvocation clone = new BLangInvocation.BLangActionInvocation();
+        source.cloneRef = clone;
+        clone.pkgAlias = source.pkgAlias;
+        clone.name = source.name;
+        clone.argExprs = cloneList(source.argExprs);
+        clone.functionPointerInvocation = source.functionPointerInvocation;
+//        clone.actionInvocation = source.actionInvocation;
+        clone.langLibInvocation = source.langLibInvocation;
+        clone.async = source.async;
+        clone.flagSet = cloneSet(source.flagSet, Flag.class);
+        clone.annAttachments = cloneList(source.annAttachments);
+        clone.requiredArgs = cloneList(source.requiredArgs);
 
-        // Ignore
+        cloneBLangAccessExpression(source, clone);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -893,9 +893,7 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.name = source.name;
         clone.argExprs = cloneList(source.argExprs);
         clone.functionPointerInvocation = source.functionPointerInvocation;
-//        clone.actionInvocation = source.actionInvocation;
         clone.langLibInvocation = source.langLibInvocation;
-        clone.async = source.async;
         clone.flagSet = cloneSet(source.flagSet, Flag.class);
         clone.annAttachments = cloneList(source.annAttachments);
         clone.requiredArgs = cloneList(source.requiredArgs);
@@ -921,7 +919,6 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.name = source.name;
         clone.argExprs = cloneList(source.argExprs);
         clone.functionPointerInvocation = source.functionPointerInvocation;
-//        clone.actionInvocation = source.actionInvocation;
         clone.langLibInvocation = source.langLibInvocation;
         clone.async = source.async;
         clone.flagSet = cloneSet(source.flagSet, Flag.class);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -921,6 +921,7 @@ public class NodeCloner extends BLangNodeVisitor {
         clone.functionPointerInvocation = source.functionPointerInvocation;
         clone.langLibInvocation = source.langLibInvocation;
         clone.async = source.async;
+        clone.remoteMethodCall = source.remoteMethodCall;
         clone.flagSet = cloneSet(source.flagSet, Flag.class);
         clone.annAttachments = cloneList(source.annAttachments);
         clone.requiredArgs = cloneList(source.requiredArgs);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -23,10 +23,12 @@ import org.ballerinalang.model.clauses.FromClauseNode;
 import org.ballerinalang.model.clauses.WhereClauseNode;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
 import org.ballerinalang.model.tree.expressions.RecordLiteralNode;
 import org.ballerinalang.model.tree.expressions.XMLNavigationAccess;
+import org.ballerinalang.model.tree.statements.StatementNode;
 import org.ballerinalang.util.diagnostic.DiagnosticCode;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
@@ -2043,33 +2045,17 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private void validateActionParentNode(DiagnosticPos pos, BLangNode node) {
         // Validate for parent nodes.
         BLangNode parent = node.parent;
-        if (parent.getKind() == NodeKind.BLOCK) {
-            return;
-        }
+
         while (parent != null) {
             final NodeKind kind = parent.getKind();
-            // Allowed node types.
-            if (kind == NodeKind.ASSIGNMENT
-                    || kind == NodeKind.EXPRESSION_STATEMENT || kind == NodeKind.RETURN
-                    || kind == NodeKind.RECORD_DESTRUCTURE || kind == NodeKind.ERROR_DESTRUCTURE
-                    || kind == NodeKind.TUPLE_DESTRUCTURE || kind == NodeKind.VARIABLE
-                    || kind == NodeKind.RECORD_VARIABLE || kind == NodeKind.TUPLE_VARIABLE
-                    || kind == NodeKind.ERROR_VARIABLE || kind == NodeKind.MATCH
-                    || kind == NodeKind.FOREACH) {
+            if (parent instanceof StatementNode) {
                 return;
-            } else if (kind == NodeKind.CHECK_PANIC_EXPR || kind == NodeKind.CHECK_EXPR
-                    || kind == NodeKind.WORKER_RECEIVE || kind == NodeKind.WORKER_FLUSH
-                    || kind == NodeKind.WORKER_SEND || kind == NodeKind.WAIT_EXPR
-                    || kind == NodeKind.GROUP_EXPR || kind == NodeKind.TRAP_EXPR) {
+            } else if (parent instanceof ActionNode || parent instanceof BLangVariable || kind == NodeKind.CHECK_EXPR ||
+                    kind == NodeKind.CHECK_PANIC_EXPR || kind == NodeKind.TRAP_EXPR || kind == NodeKind.GROUP_EXPR) {
                 parent = parent.parent;
                 if (parent.getKind() == NodeKind.BLOCK || parent.getKind() == NodeKind.BLOCK_FUNCTION_BODY) {
                     return;
                 }
-                continue;
-            } else if (kind == NodeKind.ELVIS_EXPR
-                    && ((BLangElvisExpr) parent).lhsExpr.getKind() == NodeKind.INVOCATION
-                    && ((BLangInvocation) ((BLangElvisExpr) parent).lhsExpr).actionInvocation) {
-                parent = parent.parent;
                 continue;
             }
             break;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -2015,6 +2015,12 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             return;
         }
 
+        if ((actionInvocation.symbol.tag & SymTag.CONSTRUCTOR) == SymTag.CONSTRUCTOR) {
+            dlog.error(actionInvocation.pos, DiagnosticCode.INVALID_FUNCTIONAL_CONSTRUCTOR_INVOCATION,
+                       actionInvocation.symbol.name);
+            return;
+        }
+
         validateActionInvocation(actionInvocation.pos, actionInvocation);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.clauses.FromClauseNode;
 import org.ballerinalang.model.clauses.WhereClauseNode;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
 import org.ballerinalang.model.tree.expressions.RecordLiteralNode;
@@ -1995,16 +1996,29 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             }
         }
 
-        if (invocationExpr.actionInvocation || invocationExpr.async) {
-            if (invocationExpr.actionInvocation || !this.withinLockBlock) {
+        if (invocationExpr instanceof ActionNode || invocationExpr.async) {
+            if (invocationExpr instanceof ActionNode || !this.withinLockBlock) {
                 validateActionInvocation(invocationExpr.pos, invocationExpr);
                 return;
             }
 
-            dlog.error(invocationExpr.pos, invocationExpr.functionPointerInvocation ? 
-            DiagnosticCode.USAGE_OF_WORKER_WITHIN_LOCK_IS_PROHIBITED : 
-            DiagnosticCode.USAGE_OF_START_WITHIN_LOCK_IS_PROHIBITED);
+            dlog.error(invocationExpr.pos, invocationExpr.functionPointerInvocation ?
+                    DiagnosticCode.USAGE_OF_WORKER_WITHIN_LOCK_IS_PROHIBITED :
+                    DiagnosticCode.USAGE_OF_START_WITHIN_LOCK_IS_PROHIBITED);
         }
+    }
+
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocation) {
+        analyzeExpr(actionInvocation.expr);
+        analyzeExprs(actionInvocation.requiredArgs);
+        analyzeExprs(actionInvocation.restArgs);
+
+        if (actionInvocation.symbol.kind == SymbolKind.FUNCTION &&
+                Symbols.isFlagOn(actionInvocation.symbol.flags,Flags.DEPRECATED)) {
+            dlog.warning(actionInvocation.pos, DiagnosticCode.USAGE_OF_DEPRECATED_CONSTRUCT, actionInvocation);
+        }
+
+        validateActionInvocation(actionInvocation.pos, actionInvocation);
     }
 
     private void validateActionInvocation(DiagnosticPos pos, BLangInvocation iExpr) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -666,6 +666,11 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     @Override
+    public void visit(BLangActionInvocation actionInvocation) {
+        this.visit((BLangInvocation) actionInvocation);
+    }
+
+    @Override
     public void visit(BLangQueryExpr queryExpr) {
         for (FromClauseNode fromClauseNode : queryExpr.fromClauseList) {
             analyzeNode((BLangFromClause) fromClauseNode, env);
@@ -998,10 +1003,6 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangCatch catchNode) {
-    }
-
-    @Override
-    public void visit(BLangActionInvocation actionInvocationExpr) {
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -23,7 +23,6 @@ import org.ballerinalang.model.elements.AttachPoint;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
-import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
 import org.ballerinalang.model.tree.TopLevelNode;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2653,6 +2653,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
     }
 
+    // TODO: remove unused method
     private void checkTransactionHandlerValidity(BLangExpression transactionHanlder) {
         if (transactionHanlder != null) {
             BSymbol handlerSymbol = ((BLangSimpleVarRef) transactionHanlder).symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.elements.AttachPoint;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
 import org.ballerinalang.model.tree.TopLevelNode;
@@ -672,7 +673,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
      * @param expr expression to be validated.
      */
     private void validateWorkerAnnAttachments(BLangExpression expr) {
-        if (expr != null && expr.getKind() == NodeKind.INVOCATION && ((BLangInvocation) expr).async) {
+        if (expr != null && expr instanceof BLangInvocation.BLangActionInvocation &&
+                ((BLangInvocation.BLangActionInvocation) expr).async) {
             ((BLangInvocation) expr).annAttachments.forEach(annotationAttachment -> {
                 annotationAttachment.attachPoints.add(AttachPoint.Point.WORKER);
                 annotationAttachment.accept(this);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -1051,6 +1051,11 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         }
     }
 
+    @Override
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocation) {
+        this.visit((BLangInvocation) actionInvocation);
+    }
+
     private boolean isErrorConstructorInvocation(BLangInvocation invocationExpr) {
         return invocationExpr.symbol != null && invocationExpr.symbol.kind == SymbolKind.ERROR_CONSTRUCTOR;
     }
@@ -1122,11 +1127,6 @@ public class TaintAnalyzer extends BLangNodeVisitor {
         }
 
         getCurrentAnalysisState().taintedStatus = typeTaintedStatus;
-    }
-
-    @Override
-    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
-        /* ignore */
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1782,18 +1782,13 @@ public class TypeChecker extends BLangNodeVisitor {
             return;
         }
 
-        Name pkgAlias = names.fromIdNode(iExpr.pkgAlias);
-        if (pkgAlias != Names.EMPTY) {
-            dlog.error(iExpr.pos, DiagnosticCode.PKG_ALIAS_NOT_ALLOWED_HERE);
+        // Module aliases cannot be used with methods
+        if (!validateModuleAliasUsage(iExpr)) {
             return;
         }
 
         // Find the variable reference expression type
         checkExpr(iExpr.expr, this.env, symTable.noType);
-
-        if (iExpr instanceof ActionNode) {
-            return;
-        }
 
         BType varRefType = iExpr.expr.type;
 
@@ -1817,16 +1812,27 @@ public class TypeChecker extends BLangNodeVisitor {
         }
     }
 
-    public void visit(BLangInvocation.BLangActionInvocation iExpr) {
-        this.visit((BLangInvocation) iExpr); // TODO: check if this is ok
+    public void visit(BLangInvocation.BLangActionInvocation aInv) {
+        // For an action invocation, this will only be satisfied when it's an async call of a function.
+        // e.g., start foo();
+        if (aInv.expr == null) {
+            checkFunctionInvocationExpr(aInv);
+            return;
+        }
 
-        BType exprType = iExpr.expr.type;
+        // Module aliases cannot be used with remote method call actions
+        if (!validateModuleAliasUsage(aInv)) {
+            return;
+        }
+
+        // Find the variable reference expression type
+        BType exprType = checkExpr(aInv.expr, this.env, symTable.noType);
         BType actualType = symTable.semanticError;
-        BLangVariableReference varRef = (BLangVariableReference) iExpr.expr;
+        BLangVariableReference varRef = (BLangVariableReference) aInv.expr;
 
         if (exprType == symTable.semanticError || exprType.tag != TypeTags.OBJECT ||
-                (varRef.symbol.tag & SymTag.ENDPOINT) != SymTag.ENDPOINT) {
-            dlog.error(iExpr.pos, DiagnosticCode.INVALID_ACTION_INVOCATION);
+                ((varRef.symbol.tag & SymTag.ENDPOINT) != SymTag.ENDPOINT) && !aInv.async) {
+            dlog.error(aInv.pos, DiagnosticCode.INVALID_ACTION_INVOCATION);
             resultType = actualType;
             return;
         }
@@ -1835,22 +1841,32 @@ public class TypeChecker extends BLangNodeVisitor {
         final BVarSymbol epSymbol = (BVarSymbol) varRef.symbol;
 
         Name remoteFuncQName = names
-                .fromString(Symbols.getAttachedFuncSymbolName(exprType.tsymbol.name.value, iExpr.name.value));
-        Name actionName = names.fromIdNode(iExpr.name);
+                .fromString(Symbols.getAttachedFuncSymbolName(exprType.tsymbol.name.value, aInv.name.value));
+        Name actionName = names.fromIdNode(aInv.name);
         BSymbol remoteFuncSymbol = symResolver
-                .lookupMemberSymbol(iExpr.pos, ((BObjectTypeSymbol) epSymbol.type.tsymbol).methodScope, env,
+                .lookupMemberSymbol(aInv.pos, ((BObjectTypeSymbol) epSymbol.type.tsymbol).methodScope, env,
                                     remoteFuncQName, SymTag.FUNCTION);
 
         // TODO: break this in to two separate error messages
-        if (remoteFuncSymbol == symTable.notFoundSymbol || !Symbols.isFlagOn(remoteFuncSymbol.flags, Flags.REMOTE)) {
-            dlog.error(iExpr.pos, DiagnosticCode.UNDEFINED_ACTION, actionName, epSymbol.type.tsymbol.name);
+        if (remoteFuncSymbol == symTable.notFoundSymbol ||
+                (!Symbols.isFlagOn(remoteFuncSymbol.flags, Flags.REMOTE) && !aInv.async)) {
+            dlog.error(aInv.pos, DiagnosticCode.UNDEFINED_ACTION, actionName, epSymbol.type.tsymbol.name);
             resultType = actualType;
             return;
         }
 
-        iExpr.symbol = remoteFuncSymbol;
+        aInv.symbol = remoteFuncSymbol;
 
-        checkInvocationParamAndReturnType(iExpr);
+        checkInvocationParamAndReturnType(aInv);
+    }
+
+    private boolean validateModuleAliasUsage(BLangInvocation invocation) {
+        Name pkgAlias = names.fromIdNode(invocation.pkgAlias);
+        if (pkgAlias != Names.EMPTY) {
+            dlog.error(invocation.pos, DiagnosticCode.PKG_ALIAS_NOT_ALLOWED_HERE);
+            return false;
+        }
+        return true;
     }
 
     public void visit(BLangLetExpression letExpression) {
@@ -4075,7 +4091,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
         BType retType = typeParamAnalyzer.getReturnTypeParams(env, bInvokableType.getReturnType());
 
-        if (iExpr.async) {
+        if (iExpr instanceof ActionNode && ((BLangInvocation.BLangActionInvocation) iExpr).async) {
             return this.generateFutureType(invokableSymbol, retType);
         } else {
             return retType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1783,7 +1783,7 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         // Module aliases cannot be used with methods
-        if (!validateModuleAliasUsage(iExpr)) {
+        if (invalidModuleAliasUsage(iExpr)) {
             return;
         }
 
@@ -1821,7 +1821,7 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         // Module aliases cannot be used with remote method call actions
-        if (!validateModuleAliasUsage(aInv)) {
+        if (invalidModuleAliasUsage(aInv)) {
             return;
         }
 
@@ -1846,13 +1846,13 @@ public class TypeChecker extends BLangNodeVisitor {
         }
     }
 
-    private boolean validateModuleAliasUsage(BLangInvocation invocation) {
+    private boolean invalidModuleAliasUsage(BLangInvocation invocation) {
         Name pkgAlias = names.fromIdNode(invocation.pkgAlias);
         if (pkgAlias != Names.EMPTY) {
             dlog.error(invocation.pos, DiagnosticCode.PKG_ALIAS_NOT_ALLOWED_HERE);
-            return false;
+            return true;
         }
-        return true;
+        return false;
     }
 
     public void visit(BLangLetExpression letExpression) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
@@ -49,7 +49,6 @@ public class BLangInvocation extends BLangAccessExpression implements Invocation
     //caching since at desugar level we need to identify whether this is actually attached function or not
     public BSymbol exprSymbol;
     public boolean functionPointerInvocation;
-    public boolean actionInvocation;
     public boolean langLibInvocation;
     public boolean async;
     public Set<Flag> flagSet;
@@ -122,11 +121,6 @@ public class BLangInvocation extends BLangAccessExpression implements Invocation
         return false;
     }
 
-    @Override
-    public boolean isActionInvocation() {
-        return this.actionInvocation;
-    }
-    
     @Override
     public boolean isAsync() {
         return async;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
@@ -18,6 +18,7 @@
 package org.wso2.ballerinalang.compiler.tree.expressions;
 
 import org.ballerinalang.model.elements.Flag;
+import org.ballerinalang.model.tree.ActionNode;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
@@ -211,7 +212,7 @@ public class BLangInvocation extends BLangAccessExpression implements Invocation
     /**
      * @since 0.94
      */
-    public static class BLangActionInvocation extends BLangInvocation {
+    public static class BLangActionInvocation extends BLangInvocation implements ActionNode {
 
         public BLangActionInvocation(DiagnosticPos pos,
                                      List<BLangExpression> requiredArgs,
@@ -225,6 +226,9 @@ public class BLangInvocation extends BLangAccessExpression implements Invocation
             this.symbol = symbol;
             this.type = type;
             this.async = async;
+        }
+
+        public BLangActionInvocation() {
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInvocation.java
@@ -208,19 +208,7 @@ public class BLangInvocation extends BLangAccessExpression implements Invocation
      */
     public static class BLangActionInvocation extends BLangInvocation implements ActionNode {
 
-        public BLangActionInvocation(DiagnosticPos pos,
-                                     List<BLangExpression> requiredArgs,
-                                     List<BLangExpression> restArgs,
-                                     BSymbol symbol,
-                                     BType type,
-                                     boolean async) {
-            this.pos = pos;
-            this.requiredArgs = requiredArgs;
-            this.restArgs = restArgs;
-            this.symbol = symbol;
-            this.type = type;
-            this.async = async;
-        }
+        public boolean remoteMethodCall = false;
 
         public BLangActionInvocation() {
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangWorkerSend.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangWorkerSend.java
@@ -26,7 +26,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 
 /**
- * Implementation of {@link WorkerSendNode}.
+ * Models the async-send-action.
  *
  * @since 0.94
  */

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -272,6 +272,15 @@ error.invalid.type.for.send=\
 error.invalid.usage.of.receive.expression=\
    invalid usage of receive expression, var not allowed
 
+error.invalid.wait.future.expr.mapping.constructors=\
+  ''wait'' cannot be used with mapping constructors
+
+error.invalid.wait.future.expr.actions=\
+  ''wait'' cannot be used with actions
+
+error.invalid.send.expr=\
+  expected an expression, but found an action
+
 error.assignment.count.mismatch=\
   assignment count mismatch: expected {0} values, but found {1}
 

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -633,7 +633,10 @@ error.invalid.listener.attachment=\
   invalid listener attachment
 
 error.invalid.action.invocation.syntax=\
-  invalid remote function invocation syntax, use ''->'' operator
+  invalid remote method call ''.{0}()'': use ''->{0}()'' for remote method calls
+
+error.invalid.method.invocation.syntax=\
+  invalid method call ''->{0}()'': ''->'' can only be used with remote methods
 
 error.invalid.init.invocation=\
   object ''__init'' method call is allowed only within the type descriptor
@@ -642,7 +645,7 @@ error.invalid.resource.function.invocation=\
   resource function can not be invoked with in a service
 
 error.invalid.action.invocation=\
-  invalid remote function invocation, expected an client object
+  invalid remote method call: expected a client object, but found ''{0}''
 
 error.undefined.action=\
   undefined remote function ''{0}'' in client object {1}

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1148,6 +1148,9 @@ error.invalid.error.reason.argument.to.indirect.error.constructor=\
 error.invalid.indirect.error.constructor.invocation=\
   cannot infer reason from error constructor: ''{0}''
 
+error.invalid.functional.constructor.invocation=\
+  use of ''start'' not allowed with functional constructor ''{0}'()''
+
 error.type.required.for.const.with.expressions=\
   type is required for constants with expressions
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/LSNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/LSNodeVisitor.java
@@ -79,6 +79,8 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecatedParametersDocumentation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecationDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownDocumentationLine;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownParameterDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownReturnParameterDocumentation;
@@ -1012,6 +1014,16 @@ public class LSNodeVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangStreamType streamType) {
+        // no implementation
+    }
+
+    @Override
+    public void visit(BLangMarkDownDeprecationDocumentation bLangMarkDownDeprecationDocumentation) {
+        // no implementation
+    }
+
+    @Override
+    public void visit(BLangMarkDownDeprecatedParametersDocumentation bLangMarkDownDeprecatedParametersDocumentation) {
         // no implementation
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/semantichighlighter/SemanticHighlightingVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/semantichighlighter/SemanticHighlightingVisitor.java
@@ -163,7 +163,11 @@ class SemanticHighlightingVisitor extends LSNodeVisitor {
         SemanticHighlightProvider.HighlightInfo highlightInfo =
                     new SemanticHighlightProvider.HighlightInfo(ScopeEnum.ENDPOINT, varRefExpr.variableName);
         highlights.add(highlightInfo);
+    }
 
+    @Override
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
+        this.acceptNode(actionInvocationExpr.expr);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferenceFindingVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferenceFindingVisitor.java
@@ -945,6 +945,16 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
         this.acceptNode(streamType.error);
     }
 
+    @Override
+    public void visit(BLangInvocation.BLangActionInvocation actionInvocationExpr) {
+        if (actionInvocationExpr.name.getValue().equals(this.tokenName)) {
+            DiagnosticPos pos = actionInvocationExpr.name.getPosition();
+            this.addSymbol(actionInvocationExpr, actionInvocationExpr.symbol, false, pos);
+        }
+        this.acceptNode(actionInvocationExpr.expr);
+        actionInvocationExpr.argExprs.forEach(this::acceptNode);
+    }
+
     protected void acceptNode(BLangNode node) {
         if (node == null) {
             return;

--- a/language-server/modules/langserver-core/src/test/resources/formatting/documentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/documentation.bal
@@ -1,3 +1,4 @@
+import ballerina/http;
  // This is the documentation attachment for function `doThatOnObject`.
   # `doThatOnObject` is an attached function for the object `DummyObject`.
   #

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedDocumentation.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedDocumentation.bal
@@ -1,3 +1,4 @@
+import ballerina/http;
 // This is the documentation attachment for function `doThatOnObject`.
 # `doThatOnObject` is an attached function for the object `DummyObject`.
 #

--- a/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedWait.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/expected/expectedWait.bal
@@ -30,6 +30,10 @@ function concat(string name) returns string {
     return "hello " + name;
 }
 
+function status() returns boolean {
+    return true;
+}
+
 function add_1(int i, int j) returns int {
     int k = i + j;
     int l = 0;

--- a/language-server/modules/langserver-core/src/test/resources/formatting/wait.bal
+++ b/language-server/modules/langserver-core/src/test/resources/formatting/wait.bal
@@ -27,6 +27,10 @@ function concat(string name) returns string {
     return "hello " + name;
 }
 
+function status() returns boolean {
+    return true;
+}
+
 function add_1(int i, int j) returns int {
     int k = i + j;
     int l = 0;

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
@@ -29,11 +29,23 @@ public class StartActionTest {
 
     @Test (description = "Test negative start action usage")
     public void testStartActionNegative() {
-        CompileResult negativeResult = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 4);
-        BAssertUtil.validateError(negativeResult, 0, "action invocation as an expression not allowed here", 37, 23);
-        BAssertUtil.validateError(negativeResult, 1, "action invocation as an expression not allowed here", 56, 37);
-        BAssertUtil.validateError(negativeResult, 2, "action invocation as an expression not allowed here", 71, 17);
-        BAssertUtil.validateError(negativeResult, 3, "action invocation as an expression not allowed here", 76, 25);
+        CompileResult result = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
+        int indx = 0;
+
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 37, 23);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 38, 38);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 39, 43);
+        BAssertUtil.validateError(result, indx++, "expected an expression, but found an action", 53, 9);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 53, 20);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 56, 37);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 58, 32);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 58, 49);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 71, 17);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 72, 24);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 72, 28);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 76, 25);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 90, 33);
+
+        Assert.assertEquals(result.getErrorCount(), indx);
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
@@ -30,14 +30,10 @@ public class StartActionTest {
     @Test (description = "Test negative start action usage")
     public void testStartActionNegative() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 8);
+        Assert.assertEquals(negativeResult.getErrorCount(), 4);
         BAssertUtil.validateError(negativeResult, 0, "action invocation as an expression not allowed here", 37, 23);
-        BAssertUtil.validateError(negativeResult, 1, "action invocation as an expression not allowed here", 38, 38);
-        BAssertUtil.validateError(negativeResult, 2, "action invocation as an expression not allowed here", 39, 43);
-        BAssertUtil.validateError(negativeResult, 3, "action invocation as an expression not allowed here", 56, 37);
-        BAssertUtil.validateError(negativeResult, 4, "action invocation as an expression not allowed here", 58, 49);
-        BAssertUtil.validateError(negativeResult, 5, "action invocation as an expression not allowed here", 71, 17);
-        BAssertUtil.validateError(negativeResult, 6, "action invocation as an expression not allowed here", 72, 28);
-        BAssertUtil.validateError(negativeResult, 7, "action invocation as an expression not allowed here", 76, 25);
+        BAssertUtil.validateError(negativeResult, 1, "action invocation as an expression not allowed here", 56, 37);
+        BAssertUtil.validateError(negativeResult, 2, "action invocation as an expression not allowed here", 71, 17);
+        BAssertUtil.validateError(negativeResult, 3, "action invocation as an expression not allowed here", 76, 25);
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
@@ -103,27 +103,28 @@ public class ClientObjectTest {
                                   "remote modifier not allowed in non-object attached function test3", 30, 1);
 
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                               51, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call '.pqr()': use '->pqr()' for remote method calls", 51, 13);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "undefined remote function 'abc' in client object Foo", 53, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid method call '->abc()': '->' can only be used with remote methods", 53, 13);
 
         BAssertUtil.validateError(compileResult, errIdx++, "unknown type 'XXX'", 59, 5);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
-                               61, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call: expected a client object, but found 'other'", 61, 13);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
-                               65, 9);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call: expected a client object, but found 'map'", 65, 9);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
-                               69, 9);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call: expected a client object, but found 'Bar'", 69, 9);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                               85, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call '.pqr()': use '->pqr()' for remote method calls", 85, 13);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                               93, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call '.pqr()': use '->pqr()' for remote method calls", 93, 13);
         BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 112, 5);
         BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 121, 5);
         Assert.assertEquals(compileResult.getErrorCount(), errIdx);

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
@@ -53,7 +53,7 @@ public class BasicWorkerActionsNegativeTest {
     @Test(description = "Test negative scenarios of worker actions")
     public void testNegativeWorkerActions() {
         int index = 0;
-        Assert.assertEquals(resultNegative.getErrorCount(), 20, "Worker actions negative test error count");
+
         BAssertUtil.validateError(resultNegative, index++, "invalid worker flush expression for 'w1', there are no " +
                 "worker send statements to 'w1' from 'w3'", 61, 17);
         BAssertUtil.validateError(resultNegative, index++, "invalid worker send statement position, must be a top " +
@@ -78,7 +78,10 @@ public class BasicWorkerActionsNegativeTest {
         BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 217, 30);
         BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 218, 75);
         BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 225, 30);
-        BAssertUtil.validateError(resultNegative, index, "unsupported worker reference 'wx'", 226, 25);
+        BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 226, 25);
+        BAssertUtil.validateError(resultNegative, index++, "action invocation as an expression not allowed here",
+                                  232, 23);
 
+        Assert.assertEquals(resultNegative.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/object/object_with_future_type_field.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/object/object_with_future_type_field.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public type Foo object {
-    public future<int> intFuture = start getIntValue();
+    public future<int> intFuture = doAsyncCall();
 };
 
 Foo globalFoo = new;
@@ -25,6 +25,10 @@ public function getIntFromFutureField() returns int {
     int a = wait foo.intFuture;
     int b = wait globalFoo.intFuture;
     return a + b;
+}
+
+public function doAsyncCall() returns future<int> {
+    return start getIntValue();
 }
 
 public function getIntValue() returns int {

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/packageinit/src/expressions.invocations.pkg.c/pc.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/packageinit/src/expressions.invocations.pkg.c/pc.bal
@@ -6,7 +6,11 @@ function testInitInvocation() returns (int) {
     return a:getA1();
 }
 
-future<int> intFuture = start getInt();
+future<int> intFuture = getFuture();
+
+public function getFuture() returns future<int> {
+    return start getInt();
+}
 
 public function getInt() returns int {
     return 899;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/NestedActionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/NestedActionsTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.action;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.util.BAssertUtil.validateError;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for nested actons.
+ *
+ * @since 1.3.0
+ */
+public class NestedActionsTest {
+
+    @Test
+    public void testNestedClientObjectActions() {
+        CompileResult result = BCompileUtil.compile("test-src/action/nested_actions.bal");
+        BRunUtil.invoke(result, "testNestedClientObjectActions");
+    }
+
+    @Test
+    public void testNegatives() {
+        CompileResult result = BCompileUtil.compile("test-src/action/nested_actions_negative.bal");
+        validateError(result, 0, "action invocation as an expression not allowed here", 35, 33);
+        validateError(result, 1, "action invocation as an expression not allowed here", 35, 45);
+        assertEquals(result.getErrorCount(), 2);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/TypeCastActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/TypeCastActionTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.action;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for nested actons.
+ *
+ * @since 1.3.0
+ */
+public class TypeCastActionTest {
+
+    CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/action/typecast_action.bal");
+    }
+
+    @Test(dataProvider = "FunctionList")
+    public void testTypecastActions(String funcName) {
+        BRunUtil.invoke(result, funcName);
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'int' cannot be cast to " +
+                  "'string'.*")
+    public void testCastingToIncorrectType() {
+        BRunUtil.invoke(result, "testCastingToIncorrectType");
+    }
+
+    @DataProvider(name = "FunctionList")
+    public Object[][] testFunctions() {
+        return new Object[][]{
+                {"testTypecastWithRemoteMethodCalls"},
+                {"testCastingRecords"},
+                {"testCastingObjects"},
+                {"testTypecastingActions"}
+        };
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
@@ -29,11 +29,23 @@ public class StartActionTest {
 
     @Test (description = "Test negative start action usage")
     public void testStartActionNegative() {
-        CompileResult negativeResult = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 4);
-        BAssertUtil.validateError(negativeResult, 0, "action invocation as an expression not allowed here", 37, 23);
-        BAssertUtil.validateError(negativeResult, 1, "action invocation as an expression not allowed here", 56, 37);
-        BAssertUtil.validateError(negativeResult, 2, "action invocation as an expression not allowed here", 71, 17);
-        BAssertUtil.validateError(negativeResult, 3, "action invocation as an expression not allowed here", 76, 25);
+        CompileResult result = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
+        int indx = 0;
+
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 37, 23);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 38, 38);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 39, 43);
+        BAssertUtil.validateError(result, indx++, "expected an expression, but found an action", 53, 9);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 53, 20);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 56, 37);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 58, 32);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 58, 49);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 71, 17);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 72, 24);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 72, 28);
+        BAssertUtil.validateError(result, indx++, "action invocation as an expression not allowed here", 76, 25);
+        BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 90, 33);
+
+        Assert.assertEquals(result.getErrorCount(), indx);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
@@ -30,14 +30,10 @@ public class StartActionTest {
     @Test (description = "Test negative start action usage")
     public void testStartActionNegative() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 8);
+        Assert.assertEquals(negativeResult.getErrorCount(), 4);
         BAssertUtil.validateError(negativeResult, 0, "action invocation as an expression not allowed here", 37, 23);
-        BAssertUtil.validateError(negativeResult, 1, "action invocation as an expression not allowed here", 38, 38);
-        BAssertUtil.validateError(negativeResult, 2, "action invocation as an expression not allowed here", 39, 43);
-        BAssertUtil.validateError(negativeResult, 3, "action invocation as an expression not allowed here", 56, 37);
-        BAssertUtil.validateError(negativeResult, 4, "action invocation as an expression not allowed here", 58, 49);
-        BAssertUtil.validateError(negativeResult, 5, "action invocation as an expression not allowed here", 71, 17);
-        BAssertUtil.validateError(negativeResult, 6, "action invocation as an expression not allowed here", 72, 28);
-        BAssertUtil.validateError(negativeResult, 7, "action invocation as an expression not allowed here", 76, 25);
+        BAssertUtil.validateError(negativeResult, 1, "action invocation as an expression not allowed here", 56, 37);
+        BAssertUtil.validateError(negativeResult, 2, "action invocation as an expression not allowed here", 71, 17);
+        BAssertUtil.validateError(negativeResult, 3, "action invocation as an expression not allowed here", 76, 25);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/action/start/StartActionTest.java
@@ -18,16 +18,26 @@ package org.ballerinalang.test.action.start;
 
 import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Start action negative test cases.
+ * Start action test cases.
  */
 public class StartActionTest {
 
-    @Test (description = "Test negative start action usage")
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/action/start/start_action.bal");
+    }
+
+    @Test(description = "Test negative start action usage")
     public void testStartActionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/action/start/start-action-negative.bal");
         int indx = 0;
@@ -47,5 +57,18 @@ public class StartActionTest {
         BAssertUtil.validateError(result, indx++, "'wait' cannot be used with actions", 90, 33);
 
         Assert.assertEquals(result.getErrorCount(), indx);
+    }
+
+    @Test(dataProvider = "FuncList")
+    public void testStartAction(String funcName) {
+        BRunUtil.invoke(result, funcName);
+    }
+
+    @DataProvider(name = "FuncList")
+    public Object[][] getFunctionNames() {
+        return new Object[][]{
+                {"testRecFieldFuncPointerAsyncCall"},
+                {"testObjectMethodsAsAsyncCalls"}
+        };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/endpoint/ClientObjectTest.java
@@ -103,27 +103,28 @@ public class ClientObjectTest {
                                   "remote modifier not allowed in non-object attached function test3", 30, 1);
 
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                               51, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call '.pqr()': use '->pqr()' for remote method calls", 51, 13);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "undefined remote function 'abc' in client object Foo", 53, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid method call '->abc()': '->' can only be used with remote methods", 53, 13);
 
         BAssertUtil.validateError(compileResult, errIdx++, "unknown type 'XXX'", 59, 5);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
-                               61, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call: expected a client object, but found 'other'", 61, 13);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
-                               65, 9);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call: expected a client object, but found 'map'", 65, 9);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation, expected an client object",
-                               69, 9);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call: expected a client object, but found 'Bar'", 69, 9);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                               85, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call '.pqr()': use '->pqr()' for remote method calls", 85, 13);
         BAssertUtil
-                .validateError(compileResult, errIdx++, "invalid remote function invocation syntax, use '->' operator",
-                               93, 13);
+                .validateError(compileResult, errIdx++,
+                               "invalid remote method call '.pqr()': use '->pqr()' for remote method calls", 93, 13);
         BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 112, 5);
         BAssertUtil.validateError(compileResult, errIdx++, "a remote function in a non client object", 121, 5);
         Assert.assertEquals(compileResult.getErrorCount(), errIdx);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
@@ -53,7 +53,7 @@ public class BasicWorkerActionsNegativeTest {
     @Test(description = "Test negative scenarios of worker actions")
     public void testNegativeWorkerActions() {
         int index = 0;
-        Assert.assertEquals(resultNegative.getErrorCount(), 20, "Worker actions negative test error count");
+
         BAssertUtil.validateError(resultNegative, index++, "invalid worker flush expression for 'w1', there are no " +
                 "worker send statements to 'w1' from 'w3'", 61, 17);
         BAssertUtil.validateError(resultNegative, index++, "invalid worker send statement position, must be a top " +
@@ -78,7 +78,11 @@ public class BasicWorkerActionsNegativeTest {
         BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 217, 30);
         BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 218, 75);
         BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 225, 30);
-        BAssertUtil.validateError(resultNegative, index, "unsupported worker reference 'wx'", 226, 25);
+        BAssertUtil.validateError(resultNegative, index++, "unsupported worker reference 'wx'", 226, 25);
+        BAssertUtil.validateError(resultNegative, index++, "action invocation as an expression not allowed here",
+                                  232, 23);
+
+        Assert.assertEquals(resultNegative.getErrorCount(), index, "Worker actions negative test error count");
 
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/nested_actions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/nested_actions.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo1 client object {
+    string name;
+
+    function __init(string name) {
+        self.name = name;
+    }
+
+    remote function getName() returns string {
+        return self.name;
+    }
+};
+
+function testNestedClientObjectActions() {
+    Foo1 f1 = new("foo");
+
+    future<string> fs = start f1->getName();
+    string result = wait fs;
+    assert("foo", result);
+}
+
+
+// Util functions
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string detail = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/nested_actions_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/nested_actions_negative.bal
@@ -1,0 +1,36 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo1 client object {
+    string name;
+
+    function __init(string name) {
+        self.name = name;
+    }
+
+    remote function getName(string s = "") returns string {
+        return s == "" ? self.name : self.name + "->" + s;
+    }
+};
+
+function testNestedClientObjectActions() {
+    Foo1 f1 = new("f1");
+    Foo1 f2 = new("f2");
+    Foo1 f3 = new("f3");
+
+    // actions cannot be used as arguments
+    string result = f1->getName(f2->getName(f3->getName()));
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/start/start_action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/start/start_action.bal
@@ -1,0 +1,63 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type FooRec record {|
+    function () returns string fn = () => "FOO";
+    any...;
+|};
+
+function testRecFieldFuncPointerAsyncCall() {
+    FooRec fr = {};
+    future<string> fs = start fr.fn();
+    string result = wait fs;
+    assert("FOO", result);
+
+    fr["rec"] = <FooRec>{};
+    FooRec fr2 = <FooRec>fr["rec"];
+    fs = start fr2.fn();
+    string result2 = wait fs;
+    assert("FOO", result2);
+}
+
+type BarObj client object {
+    remote function getInt() returns int => 100;
+
+    function getName() returns string => "BAR";
+};
+
+function testObjectMethodsAsAsyncCalls() {
+    BarObj bo = new;
+    future<int> fi = start bo->getInt();
+    int resulti = wait fi;
+    assert(100, resulti);
+
+    future<string> fs = start bo->getName();
+    string results = wait fs;
+    assert("BAR", results);
+}
+
+
+// Util functions
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string detail = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/start/start_action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/start/start_action.bal
@@ -44,7 +44,7 @@ function testObjectMethodsAsAsyncCalls() {
     int resulti = wait fi;
     assert(100, resulti);
 
-    future<string> fs = start bo->getName();
+    future<string> fs = start bo.getName();
     string results = wait fs;
     assert("BAR", results);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/action/typecast_action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/action/typecast_action.bal
@@ -1,0 +1,137 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Foo1 client object {
+    any val;
+
+    function __init(any val) {
+        self.val = val;
+    }
+
+    remote function getValue() returns any {
+        return self.val;
+    }
+
+    function setValue(any val) {
+        self.val = val;
+    }
+};
+
+function testTypecastWithRemoteMethodCalls() {
+    Foo1 foo = new("Foo");
+
+    string s1 = <string>foo->getValue();
+    assert("Foo", s1);
+
+    foo.setValue(10);
+    int i1 = <int>foo->getValue();
+    assert(10, i1);
+
+    foo.setValue(12.34);
+    float f1 = <float>foo->getValue();
+    assert(12.34, f1);
+
+    foo.setValue(23.45d);
+    decimal d1 = <decimal>foo->getValue();
+    assert(23.45d, d1);
+
+    foo.setValue(true);
+    boolean b1 = <boolean>foo->getValue();
+    assert(true, b1);
+}
+
+type Person record {
+    string name = "John Doe";
+    int age = 20;
+};
+
+type Student record {|
+    *Person;
+    string school = "Hogwarts";
+|};
+
+function testCastingRecords() {
+    Student s1 = {name: "Jane Doe", age: 25};
+    Foo1 foo = new(s1);
+
+    Student s2 = <Student>foo->getValue();
+    assert(<Student>{name: "Jane Doe", age: 25, school: "Hogwarts"}, s2);
+
+    Person p1 = <Person>foo->getValue();
+    assert(<Person>{name: "Jane Doe", age: 25, "school": "Hogwarts"}, p1);
+
+    Person p2 = <record{ string name; int age; }>foo->getValue();
+    assert(<Person>{name: "Jane Doe", age: 25, "school": "Hogwarts"}, p2);
+}
+
+type PersonObj object {
+    string name;
+    int age;
+
+    function __init(string name, int age) {
+        self.name = name;
+        self.age = age;
+    }
+
+    function getDetails(string 'field) returns string|int {
+        if ('field == "name") {
+            return self.name;
+        } else {
+            return self.age;
+        }
+    }
+
+    function toString() returns string {
+        return "name=" + self.name + " age=" + self.age.toString();
+    }
+};
+
+function testCastingObjects() {
+    PersonObj p1 = new("John Doe", 25);
+    Foo1 foo = new(p1);
+
+    PersonObj p2 = <PersonObj>foo->getValue();
+    assert("name=John Doe age=25", p2.toString());
+}
+
+function testTypecastingActions() {
+    PersonObj po = new("John Doe", 25);
+
+    future<string|int> f1 = start po.getDetails("name");
+    string name = <string>wait f1;
+    assert("John Doe", name);
+
+    f1 = start po.getDetails("age");
+    int age = <int>wait f1;
+    assert(25, age);
+}
+
+function testCastingToIncorrectType() {
+    Foo1 foo = new(100);
+    string s = <string>foo->getValue();
+}
+
+// Util functions
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string detail = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/endpoint/new/remote_basic_negative.bal
@@ -47,9 +47,9 @@ type Foo client object {
 
 function testFunc1() {
     Foo x = new;
-    // invalid remote function invocation syntax, use '->' operator
+    // invalid remote method call '.pqr()': use '->pqr()' for remote method calls
     var y = x.pqr("test");
-    // undefined remote function 'abc' in endpoint Foo
+    // invalid method call '->abc()': '->' can only be used with remote methods
     var z = x->abc("test");
 }
 
@@ -81,7 +81,7 @@ Foo gep = new;
 function testFunc5() {
     var y = gep->pqr("test");
 
-    // invalid remote function invocation syntax, use '->' operator
+    // invalid remote method call '.pqr()': use '->pqr()' for remote method calls
     var z = gep.pqr("test");
 }
 
@@ -89,7 +89,7 @@ function testFunc5() {
 function testFunc6(Foo ep, string b) {
     var y = ep->pqr("test");
 
-    // invalid remote function invocation syntax, use '->' operator
+    // invalid remote method call '.pqr()': use '->pqr()' for remote method calls
     var z = ep.pqr("test");
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_with_future_type_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_with_future_type_field.bal
@@ -15,7 +15,7 @@
 // under the License.
 
 public type Foo object {
-    public future<int> intFuture = start getIntValue();
+    public future<int> intFuture = getFuture();
 };
 
 Foo globalFoo = new;
@@ -29,4 +29,8 @@ public function getIntFromFutureField() returns int {
 
 public function getIntValue() returns int {
     return 10;
+}
+
+public function getFuture() returns future<int> {
+    return start getIntValue();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/packageinit/src/expressions.invocations.pkg.c/pc.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/packageinit/src/expressions.invocations.pkg.c/pc.bal
@@ -6,7 +6,11 @@ function testInitInvocation() returns (int) {
     return a:getA1();
 }
 
-future<int> intFuture = start getInt();
+future<int> intFuture = getFuture();
+
+public function getFuture() returns future<int> {
+    return start getInt();
+}
 
 public function getInt() returns int {
     return 899;


### PR DESCRIPTION
## Purpose
> This PR refactors how function/method calls and action invocations are modeled. Previously both these types were modeled using the `BLangInvocation` class. With this PR, this is separated in to two: `BLangInvocation` and `BLangActionInvocation` (a subclass of `BLangInvocation`). This PR also refactors how nested actions are validated. It also adds the type-cast action. 
> Fixes #17993

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
