### PR TITLE
Add failOnErrors attribute to openapi annotation

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -39,4 +39,5 @@ public class Constants {
     static final String TAGS = "tags";
     static final String OPERATIONS = "operations";
     static final String BODY = "body";
+    static final String FAILONERRORS = "failOnErrors";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -230,12 +230,14 @@ class ValidatorUtil {
      *
      * @param tags                    lists of tags to enable validation on
      * @param operations              list of operations enable validation on
+     * @param kind                    Diagnostic.Kind value for enabaling the avoid validate fail
      * @param resourceSummaryList     list of resource summaries
      * @param openAPISummaryList      list of openAPI path summaries
      * @param openAPIComponentSummary component summaries
      * @param dLog                    diagnostic logger
      */
     static void validateResourcesAgainstOpenApi(List<String> tags, List<String> operations,
+                                                Diagnostic.Kind kind,
                                                 List<ResourceSummary> resourceSummaryList,
                                                 List<OpenAPIPathSummary> openAPISummaryList,
                                                 OpenAPIComponentSummary openAPIComponentSummary, DiagnosticLog dLog) {
@@ -246,8 +248,9 @@ class ValidatorUtil {
             OpenAPIPathSummary openAPIPathSummary = getOpenApiSummaryByPath(resourceSummary.getPath(),
                     openAPISummaryList);
             if (openAPIPathSummary == null) {
-                dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceSummary.getPathPosition(),
+                dLog.logDiagnostic(kind, resourceSummary.getPathPosition(),
                         ErrorMessages.undocumentedResourcePath(resourceSummary.getPath()));
+
             } else {
                 List<String> unmatchedMethods = new ArrayList<>();
                 if (!operationFilteringEnabled && !tagFilteringEnabled) {
@@ -281,29 +284,31 @@ class ValidatorUtil {
                                         if (schema != null) {
                                             isExist = validateResourceAgainstOpenAPIParams(parameter,
                                                     parameter.getParameter().symbol, schema, dLog, resourceMethod,
-                                                    resourceSummary.getPath());
+                                                    resourceSummary.getPath(), kind);
                                         }
                                     }
                                 } else if (openAPIParameter.getName().equals(parameter.getName())) {
                                     isExist = validateResourceAgainstOpenAPIParams(parameter,
                                             parameter.getParameter().symbol,
                                             openAPIParameter.getParameter().getSchema(), dLog, resourceMethod,
-                                            resourceSummary.getPath());
+                                            resourceSummary.getPath(), kind);
                                 }
                             }
 
                             if (!isExist) {
-                                dLog.logDiagnostic(Diagnostic.Kind.ERROR, parameter.getParameter().getPosition(),
+                                dLog.logDiagnostic(kind, parameter.getParameter().getPosition(),
                                         ErrorMessages.undocumentedResourceParameter(parameter.getName(),
                                                 resourceMethod, resourceSummary.getPath()));
+
                             }
                         }
                     }
 
                     String methods = getUnmatchedMethodList(unmatchedMethods);
                     if (!openAPIPathSummary.getAvailableOperations().containsAll(resourceSummary.getMethods())) {
-                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceSummary.getMethodsPosition(),
+                        dLog.logDiagnostic(kind, resourceSummary.getMethodsPosition(),
                                 ErrorMessages.undocumentedResourceMethods(methods, resourceSummary.getPath()));
+
                     }
                 }
             }
@@ -322,6 +327,7 @@ class ValidatorUtil {
      * @param dLog                    diagnostic logger
      */
     static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags, List<String> operations,
+                                                Diagnostic.Kind kind,
                                                 List<ResourceSummary> resourceSummaryList,
                                                 List<OpenAPIPathSummary> openAPISummaryList,
                                                 OpenAPIComponentSummary openAPIComponentSummary,
@@ -333,7 +339,7 @@ class ValidatorUtil {
             List<ResourceSummary> resourceSummaries = getResourceSummaryByPath(openApiSummary.getPath(),
                     resourceSummaryList);
             if (resourceSummaries == null) {
-                dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                         ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
             } else {
                 List<String> allAvailableResourceMethods = getAllMethodsInResourceSummaries(resourceSummaries);
@@ -349,30 +355,32 @@ class ValidatorUtil {
                             if (operations.contains(method) && openApiSummary.hasTags(tags, method)) {
                                 validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                         resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                        serviceNode);
+                                        serviceNode, kind);
                             }
                         }
 
                         if (unmatchedMethods.size() > 0) {
                             String methods = getUnmatchedMethodList(unmatchedMethods);
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                            dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                                     ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
                                             openApiSummary.getPath()));
+
                         }
                     } else {
                         for (String method : openApiSummary.getAvailableOperations()) {
                             if (operations.contains(method)) {
                                 validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                         resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                        serviceNode);
+                                        serviceNode, kind);
                             }
                         }
 
                         if (unmatchedMethods.size() > 0) {
                             String methods = getUnmatchedMethodList(unmatchedMethods);
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                            dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                                     ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
                                             openApiSummary.getPath()));
+
                         }
                     }
                 } else {
@@ -383,28 +391,30 @@ class ValidatorUtil {
                             if (openApiSummary.hasTags(tags, method)) {
                                 validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                         resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                        serviceNode);
+                                        serviceNode, kind);
                             }
                         }
 
                         if (unmatchedMethods.size() > 0) {
                             String methods = getUnmatchedMethodList(unmatchedMethods);
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                            dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                                     ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
                                             openApiSummary.getPath()));
+
                         }
                     } else {
                         for (String method : openApiSummary.getAvailableOperations()) {
                             validateOperationForOpenAPI(unmatchedMethods, allAvailableResourceMethods,
                                     resourceSummaries, method, openApiSummary, dLog, openAPIComponentSummary,
-                                    serviceNode);
+                                    serviceNode, kind);
                         }
 
                         String methods = getUnmatchedMethodList(unmatchedMethods);
                         if (!allAvailableResourceMethods.containsAll(openApiSummary.getAvailableOperations())) {
-                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                            dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                                     ErrorMessages.unimplementedOpenAPIOperationsForPath(methods,
                                             openApiSummary.getPath()));
+
                         }
                     }
                 }
@@ -442,7 +452,7 @@ class ValidatorUtil {
                                                     List<ResourceSummary> resourceSummaries, String method,
                                                     OpenAPIPathSummary openApiSummary, DiagnosticLog dLog,
                                                     OpenAPIComponentSummary openApiComponentSummary,
-                                                    ServiceNode serviceNode) {
+                                                    ServiceNode serviceNode, Diagnostic.Kind kind) {
         boolean noMatch = true;
         for (String resourceMethod : allAvailableResourceMethods) {
             if (resourceMethod.equals(method)) {
@@ -457,14 +467,14 @@ class ValidatorUtil {
 
         // Check for parameter mismatch.
         checkForParameterMismatch(openApiSummary, resourceSummaries, method, serviceNode, openApiComponentSummary,
-                dLog);
+                dLog, kind);
     }
 
     private static void checkForParameterMismatch(OpenAPIPathSummary openApiSummary,
                                                   List<ResourceSummary> resourceSummaries,
                                                   String method, ServiceNode serviceNode,
                                                   OpenAPIComponentSummary openAPIComponentSummary,
-                                                  DiagnosticLog dLog) {
+                                                  DiagnosticLog dLog, Diagnostic.Kind kind) {
         List<OpenAPIParameter> operationParamNames = openApiSummary
                 .getParamNamesForOperation(method);
         ResourceSummary resourceSummaryForMethod = getResourceSummaryByMethod(resourceSummaries, method);
@@ -481,12 +491,13 @@ class ValidatorUtil {
                             if (schema != null) {
                                 isExist = validateOpenAPIAgainResourceParams(parameter,
                                         parameter.getParameter().symbol, schema, dLog, method,
-                                        openApiSummary.getPath());
+                                        openApiSummary.getPath(), kind);
                             }
                         }
                     } else if (openAPIParameter.getName().equals(parameter.getName())) {
                         isExist = validateOpenAPIAgainResourceParams(parameter, parameter.getParameter().symbol,
-                                openAPIParameter.getParameter().getSchema(), dLog, method, openApiSummary.getPath());
+                                openAPIParameter.getParameter().getSchema(), dLog, method, openApiSummary.getPath(),
+                                kind);
                     }
 
                     if (!isExist) {
@@ -497,16 +508,18 @@ class ValidatorUtil {
 
                 if (!isExist) {
                     if (nonExistingResourceParameter != null) {
-                        dLog.logDiagnostic(Diagnostic.Kind.ERROR,
+                        dLog.logDiagnostic(kind,
                                 nonExistingResourceParameter.getParameter().getPosition(),
                                 ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
                                         method, resourceSummaryForMethod.getPath()));
+
                     } else {
-                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, getServiceNamePosition(serviceNode),
+                        dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                                 ErrorMessages.unimplementedParameterForOperation(openAPIParameter.getName(),
                                         method, resourceSummaryForMethod.getPath()));
+
                     }
-                    break;
+
                 }
             }
         }
@@ -514,7 +527,8 @@ class ValidatorUtil {
 
     private static boolean validateResourceAgainstOpenAPIParams(ResourceParameter resourceParameter,
                                                                 BVarSymbol resourceParameterType, Schema openAPIParam,
-                                                                DiagnosticLog dLog, String method, String path) {
+                                                                DiagnosticLog dLog, String method, String path,
+                                                                Diagnostic.Kind kind) {
         BType resourceParamType = resourceParameterType.getType();
 
         if (resourceParamType.getKind().typeName().equals("record")
@@ -532,15 +546,16 @@ class ValidatorUtil {
                         isExist = true;
                         if (ValidatorUtil.convertOpenAPITypeToBallerina(entry.getValue().getType()).equals("record")) {
                             isExist = validateResourceAgainstOpenAPIParams(resourceParameter,
-                                    field.symbol, entry.getValue(), dLog, method, path);
+                                    field.symbol, entry.getValue(), dLog, method, path, kind);
                         }
                     }
                 }
 
                 if (!isExist) {
-                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, field.pos,
+                    dLog.logDiagnostic(kind, field.pos,
                             ErrorMessages.undocumentedFieldInRecordParam(field.name.getValue(),
                                     resourceParameter.getName(), method, path));
+
                 }
             }
             return true;
@@ -567,7 +582,8 @@ class ValidatorUtil {
     private static boolean validateOpenAPIAgainResourceParams(ResourceParameter resourceParam,
                                                               BVarSymbol resourceParameterType,
                                                               Schema openAPIParam,
-                                                              DiagnosticLog dLog, String operation, String path) {
+                                                              DiagnosticLog dLog, String operation, String path,
+                                                              Diagnostic.Kind kind) {
         BType resourceParamType = resourceParameterType.getType();
         if (resourceParamType.getKind().typeName().equals("record")
                 && resourceParamType instanceof BRecordType
@@ -584,15 +600,16 @@ class ValidatorUtil {
                         isExist = true;
                         if (ValidatorUtil.convertOpenAPITypeToBallerina(entry.getValue().getType()).equals("record")) {
                             isExist = validateOpenAPIAgainResourceParams(resourceParam, field.symbol, entry.getValue(),
-                                    dLog, operation, path);
+                                    dLog, operation, path, kind);
                         }
                     }
                 }
 
                 if (!isExist) {
-                    dLog.logDiagnostic(Diagnostic.Kind.ERROR, resourceParam.getParameter().getPosition(),
+                    dLog.logDiagnostic(kind, resourceParam.getParameter().getPosition(),
                             ErrorMessages.unimplementedFieldInOperation(entry.getKey(), resourceParam.getName(),
                                     operation, path));
+
                 }
             }
             return true;

--- a/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
+++ b/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
@@ -18,10 +18,12 @@
 # + contract - OpenApi Contract link
 # + tags - OpenApi Tags
 # + operations - OpenApi Operations
+# + failOnErrors - OpenApi Validator Enable
 public type ServiceInformation record {|
     string contract = "";
     string[]? tags = [];
     string[]? operations = [];
+    boolean failOnErrors = true;
 |};
 
 # Configuration elements for client code generation.


### PR DESCRIPTION
## Purpose
> An option in the annotation to make validator error warning instead of build errors

## Samples
> Add failOnError field as false for making validator error warning instead of building failed.

> @openapi:ServiceInfo {
    contract: "resources/test.yaml",
    failOnErrors: false
    }


## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
