### PR TITLE
Consider the widthWithMinutiae in node width calculation algorithm

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNode.java
@@ -90,7 +90,7 @@ public abstract class STNode {
     }
 
     /**
-     * Update various fields properties during the internal node creation time.
+     * Update various field properties during the internal node creation time.
      * <p>
      * Here we update following four width related fields.
      * width                       - width of the node without minutiae
@@ -145,7 +145,7 @@ public abstract class STNode {
     private int getFirstChildIndex(STNode... children) {
         for (int index = 0; index < children.length; index++) {
             STNode child = children[index];
-            if (SyntaxUtils.isSTNodePresent(child) && child.width != 0) {
+            if (SyntaxUtils.isSTNodePresent(child) && child.widthWithMinutiae != 0) {
                 return index;
             }
         }
@@ -155,7 +155,7 @@ public abstract class STNode {
     private int getLastChildIndex(STNode... children) {
         for (int index = children.length - 1; index >= 0; index--) {
             STNode child = children[index];
-            if (SyntaxUtils.isSTNodePresent(child) && child.width != 0) {
+            if (SyntaxUtils.isSTNodePresent(child) && child.widthWithMinutiae != 0) {
                 return index;
             }
         }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/incremental/ModuleLevelDeclarationTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/incremental/ModuleLevelDeclarationTest.java
@@ -17,8 +17,15 @@
  */
 package io.ballerinalang.compiler.parser.test.incremental;
 
+import io.ballerinalang.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerinalang.compiler.syntax.tree.IdentifierToken;
 import io.ballerinalang.compiler.syntax.tree.Node;
 import io.ballerinalang.compiler.syntax.tree.SyntaxTree;
+import io.ballerinalang.compiler.text.TextDocument;
+import io.ballerinalang.compiler.text.TextDocumentChange;
+import io.ballerinalang.compiler.text.TextDocuments;
+import io.ballerinalang.compiler.text.TextEdit;
+import io.ballerinalang.compiler.text.TextRange;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -37,5 +44,22 @@ public class ModuleLevelDeclarationTest extends AbstractIncrementalParserTest {
 
         // TODO This is fragile way to test. Improve
         Assert.assertEquals(newNodes.length, 5);
+    }
+
+    @Test
+    public void testUpdatingEmptyDocument() {
+        String input = " \n  ";
+        TextDocument textDocument = TextDocuments.from(input);
+        SyntaxTree oldTree = SyntaxTree.from(textDocument);
+
+        // Applying a change
+        TextEdit[] edits = new TextEdit[]{new TextEdit(new TextRange(0, 0), "public function main() {\n }\n")};
+        TextDocumentChange textDocumentChange = new TextDocumentChange(edits);
+        SyntaxTree newTree = SyntaxTree.from(oldTree, textDocumentChange);
+
+        FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) newTree.modulePart().members().get(0);
+        IdentifierToken funcName = functionDefinitionNode.functionName();
+
+        Assert.assertEquals(funcName.text(), "main");
     }
 }


### PR DESCRIPTION
## Purpose
Incremental parsing with a blank .bal file fails due to a bug in the node width calculation algorithm. I've used the width of a node in some places, but I should have used the width with the full minutiae.

Fixes #23275

## Samples
This PR makes the following code to work
```java
    @Test
    public void testUpdatingEmptyDocument() {
        String input = " \n  ";
        TextDocument textDocument = TextDocuments.from(input);
        SyntaxTree oldTree = SyntaxTree.from(textDocument);

        // Applying a change
        TextEdit[] edits = new TextEdit[]{new TextEdit(new TextRange(0, 0), "public function main() {\n }\n")};
        TextDocumentChange textDocumentChange = new TextDocumentChange(edits);
        SyntaxTree newTree = SyntaxTree.from(oldTree, textDocumentChange);

        FunctionDefinitionNode functionDefinitionNode = (FunctionDefinitionNode) newTree.modulePart().members().get(0);
        IdentifierToken funcName = functionDefinitionNode.functionName();

        Assert.assertEquals(funcName.text(), "main");
    }
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
