### PR TITLE
Add overriding support for fields and methods of records and fields

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1883,7 +1883,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             return ((BStructureType) referredType).fields.values().stream().filter(f -> {
                 if (fieldNames.containsKey(f.name.value)) {
                     BLangSimpleVariable existingVariable = fieldNames.get(f.name.value);
-                    return !types.isAssignable(f.type, existingVariable.type);
+                    return !types.isAssignable(existingVariable.type, f.type);
                 }
                 return true;
             }).map(field -> {
@@ -1961,7 +1961,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             return false;
         }
 
-        if (!types.isAssignable(referencedFuncSym.type, attachedFuncSym.type)) {
+        if (!types.isAssignable(attachedFuncSym.type, referencedFuncSym.type)) {
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1896,14 +1896,14 @@ public class SymbolEnter extends BLangNodeVisitor {
     }
 
     private void defineReferencedFunction(BLangTypeDefinition typeDef, SymbolEnv objEnv, BLangType typeRef,
-                                          BAttachedFunction referencedFunc, Set<String> referencedFunctions) {
+                                          BAttachedFunction referencedFunc, Set<String> includedFunctionNames) {
         String referencedFuncName = referencedFunc.funcName.value;
         Name funcName = names.fromString(
                 Symbols.getAttachedFuncSymbolName(typeDef.symbol.name.value, referencedFuncName));
         BSymbol matchingObjFuncSym = symResolver.lookupSymbolInMainSpace(objEnv, funcName);
 
         if (matchingObjFuncSym != symTable.notFoundSymbol) {
-            if (!referencedFunctions.add(referencedFuncName)) {
+            if (!includedFunctionNames.add(referencedFuncName)) {
                 dlog.error(typeRef.pos, DiagnosticCode.REDECLARED_SYMBOL, referencedFuncName);
                 return;
             }
@@ -1917,7 +1917,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                            referencedFunc.funcName, typeRef);
             }
 
-            if (!isFunctionAssignable((BInvokableSymbol) matchingObjFuncSym, referencedFunc.symbol)) {
+            if (!hasSameFunctionSignature((BInvokableSymbol) matchingObjFuncSym, referencedFunc.symbol)) {
                 Optional<BLangFunction> matchingFunc = ((BLangObjectTypeNode) typeDef.typeNode)
                         .functions.stream().filter(fn -> fn.symbol == matchingObjFuncSym).findFirst();
                 DiagnosticPos pos = matchingFunc.isPresent() ? matchingFunc.get().pos : typeRef.pos;
@@ -1956,7 +1956,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         ((BObjectTypeSymbol) typeDef.symbol).referencedFunctions.add(attachedFunc);
     }
 
-    private boolean isFunctionAssignable(BInvokableSymbol attachedFuncSym, BInvokableSymbol referencedFuncSym) {
+    private boolean hasSameFunctionSignature(BInvokableSymbol attachedFuncSym, BInvokableSymbol referencedFuncSym) {
         if (!hasSameVisibilityModifier(referencedFuncSym.flags, attachedFuncSym.flags)) {
             return false;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1205,7 +1205,8 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         if (this.env.logErrors && symbol == symTable.notFoundSymbol) {
-            if (!missingNodesHelper.isMissingNode(pkgAlias) && !missingNodesHelper.isMissingNode(typeName)) {
+            if (!missingNodesHelper.isMissingNode(pkgAlias) && !missingNodesHelper.isMissingNode(typeName) &&
+                    !symbolEnter.isUnknownTypeRef(userDefinedTypeNode)) {
                 dlog.error(userDefinedTypeNode.pos, diagCode, typeName);
             }
             resultType = symTable.semanticError;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangStructureTypeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangStructureTypeNode.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -63,7 +64,7 @@ public abstract class BLangStructureTypeNode extends BLangType implements Struct
 
     @Override
     public List<? extends TypeNode> getTypeReferences() {
-        return this.typeRefs;
+        return Collections.unmodifiableList(this.typeRefs);
     }
 
     @Override

--- a/tests/jballerina-bstring-unit-test/src/test/resources/test-src/object/object-type-reference-cyclic-dependency-negative.bal
+++ b/tests/jballerina-bstring-unit-test/src/test/resources/test-src/object/object-type-reference-cyclic-dependency-negative.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Direct circular reference
+type Foo abstract object {
+    *Foo;
+};
+
+// Indirect circular references
+type A abstract object {
+    *B;
+};
+
+type B abstract object {
+    *C;
+};
+
+type C abstract object {
+    *D;
+    *E;
+};
+
+type D abstract object {
+    *A;
+};
+
+type E abstract object {
+    *C;
+};

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -578,7 +578,7 @@ public class ObjectInBaloTest {
     public void testObjectReferingTypeFromBaloNegative() {
         CompileResult result =
                 BCompileUtil.compile("test-src/balo/test_balo/object/test_objects_type_reference_negative.bal");
-        Assert.assertEquals(result.getErrorCount(), 6);
+        Assert.assertEquals(result.getErrorCount(), 5);
         int i = 0;
         BAssertUtil.validateError(result, i++, "undefined field 'name' in object 'Manager1'", 25, 13);
         BAssertUtil.validateError(result, i++, "undefined field 'age' in object 'Manager1'", 26, 13);
@@ -590,7 +590,6 @@ public class ObjectInBaloTest {
                                   "no implementation found for the function 'getName' of non-abstract object " +
                                           "'Manager2'",
                                   36, 5);
-        BAssertUtil.validateError(result, i++, "redeclared symbol 'dpt'", 38, 6);
         BAssertUtil.validateError(result, i,
                                   "incompatible type reference 'foo:NormalPerson': a referenced object cannot have " +
                                           "non-public fields or methods",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectIncludeOverrideBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectIncludeOverrideBaloTest.java
@@ -1,0 +1,61 @@
+/*
+*  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+*  Unless required by applicable law or agreed to in writing,
+*  software distributed under the License is distributed on an
+*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*  KIND, either express or implied.  See the License for the
+*  specific language governing permissions and limitations
+*  under the License.
+*/
+package org.ballerinalang.test.balo.object;
+
+import org.ballerinalang.test.balo.BaloCreator;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for user defined object types in ballerina.
+ */
+public class ObjectIncludeOverrideBaloTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        BaloCreator.cleanCacheDirectories();
+        BaloCreator.createAndSetupBalo("test-src/balo/test_projects/test_project", "testorg", "foo");
+        result = BCompileUtil.compile("test-src/balo/test_balo/object/object_override_includes.bal");
+    }
+
+    @Test
+    public void testSimpleObjectOverridingSimilarObject() {
+        BRunUtil.invoke(result, "testSimpleObjectOverridingSimilarObject");
+    }
+
+    @Test
+    public void testObjectOverrideInterfaceWithInterface() {
+        BRunUtil.invoke(result, "testObjectOverrideInterfaceWithInterface");
+    }
+
+    @Test
+    public void testObjectWithOverriddenFieldsAndMethods() {
+        BRunUtil.invoke(result, "testObjectWithOverriddenFieldsAndMethods");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
@@ -58,7 +58,6 @@ public class ClosedRecordTypeReferenceTest {
     public void negativeTests() {
         CompileResult negative = BCompileUtil.compile("test-src/record/closed_record_type_reference_negative.bal");
         int index = 0;
-        assertEquals(negative.getErrorCount(), 15);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'PersonObj' is not a record", 28, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'IntOrFloat' is not a record", 35, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'FiniteT' is not a record", 41, 6);
@@ -69,11 +68,11 @@ public class ClosedRecordTypeReferenceTest {
         BAssertUtil.validateError(negative, index++, "incompatible types: 'byte' is not a record", 49, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'json' is not a record", 50, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'xml' is not a record", 51, 6);
-        BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 60, 6);
-        BAssertUtil.validateError(negative, index++, "missing non-defaultable required record field 'gender'", 77, 18);
-        BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 82, 6);
-        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 86, 6);
-        BAssertUtil.validateError(negative, index, "unknown type 'Data'", 91, 6);
+        BAssertUtil.validateError(negative, index++, "missing non-defaultable required record field 'gender'", 67, 18);
+        BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 72, 6);
+        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 76, 6);
+        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 81, 6);
+        assertEquals(negative.getErrorCount(), index);
     }
 
     @Test(description = "Test case for type referencing all value-typed fields")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
@@ -58,7 +58,6 @@ public class OpenRecordTypeReferenceTest {
     public void negativeTests() {
         CompileResult negative = BCompileUtil.compile("test-src/record/open_record_type_reference_negative.bal");
         int index = 0;
-        assertEquals(negative.getErrorCount(), 15);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'PersonObj' is not a record", 28, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'IntOrFloat' is not a record", 35, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'FiniteT' is not a record", 41, 6);
@@ -69,11 +68,11 @@ public class OpenRecordTypeReferenceTest {
         BAssertUtil.validateError(negative, index++, "incompatible types: 'byte' is not a record", 49, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'json' is not a record", 50, 6);
         BAssertUtil.validateError(negative, index++, "incompatible types: 'xml' is not a record", 51, 6);
-        BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 60, 6);
-        BAssertUtil.validateError(negative, index++, "missing non-defaultable required record field 'gender'", 77, 18);
-        BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 82, 6);
-        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 86, 6);
-        BAssertUtil.validateError(negative, index, "unknown type 'Data'", 91, 6);
+        BAssertUtil.validateError(negative, index++, "missing non-defaultable required record field 'gender'", 67, 18);
+        BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 72, 6);
+        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 76, 6);
+        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 81, 6);
+        assertEquals(negative.getErrorCount(), index);
     }
 
     @Test(description = "Test case for type referencing all value-typed fields")
@@ -169,6 +168,11 @@ public class OpenRecordTypeReferenceTest {
         assertEquals(manager.get("adr").stringValue(), "{city:\"\", country:\"\"}");
         assertEquals(manager.get("company").stringValue(), "");
         assertEquals(manager.get("dept").stringValue(), "");
+    }
+
+    @Test()
+    public void testCreatingRecordWithOverriddenFields() {
+        BRunUtil.invoke(compileResult, "testCreatingRecordWithOverriddenFields");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
@@ -70,8 +70,8 @@ public class OpenRecordTypeReferenceTest {
         BAssertUtil.validateError(negative, index++, "incompatible types: 'xml' is not a record", 51, 6);
         BAssertUtil.validateError(negative, index++, "missing non-defaultable required record field 'gender'", 67, 18);
         BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 72, 6);
-        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 81, 6);
         BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 76, 6);
+        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 81, 6);
         assertEquals(negative.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
@@ -70,8 +70,8 @@ public class OpenRecordTypeReferenceTest {
         BAssertUtil.validateError(negative, index++, "incompatible types: 'xml' is not a record", 51, 6);
         BAssertUtil.validateError(negative, index++, "missing non-defaultable required record field 'gender'", 67, 18);
         BAssertUtil.validateError(negative, index++, "redeclared symbol 'name'", 72, 6);
-        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 76, 6);
         BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 81, 6);
+        BAssertUtil.validateError(negative, index++, "unknown type 'Data'", 76, 6);
         assertEquals(negative.getErrorCount(), index);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -73,7 +73,7 @@ public class ObjectTypeReferenceTest {
                                   "cyclic type reference in '[E, C, E]'", 74, 1);
         BAssertUtil.validateError(negativeResult, i++,
                                   "no implementation found for the function 'getName' of non-abstract object " +
-                                          "'Manager2'",96, 5);
+                                          "'Manager2'", 96, 5);
         BAssertUtil.validateError(negativeResult, i++,
                 "no implementation found for the function 'getSalary' of non-abstract object 'Manager2'", 96, 5);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: 'Q' is not an object", 101, 6);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -92,28 +92,36 @@ public class ObjectTypeReferenceTest {
     public void testSimpleObjectTypeReferenceNegative_1() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/object/object-type-reference-1-negative.bal");
         int i = 0;
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[Foo, Foo]'", 49, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[A, B, C, D, A]'", 54, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 54, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[B, C, D, A, B]'", 58, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 58, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 62, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 62, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 67, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[D, A, B, C, D]'", 67, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 71, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[E, C, E]'", 71, 1);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 27, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 27, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 28, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 42, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 42, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 45, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 93, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 93, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 93, 6);
-//        BAssertUtil.validateError(negativeResult, i++, "variable 'name' is not initialized", 96, 16);
-//        BAssertUtil.validateError(negativeResult, i++, "variable 'salary' is not initialized", 100, 16);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 27, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 27, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 28, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 42, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 42, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 45, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 66, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 66, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 66, 6);
+        BAssertUtil.validateError(negativeResult, i++, "variable 'name' is not initialized", 69, 16);
+        BAssertUtil.validateError(negativeResult, i++, "variable 'salary' is not initialized", 73, 16);
+        Assert.assertEquals(negativeResult.getErrorCount(), i);
+    }
+
+    @Test
+    public void testCyclicDependencyReferencesObjectTypeReferenceNegative() {
+        CompileResult negativeResult = BCompileUtil.compile("test-src/object/object-type-reference-cyclic-dependency" +
+                                                                    "-negative.bal");
+        int i = 0;
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[Foo, Foo]'", 18, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[A, B, C, D, A]'", 23, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 23, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[B, C, D, A, B]'", 27, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 27, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 31, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 31, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 36, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[D, A, B, C, D]'", 36, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 40, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[E, C, E]'", 40, 1);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -50,7 +50,30 @@ public class ObjectTypeReferenceTest {
                 6);
         BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'salary'", 48, 6);
         BAssertUtil.validateError(negativeResult, i++,
-                "no implementation found for the function 'getName' of non-abstract object 'Manager2'", 96, 5);
+                                  "cyclic type reference in '[Foo, Foo]'", 52, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[A, B, C, D, A]'", 57, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[C, E, C]'", 57, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[B, C, D, A, B]'", 61, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                "cyclic type reference in '[C, E, C]'", 61, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[C, D, A, B, C]'", 65, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[C, E, C]'", 65, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[C, E, C]'", 70, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[D, A, B, C, D]'", 70, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[C, D, A, B, C]'", 74, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "cyclic type reference in '[E, C, E]'", 74, 1);
+        BAssertUtil.validateError(negativeResult, i++,
+                                  "no implementation found for the function 'getName' of non-abstract object " +
+                                          "'Manager2'",96, 5);
         BAssertUtil.validateError(negativeResult, i++,
                 "no implementation found for the function 'getSalary' of non-abstract object 'Manager2'", 96, 5);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: 'Q' is not an object", 101, 6);
@@ -68,19 +91,30 @@ public class ObjectTypeReferenceTest {
     @Test
     public void testSimpleObjectTypeReferenceNegative_1() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/object/object-type-reference-1-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 11);
         int i = 0;
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 27, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 27, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 28, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 42, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 42, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 45, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 93, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 93, 6);
-        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 93, 6);
-        BAssertUtil.validateError(negativeResult, i++, "variable 'name' is not initialized", 96, 16);
-        BAssertUtil.validateError(negativeResult, i, "variable 'salary' is not initialized", 100, 16);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[Foo, Foo]'", 49, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[A, B, C, D, A]'", 54, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 54, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[B, C, D, A, B]'", 58, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 58, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 62, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 62, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 67, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[D, A, B, C, D]'", 67, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 71, 1);
+        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[E, C, E]'", 71, 1);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 27, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 27, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 28, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 42, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 42, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 45, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'age'", 93, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'name'", 93, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'salary'", 93, 6);
+//        BAssertUtil.validateError(negativeResult, i++, "variable 'name' is not initialized", 96, 16);
+//        BAssertUtil.validateError(negativeResult, i++, "variable 'salary' is not initialized", 100, 16);
+        Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
     @Test
@@ -101,7 +135,7 @@ public class ObjectTypeReferenceTest {
         Assert.assertEquals(negativeResult.getErrorCount(), 2);
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'x'", 18, 6);
-        BAssertUtil.validateError(negativeResult, i, "uninitialized field 'y'", 18, 6);
+        BAssertUtil.validateError(negativeResult, i++, "uninitialized field 'y'", 18, 6);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -249,8 +249,8 @@ public class ObjectTypeReferenceTest {
                                           " found 'function test8(string s, public int i)'", 86, 5);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test9(int:Signed16 anInt, Bar.." +
-                                          ". bars) returns int', found 'function test9(int:Signed16 anInt, Bar... " +
-                                          "bars) returns int:Signed16'",
+                                          ". bars) returns int:Signed16', found 'function test9(int:Signed16 anInt, " +
+                                          "Bar... bars) returns int'",
                                   91, 5);
         Assert.assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -45,7 +45,6 @@ public class ObjectTypeReferenceTest {
     public void testSimpleObjectTypeReferenceSemanticsNegative_1() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/object/object-type-reference-1-semantics" +
                 "-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 12);
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: 'Employee1' is not an object", 32,
                 6);
@@ -60,10 +59,10 @@ public class ObjectTypeReferenceTest {
                 "function through referenced type 'ObjectWithFunction'", 120, 5);
         BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'getName': trying to copy a duplicate " +
                 "function through referenced type 'ObjectWithRedeclaredFunction_1'", 125, 6);
-        BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'x'", 134, 6);
-        BAssertUtil.validateError(negativeResult, i++, "unknown type 'Baz'", 142, 6);
-        BAssertUtil.validateError(negativeResult, i++, "unknown type 'Tar'", 146, 6);
-        BAssertUtil.validateError(negativeResult, i, "redeclared symbol 'xyz'", 167, 6);
+        BAssertUtil.validateError(negativeResult, i++, "unknown type 'Baz'", 129, 6);
+        BAssertUtil.validateError(negativeResult, i++, "unknown type 'Tar'", 133, 6);
+        BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'xyz'", 154, 6);
+        Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
     @Test
@@ -169,39 +168,49 @@ public class ObjectTypeReferenceTest {
     }
 
     @Test
+    public void testCreatingObjectWithOverriddenFields() {
+        BRunUtil.invoke(compileResult, "testCreatingObjectWithOverriddenFields");
+    }
+
+    @Test
     public void testTypeReferencedFunctionImplementation() {
         CompileResult result = BCompileUtil.compile("test-src/object/object_func_reference_neg.bal");
         int index = 0;
-
-        Assert.assertEquals(result.getErrorCount(), 8);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test1(string aString, int " +
                                           "anInt) returns (string|error)', found 'function test1(string str, int " +
                                           "anInt)" +
-                                          " returns (string|error)'", 53, 5);
+                                          " returns (string|error)'", 55, 5);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'public function test2(string aString)', " +
-                                          "found 'function test2(string aString)'", 58, 5);
+                                          "found 'function test2(string aString)'", 60, 5);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test3(int anInt, string " +
                                           "aString, string defaultable, int def2)', found 'function test3(string " +
-                                          "aString, int anInt, string defaultable, int def2) returns string'", 61, 5);
+                                          "aString, int anInt, string defaultable, int def2) returns string'", 63, 5);
         BAssertUtil.validateError(result, index++,
-                                  "mismatched function signatures: expected 'function test4(string aString, int " +
-                                          "anInt, Bar... bars) returns string', found 'function test4(string aString," +
-                                          " int anInt, AnotherBar... bars) returns string'", 66, 5);
+                                  "mismatched function signatures: expected 'function test4(string aString, " +
+                                          "int:Signed16 anInt, Bar... bars) returns string', found 'function test4" +
+                                          "(string aString, int anInt, AnotherBar... bars) returns string'",
+                                  68, 5);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test5(ON|OFF... status) returns" +
-                                          " Bar', found 'function test5(ON|OFF... stat) returns Bar'", 71, 5);
+                                          " Bar', found 'function test5(ON|OFF... stat) returns Bar'", 73, 5);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test6([string,ON|OFF]... tup)'," +
-                                          " found 'function test6([string,ON|OFF]... tupl)'", 76, 5);
+                                          " found 'function test6([string,ON|OFF]... tupl)'", 78, 5);
         BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test7() returns ON|OFF', found " +
-                                          "'function test7(int x) returns ON|OFF'", 79, 5);
-        BAssertUtil.validateError(result, index,
+                                          "'function test7(int x) returns ON|OFF'", 81, 5);
+        BAssertUtil.validateError(result, index++,
                                   "mismatched function signatures: expected 'function test8(public string s, int i)'," +
-                                          " found 'function test8(string s, public int i)'", 84, 5);
+                                          " found 'function test8(string s, public int i)'", 86, 5);
+        BAssertUtil.validateError(result, index++,
+                                  "mismatched function signatures: expected 'function test9(int:Signed16 anInt, Bar.." +
+                                          ". bars) returns int', found 'function test9(int:Signed16 anInt, Bar... " +
+                                          "bars) returns int:Signed16'",
+                                  91, 5);
+        Assert.assertEquals(result.getErrorCount(), index);
     }
 
     @Test
@@ -219,5 +228,10 @@ public class ObjectTypeReferenceTest {
         BAssertUtil.validateError(result, index,
                                   "incompatible type reference 'abc:Baz': a referenced object cannot have non-public " +
                                           "fields or methods", 22, 6);
+    }
+
+    @Test
+    public void testCreatingObjectWithOverriddenMethods() {
+        BRunUtil.invoke(compileResult, "testCreatingObjectWithOverriddenMethods");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/object_override_includes.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/object_override_includes.bal
@@ -1,0 +1,89 @@
+import testorg/foo;
+
+public type NewButSameBin object {
+    *foo:Bin;
+    public int age;
+    public string name;
+    public int year;
+    public string month;
+
+    public function attachFunc1(int add, string value1) returns [int, string] {
+        return [2, "dummy"];
+    }
+
+    public function attachInterface(int add, string value1) returns [int, string] {
+        return [2, "dummy"];
+    }
+
+    public function __init(int age, string name, int year, string month) {
+        self.age = age;
+        self.name = name;
+        self.year = year;
+        self.month = month;
+    }
+};
+
+public function testSimpleObjectOverridingSimilarObject () {
+    NewButSameBin p = new (20, "Bob", 2020, "march");
+    assertEquality(20, p.age);
+    assertEquality("Bob", p.name);
+    assertEquality(2020, p.year);
+    assertEquality("march", p.month);
+}
+
+public type DustBinOverridingBin object {
+    public int age = 20;
+    public string name = "sample name";
+    public int year = 50;
+    public string month = "february";
+
+    *foo:Bin;
+
+    public function __init (int year, int count, string name = "sample value1", string val1 = "default value") {
+        self.year = year;
+        self.name = name;
+        self.age = self.age + count + 50;
+        self.month = val1 + " uuuu";
+    }
+
+    public function attachFunc1(int add, string value1) returns [int, string] {
+        int count = self.age + add;
+        string val2 = value1 + self.month;
+        return [count, val2];
+    }
+
+    public function attachInterface(int add, string value1) returns [int, string] {
+        int count = self.age + add;
+        string val2 = value1 + self.month;
+        return [count, val2];
+    }
+};
+
+public function testObjectOverrideInterfaceWithInterface() {
+    foo:Bin p = new DustBinOverridingBin(100, 10, val1 = "adding");
+    assertEquality(80, p.age);
+    assertEquality("sample value1", p.name);
+    assertEquality(100, p.year);
+    assertEquality("adding uuuu", p.month);
+}
+
+public function testObjectWithOverriddenFieldsAndMethods() {
+    foo:ManagingDirector p = new foo:ManagingDirector(20, "John");
+    assertEquality(2000000, p.getBonus(1, 1));
+    assertEquality("Hello Director, John", p.getName());
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/foo/object_type_inclusion_overrides.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/foo/object_type_inclusion_overrides.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public type ManagingDirector object {
+    *Person1;
+    *Employee1;
+
+    int shares = 2000;
+    int|float salary;
+
+    public function __init(int age, string name) {
+        self.age = age;
+        self.name = name;
+        self.salary = 1000.0;
+    }
+
+    public function getBonus(float ratio, int months=8) returns float {
+        return <float>(self.salary) * ratio * months * self.shares;
+    }
+
+    public function getName(string greeting = "Hello Director,") returns string {
+        return greeting + " " + self.name;
+    }
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/foo/object_type_inclusion_overrides.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/foo/object_type_inclusion_overrides.bal
@@ -16,10 +16,10 @@
 
 public type ManagingDirector object {
     *Person1;
-    *Employee1;
+    *Employee3;
 
     int shares = 2000;
-    int|float salary;
+    float salary;
 
     public function __init(int age, string name) {
         self.age = age;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/foo/object_type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/foo/object_type_reference.bal
@@ -103,3 +103,9 @@ public type CorronifiedEmployee object {
 public type NormalPerson object {
     string name = "John";
 };
+
+public type Employee3 abstract object {
+    public int|float salary;
+
+    public function getBonus(float ratio, int months=12) returns float;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/records/common_models.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/records/common_models.bal
@@ -1,0 +1,8 @@
+type Name record {
+    string name = "";
+};
+
+type AgedPerson record {
+    *Name;
+    int|string age = 127;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/records/common_models.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/records/common_models.bal
@@ -1,8 +1,24 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 type Name record {
     string name = "";
 };
 
-type AgedPerson record {
+public type AgedPerson record {
     *Name;
     int|string age = 127;
 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/records/common_models.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/records/common_models.bal
@@ -20,5 +20,5 @@ type Name record {
 
 public type AgedPerson record {
     *Name;
-    int|string age = 127;
+    int|string|float age = 127;
 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-negative.bal
@@ -45,33 +45,6 @@ type ManagerWithTwoSalaries object {
     *EmployeeWithSalary;
 };
 
-// Direct circular reference
-type Foo abstract object {
-    *Foo;
-};
-
-// Indirect circular references
-type A abstract object {
-    *B;
-};
-
-type B abstract object {
-    *C;
-};
-
-type C abstract object {
-    *D;
-    *E;
-};
-
-type D abstract object {
-    *A;
-};
-
-type E abstract object {
-    *C;
-};
-
 // Test errors for unimplemented methods
 type Person2 abstract object {
     public int age;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-semantics-negative.bal
@@ -48,33 +48,6 @@ type ManagerWithTwoSalaries object {
     *AnotherEmployeeWithSalary;
 };
 
-// Direct circular reference
-type Foo abstract object {
-    *Foo;
-};
-
-// Indirect circular references
-type A abstract object {
-    *B;
-};
-
-type B abstract object {
-    *C;
-};
-
-type C abstract object {
-    *D;
-    *E;
-};
-
-type D abstract object {
-    *A;
-};
-
-type E abstract object {
-    *C;
-};
-
 // Test errors for unimplemented methods
 type Person2 abstract object {
     public int age;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-semantics-negative.bal
@@ -125,19 +125,6 @@ type ObjectWithRedeclaredFunction_2 abstract object {
     *ObjectWithRedeclaredFunction_1;
 };
 
-type RedecalredFieldObject_1 abstract object {
-    int x;
-};
-
-type RedecalredFieldObject_2 abstract object {
-    int x;
-    *RedecalredFieldObject_1;
-};
-
-type RedecalredFieldObject_3 abstract object {
-    *RedecalredFieldObject_2;
-};
-
 type Bar object {
     *Baz;   // non existing type
 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-1-semantics-negative.bal
@@ -48,6 +48,33 @@ type ManagerWithTwoSalaries object {
     *AnotherEmployeeWithSalary;
 };
 
+// Direct circular reference
+type Foo abstract object {
+    *Foo;
+};
+
+// Indirect circular references
+type A abstract object {
+    *B;
+};
+
+type B abstract object {
+    *C;
+};
+
+type C abstract object {
+    *D;
+    *E;
+};
+
+type D abstract object {
+    *A;
+};
+
+type E abstract object {
+    *C;
+};
+
 // Test errors for unimplemented methods
 type Person2 abstract object {
     public int age;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-cyclic-dependency-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference-cyclic-dependency-negative.bal
@@ -1,0 +1,42 @@
+// Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Direct circular reference
+type Foo abstract object {
+    *Foo;
+};
+
+// Indirect circular references
+type A abstract object {
+    *B;
+};
+
+type B abstract object {
+    *C;
+};
+
+type C abstract object {
+    *D;
+    *E;
+};
+
+type D abstract object {
+    *A;
+};
+
+type E abstract object {
+    *C;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -14,6 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/lang.'int;
+import ballerina/test;
+
 type Person1 abstract object {
     public int age;
     public string name;
@@ -189,6 +192,69 @@ public function testNonAbstractObjectInclusion() {
 
     FireAnt dullAnt = new FireAnt(0);
     assertEquality(dullAnt.getId(), ());
+}
+
+// Type inclusion tests
+
+type AgeDataObject abstract object {
+    'int:Signed8 age;
+};
+
+type DefaultPerson object {
+    *AgeDataObject;
+    int age;
+    string name;
+
+    function __init(int age=18, string name = "UNKNOWN") {
+       self.age = age;
+       self.name = name;
+    }
+};
+
+function testCreatingObjectWithOverriddenFields() {
+    DefaultPerson dummyPerson = new DefaultPerson();
+    test:assertEquals(dummyPerson.age, 18);
+    dummyPerson.age = 400;
+    test:assertEquals(dummyPerson.age, 400);
+    test:assertEquals(dummyPerson.name, "UNKNOWN");
+}
+
+type NameInterface abstract object {
+    public function getName(string greeting = "Hi") returns string;
+};
+
+type AgeInterface abstract object {
+    *AgeDataObject;
+    public function setAge('int:Signed8 age = 0) returns 'int:Signed8;
+};
+
+type DefaultPersonGreetedName object {
+    *NameInterface;
+    *AgeInterface;
+    string name;
+    'int:Signed16 age;
+
+    function __init('int:Signed16 age = 18, string name = "UNKNOWN") {
+       self.age = age;
+       self.name = name;
+    }
+
+    public function getName(string greeting = "Hello") returns string {
+        return greeting + " " + self.name;
+    }
+
+    public function setAge('int:Signed8 age = 0) returns int {
+        self.age = age;
+        return self.age;
+    }
+};
+
+function testCreatingObjectWithOverriddenMethods() {
+    DefaultPersonGreetedName dummyPerson = new DefaultPersonGreetedName(name="Doe");
+    test:assertEquals(dummyPerson.age, 18);
+    int age = dummyPerson.setAge(80);
+    test:assertEquals(dummyPerson.age, 80);
+    test:assertEquals(dummyPerson.getName(), "Hello Doe");
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -158,18 +158,6 @@ public function testAbstractObjectFuncWithDefaultVal() returns [string, float] {
 type Ant object {
     int id;
 
-    public function __init() {
-        self.id = 0;
-    }
-
-    public function getId() returns int {
-        return self.id;
-    }
-};
-
-type FireAnt object {
-    *Ant;
-
     public function __init(int id) {
         self.id = id;
     }
@@ -183,23 +171,38 @@ type FireAnt object {
     }
 };
 
+type FireAnt object {
+    *Ant;
+
+    public function __init(int id) {
+        self.id = id;
+    }
+
+    public function getId() returns int {
+        return self.id;
+    }
+};
+
 public function testNonAbstractObjectInclusion() {
     FireAnt notoriousFireAnt = new FireAnt(7);
     assertEquality(notoriousFireAnt.getId(), 7);
 
-    FireAnt dullAnt = new FireAnt(0);
-    assertEquality(dullAnt.getId(), ());
+    Ant dullAnt = new FireAnt(0);
+    assertEquality(dullAnt.getId(), 0);
+
+    Ant nullAnt = new Ant(0);
+    assertEquality(nullAnt.getId(), ());
 }
 
 // Type inclusion tests
 
 type AgeDataObject abstract object {
-    int age;
+    int|float age;
 };
 
 type DefaultPerson object {
     *AgeDataObject;
-    int|float age;
+    int age;
     string name;
 
     function __init(int age=18, string name = "UNKNOWN") {
@@ -222,7 +225,7 @@ type NameInterface abstract object {
 
 type AgeInterface abstract object {
     *AgeDataObject;
-    public function setAge(int|string age = 0) returns int;
+    public function setAge(int age = 0) returns int;
 };
 
 type DefaultPersonGreetedName object {
@@ -240,9 +243,13 @@ type DefaultPersonGreetedName object {
         return greeting + " " + self.name;
     }
 
-    public function setAge(int age = 0) returns int {
-        self.age = age;
-        return self.age;
+    public function setAge(int|float age = 0) returns int {
+        if (age is int) {
+            self.age = age;
+            return self.age;
+        }
+        self.age = <int>age;
+        return -1;
     }
 };
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -14,9 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/lang.'int;
-import ballerina/test;
-
 type Person1 abstract object {
     public int age;
     public string name;
@@ -197,12 +194,12 @@ public function testNonAbstractObjectInclusion() {
 // Type inclusion tests
 
 type AgeDataObject abstract object {
-    'int:Signed8 age;
+    int age;
 };
 
 type DefaultPerson object {
     *AgeDataObject;
-    int age;
+    int|float age;
     string name;
 
     function __init(int age=18, string name = "UNKNOWN") {
@@ -213,10 +210,10 @@ type DefaultPerson object {
 
 function testCreatingObjectWithOverriddenFields() {
     DefaultPerson dummyPerson = new DefaultPerson();
-    test:assertEquals(dummyPerson.age, 18);
+    assertEquality(dummyPerson.age, 18);
     dummyPerson.age = 400;
-    test:assertEquals(dummyPerson.age, 400);
-    test:assertEquals(dummyPerson.name, "UNKNOWN");
+    assertEquality(dummyPerson.age, 400);
+    assertEquality(dummyPerson.name, "UNKNOWN");
 }
 
 type NameInterface abstract object {
@@ -225,16 +222,16 @@ type NameInterface abstract object {
 
 type AgeInterface abstract object {
     *AgeDataObject;
-    public function setAge('int:Signed8 age = 0) returns 'int:Signed8;
+    public function setAge(int|string age = 0) returns int;
 };
 
 type DefaultPersonGreetedName object {
     *NameInterface;
     *AgeInterface;
     string name;
-    'int:Signed16 age;
+    int age;
 
-    function __init('int:Signed16 age = 18, string name = "UNKNOWN") {
+    function __init(int age = 18, string name = "UNKNOWN") {
        self.age = age;
        self.name = name;
     }
@@ -243,7 +240,7 @@ type DefaultPersonGreetedName object {
         return greeting + " " + self.name;
     }
 
-    public function setAge('int:Signed8 age = 0) returns int {
+    public function setAge(int age = 0) returns int {
         self.age = age;
         return self.age;
     }
@@ -251,10 +248,25 @@ type DefaultPersonGreetedName object {
 
 function testCreatingObjectWithOverriddenMethods() {
     DefaultPersonGreetedName dummyPerson = new DefaultPersonGreetedName(name="Doe");
-    test:assertEquals(dummyPerson.age, 18);
+    assertEquality(dummyPerson.age, 18);
     int age = dummyPerson.setAge(80);
-    test:assertEquals(dummyPerson.age, 80);
-    test:assertEquals(dummyPerson.getName(), "Hello Doe");
+    assertEquality(dummyPerson.age, 80);
+    assertEquality(dummyPerson.getName(), "Hello Doe");
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }
 
 const ASSERTION_ERROR_REASON = "AssertionError";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -268,18 +268,3 @@ function assertEquality(any|error expected, any|error actual) {
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }
-
-const ASSERTION_ERROR_REASON = "AssertionError";
-
-function assertEquality(any|error expected, any|error actual) {
-    if expected is anydata && actual is anydata && expected == actual {
-        return;
-    }
-
-    if expected === actual {
-        return;
-    }
-
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
-}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_func_reference_neg.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_func_reference_neg.bal
@@ -45,7 +45,7 @@ public type Foo abstract object {
 
     function test8(public string s, int i);
 
-    function test9('int:Signed16 anInt, Bar... bars) returns int;
+    function test9('int:Signed16 anInt, Bar... bars) returns 'int:Signed16;
 };
 
 public type FooImpl1 object {
@@ -88,7 +88,7 @@ public type FooImpl1 object {
     }
 
     // not assignable : return type
-    function test9('int:Signed16 anInt, Bar... bars) returns 'int:Signed16 {
+    function test9('int:Signed16 anInt, Bar... bars) returns int {
         return 0;
     }
 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_func_reference_neg.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_func_reference_neg.bal
@@ -13,6 +13,7 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/lang.'int;
 
 type Bar record {
     string sbar = "sBar";
@@ -34,7 +35,7 @@ public type Foo abstract object {
 
     function test3(int anInt, string aString, string defaultable = "foo", int def2 = 10);
 
-    function test4(string aString, int anInt, Bar... bars) returns string;
+    function test4(string aString, 'int:Signed16 anInt, Bar... bars) returns string;
 
     function test5(Status... status) returns Bar;
 
@@ -44,6 +45,7 @@ public type Foo abstract object {
 
     function test8(public string s, int i);
 
+    function test9('int:Signed16 anInt, Bar... bars) returns int;
 };
 
 public type FooImpl1 object {
@@ -62,8 +64,8 @@ public type FooImpl1 object {
         return "";
     }
 
-    // param type mismatch
-    function test4(string aString, int anInt, AnotherBar... bars) returns string {
+    // not assignable : param type
+    function test4(string aString,int anInt, AnotherBar... bars) returns string {
         return "";
     }
 
@@ -83,5 +85,10 @@ public type FooImpl1 object {
     // param visibility modifier mismatch
     function test8(string s, public int i) {
 
+    }
+
+    // not assignable : return type
+    function test9('int:Signed16 anInt, Bar... bars) returns 'int:Signed16 {
+        return 0;
     }
 };

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/closed_record_type_reference_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/closed_record_type_reference_negative.bal
@@ -51,16 +51,6 @@ type Foo3 record {|
     *xml;
 |};
 
-type Person1 record {
-    string name;
-    int age;
-};
-
-type Student1 record {|
-    *Person1;
-    string name;
-|};
-
 type Gender "male"|"female";
 
 type Person2 record {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
@@ -186,7 +186,7 @@ function testDefaultValueInitInBALOs() returns records:BManager {
 
 type DefaultPerson record {
     *records:AgedPerson;
-    int|string|float age = 18;
+    int|string age = 18;
     string name = "UNKNOWN";
 };
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
@@ -15,6 +15,8 @@
 // under the License.
 
 import testorg/records;
+import ballerina/lang.'int;
+import ballerina/test;
 
 // TESTS FOR RECORDS WHERE THE REFERENCED TYPE ONLY HAS VALUE TYPE FIELDS
 
@@ -180,4 +182,29 @@ function testDefaultValueInit() returns ManagerRec {
 function testDefaultValueInitInBALOs() returns records:BManager {
     records:BManager mgr = {};
     return mgr;
+}
+
+// Test overriding of referenced fields
+
+type Name record {
+    string name = "";
+};
+
+type AgedPerson record {
+    *Name;
+    'int:Signed8 age = 127;
+};
+
+type DefaultPerson record {
+    *AgedPerson;
+    int age = 18;
+    string name = "UNKNOWN";
+};
+
+function testCreatingRecordWithOverriddenFields() {
+    DefaultPerson dummyPerson = {};
+    test:assertEquals(18, dummyPerson.age);
+    dummyPerson.age = 400;
+    test:assertEquals(400, dummyPerson.age);
+    test:assertEquals("UNKNOWN", dummyPerson.name);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
@@ -15,8 +15,6 @@
 // under the License.
 
 import testorg/records;
-import ballerina/lang.'int;
-import ballerina/test;
 
 // TESTS FOR RECORDS WHERE THE REFERENCED TYPE ONLY HAS VALUE TYPE FIELDS
 
@@ -186,25 +184,31 @@ function testDefaultValueInitInBALOs() returns records:BManager {
 
 // Test overriding of referenced fields
 
-type Name record {
-    string name = "";
-};
-
-type AgedPerson record {
-    *Name;
-    'int:Signed8 age = 127;
-};
-
 type DefaultPerson record {
-    *AgedPerson;
-    int age = 18;
+    *records:AgedPerson;
+    int|string|float age = 18;
     string name = "UNKNOWN";
 };
 
 function testCreatingRecordWithOverriddenFields() {
     DefaultPerson dummyPerson = {};
-    test:assertEquals(18, dummyPerson.age);
+    assertEquality(18, dummyPerson.age);
     dummyPerson.age = 400;
-    test:assertEquals(400, dummyPerson.age);
-    test:assertEquals("UNKNOWN", dummyPerson.name);
+    assertEquality(400, dummyPerson.age);
+    assertEquality("UNKNOWN", dummyPerson.name);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference_negative.bal
@@ -51,16 +51,6 @@ type Foo3 record {
     *xml;
 };
 
-type Person1 record {
-    string name;
-    int age;
-};
-
-type Student1 record {
-    *Person1;
-    string name;
-};
-
 type Gender "male"|"female";
 
 type Person2 record {


### PR DESCRIPTION
## Purpose
Fixes #23216, #23231

## Samples
Now we support below cases

Case 1: overriding record fields
```Ballerina
import ballerina/lang.'int;

type A record {|
    int overrideMe;
    'int:Unsigned8 sub;
|};

type C record {|
    *A;
    int overrideMe;
    'int:Unsigned8 sub;
|};
```

Case 2: overriding object fields and method declarations
```Ballerina
import ballerina/lang.'int;

type AgeInterface abstract object {
    'int:Signed8 age;
    public function setAge('int:Signed8 age = 0) returns 'int:Signed8;
};

type DefaultPersonGreetedName object {
    *AgeInterface;
    'int:Signed8 age = 0;

    public function setAge('int:Signed8 age = 0) returns 'int:Signed8 {
        self.age = <'int:Signed8>age;
        return self.age;
    }
};
```

## Remarks
Also need to fix cyclic dependency

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [x] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
