### PR TITLE
Add capability to configure POP3 and IMAP4 custom properties

### DIFF
--- a/stdlib/email/src/main/ballerina/src/email/imap_client_endpoint.bal
+++ b/stdlib/email/src/main/ballerina/src/email/imap_client_endpoint.bal
@@ -61,8 +61,10 @@ function imapRead(ImapClient clientEndpoint, handle folder) returns Email|Error?
 #
 # + port - Port number of the IMAP server
 # + enableSsl - If set to true, use SSL to connect and use the SSL port by default.
-#               The default value is true for the "imaps" protocol and false for the "imap" protocol.
+#               The default value is true for the "imaps" protocol and false for the "imap" protocol
+# + properties - IMAP properties to override the existing configuration
 public type ImapConfig record {|
     int port = 993;
     boolean enableSsl = true;
+    map<string>? properties = ();
 |};

--- a/stdlib/email/src/main/ballerina/src/email/pop_client_endpoint.bal
+++ b/stdlib/email/src/main/ballerina/src/email/pop_client_endpoint.bal
@@ -61,8 +61,10 @@ function popRead(PopClient clientEndpoint, handle folder) returns Email|Error? =
 #
 # + port - Port number of the POP server
 # + enableSsl - If set to true, use SSL to connect and use the SSL port by default.
-#               The default value is true for the "pop3s" protocol and false for the "pop3" protocol.
+#               The default value is true for the "pops" protocol and false for the "pop" protocol
+# + properties - POP3 properties to override the existing configuration
 public type PopConfig record {|
     int port = 995;
     boolean enableSsl = true;
+    map<string>? properties = ();
 |};

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/CommonUtil.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/CommonUtil.java
@@ -100,7 +100,7 @@ public class CommonUtil {
             for (Object propertyName : customProperties.getKeys()) {
                 if (propertyName instanceof String) {
                     properties.put(propertyName, customProperties.getStringValue((String) propertyName));
-                    log.debug("Added custom SMTP property with Name: " + propertyName + ", Value: "
+                    log.debug("Added custom protocol property with Name: " + propertyName + ", Value: "
                             + customProperties.getStringValue((String) propertyName));
                 }
             }

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailAccessUtil.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailAccessUtil.java
@@ -49,6 +49,7 @@ import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 
 import javax.mail.Address;
 import javax.mail.BodyPart;
@@ -91,6 +92,15 @@ public class EmailAccessUtil {
         properties.put(EmailConstants.PROPS_POP_SSL_ENABLE,
                 emailAccessConfig.getBooleanValue(EmailConstants.PROPS_SSL));
         properties.put(EmailConstants.MAIL_STORE_PROTOCOL, EmailConstants.POP_PROTOCOL);
+        CommonUtil.addCustomProperties(emailAccessConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
+        if (log.isDebugEnabled()) {
+            Set<String> propertySet = properties.stringPropertyNames();
+            log.debug("POP3 Properties set are as follows.");
+            for (Object propertyObj : propertySet) {
+                log.debug("Property Name: " + propertyObj + ", Value: " + properties.get(propertyObj).toString()
+                        + " ValueType: " + properties.get(propertyObj).getClass().getName());
+            }
+        }
         return properties;
     }
 
@@ -111,6 +121,15 @@ public class EmailAccessUtil {
         properties.put(EmailConstants.PROPS_IMAP_SSL_ENABLE,
                 emailAccessConfig.getBooleanValue(EmailConstants.PROPS_SSL));
         properties.put(EmailConstants.MAIL_STORE_PROTOCOL, EmailConstants.IMAP_PROTOCOL);
+        CommonUtil.addCustomProperties(emailAccessConfig.getMapValue(EmailConstants.PROPS_PROPERTIES), properties);
+        if (log.isDebugEnabled()) {
+            Set<String> propertySet = properties.stringPropertyNames();
+            log.debug("IMAP4 Properties set are as follows.");
+            for (Object propertyObj : propertySet) {
+                log.debug("Property Name: " + propertyObj + ", Value: " + properties.get(propertyObj).toString()
+                        + " ValueType: " + properties.get(propertyObj).getClass().getName());
+            }
+        }
         return properties;
     }
 

--- a/stdlib/email/src/test/resources/test-src/ImapComplexEmailReceive.bal
+++ b/stdlib/email/src/test/resources/test-src/ImapComplexEmailReceive.bal
@@ -19,8 +19,9 @@ import ballerina/mime;
 import ballerina/lang.'string as strings;
 
 email:ImapConfig imapConfig = {
-     port: 3143,
-     enableSsl: false
+     port: 31430, // This is an incorrect value. Later the correct value, 3143 will be set via a property.
+     enableSsl: false,
+     properties: {"mail.imap.port":"3143"}
 };
 
 function testReceiveComplexEmail(string host, string username, string password) returns @tainted string[] {

--- a/stdlib/email/src/test/resources/test-src/PopComplexEmailReceive.bal
+++ b/stdlib/email/src/test/resources/test-src/PopComplexEmailReceive.bal
@@ -19,8 +19,9 @@ import ballerina/mime;
 import ballerina/lang.'string as strings;
 
 email:PopConfig popConfig = {
-     port: 3110,
-     enableSsl: false
+     port: 31100, // This is an incorrect value. Later the correct value, 3110 will be set via a property.
+     enableSsl: false,
+     properties: {"mail.pop3.port":"3110"}
 };
 
 function testReceiveComplexEmail(string host, string username, string password) returns @tainted string[] {


### PR DESCRIPTION
## Purpose
Add capability to configure POP3 and IMAP4 properties for each of the respective client configurations.

Fixes #23013

## Samples
Adding a custom POP3 property `mail.pop3.port` with value `3110` to its client configuration.
```ballerina
email:PopConfig popConfig = {
     port: 31100, // This is an incorrect value. Later the correct value, 3110 will be set via a property.
     enableSsl: false,
     properties: {"mail.pop3.port":"3110"}
};
```

Adding custom IMAP3 property `mail.imap.port` with value `3143` to its client configuration.
```ballerina
email:ImapConfig imapConfig = {
     port: 31430, // This is an incorrect value. Later the correct value, 3143 will be set via a property.
     enableSsl: false,
     properties: {"mail.imap.port":"3143"}
};
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
