### PR TITLE
Make types of readonly fields a readonly intersection type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -208,7 +208,6 @@ public enum DiagnosticCode {
     OPEN_RECORD_CONSTRAINT_NOT_ALLOWED("open.record.constraint.not.allowed"),
     INVALID_RECORD_REST_DESCRIPTOR("invalid.record.rest.descriptor"),
     MISSING_REQUIRED_RECORD_FIELD("missing.required.record.field"),
-    INVALID_FIELD_FOR_READONLY_RECORD_FIELD("invalid.field.for.readonly.record.field"),
     DEFAULT_VALUES_NOT_ALLOWED_FOR_OPTIONAL_FIELDS("default.values.not.allowed.for.optional.fields"),
     INVALID_FUNCTION_POINTER_INVOCATION("invalid.function.pointer.invocation"),
     AMBIGUOUS_TYPES("ambiguous.type"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -516,6 +516,27 @@ public class BLangPackageBuilder {
         }
 
         if (isReadonly) {
+            BLangType typeNode = field.typeNode;
+            Set<Whitespace> typeNodeWS = typeNode.getWS();
+            DiagnosticPos typeNodePos = typeNode.getPosition();
+
+            BLangValueType readOnlyTypeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
+            readOnlyTypeNode.addWS(typeNodeWS);
+            readOnlyTypeNode.pos = typeNodePos;
+            readOnlyTypeNode.typeKind = (TreeUtils.stringToTypeKind("readonly"));
+
+            if (typeNode.getKind() == NodeKind.INTERSECTION_TYPE_NODE) {
+                ((BLangIntersectionTypeNode) typeNode).constituentTypeNodes.add(readOnlyTypeNode);
+            } else {
+                BLangIntersectionTypeNode intersectionTypeNode =
+                        (BLangIntersectionTypeNode) TreeBuilder.createIntersectionTypeNode();
+                intersectionTypeNode.constituentTypeNodes.add(typeNode);
+                intersectionTypeNode.constituentTypeNodes.add(readOnlyTypeNode);
+                intersectionTypeNode.addWS(typeNodeWS);
+                intersectionTypeNode.pos = typeNodePos;
+                field.typeNode = intersectionTypeNode;
+            }
+
             field.flagSet.add(Flag.READONLY);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -1530,8 +1530,6 @@ public class TypeChecker extends BLangNodeVisitor {
         boolean hasAllRequiredFields = true;
         boolean hasValidReadonlyFields = true;
 
-        boolean mutableRecordType = !Symbols.isFlagOn(type.flags, Flags.READONLY);
-
         for (BField field : type.fields.values()) {
             String fieldName = field.name.value;
 
@@ -1541,11 +1539,6 @@ public class TypeChecker extends BLangNodeVisitor {
                 if (!Symbols.isFlagOn(field.symbol.flags, Flags.READONLY) ||
                         types.isAssignable(typePosPair.type, symTable.readonlyType)) {
                     continue;
-                }
-
-                if (mutableRecordType && !Symbols.isFlagOn(field.type.flags, Flags.READONLY)) {
-                    // If the expected field type itself is readonly, an error would be logged already.
-                    dlog.error(typePosPair.pos, DiagnosticCode.INVALID_FIELD_FOR_READONLY_RECORD_FIELD, fieldName);
                 }
 
                 if (hasValidReadonlyFields) {

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -368,9 +368,6 @@ error.invalid.record.rest.descriptor=\
 error.missing.required.record.field=\
   missing non-defaultable required record field ''{0}''
 
-error.invalid.field.for.readonly.record.field=\
-  invalid field: ''readonly'' field expected for ''{0}''
-
 error.default.values.not.allowed.for.optional.fields=\
   a default value specified for optional field ''{0}''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
@@ -46,7 +46,7 @@ public class ReadonlyRecordFieldTest {
 
         validateError(result, index++, "cannot update 'readonly' record field 'name' in 'Student'", 27, 5);
         validateError(result, index++, "cannot update 'readonly' record field 'name' in 'Student'", 28, 5);
-        validateError(result, index++, "invalid field: 'readonly' field expected for 'details'", 52, 9);
+        validateError(result, index++, "incompatible types: expected 'Details & readonly', found 'Details'", 52, 9);
         validateError(result, index++, "cannot update 'readonly' record field 'details' in 'Employee'", 56, 5);
         validateError(result, index++, "cannot update 'readonly' record field 'details' in 'Employee'", 57, 5);
         validateError(result, index++, "cannot update 'readonly' record field 'details' in 'Employee'", 58, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -62,7 +62,8 @@ public class SelectivelyImmutableTypeTest {
         validateError(result, index++, "incompatible types: expected 'PersonalDetails & readonly', found " +
                 "'PersonalDetails'", 60, 18);
         validateError(result, index++, "incompatible types: expected '(A|B|any & readonly)', found 'Obj'", 78, 26);
-        validateError(result, index++, "invalid field: 'readonly' field expected for 'details'", 105, 18);
+        validateError(result, index++, "incompatible types: expected 'PersonalDetails & readonly', found " +
+                "'PersonalDetails'", 105, 18);
         validateError(result, index++, "incompatible types: expected 'Department & readonly' for field 'dept', found " +
                 "'Department'", 106, 12);
 


### PR DESCRIPTION
## Purpose
$title.

Fixes #23257

## Approach
If `readonly` is used in the individual-field-type-descriptor, a `BLangIntersectionTypeNode` with `readonly` as a constituent type node is set as the field's type node at package builder.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
