### PR TITLE
fix an issue where anonymous toplevel nodes were not created for record types.

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -438,9 +438,9 @@ public class BLangPackageBuilder {
         recordTypeNode.addWS(ws);
         recordTypeNode.isAnonymous = isAnonymous;
         recordTypeNode.isLocal = isInLocalDefinition();
-        this.varListStack.pop().forEach(variableNode -> {
+        for (BLangVariable variableNode : this.varListStack.pop()) {
             recordTypeNode.addField((SimpleVariableNode) variableNode);
-        });
+        }
         return recordTypeNode;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -866,12 +866,8 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
-
         // Validate type AB "A"| record { string f; };
-        if (!isAnonymous) {
-            isAnonymous = checkIfAnonymousInTypeDef(ctx);
-        }
+        boolean isAnonymous = checkIfAnonymousInTypeDef(ctx);
 
         this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isAnonymous, false, false);
     }
@@ -883,12 +879,8 @@ public class BLangParserListener extends BallerinaParserBaseListener {
      * @return true if is part of a union type descriptor with on the fly definition
      */
     private boolean checkIfAnonymousInTypeDef(ParserRuleContext ctx) {
-        if (!(ctx instanceof BallerinaParser.InclusiveRecordTypeDescriptorContext ||
-            ctx instanceof BallerinaParser.ExclusiveRecordTypeDescriptorContext)) {
-            return false;
-        }
-
-        return (ctx.parent.parent.parent instanceof BallerinaParser.FiniteTypeContext &&
+        boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
+        return isAnonymous ? isAnonymous : (ctx.parent.parent.parent instanceof BallerinaParser.FiniteTypeContext &&
             ctx.parent.parent.parent.getChildCount() > 1);
     }
 
@@ -907,12 +899,8 @@ public class BLangParserListener extends BallerinaParserBaseListener {
             return;
         }
 
-        boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
-
         // Validate type AB "A"| record {| string f; |};
-        if (!isAnonymous) {
-            isAnonymous = checkIfAnonymousInTypeDef(ctx);
-        }
+        boolean isAnonymous = checkIfAnonymousInTypeDef(ctx);
 
         boolean hasRestField = ctx.recordRestFieldDefinition() != null;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -870,14 +870,14 @@ public class BLangParserListener extends BallerinaParserBaseListener {
 
         // Validate type AB "A"| record { string f; };
         if (!isAnonymous) {
-                isAnonymous = checkIfAnonymousInTypeDef(ctx);
+            isAnonymous = checkIfAnonymousInTypeDef(ctx);
         }
 
         this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isAnonymous, false, false);
     }
 
     /**
-     * Validate if this is a anonymous record type describe in union with a type descriptor
+     * Validate if this is a anonymous record type describe in union with a type descriptor.
      *
      * @param ctx the current context to be validated. can be InclusiveRecordTypeDescriptor or ExclusiveRecordTypeDes.
      * @return true if is part of a union type descriptor with on the fly definition

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangParserListener.java
@@ -868,7 +868,28 @@ public class BLangParserListener extends BallerinaParserBaseListener {
 
         boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
 
+        // Validate type AB "A"| record { string f; };
+        if (!isAnonymous) {
+                isAnonymous = checkIfAnonymousInTypeDef(ctx);
+        }
+
         this.pkgBuilder.addRecordType(getCurrentPos(ctx), getWS(ctx), isAnonymous, false, false);
+    }
+
+    /**
+     * Validate if this is a anonymous record type describe in union with a type descriptor
+     *
+     * @param ctx the current context to be validated. can be InclusiveRecordTypeDescriptor or ExclusiveRecordTypeDes.
+     * @return true if is part of a union type descriptor with on the fly definition
+     */
+    private boolean checkIfAnonymousInTypeDef(ParserRuleContext ctx) {
+        if (!(ctx instanceof BallerinaParser.InclusiveRecordTypeDescriptorContext ||
+            ctx instanceof BallerinaParser.ExclusiveRecordTypeDescriptorContext)) {
+            return false;
+        }
+
+        return (ctx.parent.parent.parent instanceof BallerinaParser.FiniteTypeContext &&
+            ctx.parent.parent.parent.getChildCount() > 1);
     }
 
     @Override
@@ -887,6 +908,11 @@ public class BLangParserListener extends BallerinaParserBaseListener {
         }
 
         boolean isAnonymous = !(ctx.parent.parent instanceof BallerinaParser.FiniteTypeUnitContext);
+
+        // Validate type AB "A"| record {| string f; |};
+        if (!isAnonymous) {
+            isAnonymous = checkIfAnonymousInTypeDef(ctx);
+        }
 
         boolean hasRestField = ctx.recordRestFieldDefinition() != null;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
@@ -122,4 +122,19 @@ public class TypeDefinitionsTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testXml");
         Assert.assertEquals(returns[0].stringValue(), "<name>ballerina</name>");
     }
+
+    @Test
+    public void testAnonRecordUnionTypeDef() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testAnonRecordUnionTypeDef");
+    }
+
+    @Test
+    public void testAnonObjectUnionTypeDef() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testAnonObjectUnionTypeDef");
+    }
+
+    @Test
+    public void testAnonExclusiveRecordUnionTypeDef() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testAnonExclusiveRecordUnionTypeDef");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
@@ -134,3 +134,44 @@ function testXml() returns T12 {
     T12 x = xml `<name>ballerina</name>`;
     return x;
 }
+
+
+// ---------------------------------------------------------------------------------------------------------------------
+
+type FB "A" | object { string f; function __init(string f) { self.f = f; }};
+
+type Foo object {
+    string f;
+
+    function __init(string f) {
+        self.f = f;
+    }
+};
+
+function testAnonObjectUnionTypeDef() {
+    FB a = new Foo("FOO");
+
+    if (!(a is Foo)) {
+        panic error("Invalid type for anonObjectUnionTypeDef");
+    }
+}
+
+type FB2 "A" | record { string f; };
+
+function testAnonRecordUnionTypeDef() {
+    FB2 a = { f : "FOO"};
+
+    if (!(a is record { string f; })) {
+        panic error("Error in union with anonymous record type definitions");
+    }
+}
+
+type FB3 "A" | record {| string f; |};
+
+function testAnonExclusiveRecordUnionTypeDef() {
+    FB3 a = { f : "FOO" };
+
+    if (!(a is record {| string f; |})) {
+        panic error("Error in union with anonymous record type definitions");
+    }
+}


### PR DESCRIPTION
## Purpose
> fix an issue where anonymous top level nodes were not created for record types when they are used as members of union types.

Fixes #11183

## Approach
> In the ParserListener, isAnonymous is decided checking if there are more than 1 child available in the finiteType.

## Samples
> type FB3 "A" | record {| string f; |}; are supported now

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
