### PR TITLE
Synchronize messages and complete signal in gRPC streaming

### DIFF
--- a/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/callback/ClientCallableUnitCallBack.java
+++ b/stdlib/grpc/src/main/java/org/ballerinalang/net/grpc/callback/ClientCallableUnitCallBack.java
@@ -19,20 +19,29 @@ package org.ballerinalang.net.grpc.callback;
 
 import org.ballerinalang.jvm.values.ErrorValue;
 
+import java.util.concurrent.Semaphore;
+
 /**
  * Call back class registered for client message listener service in B7a executor.
  *
  * @since 0.995.0
  */
 public class ClientCallableUnitCallBack extends AbstractCallableUnitCallBack {
-    
+    private Semaphore semaphore;
+
+    public ClientCallableUnitCallBack(Semaphore semaphore) {
+        this.semaphore = semaphore;
+    }
+
     @Override
     public void notifySuccess() {
         super.notifySuccess();
+        semaphore.release();
     }
     
     @Override
     public void notifyFailure(ErrorValue error) {
         super.notifyFailure(error);
+        semaphore.release();
     }
 }


### PR DESCRIPTION
## Purpose
Fixes #23338

## Approach
Added locks such that the messages are processed in order and the onComplete function is triggered after all the onMessage functions are completed.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
