### PR TITLE
Introduce new API to validate OAuth2 tokens & move OAuth2 caching operations to validation logic [master]

### DIFF
--- a/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
+++ b/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
@@ -246,16 +246,6 @@ public type IntrospectionServerConfig record {|
     http:ClientConfiguration clientConfig = {};
 |};
 
-// TODO: Remove API since, no longer used this.
-# Represents cached OAuth2 information.
-#
-# + username - Username of the OAuth2 validated user
-# + scopes - Scopes of the OAuth2 validated user
-public type InboundOAuth2CacheEntry record {|
-    string username;
-    string scopes;
-|};
-
 # Represents introspection server response.
 #
 # + active - Boolean indicator of whether or not the presented token is currently active


### PR DESCRIPTION
## Purpose
This PR introduces new API (`oauth2:validateOAuth2Token`) to validate OAuth2 token and moves the OAuth2 caching operations (`addToCache` & `validateFromCache`) into `oauth2:validateOAuth2Token` API since the caching operations should be engaged for both direct and indirect API calls of `oauth2:validateOAuth2Token` API.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
