### PR TITLE
Add API to generate public key from JWKs parameters

### DIFF
--- a/bvm/ballerina-core/build.gradle
+++ b/bvm/ballerina-core/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.awaitility:awaitility'
     implementation 'com.zaxxer:HikariCP'
     implementation 'org.slf4j:slf4j-jdk14'
+    implementation 'commons-codec:commons-codec'
 }
 
 description = 'Ballerina - Core'

--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -89,6 +89,7 @@ dependencies {
     dist 'org.apache.ws.commons.axiom:axiom-impl:1.2.22'
     dist 'org.apache.ws.commons.axiom:axiom-c14n:1.2.22'
     dist 'org.apache.ws.commons.axiom:axiom-dom:1.2.22'
+    dist 'commons-codec:commons-codec:1.9'
 //    dist 'org.codehaus.woodstox:woodstox-core-asl:4.2.0'
 //    dist 'org.codehaus.woodstox:stax2-api:3.1.1'
 

--- a/stdlib/crypto/build.gradle
+++ b/stdlib/crypto/build.gradle
@@ -26,6 +26,8 @@ dependencies {
 
     interopImports project(':ballerina-time')
 
+    implementation 'commons-codec:commons-codec'
+
     baloCreat project(':lib-creator')
     implementation project(':ballerina-lang')
     implementation project(':ballerina-runtime')

--- a/stdlib/crypto/src/main/ballerina/src/crypto/crypto.bal
+++ b/stdlib/crypto/src/main/ballerina/src/crypto/crypto.bal
@@ -784,9 +784,14 @@ function externDecryptAesGcm(byte[] input, byte[] key, byte[] iv, handle padding
 } external;
 
 # Returns the `crypto:PublicKey` created with modulus and exponent retrieved from JWKs endpoint.
+# ```ballerina
+# string modulus = "luZFdW1ynitztkWLC6xKegbRWxky...";
+# string exponent = "AQAB";
+# crypto:PublicKey|crypto:Error publicKey = generatePublicKey(modulus, exponent);
+# ```
 #
-# + modulus - 'n' parameter, the modulus value for the RSA public key
-# + exponent - 'e' paramenter, the exponent value for the RSA public key
+# + modulus - JWK modulus value ('n' parameter) for the RSA public key
+# + exponent - JWK exponent value ('e' paramenter) for the RSA public key
 # + return - Reference to the public key or else a `crypto:Error` if the modulus or exponent is invalid
 public function generatePublicKey(string modulus, string exponent) returns PublicKey|Error {
     return externGeneratePublicKey(java:fromString(modulus), java:fromString(exponent));

--- a/stdlib/crypto/src/main/ballerina/src/crypto/crypto.bal
+++ b/stdlib/crypto/src/main/ballerina/src/crypto/crypto.bal
@@ -782,3 +782,17 @@ function externDecryptAesGcm(byte[] input, byte[] key, byte[] iv, handle padding
     name: "decryptAesGcm",
     class: "org.ballerinalang.stdlib.crypto.nativeimpl.Decrypt"
 } external;
+
+# Returns the `crypto:PublicKey` created with modulus and exponent retrieved from JWKs endpoint.
+#
+# + modulus - 'n' parameter, the modulus value for the RSA public key
+# + exponent - 'e' paramenter, the exponent value for the RSA public key
+# + return - Reference to the public key or else a `crypto:Error` if the modulus or exponent is invalid
+public function generatePublicKey(string modulus, string exponent) returns PublicKey|Error {
+    return externGeneratePublicKey(java:fromString(modulus), java:fromString(exponent));
+}
+
+function externGeneratePublicKey(handle modulus, handle exponent) returns PublicKey|Error = @java:Method {
+    name: "generatePublicKey",
+    class: "org.ballerinalang.stdlib.crypto.nativeimpl.Decode"
+} external;

--- a/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
+++ b/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
@@ -167,7 +167,7 @@ public class Decode {
             publicKeyMap.put(Constants.PUBLIC_KEY_RECORD_ALGORITHM_FIELD, publicKey.getAlgorithm());
             return publicKeyMap;
         } catch (InvalidKeySpecException e) {
-            throw CryptoUtils.createError("Invalid modulus or exponent: " + e.getMessage());
+            return CryptoUtils.createError("Invalid modulus or exponent: " + e.getMessage());
         } catch (NoSuchAlgorithmException e) {
             throw CryptoUtils.createError("Algorithm of the key factory is not found: " + e.getMessage());
         }

--- a/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
+++ b/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
@@ -18,6 +18,8 @@
 
 package org.ballerinalang.stdlib.crypto.nativeimpl;
 
+import org.apache.commons.codec.binary.Base64;
+
 import org.ballerinalang.jvm.BallerinaValues;
 import org.ballerinalang.jvm.values.ArrayValueImpl;
 import org.ballerinalang.jvm.values.MapValue;
@@ -29,6 +31,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.math.BigInteger;
+import java.security.KeyFactory;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -38,6 +42,9 @@ import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
 
 /**
  * Extern functions ballerina decoding keys.
@@ -144,6 +151,26 @@ public class Decode {
             throw CryptoUtils.createError("PKCS12 key store not found at: " + keyStoreFile.getAbsoluteFile());
         } catch (KeyStoreException | CertificateException | IOException e) {
             throw CryptoUtils.createError("Unable to open keystore: " + e.getMessage());
+        }
+    }
+
+    public static Object generatePublicKey(String modulus, String exponent) {
+        try {
+            byte[] decodedModulus = Base64.decodeBase64(modulus);
+            byte[] decodedExponent = Base64.decodeBase64(exponent);
+            RSAPublicKeySpec spec = new RSAPublicKeySpec(new BigInteger(1, decodedModulus),
+                                                         new BigInteger(1, decodedExponent));
+            RSAPublicKey publicKey = (RSAPublicKey) KeyFactory.getInstance("RSA").generatePublic(spec);
+
+            MapValue<String, Object> publicKeyMap = BallerinaValues.
+                    createRecordValue(Constants.CRYPTO_PACKAGE_ID, Constants.PUBLIC_KEY_RECORD);
+            publicKeyMap.addNativeData(Constants.NATIVE_DATA_PUBLIC_KEY, publicKey);
+            publicKeyMap.put(Constants.PUBLIC_KEY_RECORD_ALGORITHM_FIELD, publicKey.getAlgorithm());
+            return publicKeyMap;
+        } catch (InvalidKeySpecException e) {
+            throw CryptoUtils.createError("Invalid modulus or exponent: " + e.getMessage());
+        } catch (NoSuchAlgorithmException e) {
+            throw CryptoUtils.createError("Algorithm of the key factory is not found: " + e.getMessage());
         }
     }
 }

--- a/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
+++ b/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
@@ -19,7 +19,6 @@
 package org.ballerinalang.stdlib.crypto.nativeimpl;
 
 import org.apache.commons.codec.binary.Base64;
-
 import org.ballerinalang.jvm.BallerinaValues;
 import org.ballerinalang.jvm.values.ArrayValueImpl;
 import org.ballerinalang.jvm.values.MapValue;


### PR DESCRIPTION
## Purpose
This PR introduces a new API `generatePublicKey` to generate the public key from the JWKs parameters.

Example JWK:
```json
{
  "keys": [
    {
      "kty": "RSA",
      "e": "AQAB",
      "use": "sig",
      "kid": "NTAxZmMxNDMyZDg3MTU1ZGM0MzEzODJhZWI4NDNlZDU1OGFkNjFiMQ",
      "alg": "RS256",
      "n": "luZFdW1ynitztkWLC6xKegbRWxky-5P0p4ShYEOkHs30QI2VCuR6Qo4Bz5rTgLBrky03W1GAVrZxuvKRGj9V9-PmjdGtau4CTXu9pLLcqnruaczoSdvBYA3lS9a7zgFU0-s6kMl2EhB-rk7gXluEep7lIOenzfl2f6IoTKa2fVgVd3YKiSGsyL4tztS70vmmX121qm0sTJdKWP4HxXyqK9neolXI9fYyHOYILVNZ69z_73OOVhkh_mvTmWZLM7GM6sApmyLX6OXUp8z0pkY-vT_9-zRxxQs7GurC4_C1nK3rI_0ySUgGEafO1atNjYmlFN-M3tZX6nEcA6g94IavyQ"
    }
  ]
}
```

How to use API:
```ballerina
string modulus = "luZFdW1ynitztkWLC6xKegbRWxky...";
string exponent = "AQAB";
crypto:PublicKey|crypto:Error publicKey = generatePublicKey(modulus, exponent);
```

Fixes #22705 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
