### PR TITLE
Fix annotations not being loaded in a module's tests

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -745,14 +745,12 @@ public class JvmMethodGen {
 
     private static boolean isModuleInitFunction(BIRPackage module, BIRFunction func) {
 
-        String moduleInit = getModuleInitFuncName(module);
-        return func.name.value.equals(moduleInit);
+        return func.name.value.equals(calculateModuleInitFuncName(packageToModuleId(module)));
     }
 
-    // TODO: remove and use calculateModuleInitFuncName
-    private static String getModuleInitFuncName(BIRPackage module) {
+    private static boolean isModuleTestInitFunction(BIRPackage module, BIRFunction func) {
 
-        return calculateModuleInitFuncName(packageToModuleId(module));
+        return func.name.value.equals(calculateModuleSpecialFuncName(packageToModuleId(module), "<testinit>"));
     }
 
     private static String calculateModuleInitFuncName(PackageID id) {
@@ -1916,7 +1914,8 @@ public class JvmMethodGen {
             // process terminator
             if (!isArg || (!(terminator instanceof Return))) {
                 generateDiagnosticPos(terminator.pos, mv);
-                if (isModuleInitFunction(module, func) && terminator instanceof Return) {
+                if ((isModuleInitFunction(module, func) || isModuleTestInitFunction(module, func)) &&
+                        terminator instanceof Return) {
                     generateAnnotLoad(mv, module.typeDefs, getPackageName(module.org.value, module.name.value));
                 }
                 termGen.genTerminator(terminator, func, funcName, localVarOffset, returnVarRefIndex, attachedType,

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/AnnotationAccessTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/AnnotationAccessTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.testerina.test;
+
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Test class to test annotation access in the source and tests of a module.
+ *
+ * @since 2.0.0
+ */
+public class AnnotationAccessTest extends BaseTestCase {
+
+    private BMainInstance balClient;
+    private String projectPath;
+
+    @BeforeClass
+    public void setup() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+        projectPath = basicTestsProjectPath.toString();
+    }
+
+    @Test
+    public void testAssertTrue() throws BallerinaTestException {
+        LogLeecher passingLeecher = new LogLeecher("3 passing");
+        LogLeecher failingLeecher = new LogLeecher("0 failing");
+        balClient.runMain("test", new String[]{"annotation-access"}, null, new String[0],
+                          new LogLeecher[]{passingLeecher, failingLeecher}, projectPath);
+        passingLeecher.waitForText(20000);
+        failingLeecher.waitForText(20000);
+    }
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/annotation-access/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/annotation-access/main.bal
@@ -1,0 +1,33 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public type Annotation record {
+    int id;
+};
+
+public annotation Annotation ann on type;
+
+@ann {
+	id: 100
+}
+public type Foo record {
+	 string s;
+};
+
+public function getFooAnnotId() returns int? {
+    typedesc<any> td = Foo;
+    return td.@ann?.id;
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/annotation-access/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/annotation-access/tests/main_test.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@ann {
+    id: 1
+}
+type Employee record {
+    int id;
+};
+
+annotation testAnnot on function, object type;
+
+function foo() {
+}
+
+@testAnnot
+type Bar object {
+
+};
+
+@test:Config {}
+function testTestConstructSrcAnnotAccess() {
+    Employee e = {
+        id: 4567
+    };
+
+    typedesc<Employee> td = typeof e;
+    test:assertEquals(td.@ann?.id, 1);
+}
+
+@test:Config {}
+function testTestConstructTestAnnotAccess() {
+    typedesc<any> tdFoo = typeof foo;
+    test:assertEquals(tdFoo.@testAnnot, ());
+
+    typedesc<any> tdBar = Bar;
+    test:assertEquals(tdBar.@testAnnot, true);
+}
+
+@test:Config {}
+function testTestSrcConstructSrcAnnotAccess() {
+    test:assertEquals(getFooAnnotId(), 100);
+}

--- a/tests/testerina-integration-test/src/test/resources/testng.xml
+++ b/tests/testerina-integration-test/src/test/resources/testng.xml
@@ -39,6 +39,7 @@ under the License.
             <class name="org.ballerinalang.testerina.test.MockTest" />
             <class name="org.ballerinalang.testerina.test.ServicesTest" />
             <class name="org.ballerinalang.testerina.test.TestReportTest" />
+            <class name="org.ballerinalang.testerina.test.AnnotationAccessTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
$title. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/23043

## Approach
This did not work earlier since annotations were loaded only if the function name is "\<init>" whereas for the test module's init the name seems to be "\<testinit>".

See https://github.com/ballerina-platform/ballerina-lang/issues/23043#issuecomment-622419746 for details.

This fix checks for "\<testinit>" in addition to "\<init>".

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
