### PR TITLE
Fix NPE while retrieving certificate with invalid alias [1.2.x]

### DIFF
--- a/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
+++ b/stdlib/crypto/src/main/java/org/ballerinalang/stdlib/crypto/nativeimpl/Decode.java
@@ -102,6 +102,9 @@ public class Decode {
             }
 
             Certificate certificate = keystore.getCertificate(keyAlias);
+            if (certificate == null) {
+                return CryptoUtils.createError("Certificate cannot be recovered by using given key alias: " + keyAlias);
+            }
             MapValue<String, Object> certificateBMap = BallerinaValues.
                     createRecordValue(Constants.CRYPTO_PACKAGE_ID, Constants.CERTIFICATE_RECORD);
             if (certificate instanceof X509Certificate) {


### PR DESCRIPTION
## Purpose
This PR fixes NPE while retrieving certificate with invalid alias.

Fixes #22864

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
