### PR TITLE
Generalize assertion for crypto unit tests

### DIFF
--- a/stdlib/crypto/src/test/java/org/ballerinalang/stdlib/crypto/CryptoTest.java
+++ b/stdlib/crypto/src/test/java/org/ballerinalang/stdlib/crypto/CryptoTest.java
@@ -305,8 +305,8 @@ public class CryptoTest {
         BValue[] returnValues = BRunUtil.invoke(compileResult, "testSignRsaSha256WithInvalidKey",
                 new BValue[]{new BValueArray(payload)});
         Assert.assertFalse(returnValues == null || returnValues.length == 0 || returnValues[0] == null);
-        Assert.assertEquals(((BMap) ((BError) returnValues[0]).getDetails()).get(Constants.MESSAGE).stringValue(),
-                "Uninitialized private key: No installed provider supports this key: (null)");
+        Assert.assertTrue(((BMap) ((BError) returnValues[0]).getDetails()).get(Constants.MESSAGE).stringValue()
+                                  .contains("Uninitialized private key:"));
     }
 
     @Test(description = "Test RSA-SHA384 signing with an invalid private key")
@@ -315,8 +315,8 @@ public class CryptoTest {
         BValue[] returnValues = BRunUtil.invoke(compileResult, "testSignRsaSha384WithInvalidKey",
                 new BValue[]{new BValueArray(payload)});
         Assert.assertFalse(returnValues == null || returnValues.length == 0 || returnValues[0] == null);
-        Assert.assertEquals(((BMap) ((BError) returnValues[0]).getDetails()).get(Constants.MESSAGE).stringValue(),
-                "Uninitialized private key: No installed provider supports this key: (null)");
+        Assert.assertTrue(((BMap) ((BError) returnValues[0]).getDetails()).get(Constants.MESSAGE).stringValue()
+                                  .contains("Uninitialized private key:"));
     }
 
     @Test(description = "Test RSA-SHA512 signing with an invalid private key")
@@ -325,8 +325,8 @@ public class CryptoTest {
         BValue[] returnValues = BRunUtil.invoke(compileResult, "testSignRsaSha512WithInvalidKey",
                 new BValue[]{new BValueArray(payload)});
         Assert.assertFalse(returnValues == null || returnValues.length == 0 || returnValues[0] == null);
-        Assert.assertEquals(((BMap) ((BError) returnValues[0]).getDetails()).get(Constants.MESSAGE).stringValue(),
-                "Uninitialized private key: No installed provider supports this key: (null)");
+        Assert.assertTrue(((BMap) ((BError) returnValues[0]).getDetails()).get(Constants.MESSAGE).stringValue()
+                                  .contains("Uninitialized private key:"));
     }
 
     @Test(description = "Test RSA-MD5 signing with an invalid private key")


### PR DESCRIPTION
## Purpose
This is to make sure the tests are passing in both Travis and GitHub actions. Suspect the issue is due to the JDK version mismatch. The objective of the test cases are still valid.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
