### PR TITLE
Add unit test for building public key from JWKs paramters [master]

### DIFF
--- a/stdlib/crypto/src/test/java/org/ballerinalang/stdlib/crypto/KeyParsingTest.java
+++ b/stdlib/crypto/src/test/java/org/ballerinalang/stdlib/crypto/KeyParsingTest.java
@@ -98,4 +98,18 @@ public class KeyParsingTest {
                 new BString("ballerina"), new BString("ballerina")};
         BRunUtil.invoke(compileResult, "testParsingPublicKeyFromP12", args);
     }
+
+    @Test(description = "Check parsing public-key from a JWK parameters.")
+    public void testParsingPublicKeyFromJwk() {
+        String modulus = "luZFdW1ynitztkWLC6xKegbRWxky-5P0p4ShYEOkHs30QI2VCuR6Qo4Bz5rTgLBrky03W1GAVrZxuvKRGj9V9-" +
+                "PmjdGtau4CTXu9pLLcqnruaczoSdvBYA3lS9a7zgFU0-s6kMl2EhB-rk7gXluEep7lIOenzfl2f6IoTKa2fVgVd3YKiSGsy" +
+                "L4tztS70vmmX121qm0sTJdKWP4HxXyqK9neolXI9fYyHOYILVNZ69z_73OOVhkh_mvTmWZLM7GM6sApmyLX6OXUp8z0pkY-v" +
+                "T_9-zRxxQs7GurC4_C1nK3rI_0ySUgGEafO1atNjYmlFN-M3tZX6nEcA6g94IavyQ";
+        String exponent = "AQAB";
+        BValue[] args = {new BString(modulus), new BString(exponent)};
+        BValue[] returnValues = BRunUtil.invoke(compileResult, "testParsingPublicKeyFromJwk", args);
+        Assert.assertFalse(returnValues == null || returnValues.length == 0 || returnValues[0] == null);
+        Assert.assertEquals(((BMap) returnValues[0]).get(Constants.PUBLIC_KEY_RECORD_ALGORITHM_FIELD).stringValue(),
+                            "RSA");
+    }
 }

--- a/stdlib/crypto/src/test/resources/test-src/keyparsing-test.bal
+++ b/stdlib/crypto/src/test/resources/test-src/keyparsing-test.bal
@@ -33,3 +33,7 @@ function testParsingPublicKeyFromP12(string path, string keyStorePassword, strin
     };
     return check crypto:decodePublicKey(keyStore, keyAlias);
 }
+
+function testParsingPublicKeyFromJwk(string modulus, string exponent) returns crypto:PublicKey|crypto:Error {
+    return crypto:buildRsaPublicKey(modulus, exponent);
+}

--- a/stdlib/crypto/src/test/resources/test-src/keyparsing-test.bal
+++ b/stdlib/crypto/src/test/resources/test-src/keyparsing-test.bal
@@ -22,7 +22,7 @@ function testParsingPrivateKeyFromP12(string path, string keyStorePassword, stri
         path: path,
         password: keyStorePassword
     };
-    return check crypto:decodePrivateKey(keyStore,  keyAlias, keyPassword);
+    return crypto:decodePrivateKey(keyStore,  keyAlias, keyPassword);
 }
 
 function testParsingPublicKeyFromP12(string path, string keyStorePassword, string keyAlias)
@@ -31,7 +31,7 @@ function testParsingPublicKeyFromP12(string path, string keyStorePassword, strin
         path: path,
         password: keyStorePassword
     };
-    return check crypto:decodePublicKey(keyStore, keyAlias);
+    return crypto:decodePublicKey(keyStore, keyAlias);
 }
 
 function testParsingPublicKeyFromJwk(string modulus, string exponent) returns crypto:PublicKey|crypto:Error {


### PR DESCRIPTION
## Purpose
This PR adds a unit test for building public key from JWKs paramters. This is an extended of the PR #22890 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
