### PR TITLE
Fix using anydata for object types instead of any

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/model/BallerinaOpenApi.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/model/BallerinaOpenApi.java
@@ -146,23 +146,15 @@ public class BallerinaOpenApi implements BallerinaOpenApiObject<BallerinaOpenApi
      */
     private boolean hasPathParams(PathItem path) {
         if (null != path.getParameters() && path.getParameters().size() > 0) {
-            return path.getParameters().stream().anyMatch(parameter -> {
-                if (null == parameter.getIn()) {
-                    return false;
-                }
-                return parameter.getIn().equals("path");
-            });
+            return path.getParameters().stream()
+                    .anyMatch(parameter -> null != parameter.getIn() && parameter.getIn().equals("path"));
         }
     
         if (path.readOperations().size() > 0) {
             return path.readOperations().stream().anyMatch(operation -> {
                 if (null != operation.getParameters() && operation.getParameters().size() > 0) {
-                    return operation.getParameters().stream().anyMatch(parameter -> {
-                        if (null == parameter.getIn()) {
-                            return false;
-                        }
-                        return parameter.getIn().equals("path");
-                    });
+                    return operation.getParameters().stream()
+                            .anyMatch(parameter -> null != parameter.getIn() && parameter.getIn().equals("path"));
                 }
                 
                 return false;

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/model/BallerinaSchema.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/model/BallerinaSchema.java
@@ -161,7 +161,7 @@ public class BallerinaSchema implements BallerinaOpenApiObject<BallerinaSchema, 
                 type += "[]";
                 break;
             case "object":
-                type = "any";
+                type = "anydata";
                 break;
             default:
                 type = prop.getType();

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/test/java/org/ballerinalang/openapi/CodeGeneratorTest.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/test/java/org/ballerinalang/openapi/CodeGeneratorTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.openapi.cmd.OpenAPICommandTest;
 import org.ballerinalang.openapi.exception.BallerinaOpenApiException;
 import org.ballerinalang.openapi.model.GenSrcFile;
 import org.ballerinalang.openapi.utils.GeneratorConstants.GenType;
+import org.ballerinalang.openapi.utils.TypeExtractorUtil;
 import org.testng.Assert;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -148,6 +149,24 @@ public class CodeGeneratorTest {
             Assert.fail("Error while generating the ballerina content for the openapi definition: "
                     + yamlFile + " " + e.getMessage());
         }
+    }
+    
+    @Test
+    public void escapeIdentifierTest() {
+        Assert.assertEquals(TypeExtractorUtil.escapeIdentifier("abc"), "abc");
+        Assert.assertEquals(TypeExtractorUtil.escapeIdentifier("string"), "'string");
+        Assert.assertEquals(TypeExtractorUtil.escapeIdentifier("int"), "'int");
+        Assert.assertEquals(TypeExtractorUtil.escapeIdentifier("io.foo.bar"), "'io\\.foo\\.bar");
+        Assert.assertEquals(TypeExtractorUtil.escapeIdentifier("getV1CoreVersion"), "getV1CoreVersion");
+    }
+    
+    @Test
+    public void escapeTypeTest() {
+        Assert.assertEquals(TypeExtractorUtil.escapeType("abc"), "abc");
+        Assert.assertEquals(TypeExtractorUtil.escapeType("string"), "string");
+        Assert.assertEquals(TypeExtractorUtil.escapeType("int"), "int");
+        Assert.assertEquals(TypeExtractorUtil.escapeType("io.foo.bar"), "'io\\.foo\\.bar");
+        Assert.assertEquals(TypeExtractorUtil.escapeType("getV1CoreVersion"), "getV1CoreVersion");
     }
 
     @DataProvider(name = "fileProvider")


### PR DESCRIPTION
## Purpose
> Map object type fields of openapi to anydata field other than any. Added
tests and changes requested in https://github.com/ballerina-platform/ballerina-lang/pull/23075

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [X] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
