### PR TITLE
Enable vardclr statment tests in jballerina with new parser

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -709,7 +709,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     @Override
     public BLangNode transform(ImplicitNewExpressionNode implicitNewExprNode) {
         BLangTypeInit initNode = createTypeInit(implicitNewExprNode);
-        BLangInvocation invocationNode = createInvocation(implicitNewExprNode, implicitNewExprNode.NewKeyword());
+        BLangInvocation invocationNode = createInvocation(implicitNewExprNode, implicitNewExprNode.newKeyword());
         // Populate the argument expressions on initNode as well.
         initNode.argsExpr.addAll(invocationNode.argExprs);
         initNode.initInvocation = invocationNode;
@@ -720,7 +720,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     @Override
     public BLangNode transform(ExplicitNewExpressionNode explicitNewExprNode) {
         BLangTypeInit initNode = createTypeInit(explicitNewExprNode);
-        BLangInvocation invocationNode = createInvocation(explicitNewExprNode, explicitNewExprNode.NewKeyword());
+        BLangInvocation invocationNode = createInvocation(explicitNewExprNode, explicitNewExprNode.newKeyword());
         // Populate the argument expressions on initNode as well.
         initNode.argsExpr.addAll(invocationNode.argExprs);
         initNode.initInvocation = invocationNode;
@@ -731,7 +731,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangTypeInit initNode = (BLangTypeInit) TreeBuilder.createInitNode();
         initNode.pos = getPosition(expression);
         if (expression.kind() == SyntaxKind.EXPLICIT_NEW_EXPRESSION) {
-            Node type = ((ExplicitNewExpressionNode) expression).TypeDescriptor();
+            Node type = ((ExplicitNewExpressionNode) expression).typeDescriptor();
             initNode.userDefinedType = createTypeNode(type);
         }
 
@@ -765,14 +765,14 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         Iterator<FunctionArgumentNode> argumentsIter = null;
 
         if (expression.kind() == SyntaxKind.IMPLICIT_NEW_EXPRESSION) {
-            Optional<ParenthesizedArgList> argsList = ((ImplicitNewExpressionNode) expression).ParenthesizedArgList();
+            Optional<ParenthesizedArgList> argsList = ((ImplicitNewExpressionNode) expression).parenthesizedArgList();
             if (argsList.isPresent()) {
                 ParenthesizedArgList argList = argsList.get();
                 argumentsIter = argList.arguments().iterator();
             }
         } else {
             ParenthesizedArgList argList =
-                    (ParenthesizedArgList) ((ExplicitNewExpressionNode) expression).ParenthesizedArgList();
+                    (ParenthesizedArgList) ((ExplicitNewExpressionNode) expression).parenthesizedArgList();
             argumentsIter = argList.arguments().iterator();
         }
 

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STExplicitNewExpressionNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STExplicitNewExpressionNode.java
@@ -28,23 +28,23 @@ import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
  * @since 1.3.0
  */
 public class STExplicitNewExpressionNode extends STNewExpressionNode {
-    public final STNode NewKeyword;
-    public final STNode TypeDescriptor;
-    public final STNode ParenthesizedArgList;
+    public final STNode newKeyword;
+    public final STNode typeDescriptor;
+    public final STNode parenthesizedArgList;
 
     STExplicitNewExpressionNode(
-            STNode NewKeyword,
-            STNode TypeDescriptor,
-            STNode ParenthesizedArgList) {
+            STNode newKeyword,
+            STNode typeDescriptor,
+            STNode parenthesizedArgList) {
         super(SyntaxKind.EXPLICIT_NEW_EXPRESSION);
-        this.NewKeyword = NewKeyword;
-        this.TypeDescriptor = TypeDescriptor;
-        this.ParenthesizedArgList = ParenthesizedArgList;
+        this.newKeyword = newKeyword;
+        this.typeDescriptor = typeDescriptor;
+        this.parenthesizedArgList = parenthesizedArgList;
 
         addChildren(
-                NewKeyword,
-                TypeDescriptor,
-                ParenthesizedArgList);
+                newKeyword,
+                typeDescriptor,
+                parenthesizedArgList);
     }
 
     public Node createFacade(int position, NonTerminalNode parent) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STImplicitNewExpressionNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STImplicitNewExpressionNode.java
@@ -28,19 +28,19 @@ import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
  * @since 1.3.0
  */
 public class STImplicitNewExpressionNode extends STNewExpressionNode {
-    public final STNode NewKeyword;
-    public final STNode ParenthesizedArgList;
+    public final STNode newKeyword;
+    public final STNode parenthesizedArgList;
 
     STImplicitNewExpressionNode(
-            STNode NewKeyword,
-            STNode ParenthesizedArgList) {
+            STNode newKeyword,
+            STNode parenthesizedArgList) {
         super(SyntaxKind.IMPLICIT_NEW_EXPRESSION);
-        this.NewKeyword = NewKeyword;
-        this.ParenthesizedArgList = ParenthesizedArgList;
+        this.newKeyword = newKeyword;
+        this.parenthesizedArgList = parenthesizedArgList;
 
         addChildren(
-                NewKeyword,
-                ParenthesizedArgList);
+                newKeyword,
+                parenthesizedArgList);
     }
 
     public Node createFacade(int position, NonTerminalNode parent) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
@@ -1417,23 +1417,23 @@ public class STNodeFactory extends STAbstractNodeFactory {
     }
 
     public static STNode createExplicitNewExpressionNode(
-            STNode NewKeyword,
-            STNode TypeDescriptor,
-            STNode ParenthesizedArgList) {
+            STNode newKeyword,
+            STNode typeDescriptor,
+            STNode parenthesizedArgList) {
 
         return new STExplicitNewExpressionNode(
-                NewKeyword,
-                TypeDescriptor,
-                ParenthesizedArgList);
+                newKeyword,
+                typeDescriptor,
+                parenthesizedArgList);
     }
 
     public static STNode createImplicitNewExpressionNode(
-            STNode NewKeyword,
-            STNode ParenthesizedArgList) {
+            STNode newKeyword,
+            STNode parenthesizedArgList) {
 
         return new STImplicitNewExpressionNode(
-                NewKeyword,
-                ParenthesizedArgList);
+                newKeyword,
+                parenthesizedArgList);
     }
 
     public static STNode createParenthesizedArgList(

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ExplicitNewExpressionNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ExplicitNewExpressionNode.java
@@ -30,15 +30,15 @@ public class ExplicitNewExpressionNode extends NewExpressionNode {
         super(internalNode, position, parent);
     }
 
-    public Token NewKeyword() {
+    public Token newKeyword() {
         return childInBucket(0);
     }
 
-    public TypeDescriptorNode TypeDescriptor() {
+    public TypeDescriptorNode typeDescriptor() {
         return childInBucket(1);
     }
 
-    public Node ParenthesizedArgList() {
+    public Node parenthesizedArgList() {
         return childInBucket(2);
     }
 
@@ -55,25 +55,25 @@ public class ExplicitNewExpressionNode extends NewExpressionNode {
     @Override
     protected String[] childNames() {
         return new String[]{
-                "NewKeyword",
-                "TypeDescriptor",
-                "ParenthesizedArgList"};
+                "newKeyword",
+                "typeDescriptor",
+                "parenthesizedArgList"};
     }
 
     public ExplicitNewExpressionNode modify(
-            Token NewKeyword,
-            TypeDescriptorNode TypeDescriptor,
-            Node ParenthesizedArgList) {
+            Token newKeyword,
+            TypeDescriptorNode typeDescriptor,
+            Node parenthesizedArgList) {
         if (checkForReferenceEquality(
-                NewKeyword,
-                TypeDescriptor,
-                ParenthesizedArgList)) {
+                newKeyword,
+                typeDescriptor,
+                parenthesizedArgList)) {
             return this;
         }
 
         return NodeFactory.createExplicitNewExpressionNode(
-                NewKeyword,
-                TypeDescriptor,
-                ParenthesizedArgList);
+                newKeyword,
+                typeDescriptor,
+                parenthesizedArgList);
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ImplicitNewExpressionNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ImplicitNewExpressionNode.java
@@ -32,11 +32,11 @@ public class ImplicitNewExpressionNode extends NewExpressionNode {
         super(internalNode, position, parent);
     }
 
-    public Token NewKeyword() {
+    public Token newKeyword() {
         return childInBucket(0);
     }
 
-    public Optional<ParenthesizedArgList> ParenthesizedArgList() {
+    public Optional<ParenthesizedArgList> parenthesizedArgList() {
         return optionalChildInBucket(1);
     }
 
@@ -53,21 +53,21 @@ public class ImplicitNewExpressionNode extends NewExpressionNode {
     @Override
     protected String[] childNames() {
         return new String[]{
-                "NewKeyword",
-                "ParenthesizedArgList"};
+                "newKeyword",
+                "parenthesizedArgList"};
     }
 
     public ImplicitNewExpressionNode modify(
-            Token NewKeyword,
-            ParenthesizedArgList ParenthesizedArgList) {
+            Token newKeyword,
+            ParenthesizedArgList parenthesizedArgList) {
         if (checkForReferenceEquality(
-                NewKeyword,
-                ParenthesizedArgList)) {
+                newKeyword,
+                parenthesizedArgList)) {
             return this;
         }
 
         return NodeFactory.createImplicitNewExpressionNode(
-                NewKeyword,
-                ParenthesizedArgList);
+                newKeyword,
+                parenthesizedArgList);
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
@@ -1909,28 +1909,28 @@ public abstract class NodeFactory extends AbstractNodeFactory {
     }
 
     public static ExplicitNewExpressionNode createExplicitNewExpressionNode(
-            Token NewKeyword,
-            TypeDescriptorNode TypeDescriptor,
-            Node ParenthesizedArgList) {
-        Objects.requireNonNull(NewKeyword, "NewKeyword must not be null");
-        Objects.requireNonNull(TypeDescriptor, "TypeDescriptor must not be null");
-        Objects.requireNonNull(ParenthesizedArgList, "ParenthesizedArgList must not be null");
+            Token newKeyword,
+            TypeDescriptorNode typeDescriptor,
+            Node parenthesizedArgList) {
+        Objects.requireNonNull(newKeyword, "newKeyword must not be null");
+        Objects.requireNonNull(typeDescriptor, "typeDescriptor must not be null");
+        Objects.requireNonNull(parenthesizedArgList, "parenthesizedArgList must not be null");
 
         STNode stExplicitNewExpressionNode = STNodeFactory.createExplicitNewExpressionNode(
-                NewKeyword.internalNode(),
-                TypeDescriptor.internalNode(),
-                ParenthesizedArgList.internalNode());
+                newKeyword.internalNode(),
+                typeDescriptor.internalNode(),
+                parenthesizedArgList.internalNode());
         return stExplicitNewExpressionNode.createUnlinkedFacade();
     }
 
     public static ImplicitNewExpressionNode createImplicitNewExpressionNode(
-            Token NewKeyword,
-            ParenthesizedArgList ParenthesizedArgList) {
-        Objects.requireNonNull(NewKeyword, "NewKeyword must not be null");
+            Token newKeyword,
+            ParenthesizedArgList parenthesizedArgList) {
+        Objects.requireNonNull(newKeyword, "newKeyword must not be null");
 
         STNode stImplicitNewExpressionNode = STNodeFactory.createImplicitNewExpressionNode(
-                NewKeyword.internalNode(),
-                getOptionalSTNode(ParenthesizedArgList));
+                newKeyword.internalNode(),
+                getOptionalSTNode(parenthesizedArgList));
         return stImplicitNewExpressionNode.createUnlinkedFacade();
     }
 

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
@@ -1405,22 +1405,22 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
 
     @Override
     public Node transform(ExplicitNewExpressionNode explicitNewExpressionNode) {
-        Token NewKeyword = modifyToken(explicitNewExpressionNode.NewKeyword());
-        TypeDescriptorNode TypeDescriptor = modifyNode(explicitNewExpressionNode.TypeDescriptor());
-        Node ParenthesizedArgList = modifyNode(explicitNewExpressionNode.ParenthesizedArgList());
+        Token newKeyword = modifyToken(explicitNewExpressionNode.newKeyword());
+        TypeDescriptorNode typeDescriptor = modifyNode(explicitNewExpressionNode.typeDescriptor());
+        Node parenthesizedArgList = modifyNode(explicitNewExpressionNode.parenthesizedArgList());
         return explicitNewExpressionNode.modify(
-                NewKeyword,
-                TypeDescriptor,
-                ParenthesizedArgList);
+                newKeyword,
+                typeDescriptor,
+                parenthesizedArgList);
     }
 
     @Override
     public Node transform(ImplicitNewExpressionNode implicitNewExpressionNode) {
-        Token NewKeyword = modifyToken(implicitNewExpressionNode.NewKeyword());
-        ParenthesizedArgList ParenthesizedArgList = modifyNode(implicitNewExpressionNode.ParenthesizedArgList().orElse(null));
+        Token newKeyword = modifyToken(implicitNewExpressionNode.newKeyword());
+        ParenthesizedArgList parenthesizedArgList = modifyNode(implicitNewExpressionNode.parenthesizedArgList().orElse(null));
         return implicitNewExpressionNode.modify(
-                NewKeyword,
-                ParenthesizedArgList);
+                newKeyword,
+                parenthesizedArgList);
     }
 
     @Override

--- a/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
+++ b/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
@@ -2546,15 +2546,15 @@
             "kind": "EXPLICIT_NEW_EXPRESSION",
             "attributes": [
                 {
-                    "name": "NewKeyword",
+                    "name": "newKeyword",
                     "type": "Token"
                 },
                 {
-                    "name": "TypeDescriptor",
+                    "name": "typeDescriptor",
                     "type": "TypeDescriptorNode"
                 },
                 {
-                    "name": "ParenthesizedArgList",
+                    "name": "parenthesizedArgList",
                     "type": "Node"
                 }
             ]
@@ -2565,11 +2565,11 @@
             "kind": "IMPLICIT_NEW_EXPRESSION",
             "attributes": [
                 {
-                    "name": "NewKeyword",
+                    "name": "newKeyword",
                     "type": "Token"
                 },
                 {
-                    "name": "ParenthesizedArgList",
+                    "name": "parenthesizedArgList",
                     "type": "ParenthesizedArgList",
                     "isOptional": true
                 }

--- a/tests/jballerina-unit-test/src/test/resources/testng-new-parser.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng-new-parser.xml
@@ -76,7 +76,7 @@
 <!--            <package name="org.ballerinalang.test.statements.ifelse.*"/>-->
 <!--            <package name="org.ballerinalang.test.statements.packageimport.*"/>-->
 <!--            <package name="org.ballerinalang.test.statements.returnstmt.*"/>-->
-<!--            <package name="org.ballerinalang.test.statements.vardeclr.*"/>-->
+            <package name="org.ballerinalang.test.statements.vardeclr.*"/>
 <!--            <package name="org.ballerinalang.test.statements.whilestatement.*"/>-->
 <!--            <package name="org.ballerinalang.test.statements.variabledef.*"/>-->
 <!--            <package name="org.ballerinalang.test.statements.matchstmt.*"/>-->


### PR DESCRIPTION
## Purpose
>$title

Also fixes some inconsistencies in new-expr related nodes in the syntax tree where camel-case is not used. 

Fixes #23326

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
