### PR TITLE
Add Line Breaks to the Paragraph with the API Docs link

### DIFF
--- a/examples/maps/maps.description
+++ b/examples/maps/maps.description
@@ -1,5 +1,4 @@
 // The `map` type in Ballerina defines a mutable mapping from keys (that are strings) to values of the type specified as
-// the map's constraint type.
-//
+// the map's constraint type.<br/><br/>
 // For more information on the underlying module, 
 // see [the Map module](https://ballerina.io/learn/api-docs/ballerina/map/index.html).

--- a/examples/streams/streams.description
+++ b/examples/streams/streams.description
@@ -4,7 +4,6 @@
 // A stream can be iterated over at most once.
 // A stream has a `next()` method; a stream's iterator works by calling this method.
 // The stream type provides methods similar to lists such as `map`, `foreach`, `filter`, `reduce`, and `iterator`.
-// The stream type does not provide a length method. This is a preview feature.
-//
+// The stream type does not provide a length method. This is a preview feature.<br/><br/>
 // For more information on the underlying module, 
 // see [the lang.stream module](https://ballerina.io/learn/api-docs/ballerina/lang.stream/index.html).

--- a/examples/table/table.description
+++ b/examples/table/table.description
@@ -1,5 +1,4 @@
 // The type `table` is a data structure that organizes information in rows and columns. This example demonstrates how to
-// create an in-memory table using a type constraint, insert data to it, and then access/delete the data.
-//
+// create an in-memory table using a type constraint, insert data to it, and then access/delete the data.<br/><br/>
 // For more information on the underlying module, 
 // see [the Table module](https://ballerina.io/learn/api-docs/ballerina/table/index.html).

--- a/examples/tuple-type/tuple_type.description
+++ b/examples/tuple-type/tuple_type.description
@@ -1,5 +1,4 @@
 // A tuple is an immutable list of two or more values of a fixed length.
-// A tuple type is described by specifying the type of each member in the list.
-//
+// A tuple type is described by specifying the type of each member in the list.<br/><br/>
 // For more information on the underlying module, 
 // see [the lang.array module](https://ballerina.io/learn/api-docs/ballerina/lang.array/index.html).

--- a/examples/xml-functions/xml_functions.description
+++ b/examples/xml-functions/xml_functions.description
@@ -1,4 +1,3 @@
-// Ballerina supports various built-in functions to manipulate XML content.
-//
+// Ballerina supports various built-in functions to manipulate XML content.<br/><br/>
 // For more information on the underlying module, 
 // see [the lang.xml module](https://ballerina.io/learn/api-docs/ballerina/lang.xml/index.html).


### PR DESCRIPTION
## Purpose
This is to add line breaks to the paragraph with the API Docs link in the Values & Types, Streams, and JSON/XML BBE types.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
