### PR TITLE
Update observability connector type information to the actual sub type information

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/observability/ObserveUtils.java
@@ -79,6 +79,9 @@ public class ObserveUtils {
      */
     public static void startResourceObservation(BString serviceName, BString resourceName,
                                                 MapValue<BString, BString> tags) {
+        if (!enabled) {
+            return;
+        }
         MapValue<String, String> stringTags = new MapValueImpl<>();
         for (Map.Entry<BString, BString> tagEntry : tags.entrySet()) {
             stringTags.put(tagEntry.getKey().getValue(), tagEntry.getValue().getValue());
@@ -95,12 +98,12 @@ public class ObserveUtils {
      */
     public static void startResourceObservation(String serviceName, String resourceName,
                                                 MapValue<String, String> tags) {
-        Strand strand = Scheduler.getStrand();
         if (!enabled) {
             return;
         }
 
         ObserverContext observerContext;
+        Strand strand = Scheduler.getStrand();
         if (strand.observerContext != null) {
             observerContext = strand.observerContext;
         } else {
@@ -167,6 +170,9 @@ public class ObserveUtils {
      */
     public static void startCallableObservation(BString serviceName, BString resourceName,
                                                 MapValue<BString, BString> tags) {
+        if (!enabled) {
+            return;
+        }
         MapValue<String, String> stringTags = new MapValueImpl<>();
         for (Map.Entry<BString, BString> tagEntry : tags.entrySet()) {
             stringTags.put(tagEntry.getKey().getValue(), tagEntry.getValue().getValue());
@@ -183,11 +189,10 @@ public class ObserveUtils {
      */
     public static void startCallableObservation(String connectorName, String actionName,
                                                 MapValue<String, String> tags) {
-        Strand strand = Scheduler.getStrand();
         if (!enabled) {
             return;
         }
-
+        Strand strand = Scheduler.getStrand();
         ObserverContext observerCtx = strand.observerContext;
 
         ObserverContext newObContext = new ObserverContext();
@@ -227,10 +232,10 @@ public class ObserveUtils {
      */
     public static void logMessageToActiveSpan(String logLevel, Supplier<String> logMessage,
                                               boolean isError) {
-        Strand strand = Scheduler.getStrand();
         if (!tracingEnabled) {
             return;
         }
+        Strand strand = Scheduler.getStrand();
         Optional<ObserverContext> observerContext = getObserverContextOfCurrentFrame(strand);
         if (!observerContext.isPresent()) {
             return;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/OpenTracerExtension.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/OpenTracerExtension.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.observe.trace.extension.choreo;
 
 import io.jaegertracing.internal.JaegerTracer;
-import io.jaegertracing.internal.samplers.GuaranteedThroughputSampler;
+import io.jaegertracing.internal.samplers.RateLimitingSampler;
 import io.jaegertracing.spi.Reporter;
 import io.opentracing.Tracer;
 import org.ballerinalang.jvm.StringUtils;
@@ -62,7 +62,7 @@ public class OpenTracerExtension implements OpenTracer {
             }
         }
         return new JaegerTracer.Builder(serviceName)
-                .withSampler(new GuaranteedThroughputSampler(0.01, 0.5))
+                .withSampler(new RateLimitingSampler(2))
                 .withReporter(reporterInstance)
                 .build();
     }


### PR DESCRIPTION
## Purpose
> Since observability instrumentation is now done at the callee side, the actual sub type information was not used in the observations. Some fixes was done to dynamically get the sub type and use it instead of the referred type.

## Approach
> At compile time, the actual type name is added as a field to every object and the string is initialized in the generated init method. This is accessed when a method in the object is invoked and used in the generated observability data.