### PR TITLE
Update grammar of simple-const-expr according to 2020R1 specification

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/antlr4/BallerinaParser.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/antlr4/BallerinaParser.java
@@ -5598,6 +5598,7 @@ public class BallerinaParser extends Parser {
 			setState(1148);
 			switch (_input.LA(1)) {
 			case LEFT_PARENTHESIS:
+			case ADD:
 			case SUB:
 			case DecimalIntegerLiteral:
 			case HexIntegerLiteral:
@@ -6596,7 +6597,7 @@ public class BallerinaParser extends Parser {
 				setState(1271); 
 				_errHandler.sync(this);
 				_la = _input.LA(1);
-			} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << SERVICE) | (1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << ABSTRACT) | (1L << CLIENT) | (1L << TYPE_INT) | (1L << TYPE_BYTE) | (1L << TYPE_FLOAT) | (1L << TYPE_DECIMAL) | (1L << TYPE_BOOL) | (1L << TYPE_STRING) | (1L << TYPE_ERROR) | (1L << TYPE_MAP) | (1L << TYPE_JSON) | (1L << TYPE_XML) | (1L << TYPE_STREAM) | (1L << TYPE_ANY) | (1L << TYPE_DESC) | (1L << TYPE_FUTURE) | (1L << TYPE_ANYDATA) | (1L << TYPE_HANDLE) | (1L << TYPE_READONLY) | (1L << VAR))) != 0) || ((((_la - 100)) & ~0x3f) == 0 && ((1L << (_la - 100)) & ((1L << (LEFT_BRACE - 100)) | (1L << (LEFT_PARENTHESIS - 100)) | (1L << (LEFT_BRACKET - 100)) | (1L << (SUB - 100)) | (1L << (DecimalIntegerLiteral - 100)) | (1L << (HexIntegerLiteral - 100)) | (1L << (HexadecimalFloatingPointLiteral - 100)) | (1L << (DecimalFloatingPointNumber - 100)) | (1L << (BooleanLiteral - 100)) | (1L << (QuotedStringLiteral - 100)) | (1L << (Base16BlobLiteral - 100)) | (1L << (Base64BlobLiteral - 100)) | (1L << (NullLiteral - 100)) | (1L << (Identifier - 100)))) != 0) );
+			} while ( (((_la) & ~0x3f) == 0 && ((1L << _la) & ((1L << SERVICE) | (1L << FUNCTION) | (1L << OBJECT) | (1L << RECORD) | (1L << ABSTRACT) | (1L << CLIENT) | (1L << TYPE_INT) | (1L << TYPE_BYTE) | (1L << TYPE_FLOAT) | (1L << TYPE_DECIMAL) | (1L << TYPE_BOOL) | (1L << TYPE_STRING) | (1L << TYPE_ERROR) | (1L << TYPE_MAP) | (1L << TYPE_JSON) | (1L << TYPE_XML) | (1L << TYPE_STREAM) | (1L << TYPE_ANY) | (1L << TYPE_DESC) | (1L << TYPE_FUTURE) | (1L << TYPE_ANYDATA) | (1L << TYPE_HANDLE) | (1L << TYPE_READONLY) | (1L << VAR))) != 0) || ((((_la - 100)) & ~0x3f) == 0 && ((1L << (_la - 100)) & ((1L << (LEFT_BRACE - 100)) | (1L << (LEFT_PARENTHESIS - 100)) | (1L << (LEFT_BRACKET - 100)) | (1L << (ADD - 100)) | (1L << (SUB - 100)) | (1L << (DecimalIntegerLiteral - 100)) | (1L << (HexIntegerLiteral - 100)) | (1L << (HexadecimalFloatingPointLiteral - 100)) | (1L << (DecimalFloatingPointNumber - 100)) | (1L << (BooleanLiteral - 100)) | (1L << (QuotedStringLiteral - 100)) | (1L << (Base16BlobLiteral - 100)) | (1L << (Base64BlobLiteral - 100)) | (1L << (NullLiteral - 100)) | (1L << (Identifier - 100)))) != 0) );
 			setState(1273);
 			match(RIGHT_BRACE);
 			}
@@ -15464,6 +15465,7 @@ public class BallerinaParser extends Parser {
 		public IntegerLiteralContext integerLiteral() {
 			return getRuleContext(IntegerLiteralContext.class,0);
 		}
+		public TerminalNode ADD() { return getToken(BallerinaParser.ADD, 0); }
 		public TerminalNode SUB() { return getToken(BallerinaParser.SUB, 0); }
 		public FloatingPointLiteralContext floatingPointLiteral() {
 			return getRuleContext(FloatingPointLiteralContext.class,0);
@@ -15504,10 +15506,15 @@ public class BallerinaParser extends Parser {
 				{
 				setState(2386);
 				_la = _input.LA(1);
-				if (_la==SUB) {
+				if (_la==ADD || _la==SUB) {
 					{
 					setState(2385);
-					match(SUB);
+					_la = _input.LA(1);
+					if ( !(_la==ADD || _la==SUB) ) {
+					_errHandler.recoverInline(this);
+					} else {
+						consume();
+					}
 					}
 				}
 
@@ -15520,10 +15527,15 @@ public class BallerinaParser extends Parser {
 				{
 				setState(2390);
 				_la = _input.LA(1);
-				if (_la==SUB) {
+				if (_la==ADD || _la==SUB) {
 					{
 					setState(2389);
-					match(SUB);
+					_la = _input.LA(1);
+					if ( !(_la==ADD || _la==SUB) ) {
+					_errHandler.recoverInline(this);
+					} else {
+						consume();
+					}
 					}
 				}
 
@@ -19925,16 +19937,16 @@ public class BallerinaParser extends Parser {
 		"\3\2\2\2\u0949\u094a\3\2\2\2\u094a\u094e\3\2\2\2\u094b\u0949\3\2\2\2\u094c"+
 		"\u094d\7e\2\2\u094d\u094f\5\u016c\u00b7\2\u094e\u094c\3\2\2\2\u094e\u094f"+
 		"\3\2\2\2\u094f\u0952\3\2\2\2\u0950\u0952\5\u016c\u00b7\2\u0951\u0940\3"+
-		"\2\2\2\u0951\u0950\3\2\2\2\u0952\u0171\3\2\2\2\u0953\u0955\7r\2\2\u0954"+
+		"\2\2\2\u0951\u0950\3\2\2\2\u0952\u0171\3\2\2\2\u0953\u0955\t\21\2\2\u0954"+
 		"\u0953\3\2\2\2\u0954\u0955\3\2\2\2\u0955\u0956\3\2\2\2\u0956\u0961\5\u0176"+
-		"\u00bc\2\u0957\u0959\7r\2\2\u0958\u0957\3\2\2\2\u0958\u0959\3\2\2\2\u0959"+
-		"\u095a\3\2\2\2\u095a\u0961\5\u0174\u00bb\2\u095b\u0961\7\u00a0\2\2\u095c"+
-		"\u0961\7\u009f\2\2\u095d\u0961\5\u0178\u00bd\2\u095e\u0961\5\u017a\u00be"+
-		"\2\u095f\u0961\7\u00a3\2\2\u0960\u0954\3\2\2\2\u0960\u0958\3\2\2\2\u0960"+
-		"\u095b\3\2\2\2\u0960\u095c\3\2\2\2\u0960\u095d\3\2\2\2\u0960\u095e\3\2"+
-		"\2\2\u0960\u095f\3\2\2\2\u0961\u0173\3\2\2\2\u0962\u0963\t\30\2\2\u0963"+
-		"\u0175\3\2\2\2\u0964\u0965\t\31\2\2\u0965\u0177\3\2\2\2\u0966\u0967\7"+
-		"h\2\2\u0967\u0968\7i\2\2\u0968\u0179\3\2\2\2\u0969\u096a\t\32\2\2\u096a"+
+		"\u00bc\2\u0957\u0959\t\21\2\2\u0958\u0957\3\2\2\2\u0958\u0959\3\2\2\2"+
+		"\u0959\u095a\3\2\2\2\u095a\u0961\5\u0174\u00bb\2\u095b\u0961\7\u00a0\2"+
+		"\2\u095c\u0961\7\u009f\2\2\u095d\u0961\5\u0178\u00bd\2\u095e\u0961\5\u017a"+
+		"\u00be\2\u095f\u0961\7\u00a3\2\2\u0960\u0954\3\2\2\2\u0960\u0958\3\2\2"+
+		"\2\u0960\u095b\3\2\2\2\u0960\u095c\3\2\2\2\u0960\u095d\3\2\2\2\u0960\u095e"+
+		"\3\2\2\2\u0960\u095f\3\2\2\2\u0961\u0173\3\2\2\2\u0962\u0963\t\30\2\2"+
+		"\u0963\u0175\3\2\2\2\u0964\u0965\t\31\2\2\u0965\u0177\3\2\2\2\u0966\u0967"+
+		"\7h\2\2\u0967\u0968\7i\2\2\u0968\u0179\3\2\2\2\u0969\u096a\t\32\2\2\u096a"+
 		"\u017b\3\2\2\2\u096b\u096c\7\u00a4\2\2\u096c\u096d\7p\2\2\u096d\u096e"+
 		"\5\u0138\u009d\2\u096e\u017d\3\2\2\2\u096f\u0970\7\u0089\2\2\u0970\u0971"+
 		"\5\u0138\u009d\2\u0971\u017f\3\2\2\2\u0972\u0973\7\u00a5\2\2\u0973\u0974"+

--- a/compiler/ballerina-lang/src/main/resources/grammar/BallerinaParser.g4
+++ b/compiler/ballerina-lang/src/main/resources/grammar/BallerinaParser.g4
@@ -941,8 +941,8 @@ formalParameterList
     ;
 
 simpleLiteral
-    :   (ADD|SUB)? integerLiteral
-    |   (ADD|SUB)? floatingPointLiteral
+    :   (ADD | SUB)? integerLiteral
+    |   (ADD | SUB)? floatingPointLiteral
     |   QuotedStringLiteral
     |   BooleanLiteral
     |   nilLiteral

--- a/compiler/ballerina-lang/src/main/resources/grammar/BallerinaParser.g4
+++ b/compiler/ballerina-lang/src/main/resources/grammar/BallerinaParser.g4
@@ -941,8 +941,8 @@ formalParameterList
     ;
 
 simpleLiteral
-    :   SUB? integerLiteral
-    |   SUB? floatingPointLiteral
+    :   (ADD|SUB)? integerLiteral
+    |   (ADD|SUB)? floatingPointLiteral
     |   QuotedStringLiteral
     |   BooleanLiteral
     |   nilLiteral

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -318,23 +318,6 @@ public class FiniteTypeTest {
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), 5.0, "Value mismatch");
     }
 
-    @Test()
-    public void testFiniteTypesWithPositiveIntegers() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertNotNull(returns[0]);
-        Assert.assertTrue(returns[0] instanceof BInteger);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 5);
-    }
-    @Test()
-    public void testFiniteTypesWithPositiveFloats() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertNotNull(returns[0]);
-        Assert.assertTrue(returns[0] instanceof BFloat);
-        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.5);
-    }
-
     @Test
     public void testDifferentPrecisionDecimalAssignment() {
         BValue[] returns = BRunUtil.invoke(result, "testDifferentPrecisionDecimalAssignment");
@@ -383,5 +366,15 @@ public class FiniteTypeTest {
     public void testEscapedTypeName() {
         BValue[] returns = BRunUtil.invoke(result, "testEscapedTypeName");
         Assert.assertEquals(returns[0].stringValue(), "-");
+    }
+
+    @Test(description = "Test finite type where integer literals with positive sign as members")
+    public void testFiniteTypesWithPositiveIntegers() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
+    }
+
+    @Test(description = "Test finite type where float literals with positive sign as members")
+    public void testFiniteTypesWithPositiveFloats() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -370,11 +370,11 @@ public class FiniteTypeTest {
 
     @Test(description = "Test finite type where integer literals with positive sign as members")
     public void testFiniteTypesWithPositiveIntegers() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
+        BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
     }
 
     @Test(description = "Test finite type where float literals with positive sign as members")
     public void testFiniteTypesWithPositiveFloats() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
+        BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
     }
 }

--- a/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-bstring-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -318,6 +318,23 @@ public class FiniteTypeTest {
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), 5.0, "Value mismatch");
     }
 
+    @Test()
+    public void testFiniteTypesWithPositiveIntegers() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 5);
+    }
+    @Test()
+    public void testFiniteTypesWithPositiveFloats() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BFloat);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.5);
+    }
+
     @Test
     public void testDifferentPrecisionDecimalAssignment() {
         BValue[] returns = BRunUtil.invoke(result, "testDifferentPrecisionDecimalAssignment");

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -463,24 +463,28 @@ function testFiniteTypesWithDiscriminatedMembers() returns [any, any, any, any, 
 
 type d +3|+5;
 
-function testFiniteTypesWithPositiveIntegers() returns d {
+function testFiniteTypesWithPositiveIntegers() {
     d n = +3;
     d comparator = +3;
     if (n == comparator) {
        n = +5;
     }
-    return n;
+    if (n != 5){
+        panic error("Type mismatch");
+    }
 }
 
 type f +1.2|+1.5;
 
-function testFiniteTypesWithPositiveFloats() returns f {
+function testFiniteTypesWithPositiveFloats() {
     f n = +1.2;
     f comparator = +1.2;
     if (n == comparator) {
        n = +1.5;
     }
-    return n;
+    if (n != 1.5){
+        panic error("Type mismatch");
+    }
 }
 //public const '\- = "-";
 //public const d = "d";

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -461,30 +461,40 @@ function testFiniteTypesWithDiscriminatedMembers() returns [any, any, any, any, 
     return [a, b, c, d, e];
 }
 
-type d +3|+5;
+type PositiveInt +3|+5;
 
 function testFiniteTypesWithPositiveIntegers() {
-    d n = +3;
-    d comparator = +3;
+    PositiveInt n = +3;
+    PositiveInt comparator = +3;
     if (n == comparator) {
        n = +5;
     }
-    if (n != 5){
-        panic error("Type mismatch");
-    }
+    assertEquality(5,n);
 }
 
-type f +1.2|+1.5;
+type PositiveFloat +1.2|+1.5;
 
 function testFiniteTypesWithPositiveFloats() {
-    f n = +1.2;
-    f comparator = +1.2;
+    PositiveFloat n = +1.2;
+    PositiveFloat comparator = +1.2;
     if (n == comparator) {
        n = +1.5;
     }
-    if (n != 1.5){
-        panic error("Type mismatch");
+    assertEquality(1.5,n);
+}
+
+const ASSERTION_ERROR_REASON = "TypeAssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if (expected is anydata && actual is anydata && expected == actual) {
+        return;
     }
+    if (expected === actual) {
+        return;
+    }
+    typedesc<any|error> tActual = typeof actual;
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + tActual.toString() + "'");
 }
 //public const '\- = "-";
 //public const d = "d";

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -461,6 +461,27 @@ function testFiniteTypesWithDiscriminatedMembers() returns [any, any, any, any, 
     return [a, b, c, d, e];
 }
 
+type d +3|+5;
+
+function testFiniteTypesWithPositiveIntegers() returns d {
+    d n = +3;
+    d comparator = +3;
+    if (n == comparator) {
+       n = +5;
+    }
+    return n;
+}
+
+type f +1.2|+1.5;
+
+function testFiniteTypesWithPositiveFloats() returns f {
+    f n = +1.2;
+    f comparator = +1.2;
+    if (n == comparator) {
+       n = +1.5;
+    }
+    return n;
+}
 //public const '\- = "-";
 //public const d = "d";
 //public const s = "s";

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
@@ -230,7 +230,7 @@ public class ClosedRecordTest {
                                           "'abstract', 'client', 'int', 'byte', 'float', 'decimal', 'boolean', " +
                                           "'string', 'error', 'map', 'json', 'xml', 'stream', 'any', " +
                                           "'typedesc', 'future', 'anydata', " +
-                                          "'handle', 'readonly', '(', '[', '-', DecimalIntegerLiteral, " +
+                                          "'handle', 'readonly', '(', '[', '+', '-', DecimalIntegerLiteral, " +
                                           "HexIntegerLiteral, HexadecimalFloatingPointLiteral, " +
                                           "DecimalFloatingPointNumber, BooleanLiteral, QuotedStringLiteral, " +
                                           "Base16BlobLiteral, Base64BlobLiteral, 'null', Identifier}",
@@ -249,7 +249,7 @@ public class ClosedRecordTest {
                                           "'abstract', 'client', 'int', 'byte', 'float', 'decimal', 'boolean', " +
                                           "'string', 'error', 'map', 'json', 'xml', 'stream', 'any', " +
                                           "'typedesc', 'future', 'anydata', " +
-                                          "'handle', 'readonly', '(', '[', '-', DecimalIntegerLiteral, " +
+                                          "'handle', 'readonly', '(', '[', '+', '-', DecimalIntegerLiteral, " +
                                           "HexIntegerLiteral, HexadecimalFloatingPointLiteral, " +
                                           "DecimalFloatingPointNumber, BooleanLiteral, QuotedStringLiteral, " +
                                           "Base16BlobLiteral, Base64BlobLiteral, 'null', Identifier}",
@@ -259,7 +259,7 @@ public class ClosedRecordTest {
                                           "'abstract', 'client', 'int', 'byte', 'float', 'decimal', 'boolean', " +
                                           "'string', 'error', 'map', 'json', 'xml', 'stream', 'any', " +
                                           "'typedesc', 'future', 'anydata', " +
-                                          "'handle', 'readonly', '(', '[', '-', DecimalIntegerLiteral, " +
+                                          "'handle', 'readonly', '(', '[', '+', '-', DecimalIntegerLiteral, " +
                                           "HexIntegerLiteral, HexadecimalFloatingPointLiteral, " +
                                           "DecimalFloatingPointNumber, BooleanLiteral, QuotedStringLiteral, " +
                                           "Base16BlobLiteral, Base64BlobLiteral, 'null', Identifier}",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -367,4 +367,21 @@ public class FiniteTypeTest {
         BValue[] returns = BRunUtil.invoke(result, "testEscapedTypeName");
         Assert.assertEquals(returns[0].stringValue(), "-");
     }
+    @Test()
+    public void testFiniteTypesWithPositiveIntegers() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BInteger);
+        Assert.assertEquals(((BInteger) returns[0]).intValue(), 5);
+    }
+    @Test()
+    public void testFiniteTypesWithPositiveFloats() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BFloat);
+        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.5);
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -370,11 +370,11 @@ public class FiniteTypeTest {
 
     @Test(description = "Test finite type where integer literals with positive sign as members")
     public void testFiniteTypesWithPositiveIntegers() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
+        BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
     }
 
     @Test(description = "Test finite type where float literals with positive sign as members")
     public void testFiniteTypesWithPositiveFloats() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
+        BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -367,21 +367,14 @@ public class FiniteTypeTest {
         BValue[] returns = BRunUtil.invoke(result, "testEscapedTypeName");
         Assert.assertEquals(returns[0].stringValue(), "-");
     }
-    @Test()
+
+    @Test(description = "Test finite type where integer literals with positive sign as members")
     public void testFiniteTypesWithPositiveIntegers() {
         BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveIntegers");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertNotNull(returns[0]);
-        Assert.assertTrue(returns[0] instanceof BInteger);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 5);
-    }
-    @Test()
-    public void testFiniteTypesWithPositiveFloats() {
-        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertNotNull(returns[0]);
-        Assert.assertTrue(returns[0] instanceof BFloat);
-        Assert.assertEquals(((BFloat) returns[0]).floatValue(), 1.5);
     }
 
+    @Test(description = "Test finite type where float literals with positive sign as members")
+    public void testFiniteTypesWithPositiveFloats() {
+        BValue[] returns = BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -463,24 +463,28 @@ function testFiniteTypesWithDiscriminatedMembers() returns [any, any, any, any, 
 
 type d +3|+5;
 
-function testFiniteTypesWithPositiveIntegers() returns d {
+function testFiniteTypesWithPositiveIntegers() {
     d n = +3;
     d comparator = +3;
     if (n == comparator) {
        n = +5;
     }
-    return n;
+    if (n != 5){
+        panic error("Type mismatch");
+    }
 }
 
 type f +1.2|+1.5;
 
-function testFiniteTypesWithPositiveFloats() returns f {
+function testFiniteTypesWithPositiveFloats() {
     f n = +1.2;
     f comparator = +1.2;
     if (n == comparator) {
        n = +1.5;
     }
-    return n;
+    if (n != 1.5){
+        panic error("Type mismatch");
+    }
 }
 
 //public const '\- = "-";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -461,6 +461,28 @@ function testFiniteTypesWithDiscriminatedMembers() returns [any, any, any, any, 
     return [a, b, c, d, e];
 }
 
+type d +3|+5;
+
+function testFiniteTypesWithPositiveIntegers() returns d {
+    d n = +3;
+    d comparator = +3;
+    if (n == comparator) {
+       n = +5;
+    }
+    return n;
+}
+
+type f +1.2|+1.5;
+
+function testFiniteTypesWithPositiveFloats() returns f {
+    f n = +1.2;
+    f comparator = +1.2;
+    if (n == comparator) {
+       n = +1.5;
+    }
+    return n;
+}
+
 //public const '\- = "-";
 //public const d = "d";
 //public const s = "s";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -461,30 +461,41 @@ function testFiniteTypesWithDiscriminatedMembers() returns [any, any, any, any, 
     return [a, b, c, d, e];
 }
 
-type d +3|+5;
+type PositiveInt +3|+5;
 
 function testFiniteTypesWithPositiveIntegers() {
-    d n = +3;
-    d comparator = +3;
+    PositiveInt n = +3;
+    PositiveInt comparator = +3;
     if (n == comparator) {
        n = +5;
     }
-    if (n != 5){
-        panic error("Type mismatch");
-    }
+    assertEquality(5,n);
+
 }
 
-type f +1.2|+1.5;
+type PositiveFloat +1.2|+1.5;
 
 function testFiniteTypesWithPositiveFloats() {
-    f n = +1.2;
-    f comparator = +1.2;
+    PositiveFloat n = +1.2;
+    PositiveFloat comparator = +1.2;
     if (n == comparator) {
        n = +1.5;
     }
-    if (n != 1.5){
-        panic error("Type mismatch");
+    assertEquality(1.5,n);
+}
+
+const ASSERTION_ERROR_REASON = "TypeAssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if (expected is anydata && actual is anydata && expected == actual) {
+        return;
     }
+    if (expected === actual) {
+        return;
+    }
+    typedesc<any|error> tActual = typeof actual;
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + tActual.toString() + "'");
 }
 
 //public const '\- = "-";


### PR DESCRIPTION
## Purpose
> Update grammar of simple-const-expr as,
>simple-const-expr :=
  nil-literal
  | boolean-literal
  | [Sign] int-literal
  | [Sign] floating-point-literal
  | string-literal
  | constant-reference-expr

Fixes #13410 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
