### PR TITLE
Add failOnErrors attribute to openapi annotation [1.2.x]

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -39,4 +39,5 @@ public class Constants {
     static final String TAGS = "tags";
     static final String OPERATIONS = "operations";
     static final String BODY = "body";
+    static final String FAILONERRORS = "failOnErrors";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
@@ -72,6 +72,7 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
         this.openAPIComponentSummary = new OpenAPIComponentSummary();
         String contractURI = null;
         Boolean failOnErrors = true;
+        Diagnostic.Kind kind;
 
         for (AnnotationAttachmentNode ann : annotations) {
             if (Constants.PACKAGE.equals(ann.getPackageAlias().getValue())
@@ -185,15 +186,21 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                 }
             }
 
+            if (failOnErrors) {
+                kind = Diagnostic.Kind.ERROR;
+            } else {
+                kind = Diagnostic.Kind.WARNING;
+            }
+
             if (contractURI != null) {
                 try {
                     OpenAPI openAPI = ValidatorUtil.parseOpenAPIFile(contractURI);
                     ValidatorUtil.summarizeResources(this.resourceSummaryList, serviceNode);
                     ValidatorUtil.summarizeOpenAPI(this.openAPISummaryList, openAPI, this.openAPIComponentSummary);
-                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations, failOnErrors,
+                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations, kind,
                                                                   this.resourceSummaryList, this.openAPISummaryList,
                                                                   this.openAPIComponentSummary, dLog);
-                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, failOnErrors,
+                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, kind,
                                                                   this.resourceSummaryList,
                                                                   this.openAPISummaryList, this.openAPIComponentSummary,
                                                                   dLog);

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
@@ -71,6 +71,7 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
         List<String> operations = new ArrayList<>();
         this.openAPIComponentSummary = new OpenAPIComponentSummary();
         String contractURI = null;
+        Boolean failOnErrors = true;
 
         for (AnnotationAttachmentNode ann : annotations) {
             if (Constants.PACKAGE.equals(ann.getPackageAlias().getValue())
@@ -169,6 +170,16 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                                     }
                                 }
                             }
+                        } else if (key.equals(Constants.FAILONERRORS)) {
+                            if (valueExpr instanceof BLangLiteral) {
+                                BLangLiteral value = (BLangLiteral) valueExpr;
+                                if (value.getValue() instanceof Boolean) {
+                                    failOnErrors = (Boolean) value.getValue();
+                                } else {
+                                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
+                                            "FailOnErrors should be applied as boolean values");
+                                }
+                            }
                         }
                     }
                 }
@@ -179,10 +190,11 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                     OpenAPI openAPI = ValidatorUtil.parseOpenAPIFile(contractURI);
                     ValidatorUtil.summarizeResources(this.resourceSummaryList, serviceNode);
                     ValidatorUtil.summarizeOpenAPI(this.openAPISummaryList, openAPI, this.openAPIComponentSummary);
-                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations,
+                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations, failOnErrors,
                                                                   this.resourceSummaryList, this.openAPISummaryList,
                                                                   this.openAPIComponentSummary, dLog);
-                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, this.resourceSummaryList,
+                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, failOnErrors,
+                                                                  this.resourceSummaryList,
                                                                   this.openAPISummaryList, this.openAPIComponentSummary,
                                                                   dLog);
                 } catch (OpenApiValidatorException e) {

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -290,14 +290,14 @@ class ValidatorUtil {
                                         if (schema != null) {
                                             isExist = validateResourceAgainstOpenAPIParams(parameter,
                                                     parameter.getParameter().symbol, schema, dLog, resourceMethod,
-                                                    resourceSummary.getPath(),failOnErrors);
+                                                    resourceSummary.getPath(), failOnErrors);
                                         }
                                     }
                                 } else if (openAPIParameter.getName().equals(parameter.getName())) {
                                     isExist = validateResourceAgainstOpenAPIParams(parameter,
                                             parameter.getParameter().symbol,
                                             openAPIParameter.getParameter().getSchema(), dLog, resourceMethod,
-                                            resourceSummary.getPath(),failOnErrors);
+                                            resourceSummary.getPath(), failOnErrors);
                                 }
                             }
 
@@ -544,12 +544,13 @@ class ValidatorUtil {
                             if (schema != null) {
                                 isExist = validateOpenAPIAgainResourceParams(parameter,
                                         parameter.getParameter().symbol, schema, dLog, method,
-                                        openApiSummary.getPath(),failOnErrors);
+                                        openApiSummary.getPath(), failOnErrors);
                             }
                         }
                     } else if (openAPIParameter.getName().equals(parameter.getName())) {
                         isExist = validateOpenAPIAgainResourceParams(parameter, parameter.getParameter().symbol,
-                                openAPIParameter.getParameter().getSchema(), dLog, method, openApiSummary.getPath(), failOnErrors);
+                                openAPIParameter.getParameter().getSchema(), dLog, method, openApiSummary.getPath(),
+                                failOnErrors);
                     }
 
                     if (!isExist) {
@@ -615,7 +616,7 @@ class ValidatorUtil {
                         isExist = true;
                         if (ValidatorUtil.convertOpenAPITypeToBallerina(entry.getValue().getType()).equals("record")) {
                             isExist = validateResourceAgainstOpenAPIParams(resourceParameter,
-                                    field.symbol, entry.getValue(), dLog, method, path,failOnErrors);
+                                    field.symbol, entry.getValue(), dLog, method, path, failOnErrors);
                         }
                     }
                 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -230,12 +230,14 @@ class ValidatorUtil {
      *
      * @param tags                    lists of tags to enable validation on
      * @param operations              list of operations enable validation on
+     * @param failOnErrors            Boolean value for enabaling the avoid validate fail
      * @param resourceSummaryList     list of resource summaries
      * @param openAPISummaryList      list of openAPI path summaries
      * @param openAPIComponentSummary component summaries
      * @param dLog                    diagnostic logger
      */
     static void validateResourcesAgainstOpenApi(List<String> tags, List<String> operations,
+                                                Boolean failOnErrors,
                                                 List<ResourceSummary> resourceSummaryList,
                                                 List<OpenAPIPathSummary> openAPISummaryList,
                                                 OpenAPIComponentSummary openAPIComponentSummary, DiagnosticLog dLog) {
@@ -246,8 +248,15 @@ class ValidatorUtil {
             OpenAPIPathSummary openAPIPathSummary = getOpenApiSummaryByPath(resourceSummary.getPath(),
                     openAPISummaryList);
             if (openAPIPathSummary == null) {
-                dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceSummary.getPathPosition(),
-                        ErrorMessages.undocumentedResourcePath(resourceSummary.getPath()));
+                if (failOnErrors) {
+                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceSummary.getPathPosition(),
+                            ErrorMessages.undocumentedResourcePath(resourceSummary.getPath()));
+                } else {
+                    dLog.logDiagnostic(Diagnostic.Kind.WARNING, resourceSummary.getPathPosition(),
+                            ErrorMessages.undocumentedResourcePath(resourceSummary.getPath()));
+                    continue;
+                }
+
             } else {
                 List<String> unmatchedMethods = new ArrayList<>();
                 if (!operationFilteringEnabled && !tagFilteringEnabled) {
@@ -281,29 +290,44 @@ class ValidatorUtil {
                                         if (schema != null) {
                                             isExist = validateResourceAgainstOpenAPIParams(parameter,
                                                     parameter.getParameter().symbol, schema, dLog, resourceMethod,
-                                                    resourceSummary.getPath());
+                                                    resourceSummary.getPath(),failOnErrors);
                                         }
                                     }
                                 } else if (openAPIParameter.getName().equals(parameter.getName())) {
                                     isExist = validateResourceAgainstOpenAPIParams(parameter,
                                             parameter.getParameter().symbol,
                                             openAPIParameter.getParameter().getSchema(), dLog, resourceMethod,
-                                            resourceSummary.getPath());
+                                            resourceSummary.getPath(),failOnErrors);
                                 }
                             }
 
                             if (!isExist) {
-                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, parameter.getParameter().getPosition(),
-                                        ErrorMessages.undocumentedResourceParameter(parameter.getName(),
-                                                resourceMethod, resourceSummary.getPath()));
+                                if (failOnErrors) {
+                                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, parameter.getParameter().getPosition(),
+                                            ErrorMessages.undocumentedResourceParameter(parameter.getName(),
+                                                    resourceMethod, resourceSummary.getPath()));
+                                } else {
+                                    dLog.logDiagnostic(Diagnostic.Kind.WARNING, parameter.getParameter().getPosition(),
+                                            ErrorMessages.undocumentedResourceParameter(parameter.getName(),
+                                                    resourceMethod, resourceSummary.getPath()));
+                                    continue;
+                                }
+
                             }
                         }
                     }
 
                     String methods = getUnmatchedMethodList(unmatchedMethods);
                     if (!openAPIPathSummary.getAvailableOperations().containsAll(resourceSummary.getMethods())) {
-                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceSummary.getMethodsPosition(),
-                                ErrorMessages.undocumentedResourceMethods(methods, resourceSummary.getPath()));
+                        if (failOnErrors) {
+                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceSummary.getMethodsPosition(),
+                                    ErrorMessages.undocumentedResourceMethods(methods, resourceSummary.getPath()));
+                        } else {
+                            dLog.logDiagnostic(Diagnostic.Kind.WARNING, resourceSummary.getMethodsPosition(),
+                                    ErrorMessages.undocumentedResourceMethods(methods, resourceSummary.getPath()));
+                            continue;
+                        }
+
                     }
                 }
             }
@@ -322,6 +346,7 @@ class ValidatorUtil {
      * @param dLog                    diagnostic logger
      */
     static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags, List<String> operations,
+                                                Boolean failNoErrors,
                                                 List<ResourceSummary> resourceSummaryList,
                                                 List<OpenAPIPathSummary> openAPISummaryList,
                                                 OpenAPIComponentSummary openAPIComponentSummary,
@@ -333,8 +358,14 @@ class ValidatorUtil {
             List<ResourceSummary> resourceSummaries = getResourceSummaryByPath(openApiSummary.getPath(),
                     resourceSummaryList);
             if (resourceSummaries == null) {
-                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
-                        ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
+                if (failNoErrors) {
+                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                            ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
+                } else {
+                    dLog.logDiagnostic(Diagnostic.Kind.WARNING, getServiceNamePosition(serviceNode),
+                            ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
+                    continue;
+                }
             } else {
                 List<String> allAvailableResourceMethods = getAllMethodsInResourceSummaries(resourceSummaries);
                 List<String> unmatchedMethods = new ArrayList<>();
@@ -349,30 +380,46 @@ class ValidatorUtil {
                             if (operations.contains(method) && openApiSummary.hasTags(tags, method)) {
                                 validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                         resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                        serviceNode);
+                                        serviceNode, failNoErrors);
                             }
                         }
 
                         if (unmatchedMethods.size() > 0) {
                             String methods = getUnmatchedMethodList(unmatchedMethods);
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
-                                    ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
-                                            openApiSummary.getPath()));
+                            if (failNoErrors) {
+                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                            } else {
+                                dLog.logDiagnostic(Diagnostic.Kind.WARNING, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                                continue;
+                            }
+
                         }
                     } else {
                         for (String method : openApiSummary.getAvailableOperations()) {
                             if (operations.contains(method)) {
                                 validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                         resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                        serviceNode);
+                                        serviceNode, failNoErrors);
                             }
                         }
 
                         if (unmatchedMethods.size() > 0) {
                             String methods = getUnmatchedMethodList(unmatchedMethods);
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
-                                    ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
-                                            openApiSummary.getPath()));
+                            if (failNoErrors) {
+                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                            } else {
+                                dLog.logDiagnostic(Diagnostic.Kind.WARNING, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                                continue;
+                            }
+
                         }
                     }
                 } else {
@@ -383,28 +430,44 @@ class ValidatorUtil {
                             if (openApiSummary.hasTags(tags, method)) {
                                 validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                         resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                        serviceNode);
+                                        serviceNode, failNoErrors);
                             }
                         }
 
                         if (unmatchedMethods.size() > 0) {
                             String methods = getUnmatchedMethodList(unmatchedMethods);
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
-                                    ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
-                                            openApiSummary.getPath()));
+                            if (failNoErrors) {
+                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                            } else {
+                                dLog.logDiagnostic(Diagnostic.Kind.WARNING, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                                continue;
+                            }
+
                         }
                     } else {
                         for (String method : openApiSummary.getAvailableOperations()) {
                             validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                     resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                    serviceNode);
+                                    serviceNode, failNoErrors);
                         }
 
                         String methods = getUnmatchedMethodList(unmatchedMethods);
                         if (!allAvailableResourceMethods.containsAll(openApiSummary.getAvailableOperations())) {
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
-                                    ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
-                                            openApiSummary.getPath()));
+                            if (failNoErrors) {
+                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                            } else {
+                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                                        ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
+                                                openApiSummary.getPath()));
+                                continue;
+                            }
+
                         }
                     }
                 }
@@ -442,7 +505,7 @@ class ValidatorUtil {
                                                     List<ResourceSummary> resourceSummaries, String method,
                                                     OpenAPIPathSummary openApiSummary, DiagnosticLog dLog,
                                                     OpenAPIComponentSummary openApiComponentSummary,
-                                                    ServiceNode serviceNode) {
+                                                    ServiceNode serviceNode, Boolean failOnErrors) {
         boolean noMatch = true;
         for (String resourceMethod : allAvailableResourceMethods) {
             if (resourceMethod.equals(method)) {
@@ -457,14 +520,14 @@ class ValidatorUtil {
 
         // Check for parameter mismatch.
         checkForParameterMismatch(openApiSummary, resourceSummaries, method, serviceNode, openApiComponentSummary,
-                dLog);
+                dLog, failOnErrors);
     }
 
     private static void checkForParameterMismatch(OpenAPIPathSummary openApiSummary,
                                                   List<ResourceSummary> resourceSummaries,
                                                   String method, ServiceNode serviceNode,
                                                   OpenAPIComponentSummary openAPIComponentSummary,
-                                                  DiagnosticLog dLog) {
+                                                  DiagnosticLog dLog, Boolean failOnErrors) {
         List<OpenAPIParameter> operationParamNames = openApiSummary
                 .getParamNamesForOperation(method);
         ResourceSummary resourceSummaryForMethod = getResourceSummaryByMethod(resourceSummaries, method);
@@ -481,12 +544,12 @@ class ValidatorUtil {
                             if (schema != null) {
                                 isExist = validateOpenAPIAgainResourceParams(parameter,
                                         parameter.getParameter().symbol, schema, dLog, method,
-                                        openApiSummary.getPath());
+                                        openApiSummary.getPath(),failOnErrors);
                             }
                         }
                     } else if (openAPIParameter.getName().equals(parameter.getName())) {
                         isExist = validateOpenAPIAgainResourceParams(parameter, parameter.getParameter().symbol,
-                                openAPIParameter.getParameter().getSchema(), dLog, method, openApiSummary.getPath());
+                                openAPIParameter.getParameter().getSchema(), dLog, method, openApiSummary.getPath(), failOnErrors);
                     }
 
                     if (!isExist) {
@@ -497,16 +560,35 @@ class ValidatorUtil {
 
                 if (!isExist) {
                     if (nonExistingResourceParameter != null) {
-                        dLog.logDiagnostic(Diagnostic.Kind.ERROR,
-                                nonExistingResourceParameter.getParameter().getPosition(),
-                                ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
-                                        method, resourceSummaryForMethod.getPath()));
+                        if (failOnErrors) {
+                            dLog.logDiagnostic(Diagnostic.Kind.ERROR,
+                                    nonExistingResourceParameter.getParameter().getPosition(),
+                                    ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
+                                            method, resourceSummaryForMethod.getPath()));
+                            break;
+                        } else {
+                            dLog.logDiagnostic(Diagnostic.Kind.WARNING,
+                                    nonExistingResourceParameter.getParameter().getPosition(),
+                                    ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
+                                            method, resourceSummaryForMethod.getPath()));
+                            continue;
+                        }
+
                     } else {
-                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
-                                ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
-                                        method, resourceSummaryForMethod.getPath()));
+                        if (failOnErrors) {
+                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                                    ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
+                                            method, resourceSummaryForMethod.getPath()));
+                            break;
+                        } else {
+                            dLog.logDiagnostic(Diagnostic.Kind.WARNING, getServiceNamePosition(serviceNode),
+                                    ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
+                                            method, resourceSummaryForMethod.getPath()));
+                            continue;
+                        }
+
                     }
-                    break;
+
                 }
             }
         }
@@ -514,7 +596,8 @@ class ValidatorUtil {
 
     private static boolean validateResourceAgainstOpenAPIParams(ResourceParameter resourceParameter,
                                                                 BVarSymbol resourceParameterType, Schema openAPIParam,
-                                                                DiagnosticLog dLog, String method, String path) {
+                                                                DiagnosticLog dLog, String method, String path,
+                                                                Boolean failOnErrors) {
         BType resourceParamType = resourceParameterType.getType();
 
         if (resourceParamType.getKind().typeName().equals("record")
@@ -532,15 +615,23 @@ class ValidatorUtil {
                         isExist = true;
                         if (ValidatorUtil.convertOpenAPITypeToBallerina(entry.getValue().getType()).equals("record")) {
                             isExist = validateResourceAgainstOpenAPIParams(resourceParameter,
-                                    field.symbol, entry.getValue(), dLog, method, path);
+                                    field.symbol, entry.getValue(), dLog, method, path,failOnErrors);
                         }
                     }
                 }
 
                 if (!isExist) {
-                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, field.pos,
-                            ErrorMessages.undocumentedFieldInRecordParam(field.name.getValue(),
-                                    resourceParameter.getName(), method, path));
+                    if (failOnErrors) {
+                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, field.pos,
+                                ErrorMessages.undocumentedFieldInRecordParam(field.name.getValue(),
+                                        resourceParameter.getName(), method, path));
+                    } else {
+                        dLog.logDiagnostic(Diagnostic.Kind.WARNING, field.pos,
+                                ErrorMessages.undocumentedFieldInRecordParam(field.name.getValue(),
+                                        resourceParameter.getName(), method, path));
+                        continue;
+                    }
+
                 }
             }
             return true;
@@ -567,7 +658,8 @@ class ValidatorUtil {
     private static boolean validateOpenAPIAgainResourceParams(ResourceParameter resourceParam,
                                                               BVarSymbol resourceParameterType,
                                                               Schema openAPIParam,
-                                                              DiagnosticLog dLog, String operation, String path) {
+                                                              DiagnosticLog dLog, String operation, String path,
+                                                              Boolean failOnError) {
         BType resourceParamType = resourceParameterType.getType();
         if (resourceParamType.getKind().typeName().equals("record")
                 && resourceParamType instanceof BRecordType
@@ -584,15 +676,23 @@ class ValidatorUtil {
                         isExist = true;
                         if (ValidatorUtil.convertOpenAPITypeToBallerina(entry.getValue().getType()).equals("record")) {
                             isExist = validateOpenAPIAgainResourceParams(resourceParam, field.symbol, entry.getValue(),
-                                    dLog, operation, path);
+                                    dLog, operation, path, failOnError);
                         }
                     }
                 }
 
                 if (!isExist) {
-                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceParam.getParameter().getPosition(),
-                            ErrorMessages.unimplementedFieldInOperation(entry.getKey(), resourceParam.getName(),
-                                    operation, path));
+                    if (failOnError) {
+                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceParam.getParameter().getPosition(),
+                                ErrorMessages.unimplementedFieldInOperation(entry.getKey(), resourceParam.getName(),
+                                        operation, path));
+                    } else {
+                        dLog.logDiagnostic(Diagnostic.Kind.WARNING, resourceParam.getParameter().getPosition(),
+                                ErrorMessages.unimplementedFieldInOperation(entry.getKey(), resourceParam.getName(),
+                                        operation, path));
+                        continue;
+                    }
+
                 }
             }
             return true;

--- a/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
+++ b/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
@@ -18,10 +18,12 @@
 # + contract - OpenApi Contract link
 # + tags - OpenApi Tags
 # + operations - OpenApi Operations
+# + failOnErrors - OpenApi Validator Enable
 public type ServiceInformation record {|
     string contract = "";
     string[]? tags = [];
     string[]? operations = [];
+    boolean failOnErrors = true;
 |};
 
 # Configuration elements for client code generation.


### PR DESCRIPTION
## Purpose
> An option in the annotation to make validator error warning instead of build errors
Ie.  failOnErrors : false

## Approach

## Samples
> Add failOnError field as false for making validator error warning instead of building failed.
 
> @openapi:ServiceInfo {
    contract: "resources/test.yaml",
    failOnErrors: false
}



## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
