### PR TITLE
Add foreach statement support for the new parser

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaLexer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaLexer.java
@@ -882,6 +882,10 @@ public class BallerinaLexer {
                 return getSyntaxToken(SyntaxKind.TYPEDESC_KEYWORD);
             case LexerTerminals.TRAP:
                 return getSyntaxToken(SyntaxKind.TRAP_KEYWORD);
+            case LexerTerminals.IN:
+                return getSyntaxToken(SyntaxKind.IN_KEYWORD);
+            case LexerTerminals.FOREACH:
+                return getSyntaxToken(SyntaxKind.FOREACH_KEYWORD);
             default:
                 return getIdentifierToken(tokenText);
         }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -6864,7 +6864,7 @@ public class BallerinaParser {
      */
     private STNode parseForEachStatement() {
         startContext(ParserRuleContext.FOREACH_STMT);
-        STNode forEachKeyword = parsePanicKeyword();
+        STNode forEachKeyword = parseForEachKeyword();
         STNode type = parseTypeDescriptor();
         STNode varName = parseVariableName();
         STNode inKeyword = parseInKeyword();

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -334,6 +334,10 @@ public class BallerinaParser {
                 return parseHexFloatingPointLiteral();
             case TRAP_KEYWORD:
                 return parseTrapKeyword();
+            case IN_KEYWORD:
+                return parseInKeyword();
+            case FOREACH_KEYWORD:
+                return parseForEachKeyword();
             default:
                 throw new IllegalStateException("Cannot re-parse rule: " + context);
         }
@@ -2750,6 +2754,7 @@ public class BallerinaParser {
             case LOCK_KEYWORD:
             case OPEN_BRACE_TOKEN:
             case FORK_KEYWORD:
+            case FOREACH_KEYWORD:
 
                 // Even-though worker is not a statement, we parse it as statements.
                 // then validates it based on the context. This is done to provide
@@ -2854,6 +2859,8 @@ public class BallerinaParser {
                 return parseNamedWorkerDeclaration(getAnnotations(annots));
             case FORK_KEYWORD:
                 return parseForkStatement();
+            case FOREACH_KEYWORD:
+                return parseForEachStatement();
             default:
                 if (isTypeStartingToken(tokenKind)) {
                     // If the statement starts with a type, then its a var declaration.
@@ -6844,6 +6851,60 @@ public class BallerinaParser {
             return consume();
         } else {
             Solution sol = recover(token, ParserRuleContext.TRAP_KEYWORD);
+            return sol.recoveredNode;
+        }
+    }
+
+    /**
+     * Parse foreach statement.
+     * <code>foreach-stmt :=
+            foreach typed-binding-pattern in action-or-expr block-stmt</code>
+     *
+     * @return foreach statement
+     */
+    private STNode parseForEachStatement() {
+        startContext(ParserRuleContext.FOREACH_STMT);
+        STNode forEachKeyword = parsePanicKeyword();
+        STNode type = parseTypeDescriptor();
+        STNode varName = parseVariableName();
+        STNode inKeyword = parseInKeyword();
+        STNode actionOrExpr = parseActionOrExpression();
+        STNode blockStatement = parseBlockNode();
+        endContext();
+        return STNodeFactory.createForEachStatementNode(forEachKeyword,
+                                                        type,
+                                                        varName,
+                                                        inKeyword,
+                                                        actionOrExpr,
+                                                        blockStatement);
+    }
+
+    /**
+     * Parse foreach-keyword.
+     *
+     * @return ForEach-keyword node
+     */
+    private STNode parseForEachKeyword() {
+        STToken token = peek();
+        if (token.kind == SyntaxKind.FOREACH_KEYWORD) {
+            return consume();
+        } else {
+            Solution sol = recover(token, ParserRuleContext.FOREACH_KEYWORD);
+            return sol.recoveredNode;
+        }
+    }
+
+    /**
+     * Parse in-keyword.
+     *
+     * @return In-keyword node
+     */
+    private STNode parseInKeyword() {
+        STToken token = peek();
+        if (token.kind == SyntaxKind.IN_KEYWORD) {
+            return consume();
+        } else {
+            Solution sol = recover(token, ParserRuleContext.IN_KEYWORD);
             return sol.recoveredNode;
         }
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
@@ -76,7 +76,7 @@ public class BallerinaParserErrorHandler {
             ParserRuleContext.CONTINUE_STATEMENT, ParserRuleContext.BREAK_STATEMENT, ParserRuleContext.RETURN_STMT,
             ParserRuleContext.COMPOUND_ASSIGNMENT_STMT, ParserRuleContext.LOCAL_TYPE_DEFINITION_STMT,
             ParserRuleContext.EXPRESSION_STATEMENT, ParserRuleContext.LOCK_STMT, ParserRuleContext.BLOCK_STMT,
-            ParserRuleContext.NAMED_WORKER_DECL, ParserRuleContext.FORK_STMT };
+            ParserRuleContext.NAMED_WORKER_DECL, ParserRuleContext.FORK_STMT, ParserRuleContext.FOREACH_STMT };
 
     private static final ParserRuleContext[] VAR_DECL_RHS =
             { ParserRuleContext.SEMICOLON, ParserRuleContext.ASSIGN_OP };
@@ -1076,7 +1076,12 @@ public class BallerinaParserErrorHandler {
                 case TRAP_KEYWORD:
                     hasMatch = nextToken.kind == SyntaxKind.TRAP_KEYWORD;
                     break;
-
+                case FOREACH_KEYWORD:
+                    hasMatch = nextToken.kind == SyntaxKind.FOREACH_KEYWORD;
+                    break;
+                case IN_KEYWORD:
+                    hasMatch = nextToken.kind == SyntaxKind.IN_KEYWORD;
+                    break;
                 // Productions (Non-terminals which doesn't have alternative paths)
                 case COMP_UNIT:
                 case FUNC_DEFINITION:
@@ -1144,6 +1149,7 @@ public class BallerinaParserErrorHandler {
                 case LOCK_STMT:
                 case FORK_STMT:
                 case TRAP_EXPRESSION:
+                case FOREACH_STMT:
                 default:
                     // Stay at the same place
                     skipRule = true;
@@ -1307,7 +1313,8 @@ public class BallerinaParserErrorHandler {
         }
 
         ParserRuleContext nextContext;
-        if (parentCtx == ParserRuleContext.IF_BLOCK || parentCtx == ParserRuleContext.WHILE_BLOCK) {
+        if (parentCtx == ParserRuleContext.IF_BLOCK || parentCtx == ParserRuleContext.WHILE_BLOCK || 
+            parentCtx == ParserRuleContext.FOREACH_STMT) {
             nextContext = ParserRuleContext.BLOCK_STMT;
         } else if (isStatement(parentCtx) || parentCtx == ParserRuleContext.RECORD_FIELD ||
                 parentCtx == ParserRuleContext.OBJECT_MEMBER || parentCtx == ParserRuleContext.LISTENER_DECL ||
@@ -1553,6 +1560,7 @@ public class BallerinaParserErrorHandler {
             case CONSTANT_EXPRESSION:
             case NAMED_WORKER_DECL:
             case FORK_STMT:
+            case FOREACH_STMT:
             case PARAMETERIZED_TYPE_DESCRIPTOR:
                 startContext(currentCtx);
                 break;
@@ -1988,6 +1996,12 @@ public class BallerinaParserErrorHandler {
                 return ParserRuleContext.TRAP_KEYWORD;
             case TRAP_KEYWORD:
                 return ParserRuleContext.EXPRESSION;
+            case FOREACH_STMT:
+                return ParserRuleContext.FOREACH_KEYWORD;
+            case FOREACH_KEYWORD:
+                return ParserRuleContext.TYPE_DESCRIPTOR;
+            case IN_KEYWORD:
+                return ParserRuleContext.EXPRESSION;
             case NON_RECURSIVE_TYPE:
                 return getNextRuleForTypeDescriptor();
             case PARAMETERIZED_TYPE_DESCRIPTOR:
@@ -2257,6 +2271,9 @@ public class BallerinaParserErrorHandler {
                 } else if (parentCtx == ParserRuleContext.LOCK_STMT) {
                     endContext();
                     return ParserRuleContext.STATEMENT;
+                } else if (parentCtx == ParserRuleContext.FOREACH_STMT) {
+                    endContext();
+                    return ParserRuleContext.STATEMENT;
                 }
                 return ParserRuleContext.STATEMENT;
             case MAPPING_CONSTRUCTOR:
@@ -2332,6 +2349,8 @@ public class BallerinaParserErrorHandler {
             } else {
                 return ParserRuleContext.ASSIGN_OP;
             }
+        } else if (parentCtx == ParserRuleContext.FOREACH_STMT) {
+            return ParserRuleContext.IN_KEYWORD;
         } else if (isStatement(parentCtx) || parentCtx == ParserRuleContext.LISTENER_DECL ||
                 parentCtx == ParserRuleContext.CONSTANT_DECL) {
             return ParserRuleContext.VAR_DECL_STMT_RHS;
@@ -2563,6 +2582,7 @@ public class BallerinaParserErrorHandler {
             case EXPRESSION_STATEMENT:
             case LOCK_STMT:
             case FORK_STMT:
+            case FOREACH_STMT:
                 return true;
             default:
                 return false;
@@ -2907,6 +2927,10 @@ public class BallerinaParserErrorHandler {
                 return SyntaxKind.MAP_KEYWORD;
             case TRAP_KEYWORD:
                 return SyntaxKind.TRAP_KEYWORD;
+            case FOREACH_KEYWORD:
+                return SyntaxKind.FOREACH_KEYWORD;
+            case IN_KEYWORD:
+                return SyntaxKind.IN_KEYWORD;
 
             // TODO:
             case COMP_UNIT:
@@ -2980,6 +3004,7 @@ public class BallerinaParserErrorHandler {
             case DEFAULT_WORKER:
             case DEFAULT_WORKER_INIT:
             case TRAP_EXPRESSION:
+            case FOREACH_STMT:
             default:
                 break;
         }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/LexerTerminals.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/LexerTerminals.java
@@ -67,6 +67,8 @@ public class LexerTerminals {
     public static final String XMLNS = "xmlns";
     public static final String FORK = "fork";
     public static final String TRAP = "trap";
+    public static final String IN = "in";
+    public static final String FOREACH = "foreach";
 
     // Types
     public static final String INT = "int";

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/ParserRuleContext.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/ParserRuleContext.java
@@ -146,6 +146,7 @@ public enum ParserRuleContext {
     LOCK_STMT("lock-stmt"),
     NAMED_WORKER_DECL("named-worker-decl"),
     FORK_STMT("fork-stmt"),
+    FOREACH_STMT("foreach-stmt"),
 
     // Keywords
     RETURNS_KEYWORD("returns"),
@@ -188,6 +189,8 @@ public enum ParserRuleContext {
     WORKER_KEYWORD("worker"),
     FORK_KEYWORD("fork"),
     TRAP_KEYWORD("trap"),
+    IN_KEYWORD("in"),
+    FOREACH_KEYWORD("foreach"),
 
     // Syntax tokens
     OPEN_PARENTHESIS("("),

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STForEachStatementNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STForEachStatementNode.java
@@ -1,0 +1,65 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.internal.parser.tree;
+
+import io.ballerinalang.compiler.syntax.tree.ForEachStatementNode;
+import io.ballerinalang.compiler.syntax.tree.Node;
+import io.ballerinalang.compiler.syntax.tree.NonTerminalNode;
+import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
+
+/**
+ * This is a generated internal syntax tree node.
+ *
+ * @since 1.3.0
+ */
+public class STForEachStatementNode extends STStatementNode {
+    public final STNode forEachKeyword;
+    public final STNode typeDescriptor;
+    public final STNode variableName;
+    public final STNode inKeyword;
+    public final STNode ActionOrExpressionNode;
+    public final STNode blockStatement;
+
+    STForEachStatementNode(
+            STNode forEachKeyword,
+            STNode typeDescriptor,
+            STNode variableName,
+            STNode inKeyword,
+            STNode ActionOrExpressionNode,
+            STNode blockStatement) {
+        super(SyntaxKind.FOREACH_STATEMENT);
+        this.forEachKeyword = forEachKeyword;
+        this.typeDescriptor = typeDescriptor;
+        this.variableName = variableName;
+        this.inKeyword = inKeyword;
+        this.ActionOrExpressionNode = ActionOrExpressionNode;
+        this.blockStatement = blockStatement;
+
+        addChildren(
+                forEachKeyword,
+                typeDescriptor,
+                variableName,
+                inKeyword,
+                ActionOrExpressionNode,
+                blockStatement);
+    }
+
+    public Node createFacade(int position, NonTerminalNode parent) {
+        return new ForEachStatementNode(this, position, parent);
+    }
+}

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
@@ -334,6 +334,23 @@ public class STNodeFactory extends STAbstractNodeFactory {
                 closeBraceToken);
     }
 
+    public static STNode createForEachStatementNode(
+            STNode forEachKeyword,
+            STNode typeDescriptor,
+            STNode variableName,
+            STNode inKeyword,
+            STNode ActionOrExpressionNode,
+            STNode blockStatement) {
+
+        return new STForEachStatementNode(
+                forEachKeyword,
+                typeDescriptor,
+                variableName,
+                inKeyword,
+                ActionOrExpressionNode,
+                blockStatement);
+    }
+
     public static STNode createBinaryExpressionNode(
             SyntaxKind kind,
             STNode lhsExpr,

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ForEachStatementNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ForEachStatementNode.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.syntax.tree;
+
+import io.ballerinalang.compiler.internal.parser.tree.STNode;
+
+/**
+ * This is a generated syntax tree node.
+ *
+ * @since 1.3.0
+ */
+public class ForEachStatementNode extends StatementNode {
+
+    public ForEachStatementNode(STNode internalNode, int position, NonTerminalNode parent) {
+        super(internalNode, position, parent);
+    }
+
+    public Token forEachKeyword() {
+        return childInBucket(0);
+    }
+
+    public Node typeDescriptor() {
+        return childInBucket(1);
+    }
+
+    public Token variableName() {
+        return childInBucket(2);
+    }
+
+    public Token inKeyword() {
+        return childInBucket(3);
+    }
+
+    public Node ActionOrExpressionNode() {
+        return childInBucket(4);
+    }
+
+    public StatementNode blockStatement() {
+        return childInBucket(5);
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(NodeTransformer<T> visitor) {
+        return visitor.transform(this);
+    }
+
+    @Override
+    protected String[] childNames() {
+        return new String[]{
+                "forEachKeyword",
+                "typeDescriptor",
+                "variableName",
+                "inKeyword",
+                "ActionOrExpressionNode",
+                "blockStatement"};
+    }
+
+    public ForEachStatementNode modify(
+            Token forEachKeyword,
+            Node typeDescriptor,
+            Token variableName,
+            Token inKeyword,
+            Node ActionOrExpressionNode,
+            StatementNode blockStatement) {
+        if (checkForReferenceEquality(
+                forEachKeyword,
+                typeDescriptor,
+                variableName,
+                inKeyword,
+                ActionOrExpressionNode,
+                blockStatement)) {
+            return this;
+        }
+
+        return NodeFactory.createForEachStatementNode(
+                forEachKeyword,
+                typeDescriptor,
+                variableName,
+                inKeyword,
+                ActionOrExpressionNode,
+                blockStatement);
+    }
+}

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
@@ -436,6 +436,30 @@ public abstract class NodeFactory extends AbstractNodeFactory {
         return stForkStatementNode.createUnlinkedFacade();
     }
 
+    public static ForEachStatementNode createForEachStatementNode(
+            Token forEachKeyword,
+            Node typeDescriptor,
+            Token variableName,
+            Token inKeyword,
+            Node ActionOrExpressionNode,
+            StatementNode blockStatement) {
+        Objects.requireNonNull(forEachKeyword, "forEachKeyword must not be null");
+        Objects.requireNonNull(typeDescriptor, "typeDescriptor must not be null");
+        Objects.requireNonNull(variableName, "variableName must not be null");
+        Objects.requireNonNull(inKeyword, "inKeyword must not be null");
+        Objects.requireNonNull(ActionOrExpressionNode, "ActionOrExpressionNode must not be null");
+        Objects.requireNonNull(blockStatement, "blockStatement must not be null");
+
+        STNode stForEachStatementNode = STNodeFactory.createForEachStatementNode(
+                forEachKeyword.internalNode(),
+                typeDescriptor.internalNode(),
+                variableName.internalNode(),
+                inKeyword.internalNode(),
+                ActionOrExpressionNode.internalNode(),
+                blockStatement.internalNode());
+        return stForEachStatementNode.createUnlinkedFacade();
+    }
+
     public static BinaryExpressionNode createBinaryExpressionNode(
             SyntaxKind kind,
             Node lhsExpr,

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeTransformer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeTransformer.java
@@ -128,6 +128,10 @@ public abstract class NodeTransformer<T> {
         return transformSyntaxNode(forkStatementNode);
     }
 
+    public T transform(ForEachStatementNode forEachStatementNode) {
+        return transformSyntaxNode(forEachStatementNode);
+    }
+
     public T transform(BinaryExpressionNode binaryExpressionNode) {
         return transformSyntaxNode(binaryExpressionNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeVisitor.java
@@ -127,6 +127,10 @@ public abstract class NodeVisitor {
         visitSyntaxNode(forkStatementNode);
     }
 
+    public void visit(ForEachStatementNode forEachStatementNode) {
+        visitSyntaxNode(forEachStatementNode);
+    }
+
     public void visit(BinaryExpressionNode binaryExpressionNode) {
         visitSyntaxNode(binaryExpressionNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/SyntaxKind.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/SyntaxKind.java
@@ -65,6 +65,8 @@ public enum SyntaxKind {
     LOCK_KEYWORD(216, "lock"),
     FORK_KEYWORD(217, "fork"),
     TRAP_KEYWORD(218,"trap"),
+    IN_KEYWORD(219,"in"),
+    FOREACH_KEYWORD(220,"foreach"),
 
     // Type keywords
     INT_KEYWORD(250, "int"),
@@ -169,6 +171,7 @@ public enum SyntaxKind {
     LOCK_STATEMENT(1214),
     NAMED_WORKER_DECLARATION(1215),
     FORK_STATEMENT(1216),
+    FOREACH_STATEMENT(1217),
 
     // Expressions
     BINARY_EXPRESSION(1300),

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
@@ -329,6 +329,23 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
     }
 
     @Override
+    public Node transform(ForEachStatementNode forEachStatementNode) {
+        Token forEachKeyword = modifyToken(forEachStatementNode.forEachKeyword());
+        Node typeDescriptor = modifyNode(forEachStatementNode.typeDescriptor());
+        Token variableName = modifyToken(forEachStatementNode.variableName());
+        Token inKeyword = modifyToken(forEachStatementNode.inKeyword());
+        Node ActionOrExpressionNode = modifyNode(forEachStatementNode.ActionOrExpressionNode());
+        StatementNode blockStatement = modifyNode(forEachStatementNode.blockStatement());
+        return forEachStatementNode.modify(
+                forEachKeyword,
+                typeDescriptor,
+                variableName,
+                inKeyword,
+                ActionOrExpressionNode,
+                blockStatement);
+    }
+
+    @Override
     public Node transform(BinaryExpressionNode binaryExpressionNode) {
         Node lhsExpr = modifyNode(binaryExpressionNode.lhsExpr());
         Token operator = modifyToken(binaryExpressionNode.operator());

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/ParserTestUtils.java
@@ -424,6 +424,10 @@ public class ParserTestUtils {
                 return SyntaxKind.FORK_KEYWORD;
             case "TRAP_KEYWORD":
                 return SyntaxKind.TRAP_KEYWORD;
+            case "FOREACH_KEYWORD":
+                return SyntaxKind.FOREACH_KEYWORD;
+            case "IN_KEYWORD":
+                return SyntaxKind.IN_KEYWORD;
 
             // Operators
             case "PLUS_TOKEN":
@@ -596,6 +600,8 @@ public class ParserTestUtils {
                 return SyntaxKind.LOCK_STATEMENT;
             case "FORK_STATEMENT":
                 return SyntaxKind.FORK_STATEMENT;
+            case "FOREACH_STATEMENT":
+                return SyntaxKind.FOREACH_STATEMENT;
 
             // Types
             case "TYPE_DESC":

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/ForEachStatementTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/ForEachStatementTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerinalang.compiler.parser.test.syntax.statements;
+
+import org.testng.annotations.Test;
+
+/**
+ * Test parsing ForEach statements.
+ */
+public class ForEachStatementTest extends AbstractStatementTest {
+
+    // Valid syntax tests
+
+   @Test
+    public void testForEachStmt() {
+        testFile("forEach-stmt/forEach_stmt_source_01.bal",
+        "forEach-stmt/forEach_stmt_assert_01.json");
+    }
+
+    @Test
+    public void testEmptyForEachStmt() {
+        testFile("forEach-stmt/forEach_stmt_source_02.bal",
+        "forEach-stmt/forEach_stmt_assert_02.json");
+    }
+
+    @Test
+    public void testMultileForEachStmt() {
+        testFile("forEach-stmt/forEach_stmt_source_03.bal",
+        "forEach-stmt/forEach_stmt_assert_03.json");
+    }
+
+    // Recovery tests
+
+    @Test
+    public void testForEachStmtWithMissingClosingBraces() {
+        testFile("forEach-stmt/forEach_stmt_source_04.bal",
+        "forEach-stmt/forEach_stmt_assert_04.json");
+    }
+
+    @Test
+    public void testForEachStmtwithMissingInKeyword() {
+        testFile("forEach-stmt/forEach_stmt_source_05.bal",
+        "forEach-stmt/forEach_stmt_assert_05.json");
+    }
+
+    @Test
+    public void testNestedObjectRecovery() {
+        testFile("forEach-stmt/forEach_stmt_source_06.bal",
+        "forEach-stmt/forEach_stmt_assert_06.json");
+    }
+
+    @Test
+    public void testForEachStmtwithMissingExpression() {
+        testFile("forEach-stmt/forEach_stmt_source_07.bal",
+        "forEach-stmt/forEach_stmt_assert_07.json");
+    }
+
+    @Test
+    public void testForEachStmtwithMissingTypeDescriptor() {
+        testFile("forEach-stmt/forEach_stmt_source_08.bal",
+        "forEach-stmt/forEach_stmt_assert_08.json");
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_01.json
@@ -1,0 +1,136 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "VAR_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_02.json
@@ -1,0 +1,87 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "VAR_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": []
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_03.json
@@ -1,0 +1,222 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "VAR_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "INT_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_04.json
@@ -1,0 +1,138 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "VAR_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN",
+                                            "isMissing": true
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN",
+                    "isMissing": true
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_05.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_05.json
@@ -1,0 +1,137 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "VAR_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD",
+                                    "isMissing": true
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_06.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_06.json
@@ -1,0 +1,135 @@
+{
+                    "kind": "FUNCTION_DEFINITION",
+                    "children": [
+                        {
+                            "kind": "METADATA",
+                            "children": [
+                                {
+                                    "kind": "LIST",
+                                    "children": []
+                                }
+                            ]
+                        },
+                        {
+                            "kind": "PUBLIC_KEYWORD"
+                        },
+                        {
+                            "kind": "FUNCTION_KEYWORD"
+                        },
+                        {
+                            "kind": "IDENTIFIER_TOKEN",
+                            "value": "foo"
+                        },
+                        {
+                            "kind": "OPEN_PAREN_TOKEN"
+                        },
+                        {
+                            "kind": "LIST",
+                            "children": []
+                        },
+                        {
+                            "kind": "CLOSE_PAREN_TOKEN"
+                        },
+                        {
+                            "kind": "FUNCTION_BODY_BLOCK",
+                            "children": [
+                                {
+                                    "kind": "OPEN_BRACE_TOKEN"
+                                },
+                                {
+                                    "kind": "LIST",
+                                    "children": [
+                                        {
+                                            "kind": "FOREACH_STATEMENT",
+                                            "children": [
+                                                {
+                                                    "kind": "FOREACH_KEYWORD"
+                                                },
+                                                {
+                                                    "kind": "VAR_KEYWORD"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "v"
+                                                },
+                                                {
+                                                    "kind": "IN_KEYWORD"
+                                                },
+                                                {
+                                                    "kind": "IDENTIFIER_TOKEN",
+                                                    "value": "fruits"
+                                                },
+                                                {
+                                                    "kind": "BLOCK_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "OPEN_BRACE_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": [
+                                                                {
+                                                                    "kind": "LOCAL_VAR_DECL",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "LIST",
+                                                                            "children": []
+                                                                        },
+                                                                        {
+                                                                            "kind": "INT_KEYWORD"
+                                                                        },
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "k"
+                                                                        },
+                                                                        {
+                                                                            "kind": "EQUAL_TOKEN",
+                                                                            "isMissing": true
+                                                                        },
+                                                                        {
+                                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                            "value": "2"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                },
+                                                                {
+                                                                    "kind": "ASSIGNMENT_STATEMENT",
+                                                                    "children": [
+                                                                        {
+                                                                            "kind": "IDENTIFIER_TOKEN",
+                                                                            "value": "k"
+                                                                        },
+                                                                        {
+                                                                            "kind": "EQUAL_TOKEN",
+                                                                            "isMissing": true
+                                                                        },
+                                                                        {
+                                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                                            "value": "5"
+                                                                        },
+                                                                        {
+                                                                            "kind": "SEMICOLON_TOKEN"
+                                                                        }
+                                                                    ]
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "kind": "CLOSE_BRACE_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "kind": "CLOSE_BRACE_TOKEN"
+                                }
+                            ]
+                        }
+                    ]
+                }

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_07.json
@@ -1,0 +1,149 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "VAR_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "MAPPING_CONSTRUCTOR",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": []
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN",
+                                            "isMissing": true
+                                        }
+                                    ]
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN",
+                                            "isMissing": true
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_08.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_assert_08.json
@@ -1,0 +1,137 @@
+{
+    "kind": "FUNCTION_DEFINITION",
+    "children": [
+        {
+            "kind": "METADATA",
+            "children": [
+                {
+                    "kind": "LIST",
+                    "children": []
+                }
+            ]
+        },
+        {
+            "kind": "PUBLIC_KEYWORD"
+        },
+        {
+            "kind": "FUNCTION_KEYWORD"
+        },
+        {
+            "kind": "IDENTIFIER_TOKEN",
+            "value": "foo"
+        },
+        {
+            "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+            "kind": "LIST",
+            "children": []
+        },
+        {
+            "kind": "CLOSE_PAREN_TOKEN"
+        },
+        {
+            "kind": "FUNCTION_BODY_BLOCK",
+            "children": [
+                {
+                    "kind": "OPEN_BRACE_TOKEN"
+                },
+                {
+                    "kind": "LIST",
+                    "children": [
+                        {
+                            "kind": "FOREACH_STATEMENT",
+                            "children": [
+                                {
+                                    "kind": "FOREACH_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "v"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "isMissing": true
+                                },
+                                {
+                                    "kind": "IN_KEYWORD"
+                                },
+                                {
+                                    "kind": "IDENTIFIER_TOKEN",
+                                    "value": "fruits"
+                                },
+                                {
+                                    "kind": "BLOCK_STATEMENT",
+                                    "children": [
+                                        {
+                                            "kind": "OPEN_BRACE_TOKEN"
+                                        },
+                                        {
+                                            "kind": "LIST",
+                                            "children": [
+                                                {
+                                                    "kind": "LOCAL_VAR_DECL",
+                                                    "children": [
+                                                        {
+                                                            "kind": "LIST",
+                                                            "children": []
+                                                        },
+                                                        {
+                                                            "kind": "INT_KEYWORD"
+                                                        },
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "2"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "kind": "COMPOUND_ASSIGNMENT_STATEMENT",
+                                                    "children": [
+                                                        {
+                                                            "kind": "IDENTIFIER_TOKEN",
+                                                            "value": "k"
+                                                        },
+                                                        {
+                                                            "kind": "PLUS_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "EQUAL_TOKEN"
+                                                        },
+                                                        {
+                                                            "kind": "DECIMAL_INTEGER_LITERAL",
+                                                            "value": "5"
+                                                        },
+                                                        {
+                                                            "kind": "SEMICOLON_TOKEN"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        },
+                                        {
+                                            "kind": "CLOSE_BRACE_TOKEN"
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "kind": "CLOSE_BRACE_TOKEN"
+                }
+            ]
+        }
+    ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_01.bal
@@ -1,0 +1,8 @@
+public function foo() {
+
+    foreach var v in fruits {
+        int k = 2;
+        k+=5;
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_02.bal
@@ -1,0 +1,6 @@
+public function foo() {
+
+    foreach var v in fruits {
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_03.bal
@@ -1,0 +1,12 @@
+public function foo() {
+
+    foreach var v in fruits {
+        int k = 2;
+        k+=5;
+    }
+
+    foreach int v in fruits {
+        int k = 2;
+        k+=5;
+    }
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_04.bal
@@ -1,0 +1,6 @@
+public function foo() {
+
+    foreach var v in fruits {
+        int k = 2;
+        k+=5;
+    

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_05.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_05.bal
@@ -1,0 +1,8 @@
+public function foo() {
+
+    foreach var v fruits {
+        int k = 2;
+        k+=5;
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_06.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_06.bal
@@ -1,0 +1,8 @@
+public function foo() {
+
+    foreach var v in fruits{
+        int k  2;
+        k 5;
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_07.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_07.bal
@@ -1,0 +1,8 @@
+public function foo() {
+
+    foreach var v in {
+        int k = 2;
+        k+=5;
+    }
+
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_08.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/forEach-stmt/forEach_stmt_source_08.bal
@@ -1,0 +1,8 @@
+public function foo() {
+
+    foreach v in fruits {
+        int k = 2;
+        k+=5;
+    }
+
+}

--- a/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
+++ b/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
@@ -569,6 +569,37 @@
             ]
         },
         {
+            "name": "ForEachStatementNode",
+            "base": "StatementNode",
+            "kind": "FOREACH_STATEMENT",
+            "attributes": [
+                {
+                    "name": "forEachKeyword",
+                    "type": "Token"
+                },
+                {
+                    "name": "typeDescriptor",
+                    "type": "Node"
+                },
+                {
+                    "name": "variableName",
+                    "type": "Token"
+                },
+                {
+                    "name": "inKeyword",
+                    "type": "Token"
+                },
+                {
+                    "name": "ActionOrExpressionNode",
+                    "type": "Node"
+                },
+                {
+                    "name": "blockStatement",
+                    "type": "StatementNode"
+                }
+            ]
+        },
+        {
             "name": "ExpressionNode",
             "base": "Node",
             "isAbstract": true


### PR DESCRIPTION
Add foreach statement support to incremental parser

<code>foreach-stmt := foreach typed-binding-pattern in action-or-expr block-stmt</code>

https://ballerina.io/spec/lang/2020R1/#foreach-stmt

Closes: #22813 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
