### PR TITLE
Send and receive custom email headers with Email Connector

### DIFF
--- a/stdlib/email/src/main/ballerina/src/email/commons.bal
+++ b/stdlib/email/src/main/ballerina/src/email/commons.bal
@@ -24,6 +24,7 @@ import ballerina/mime;
 # + subject - Subject of email
 # + body - Body of the email message
 # + contentType - Content Type of the Body
+# + headers - Header list
 # + from - From address
 # + sender - Sender's address
 # + replyTo - Reply To addresses
@@ -35,10 +36,20 @@ public type Email record {|
     string subject;
     string|xml|json body;
     string contentType?;
+    Header[] headers?;
     string 'from;
     string sender?;
     string[] replyTo?;
     mime:Entity[] attachments?;
+|};
+
+# Email message headers.
+#
+# + name - Header name
+# + value - Header value
+public type Header record {|
+    string name;
+    string value;
 |};
 
 # Default folder to read emails.

--- a/stdlib/email/src/main/ballerina/src/email/commons.bal
+++ b/stdlib/email/src/main/ballerina/src/email/commons.bal
@@ -36,20 +36,11 @@ public type Email record {|
     string subject;
     string|xml|json body;
     string contentType?;
-    Header[] headers?;
+    map<string> headers?;
     string 'from;
     string sender?;
     string[] replyTo?;
     mime:Entity[] attachments?;
-|};
-
-# Email message headers.
-#
-# + name - Header name
-# + value - Header value
-public type Header record {|
-    string name;
-    string value;
 |};
 
 # Default folder to read emails.

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailAccessUtil.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailAccessUtil.java
@@ -30,6 +30,7 @@ import org.ballerinalang.jvm.types.BTypes;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.ArrayValueImpl;
 import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.jvm.values.MapValueImpl;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.XMLSequence;
 import org.ballerinalang.jvm.values.XMLValue;
@@ -152,7 +153,7 @@ public class EmailAccessUtil {
         BArray replyToAddressArrayValue = getAddressBArrayList(message.getReplyTo());
         String subject = getStringNullChecked(message.getSubject());
         String messageBody = extractBodyFromMessage(message);
-        BArray headers = extractHeadersFromMessage(message);
+        MapValue headers = extractHeadersFromMessage(message);
         String messageContentType = message.getContentType();
         String fromAddress = extractFromAddressFromMessage(message);
         String senderAddress = getSenderAddress(message);
@@ -183,19 +184,15 @@ public class EmailAccessUtil {
         return BallerinaValues.createRecordValue(EmailConstants.EMAIL_PACKAGE_ID, EmailConstants.EMAIL, valueMap);
     }
 
-    private static BArray extractHeadersFromMessage(Message message) throws MessagingException {
-        BType typeOfHeader = createHeaderMap().getType();
-        ArrayValue headersArrayValue = new ArrayValueImpl(new BArrayType(typeOfHeader));
+    private static MapValue<String, String> extractHeadersFromMessage(Message message) throws MessagingException {
+        MapValue<String, String> headerMap = new MapValueImpl<>();
         Enumeration<Header> headers = message.getAllHeaders();
         if (headers.hasMoreElements()) {
             while (headers.hasMoreElements()) {
                 Header header = headers.nextElement();
-                MapValue messageHeader = createHeaderMap();
-                messageHeader.put(EmailConstants.MESSAGE_HEADER_NAME, header.getName());
-                messageHeader.put(EmailConstants.MESSAGE_HEADER_VALUE, header.getValue());
-                headersArrayValue.append(messageHeader);
+                headerMap.put(header.getName(), header.getValue());
             }
-            return headersArrayValue;
+            return headerMap;
         }
         return null;
     }
@@ -354,10 +351,6 @@ public class EmailAccessUtil {
 
     private static ObjectValue createEntityObject() {
         return BallerinaValues.createObjectValue(PROTOCOL_MIME_PKG_ID, ENTITY);
-    }
-
-    private static MapValue createHeaderMap() {
-        return BallerinaValues.createRecordValue(EmailConstants.EMAIL_PACKAGE_ID, EmailConstants.HEADER);
     }
 
     private static String extractFromAddressFromMessage(Message message) throws MessagingException {

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailConstants.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailConstants.java
@@ -45,8 +45,6 @@ public class EmailConstants {
     public static final String MESSAGE_REPLY_TO = "replyTo";
     public static final String MESSAGE_ATTACHMENTS = "attachments";
     public static final String MESSAGE_HEADERS = "headers";
-    public static final String MESSAGE_HEADER_NAME = "name";
-    public static final String MESSAGE_HEADER_VALUE = "value";
 
     // Common constants to POP and IMAP
     public static final String PROPS_PROPERTIES = "properties";

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailConstants.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/EmailConstants.java
@@ -44,10 +44,11 @@ public class EmailConstants {
     public static final String MESSAGE_SENDER = "sender";
     public static final String MESSAGE_REPLY_TO = "replyTo";
     public static final String MESSAGE_ATTACHMENTS = "attachments";
+    public static final String MESSAGE_HEADERS = "headers";
+    public static final String MESSAGE_HEADER_NAME = "name";
+    public static final String MESSAGE_HEADER_VALUE = "value";
 
     // Common constants to POP and IMAP
-    public static final String KEY = "key";
-    public static final String VALUE = "value";
     public static final String PROPS_PROPERTIES = "properties";
     public static final String PROPS_SSL = "enableSsl";
     public static final String PROPS_HOST = "host";
@@ -103,6 +104,7 @@ public class EmailConstants {
 
     public static final String EMAIL = "Email";
     public static final String ERROR = "Error";
+    public static final String HEADER = "Header";
 
     private EmailConstants() {
         // private constructor

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -133,7 +133,25 @@ public class SmtpUtil {
         } else {
             addBodyAndAttachments(emailMessage, messageBody, bodyContentType, attachments);
         }
+        addMessageHeaders(emailMessage, message);
         return emailMessage;
+    }
+
+    private static void addMessageHeaders(MimeMessage emailMessage, MapValue message) throws MessagingException {
+        ArrayValue headers = message.getArrayValue(EmailConstants.MESSAGE_HEADERS);
+        if (headers != null) {
+            for (int i = 0; i < headers.size(); i++) {
+                Object headerObj = headers.get(i);
+                if (headerObj instanceof MapValue) {
+                    MapValue header = (MapValue) headerObj;
+                    String headerName = header.getStringValue(EmailConstants.MESSAGE_HEADER_NAME);
+                    String headerValue = header.getStringValue(EmailConstants.MESSAGE_HEADER_VALUE);
+                    if (isNotEmpty(headerName) && isNotEmpty(headerValue)) {
+                        emailMessage.addHeader(headerName, headerValue);
+                    }
+                }
+            }
+        }
     }
 
     private static void addBodyAndAttachments(MimeMessage emailMessage, String messageBody, String bodyContentType,

--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -138,18 +138,11 @@ public class SmtpUtil {
     }
 
     private static void addMessageHeaders(MimeMessage emailMessage, MapValue message) throws MessagingException {
-        ArrayValue headers = message.getArrayValue(EmailConstants.MESSAGE_HEADERS);
+        MapValue headers = message.getMapValue(EmailConstants.MESSAGE_HEADERS);
         if (headers != null) {
-            for (int i = 0; i < headers.size(); i++) {
-                Object headerObj = headers.get(i);
-                if (headerObj instanceof MapValue) {
-                    MapValue header = (MapValue) headerObj;
-                    String headerName = header.getStringValue(EmailConstants.MESSAGE_HEADER_NAME);
-                    String headerValue = header.getStringValue(EmailConstants.MESSAGE_HEADER_VALUE);
-                    if (isNotEmpty(headerName) && isNotEmpty(headerValue)) {
-                        emailMessage.addHeader(headerName, headerValue);
-                    }
-                }
+            String[] headerNames = (String[]) headers.getKeys();
+            for (String headerName : headerNames) {
+                emailMessage.addHeader(headerName, headers.getStringValue(headerName));
             }
         }
     }

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/ImapComplexEmailReceiveTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/ImapComplexEmailReceiveTest.java
@@ -145,8 +145,7 @@ public class ImapComplexEmailReceiveTest {
         assertEquals(new String(ATTACHMENT4_BINARY), result[10]);
         assertEquals(ATTACHMENT1_HEADER1_VALUE_TEXT, result[11]);
         Assert.assertTrue(result[12].startsWith(MimeConstants.TEXT_PLAIN));
-        assertEquals(HEADER1_NAME, result[13]);
-        assertEquals(HEADER1_VALUE, result[14]);
+        assertEquals(HEADER1_VALUE, result[13]);
     }
 
     private String concatAddresses(String[] addresses) {

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/ImapComplexEmailReceiveTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/ImapComplexEmailReceiveTest.java
@@ -63,12 +63,16 @@ public class ImapComplexEmailReceiveTest {
     private static final String EMAIL_USER_ADDRESS = "hascode@localhost";
     private static final String EMAIL_FROM = "someone@localhost.com";
     private static final String EMAIL_SENDER = "someone2@localhost.com";
+    private static final String EMAIL_SUBJECT = "Test E-Mail";
+    private static final String EMAIL_TEXT = "This is a test e-mail.";
+    private static final String HEADER1_NAME = "header1_name";
+    private static final String HEADER1_VALUE = "header1_value";
     private static final String ATTACHMENT1_TEXT = "Sample attachment text";
     private static final String ATTACHMENT2_TEXT = "{\"bodyPart\":\"jsonPart\"}";
     private static final String ATTACHMENT3_TEXT = "<name>Ballerina xml file part</name>";
     private static final byte[] ATTACHMENT4_BINARY = "This is a sample source of bytes.".getBytes();
-    private static final String EMAIL_SUBJECT = "Test E-Mail";
-    private static final String EMAIL_TEXT = "This is a test e-mail.";
+    private static final String ATTACHMENT1_HEADER1_NAME_TEXT = "H1";
+    private static final String ATTACHMENT1_HEADER1_VALUE_TEXT = "V1";
     private static final String[] EMAIL_TO_ADDRESSES = {"hascode1@localhost", "hascode2@localhost"};
     private static final String[] EMAIL_CC_ADDRESSES = {"hascode3@localhost", "hascode4@localhost"};
     private static final String[] EMAIL_BCC_ADDRESSES = {"hascode5@localhost", "hascode6@localhost"};
@@ -101,6 +105,7 @@ public class ImapComplexEmailReceiveTest {
         MimeBodyPart attachment3 = new MimeBodyPart();
         MimeBodyPart attachment4 = new MimeBodyPart();
         attachment1.setContent(ATTACHMENT1_TEXT, MimeConstants.TEXT_PLAIN);
+        attachment1.addHeader(ATTACHMENT1_HEADER1_NAME_TEXT, ATTACHMENT1_HEADER1_VALUE_TEXT);
         attachment2.setContent(ATTACHMENT2_TEXT, MimeConstants.APPLICATION_JSON);
         attachment3.setContent(ATTACHMENT3_TEXT, MimeConstants.APPLICATION_XML);
         attachment4.setContent(ATTACHMENT4_BINARY, MimeConstants.OCTET_STREAM);
@@ -110,6 +115,7 @@ public class ImapComplexEmailReceiveTest {
         multipartMessage.addBodyPart(attachment3);
         multipartMessage.addBodyPart(attachment4);
         message.setContent(multipartMessage);
+        message.addHeader(HEADER1_NAME, HEADER1_VALUE);
 
         // Use greenmail to store the message
         user.deliver(message);
@@ -137,10 +143,14 @@ public class ImapComplexEmailReceiveTest {
         assertEquals(ATTACHMENT2_TEXT, result[8]);
         assertEquals(ATTACHMENT3_TEXT, result[9]);
         assertEquals(new String(ATTACHMENT4_BINARY), result[10]);
+        assertEquals(ATTACHMENT1_HEADER1_VALUE_TEXT, result[11]);
+        Assert.assertTrue(result[12].startsWith(MimeConstants.TEXT_PLAIN));
+        assertEquals(HEADER1_NAME, result[13]);
+        assertEquals(HEADER1_VALUE, result[14]);
     }
 
     private String concatAddresses(String[] addresses) {
-        StringBuilder stringBuilder = new StringBuilder("");
+        StringBuilder stringBuilder = new StringBuilder();
         for (String address : addresses) {
             stringBuilder.append(address);
         }

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/PopComplexEmailReceiveTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/PopComplexEmailReceiveTest.java
@@ -145,8 +145,7 @@ public class PopComplexEmailReceiveTest {
         assertEquals(new String(ATTACHMENT4_BINARY), result[10]);
         assertEquals(ATTACHMENT1_HEADER1_VALUE_TEXT, result[11]);
         Assert.assertTrue(result[12].startsWith(MimeConstants.TEXT_PLAIN));
-        assertEquals(HEADER1_NAME, result[13]);
-        assertEquals(HEADER1_VALUE, result[14]);
+        assertEquals(HEADER1_VALUE, result[13]);
     }
 
     private String concatAddresses(String[] addresses) {

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/PopComplexEmailReceiveTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/PopComplexEmailReceiveTest.java
@@ -65,6 +65,8 @@ public class PopComplexEmailReceiveTest {
     private static final String EMAIL_SENDER = "someone2@localhost.com";
     private static final String EMAIL_SUBJECT = "Test E-Mail";
     private static final String EMAIL_TEXT = "This is a test e-mail.";
+    private static final String HEADER1_NAME = "header1_name";
+    private static final String HEADER1_VALUE = "header1_value";
     private static final String ATTACHMENT1_TEXT = "Sample attachment text";
     private static final String ATTACHMENT2_TEXT = "{\"bodyPart\":\"jsonPart\"}";
     private static final String ATTACHMENT3_TEXT = "<name>Ballerina xml file part</name>";
@@ -113,6 +115,7 @@ public class PopComplexEmailReceiveTest {
         multipartMessage.addBodyPart(attachment3);
         multipartMessage.addBodyPart(attachment4);
         message.setContent(multipartMessage);
+        message.addHeader(HEADER1_NAME, HEADER1_VALUE);
 
         // Use greenmail to store the message
         user.deliver(message);
@@ -142,6 +145,8 @@ public class PopComplexEmailReceiveTest {
         assertEquals(new String(ATTACHMENT4_BINARY), result[10]);
         assertEquals(ATTACHMENT1_HEADER1_VALUE_TEXT, result[11]);
         Assert.assertTrue(result[12].startsWith(MimeConstants.TEXT_PLAIN));
+        assertEquals(HEADER1_NAME, result[13]);
+        assertEquals(HEADER1_VALUE, result[14]);
     }
 
     private String concatAddresses(String[] addresses) {

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/SmtpComplexEmailSendTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/SmtpComplexEmailSendTest.java
@@ -82,6 +82,8 @@ public class SmtpComplexEmailSendTest {
     private static final String EMAIL_SUBJECT = "Test E-Mail";
     private static final String EMAIL_TEXT = "This is a test e-mail.";
     private static final String EMAIL_CONTENT_TYPE = "text/html";
+    private static final String HEADER1_NAME = "header1_name";
+    private static final String HEADER1_VALUE = "header1_value";
     private static final String[] EMAIL_TO_ADDRESSES = {"hascode1@localhost", "hascode2@localhost"};
     private static final String[] EMAIL_CC_ADDRESSES = {"hascode3@localhost", "hascode4@localhost"};
     private static final String[] EMAIL_BCC_ADDRESSES = {"hascode5@localhost", "hascode6@localhost"};
@@ -131,6 +133,7 @@ public class SmtpComplexEmailSendTest {
             testAttachment5((MimeBodyPart) multiPart.getBodyPart(5));
             testAttachment6((MimeBodyPart) multiPart.getBodyPart(6));
 
+            assertEquals(HEADER1_VALUE, message.getHeader(HEADER1_NAME)[0]);
             assertEquals(EMAIL_FROM, message.getFrom()[0].toString());
             assertEquals(EMAIL_SENDER, message.getSender().toString());
             assertTrue(containAddresses(message.getRecipients(Message.RecipientType.TO), EMAIL_TO_ADDRESSES));

--- a/stdlib/email/src/test/resources/test-src/ImapComplexEmailReceive.bal
+++ b/stdlib/email/src/test/resources/test-src/ImapComplexEmailReceive.bal
@@ -64,6 +64,22 @@ function testReceiveComplexEmail(string host, string username, string password) 
                 } else {
                     return [];
                 }
+                returnArray[11] = attachments[0].getHeader("H1");
+                returnArray[12] = attachments[0].getContentType();
+                email:Header[]? headers = emailResponse?.headers;
+                if (headers is email:Header[]) {
+                    foreach var header in headers {
+                        json? tmpHeader = header;
+                        if (!(tmpHeader is error?)) {
+                            json|error name = tmpHeader.name;
+                            json|error value = tmpHeader.value;
+                            if (name is string && name == "header1_name" && value is string) {
+                                returnArray[13] = <string>name;
+                                returnArray[14] = <string>value;
+                            }
+                        }
+                    }
+                }
             }
             return returnArray;
         } else if (emailResponse is ()) {
@@ -76,9 +92,9 @@ function testReceiveComplexEmail(string host, string username, string password) 
     }
 }
 
-function getNonNilString(string? sender) returns string {
-    if sender is string {
-        return sender;
+function getNonNilString(string? nilableString) returns string {
+    if nilableString is string {
+        return nilableString;
     } else {
         return "";
     }

--- a/stdlib/email/src/test/resources/test-src/ImapComplexEmailReceive.bal
+++ b/stdlib/email/src/test/resources/test-src/ImapComplexEmailReceive.bal
@@ -66,18 +66,11 @@ function testReceiveComplexEmail(string host, string username, string password) 
                 }
                 returnArray[11] = attachments[0].getHeader("H1");
                 returnArray[12] = attachments[0].getContentType();
-                email:Header[]? headers = emailResponse?.headers;
-                if (headers is email:Header[]) {
-                    foreach var header in headers {
-                        json? tmpHeader = header;
-                        if (!(tmpHeader is error?)) {
-                            json|error name = tmpHeader.name;
-                            json|error value = tmpHeader.value;
-                            if (name is string && name == "header1_name" && value is string) {
-                                returnArray[13] = <string>name;
-                                returnArray[14] = <string>value;
-                            }
-                        }
+                json? headers = emailResponse?.headers;
+                if (!(headers is ())) {
+                    json|error headerValue = headers.header1_name;
+                    if (headerValue is json && !(headerValue is ())) {
+                        returnArray[13] = <string>headerValue;
                     }
                 }
             }

--- a/stdlib/email/src/test/resources/test-src/PopComplexEmailReceive.bal
+++ b/stdlib/email/src/test/resources/test-src/PopComplexEmailReceive.bal
@@ -66,18 +66,11 @@ function testReceiveComplexEmail(string host, string username, string password) 
                 }
                 returnArray[11] = attachments[0].getHeader("H1");
                 returnArray[12] = attachments[0].getContentType();
-                email:Header[]? headers = emailResponse?.headers;
-                if (headers is email:Header[]) {
-                    foreach var header in headers {
-                        json? tmpHeader = header;
-                        if (!(tmpHeader is error?)) {
-                            json|error name = tmpHeader.name;
-                            json|error value = tmpHeader.value;
-                            if (name is string && name == "header1_name" && value is string) {
-                                returnArray[13] = <string>name;
-                                returnArray[14] = <string>value;
-                            }
-                        }
+                json? headers = emailResponse?.headers;
+                if (!(headers is ())) {
+                    json|error headerValue = headers.header1_name;
+                    if (headerValue is json && !(headerValue is ())) {
+                        returnArray[13] = <string>headerValue;
                     }
                 }
             }

--- a/stdlib/email/src/test/resources/test-src/PopComplexEmailReceive.bal
+++ b/stdlib/email/src/test/resources/test-src/PopComplexEmailReceive.bal
@@ -66,6 +66,20 @@ function testReceiveComplexEmail(string host, string username, string password) 
                 }
                 returnArray[11] = attachments[0].getHeader("H1");
                 returnArray[12] = attachments[0].getContentType();
+                email:Header[]? headers = emailResponse?.headers;
+                if (headers is email:Header[]) {
+                    foreach var header in headers {
+                        json? tmpHeader = header;
+                        if (!(tmpHeader is error?)) {
+                            json|error name = tmpHeader.name;
+                            json|error value = tmpHeader.value;
+                            if (name is string && name == "header1_name" && value is string) {
+                                returnArray[13] = <string>name;
+                                returnArray[14] = <string>value;
+                            }
+                        }
+                    }
+                }
             }
             return returnArray;
         } else if (emailResponse is ()) {
@@ -78,9 +92,9 @@ function testReceiveComplexEmail(string host, string username, string password) 
     }
 }
 
-function getNonNilString(string? sender) returns string {
-    if sender is string {
-        return sender;
+function getNonNilString(string? nilableString) returns string {
+    if nilableString is string {
+        return nilableString;
     } else {
         return "";
     }

--- a/stdlib/email/src/test/resources/test-src/SmtpComplexEmailSend.bal
+++ b/stdlib/email/src/test/resources/test-src/SmtpComplexEmailSend.bal
@@ -76,11 +76,13 @@ function testSendComplexEmail(string host, string username, string password, str
         subject: subject,
         body: body,
         contentType: contentType,
+        headers: [{name: "header1_name", value: "header1_value"}],
         'from: fromAddress,
         sender: sender,
         replyTo: replyToAddresses,
         attachments: bodyParts
     };
+
     if (smtpClient is email:SmtpClient) {
         return smtpClient->send(email);
     } else {

--- a/stdlib/email/src/test/resources/test-src/SmtpComplexEmailSend.bal
+++ b/stdlib/email/src/test/resources/test-src/SmtpComplexEmailSend.bal
@@ -76,7 +76,7 @@ function testSendComplexEmail(string host, string username, string password, str
         subject: subject,
         body: body,
         contentType: contentType,
-        headers: [{name: "header1_name", value: "header1_value"}],
+        headers: {header1_name: "header1_value"},
         'from: fromAddress,
         sender: sender,
         replyTo: replyToAddresses,


### PR DESCRIPTION
## Purpose
Custom email headers should be set when sending an email and should receive all the email headers when receiving/listening.

Fixes #23342

## Approach
Add the `headers` field to `email:Email` record with custom headers to be sent. Receive/listen the email with all the headers in the `headers` field in `email:Email` record.

## Samples
Modify the `email` record as follows to send custom email headers.

 ```ballerina
   email:Email email = {
        to: toAddresses,
        cc: ccAddresses,
        bcc: bccAddresses,
        subject: subject,
        body: body,
        contentType: contentType,
        headers: {header1_name: "header1_value"},
        'from: fromAddress,
        sender: sender,
        replyTo: replyToAddresses,
        attachments: bodyParts
    };
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
