### PR TITLE
Add failOnError attribute to openapi annotation [master]

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -39,4 +39,5 @@ public class Constants {
     static final String TAGS = "tags";
     static final String OPERATIONS = "operations";
     static final String BODY = "body";
+    static final String FAILONERRORS = "failOnErrors";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
@@ -71,6 +71,7 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
         List<String> operations = new ArrayList<>();
         this.openAPIComponentSummary = new OpenAPIComponentSummary();
         String contractURI = null;
+        Boolean failOnErrors = true;
 
         for (AnnotationAttachmentNode ann : annotations) {
             if (Constants.PACKAGE.equals(ann.getPackageAlias().getValue())
@@ -169,6 +170,16 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                                     }
                                 }
                             }
+                        }  else if (key.equals(Constants.FAILONERRORS)) {
+                            if (valueExpr instanceof BLangLiteral) {
+                                BLangLiteral value = (BLangLiteral) valueExpr;
+                                if (value.getValue() instanceof Boolean) {
+                                    failOnErrors = (Boolean) value.getValue();
+                                } else {
+                                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
+                                            "FailOnErrors should be applied as boolean values");
+                                }
+                            }
                         }
                     }
                 }
@@ -179,10 +190,11 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                     OpenAPI openAPI = ValidatorUtil.parseOpenAPIFile(contractURI);
                     ValidatorUtil.summarizeResources(this.resourceSummaryList, serviceNode);
                     ValidatorUtil.summarizeOpenAPI(this.openAPISummaryList, openAPI, this.openAPIComponentSummary);
-                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations,
+                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations, failOnErrors,
                                                                   this.resourceSummaryList, this.openAPISummaryList,
                                                                   this.openAPIComponentSummary, dLog);
-                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, this.resourceSummaryList,
+                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, failOnErrors,
+                                                                  this.resourceSummaryList,
                                                                   this.openAPISummaryList, this.openAPIComponentSummary,
                                                                   dLog);
                 } catch (OpenApiValidatorException e) {

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
@@ -72,6 +72,7 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
         this.openAPIComponentSummary = new OpenAPIComponentSummary();
         String contractURI = null;
         Boolean failOnErrors = true;
+        Diagnostic.Kind kind;
 
         for (AnnotationAttachmentNode ann : annotations) {
             if (Constants.PACKAGE.equals(ann.getPackageAlias().getValue())
@@ -185,15 +186,21 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                 }
             }
 
+            if (failOnErrors) {
+                kind = Diagnostic.Kind.ERROR;
+            } else {
+                kind = Diagnostic.Kind.WARNING;
+            }
+
             if (contractURI != null) {
                 try {
                     OpenAPI openAPI = ValidatorUtil.parseOpenAPIFile(contractURI);
                     ValidatorUtil.summarizeResources(this.resourceSummaryList, serviceNode);
                     ValidatorUtil.summarizeOpenAPI(this.openAPISummaryList, openAPI, this.openAPIComponentSummary);
-                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations, failOnErrors,
+                    ValidatorUtil.validateOpenApiAgainstResources(serviceNode, tags, operations, kind,
                                                                   this.resourceSummaryList, this.openAPISummaryList,
                                                                   this.openAPIComponentSummary, dLog);
-                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, failOnErrors,
+                    ValidatorUtil.validateResourcesAgainstOpenApi(tags, operations, kind,
                                                                   this.resourceSummaryList,
                                                                   this.openAPISummaryList, this.openAPIComponentSummary,
                                                                   dLog);

--- a/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
+++ b/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
@@ -18,10 +18,12 @@
 # + contract - OpenApi Contract link
 # + tags - OpenApi Tags
 # + operations - OpenApi Operations
+# + failOnErrors - OpenApi Validator Enable
 public type ServiceInformation record {|
     string contract = "";
     string[]? tags = [];
     string[]? operations = [];
+    boolean failOnErrors = true;
 |};
 
 # Configuration elements for client code generation.


### PR DESCRIPTION
## Purpose
> An option in the annotation to make validator error warning instead of build errors

## Samples
>  Add failOnError field as false for making validator error warning instead of building failed.

    @openapi:ServiceInfo {
    contract: "resources/test.yaml",
    failOnErrors: false
    }

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
