### PR TITLE
Add support for using variable references in extern functions' return types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -536,6 +536,8 @@ public enum DiagnosticCode {
     INVALID_WAIT_MAPPING_CONSTRUCTORS("invalid.wait.future.expr.mapping.constructors"),
     INVALID_WAIT_ACTIONS("invalid.wait.future.expr.actions"),
     INVALID_SEND_EXPR("invalid.send.expr"),
+
+    INVALID_RETURN_TYPE_PARAMETERIZATION("invalid.return.type.parameterization")
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -537,7 +537,8 @@ public enum DiagnosticCode {
     INVALID_WAIT_ACTIONS("invalid.wait.future.expr.actions"),
     INVALID_SEND_EXPR("invalid.send.expr"),
 
-    INVALID_RETURN_TYPE_PARAMETERIZATION("invalid.return.type.parameterization")
+    INVALID_RETURN_TYPE_PARAMETERIZATION("invalid.return.type.parameterization"),
+    INVALID_TYPEDESC_PARAM("invalid.typedesc.param")
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -538,7 +538,8 @@ public enum DiagnosticCode {
     INVALID_SEND_EXPR("invalid.send.expr"),
 
     INVALID_RETURN_TYPE_PARAMETERIZATION("invalid.return.type.parameterization"),
-    INVALID_TYPEDESC_PARAM("invalid.typedesc.param")
+    INVALID_TYPEDESC_PARAM("invalid.typedesc.param"),
+    TYPEDESC_PARAM_NOT_FOUND("typedesc.param.not.found")
     ;
     private String value;
 

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -537,7 +537,7 @@ public enum DiagnosticCode {
     INVALID_WAIT_ACTIONS("invalid.wait.future.expr.actions"),
     INVALID_SEND_EXPR("invalid.send.expr"),
 
-    INVALID_RETURN_TYPE_PARAMETERIZATION("invalid.return.type.parameterization"),
+    INVALID_USE_OF_TYPEDESC_PARAM("invalid.use.of.typedesc.param"),
     INVALID_TYPEDESC_PARAM("invalid.typedesc.param"),
     TYPEDESC_PARAM_NOT_FOUND("typedesc.param.not.found")
     ;

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -538,9 +538,8 @@ public enum DiagnosticCode {
     INVALID_SEND_EXPR("invalid.send.expr"),
 
     INVALID_USE_OF_TYPEDESC_PARAM("invalid.use.of.typedesc.param"),
-    INVALID_TYPEDESC_PARAM("invalid.typedesc.param"),
-    TYPEDESC_PARAM_NOT_FOUND("typedesc.param.not.found")
-    ;
+    INVALID_PARAM_TYPE_FOR_RETURN_TYPE("invalid.param.type.for.return.type"),
+    INVALID_TYPEDESC_PARAM("invalid.typedesc.param");
     private String value;
 
     DiagnosticCode(String value) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -102,7 +102,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import static org.wso2.ballerinalang.util.LambdaExceptionUtils.rethrow;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -812,6 +812,7 @@ public class BIRPackageSymbolEnter {
                             names.fromString(recordName), env.pkgSymbol.pkgID, null, env.pkgSymbol);
                     recordSymbol.scope = new Scope(recordSymbol);
                     BRecordType recordType = new BRecordType(recordSymbol);
+                    recordType.flags = flags;
                     recordSymbol.type = recordType;
 
                     compositeStack.push(recordType);
@@ -872,10 +873,12 @@ public class BIRPackageSymbolEnter {
                 case TypeTags.TYPEDESC:
                     BTypedescType typedescType = new BTypedescType(null, symTable.typeDesc.tsymbol);
                     typedescType.constraint = readTypeFromCp();
+                    typedescType.flags = flags;
                     return typedescType;
                 case TypeTags.STREAM:
                     BStreamType bStreamType = new BStreamType(TypeTags.STREAM, null, null, symTable.streamType.tsymbol);
                     bStreamType.constraint = readTypeFromCp();
+                    bStreamType.flags = flags;
                     boolean hasError = inputStream.readByte() == 1;
                     if (hasError) {
                         bStreamType.error = readTypeFromCp();
@@ -883,6 +886,7 @@ public class BIRPackageSymbolEnter {
                     return bStreamType;
                 case TypeTags.TABLE:
                     BTableType bTableType = new BTableType(TypeTags.TABLE, null, symTable.tableType.tsymbol);
+                    bTableType.flags = flags;
                     bTableType.constraint = readTypeFromCp();
                     boolean hasFieldNameList = inputStream.readByte() == 1;
                     boolean hasKeyConstraint = inputStream.readByte() == 1;
@@ -908,6 +912,7 @@ public class BIRPackageSymbolEnter {
                 case TypeTags.MAP:
                     BMapType bMapType = new BMapType(TypeTags.MAP, null, symTable.mapType.tsymbol);
                     bMapType.constraint = readTypeFromCp();
+                    bMapType.flags = flags;
                     return bMapType;
                 case TypeTags.INVOKABLE:
                     BInvokableType bInvokableType = new BInvokableType(null, null, null, null);
@@ -940,6 +945,7 @@ public class BIRPackageSymbolEnter {
                             .of(Flag.PUBLIC)), Names.EMPTY, env.pkgSymbol.pkgID, null, env.pkgSymbol.owner);
                     BArrayType bArrayType = new BArrayType(null, arrayTypeSymbol, size, BArrayState.valueOf(state));
                     bArrayType.eType = readTypeFromCp();
+                    bArrayType.flags = flags;
                     return bArrayType;
                 case TypeTags.UNION:
                     BTypeSymbol unionTypeSymbol = Symbols.createTypeSymbol(SymTag.UNION_TYPE, Flags.asMask(EnumSet
@@ -950,6 +956,7 @@ public class BIRPackageSymbolEnter {
                     for (int i = 0; i < unionMemberCount; i++) {
                         unionType.add(readTypeFromCp());
                     }
+                    unionType.flags = flags;
                     return unionType;
                 case TypeTags.INTERSECTION:
                     BTypeSymbol intersectionTypeSymbol = Symbols.createTypeSymbol(SymTag.INTERSECTION_TYPE,
@@ -994,6 +1001,7 @@ public class BIRPackageSymbolEnter {
                     BType detailsType = readTypeFromCp();
                     errorType.reasonType = reasonType;
                     errorType.detailType = detailsType;
+                    errorType.flags = flags;
                     errorSymbol.type = errorType;
                     errorSymbol.pkgID = pkgId;
                     errorSymbol.name = names.fromString(errorName);
@@ -1012,6 +1020,7 @@ public class BIRPackageSymbolEnter {
                     BTypeSymbol tupleTypeSymbol = Symbols.createTypeSymbol(SymTag.TUPLE_TYPE, Flags.asMask(EnumSet
                             .of(Flag.PUBLIC)), Names.EMPTY, env.pkgSymbol.pkgID, null, env.pkgSymbol.owner);
                     BTupleType bTupleType = new BTupleType(tupleTypeSymbol, null);
+                    bTupleType.flags = flags;
                     int tupleMemberCount = inputStream.readInt();
                     List<BType> tupleMemberTypes = new ArrayList<>();
                     for (int i = 0; i < tupleMemberCount; i++) {
@@ -1022,6 +1031,7 @@ public class BIRPackageSymbolEnter {
                 case TypeTags.FUTURE:
                     BFutureType bFutureType = new BFutureType(TypeTags.FUTURE, null, symTable.futureType.tsymbol);
                     bFutureType.constraint = readTypeFromCp();
+                    bFutureType.flags = flags;
                     return bFutureType;
                 case TypeTags.FINITE:
                     String finiteTypeName = getStringCPEntryValue(inputStream);
@@ -1030,6 +1040,7 @@ public class BIRPackageSymbolEnter {
                             names.fromString(finiteTypeName), env.pkgSymbol.pkgID, null, env.pkgSymbol);
                     symbol.scope = new Scope(symbol);
                     BFiniteType finiteType = new BFiniteType(symbol);
+                    finiteType.flags = flags;
                     symbol.type = finiteType;
                     int valueSpaceSize = inputStream.readInt();
                     for (int i = 0; i < valueSpaceSize; i++) {
@@ -1056,6 +1067,7 @@ public class BIRPackageSymbolEnter {
                     } else {
                         objectType = new BObjectType(objectSymbol);
                     }
+                    objectType.flags = flags;
                     objectSymbol.type = objectType;
                     addShapeCP(objectType, cpI);
                     compositeStack.push(objectType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -503,7 +503,7 @@ public class BIRGen extends BLangNodeVisitor {
 
         // TODO: Return variable with NIL type should be written to BIR
         // Special %0 location for storing return values
-        BType retType = typeBuilder.buildType(astFunc.symbol.type.getReturnType(), astFunc.symbol.type.tsymbol);
+        BType retType = typeBuilder.buildType(astFunc.symbol.type.getReturnType());
         birFunc.returnVariable = new BIRVariableDcl(astFunc.pos, retType, this.env.nextLocalVarId(names),
                                                     VarScope.FUNCTION, VarKind.RETURN, null);
         birFunc.localVars.add(0, birFunc.returnVariable);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -157,10 +157,10 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerUtils;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.programfile.CompiledBinaryFile.BIRPackageFile;
@@ -214,7 +214,7 @@ public class BIRGen extends BLangNodeVisitor {
     // Required variables for Mock function implementation
     private static final String MOCK_ANNOTATION_DELIMITER = "#";
 
-    private ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
+    private ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
 
     public static BIRGen getInstance(CompilerContext context) {
         BIRGen birGen = context.get(BIR_GEN);
@@ -503,7 +503,7 @@ public class BIRGen extends BLangNodeVisitor {
 
         // TODO: Return variable with NIL type should be written to BIR
         // Special %0 location for storing return values
-        BType retType = typeBuilder.buildType(astFunc.symbol.type.getReturnType());
+        BType retType = typeBuilder.build(astFunc.symbol.type.getReturnType());
         birFunc.returnVariable = new BIRVariableDcl(astFunc.pos, retType, this.env.nextLocalVarId(names),
                                                     VarScope.FUNCTION, VarKind.RETURN, null);
         birFunc.localVars.add(0, birFunc.returnVariable);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -157,6 +157,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerUtils;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -212,6 +213,8 @@ public class BIRGen extends BLangNodeVisitor {
 
     // Required variables for Mock function implementation
     private static final String MOCK_ANNOTATION_DELIMITER = "#";
+
+    private ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
 
     public static BIRGen getInstance(CompilerContext context) {
         BIRGen birGen = context.get(BIR_GEN);
@@ -500,8 +503,9 @@ public class BIRGen extends BLangNodeVisitor {
 
         // TODO: Return variable with NIL type should be written to BIR
         // Special %0 location for storing return values
-        birFunc.returnVariable = new BIRVariableDcl(astFunc.pos, astFunc.symbol.type.getReturnType(),
-                this.env.nextLocalVarId(names), VarScope.FUNCTION, VarKind.RETURN, null);
+        BType retType = typeBuilder.buildType(astFunc.symbol.type.getReturnType(), astFunc.symbol.type.tsymbol);
+        birFunc.returnVariable = new BIRVariableDcl(astFunc.pos, retType, this.env.nextLocalVarId(names),
+                                                    VarScope.FUNCTION, VarKind.RETURN, null);
         birFunc.localVars.add(0, birFunc.returnVariable);
 
         //add closure vars

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -1552,7 +1552,6 @@ public class JvmMethodGen {
 
         BIRVariableDcl varDcl = getVariableDcl(localVars.get(0));
         returnVarRefIndex = indexMap.getIndex(varDcl);
-//        BType returnType = func.type.retType;
         genDefaultValue(mv, retType, returnVarRefIndex);
 
         BIRVariableDcl stateVar = new BIRVariableDcl(symbolTable.stringType, //should  be javaInt

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -233,18 +233,17 @@ import static org.wso2.ballerinalang.compiler.bir.model.InstructionKind.FP_LOAD;
 public class JvmMethodGen {
 
     private static final FunctionParamComparator FUNCTION_PARAM_COMPARATOR = new FunctionParamComparator();
+    private static ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
     private int nextId = -1;
     private int nextVarId = -1;
     private JvmPackageGen jvmPackageGen;
     private SymbolTable symbolTable;
-    private ConcreteBTypeBuilder typeBuilder;
     private BUnionType errorOrNilType;
 
     public JvmMethodGen(JvmPackageGen jvmPackageGen) {
 
         this.jvmPackageGen = jvmPackageGen;
         this.symbolTable = jvmPackageGen.symbolTable;
-        this.typeBuilder = new ConcreteBTypeBuilder();
         this.errorOrNilType = BUnionType.create(null, symbolTable.errorType, symbolTable.nilType);
     }
 
@@ -1106,6 +1105,7 @@ public class JvmMethodGen {
     }
 
     private static String generateReturnType(BType bType, boolean isExtern /* = false */) {
+        bType = typeBuilder.buildType(bType);
 
         if (bType == null || bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
             if (isExtern) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -66,8 +66,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.util.Flags;
@@ -233,7 +233,7 @@ import static org.wso2.ballerinalang.compiler.bir.model.InstructionKind.FP_LOAD;
 public class JvmMethodGen {
 
     private static final FunctionParamComparator FUNCTION_PARAM_COMPARATOR = new FunctionParamComparator();
-    private static ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
+    private static ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
     private int nextId = -1;
     private int nextVarId = -1;
     private JvmPackageGen jvmPackageGen;
@@ -1105,7 +1105,7 @@ public class JvmMethodGen {
     }
 
     private static String generateReturnType(BType bType, boolean isExtern /* = false */) {
-        bType = typeBuilder.buildType(bType);
+        bType = typeBuilder.build(bType);
 
         if (bType == null || bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
             if (isExtern) {
@@ -1476,7 +1476,7 @@ public class JvmMethodGen {
         // generate method desc
         BType retType = func.type.retType;
         if (isExternFunc(func) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(func.type.retType);
+            retType = typeBuilder.build(func.type.retType);
         }
 
         String desc = getMethodDesc(func.type.paramTypes, retType, null, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -57,6 +57,7 @@ import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
@@ -1474,8 +1475,8 @@ public class JvmMethodGen {
 
         // generate method desc
         BType retType = func.type.retType;
-        if (isExternFunc(func) && !func.type.paramTypes.isEmpty()) {
-            retType = typeBuilder.buildType(func.type.retType, null);
+        if (isExternFunc(func) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
+            retType = typeBuilder.buildType(func.type.retType);
         }
 
         String desc = getMethodDesc(func.type.paramTypes, retType, null, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -1476,7 +1476,7 @@ public class JvmMethodGen {
         // generate method desc
         BType retType = func.type.retType;
         if (isExternFunc(func) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(func.type.retType);
+            retType = typeBuilder.buildType(func.type.retType, func.type.tsymbol);
         }
 
         String desc = getMethodDesc(func.type.paramTypes, retType, null, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -1476,7 +1476,7 @@ public class JvmMethodGen {
         // generate method desc
         BType retType = func.type.retType;
         if (isExternFunc(func) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(func.type.retType, func.type.tsymbol);
+            retType = typeBuilder.buildType(func.type.retType);
         }
 
         String desc = getMethodDesc(func.type.paramTypes, retType, null, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -356,7 +356,7 @@ public class JvmPackageGen {
 
         BType retType = functionTypeDesc.retType;
         if (isExternFunc(currentFunc) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(retType);
+            retType = typeBuilder.buildType(retType, functionTypeDesc.tsymbol);
         }
 
         String jvmMethodDescription = getMethodDesc(functionTypeDesc.paramTypes, retType, attachedType, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -356,7 +356,7 @@ public class JvmPackageGen {
 
         BType retType = functionTypeDesc.retType;
         if (isExternFunc(currentFunc) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(retType, functionTypeDesc.tsymbol);
+            retType = typeBuilder.buildType(retType);
         }
 
         String jvmMethodDescription = getMethodDesc(functionTypeDesc.paramTypes, retType, attachedType, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -54,9 +54,9 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLogHelper;
 import org.wso2.ballerinalang.util.Flags;
@@ -129,7 +129,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethod
 public class JvmPackageGen {
 
     private static final CompilerContext.Key<JvmPackageGen> JVM_PACKAGE_GEN_KEY = new CompilerContext.Key<>();
-    private static ConcreteBTypeBuilder typeBuilder;
+    private static ResolvedTypeBuilder typeBuilder;
 
     public final SymbolTable symbolTable;
     public final PackageCache packageCache;
@@ -150,7 +150,7 @@ public class JvmPackageGen {
         this.packageCache = packageCache;
         this.dlog = dlog;
         jvmMethodGen = new JvmMethodGen(this);
-        typeBuilder = new ConcreteBTypeBuilder();
+        typeBuilder = new ResolvedTypeBuilder();
 
         JvmCastGen.symbolTable = symbolTable;
         JvmInstructionGen.anyType = symbolTable.anyType;
@@ -356,7 +356,7 @@ public class JvmPackageGen {
 
         BType retType = functionTypeDesc.retType;
         if (isExternFunc(currentFunc) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(retType);
+            retType = typeBuilder.build(retType);
         }
 
         String jvmMethodDescription = getMethodDesc(functionTypeDesc.paramTypes, retType, attachedType, false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -675,7 +675,8 @@ public class JvmTerminatorGen {
             jvmClass = getModuleLevelClassName(orgName, moduleName, version,
                                                cleanupPathSeperators(cleanupBalExt(balFileName)));
             //TODO: add receiver:  BType attachedType = type.r != null ? receiver.type : null;
-            methodDesc = getMethodDesc(params, type.retType, null, false);
+            BType retType = typeBuilder.buildType(type.retType);
+            methodDesc = getMethodDesc(params, retType, null, false);
         }
         this.mv.visitMethodInsn(INVOKESTATIC, jvmClass, cleanMethodName, methodDesc, false);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -42,8 +42,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
@@ -152,7 +152,7 @@ public class JvmTerminatorGen {
     private JvmInstructionGen jvmInstructionGen;
     private PackageCache packageCache;
     private SymbolTable symbolTable;
-    private ConcreteBTypeBuilder typeBuilder;
+    private ResolvedTypeBuilder typeBuilder;
 
     public JvmTerminatorGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, LabelGenerator labelGen,
                             JvmErrorGen errorGen, BIRNode.BIRPackage module, JvmInstructionGen jvmInstructionGen,
@@ -167,7 +167,7 @@ public class JvmTerminatorGen {
         this.jvmInstructionGen = jvmInstructionGen;
         this.symbolTable = jvmPackageGen.symbolTable;
         this.currentPackageName = getPackageName(module.org.value, module.name.value, module.version.value);
-        this.typeBuilder = new ConcreteBTypeBuilder();
+        this.typeBuilder = new ResolvedTypeBuilder();
     }
 
     private static void genYieldCheckForLock(MethodVisitor mv, LabelGenerator labelGen, String funcName,
@@ -675,7 +675,7 @@ public class JvmTerminatorGen {
             jvmClass = getModuleLevelClassName(orgName, moduleName, version,
                                                cleanupPathSeperators(cleanupBalExt(balFileName)));
             //TODO: add receiver:  BType attachedType = type.r != null ? receiver.type : null;
-            BType retType = typeBuilder.buildType(type.retType);
+            BType retType = typeBuilder.build(type.retType);
             methodDesc = getMethodDesc(params, retType, null, false);
         }
         this.mv.visitMethodInsn(INVOKESTATIC, jvmClass, cleanMethodName, methodDesc, false);
@@ -1140,7 +1140,7 @@ public class JvmTerminatorGen {
         if (isObserved) {
             emitStopObservationInvocation(this.mv, localVarOffset);
         }
-        BType bType = typeBuilder.buildType(func.type.retType);
+        BType bType = typeBuilder.build(func.type.retType);
         if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -1139,7 +1139,7 @@ public class JvmTerminatorGen {
         if (isObserved) {
             emitStopObservationInvocation(this.mv, localVarOffset);
         }
-        BType bType = typeBuilder.buildType(func.type.retType, func.type.tsymbol);
+        BType bType = typeBuilder.buildType(func.type.retType);
         if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -145,7 +145,7 @@ public class InteropMethodGen {
             retType = typeBuilder.buildType(birFunc.type.retType);
         }
 
-        String desc = getMethodDesc(birFunc.type.paramTypes, birFunc.type.retType, null, false);
+        String desc = getMethodDesc(birFunc.type.paramTypes, retType, null, false);
         int access = ACC_PUBLIC + ACC_STATIC;
 
         MethodVisitor mv = classWriter.visitMethod(access, birFunc.name.value, desc, null, null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -41,6 +41,7 @@ import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
@@ -117,6 +118,8 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPacka
  */
 public class InteropMethodGen {
 
+    private static final ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
+
     static void genJFieldForInteropField(JFieldFunctionWrapper jFieldFuncWrapper,
                                          ClassWriter classWriter,
                                          BIRPackage birModule,
@@ -134,6 +137,12 @@ public class InteropMethodGen {
 
         // Generate method desc
         BIRFunction birFunc = jFieldFuncWrapper.func;
+        BType retType = birFunc.type.retType;
+
+        if (!birFunc.parameters.isEmpty()) {
+            retType = typeBuilder.buildType(birFunc.type.retType, null);
+        }
+
         String desc = getMethodDesc(birFunc.type.paramTypes, birFunc.type.retType, null, false);
         int access = ACC_PUBLIC + ACC_STATIC;
 
@@ -246,7 +255,7 @@ public class InteropMethodGen {
         }
 
         // Handle return type
-        BType retType = birFunc.type.retType;
+//        BType retType = birFunc.type.retType;
         BIRVariableDcl retVarDcl = new BIRVariableDcl(retType, new Name("$_ret_var_$"), null, VarKind.LOCAL);
         int returnVarRefIndex = indexMap.getIndex(retVarDcl);
 
@@ -285,6 +294,9 @@ public class InteropMethodGen {
                                     JvmMethodGen jvmMethodGen) {
         // resetting the variable generation index
         BType retType = birFunc.type.retType;
+        if (!birFunc.type.paramTypes.isEmpty()) {
+            retType = typeBuilder.buildType(birFunc.type.retType, null);
+        }
         JMethod jMethod = extFuncWrapper.jMethod;
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();
         JType jMethodRetType = JInterop.getJType(jMethod.getReturnType());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -42,8 +42,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -120,7 +120,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPacka
  */
 public class InteropMethodGen {
 
-    private static final ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
+    private static final ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
 
     static void genJFieldForInteropField(JFieldFunctionWrapper jFieldFuncWrapper,
                                          ClassWriter classWriter,
@@ -142,7 +142,7 @@ public class InteropMethodGen {
         BType retType = birFunc.type.retType;
 
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(birFunc.type.retType);
+            retType = typeBuilder.build(birFunc.type.retType);
         }
 
         String desc = getMethodDesc(birFunc.type.paramTypes, retType, null, false);
@@ -296,7 +296,7 @@ public class InteropMethodGen {
         // resetting the variable generation index
         BType retType = birFunc.type.retType;
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(birFunc.type.retType);
+            retType = typeBuilder.build(birFunc.type.retType);
         }
         JMethod jMethod = extFuncWrapper.jMethod;
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -142,7 +142,7 @@ public class InteropMethodGen {
         BType retType = birFunc.type.retType;
 
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(birFunc.type.retType);
+            retType = typeBuilder.buildType(birFunc.type.retType, birFunc.type.tsymbol);
         }
 
         String desc = getMethodDesc(birFunc.type.paramTypes, birFunc.type.retType, null, false);
@@ -297,7 +297,7 @@ public class InteropMethodGen {
         // resetting the variable generation index
         BType retType = birFunc.type.retType;
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(birFunc.type.retType);
+            retType = typeBuilder.buildType(birFunc.type.retType, birFunc.type.tsymbol);
         }
         JMethod jMethod = extFuncWrapper.jMethod;
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -142,7 +142,7 @@ public class InteropMethodGen {
         BType retType = birFunc.type.retType;
 
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(birFunc.type.retType, birFunc.type.tsymbol);
+            retType = typeBuilder.buildType(birFunc.type.retType);
         }
 
         String desc = getMethodDesc(birFunc.type.paramTypes, birFunc.type.retType, null, false);
@@ -297,7 +297,7 @@ public class InteropMethodGen {
         // resetting the variable generation index
         BType retType = birFunc.type.retType;
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(birFunc.type.retType, birFunc.type.tsymbol);
+            retType = typeBuilder.buildType(birFunc.type.retType);
         }
         JMethod jMethod = extFuncWrapper.jMethod;
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -257,7 +257,6 @@ public class InteropMethodGen {
         }
 
         // Handle return type
-//        BType retType = birFunc.type.retType;
         BIRVariableDcl retVarDcl = new BIRVariableDcl(retType, new Name("$_ret_var_$"), null, VarKind.LOCAL);
         int returnVarRefIndex = indexMap.getIndex(retVarDcl);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -39,11 +39,13 @@ import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -139,8 +141,8 @@ public class InteropMethodGen {
         BIRFunction birFunc = jFieldFuncWrapper.func;
         BType retType = birFunc.type.retType;
 
-        if (!birFunc.parameters.isEmpty()) {
-            retType = typeBuilder.buildType(birFunc.type.retType, null);
+        if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
+            retType = typeBuilder.buildType(birFunc.type.retType);
         }
 
         String desc = getMethodDesc(birFunc.type.paramTypes, birFunc.type.retType, null, false);
@@ -294,8 +296,8 @@ public class InteropMethodGen {
                                     JvmMethodGen jvmMethodGen) {
         // resetting the variable generation index
         BType retType = birFunc.type.retType;
-        if (!birFunc.type.paramTypes.isEmpty()) {
-            retType = typeBuilder.buildType(birFunc.type.retType, null);
+        if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
+            retType = typeBuilder.buildType(birFunc.type.retType);
         }
         JMethod jMethod = extFuncWrapper.jMethod;
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
@@ -20,7 +20,7 @@ package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
@@ -45,7 +45,7 @@ class JMethodRequest {
     boolean returnsBErrorType = false;
     boolean restParamExist = false;
 
-    private static ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
+    private static ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
 
     private JMethodRequest() {
 
@@ -83,7 +83,7 @@ class JMethodRequest {
         jMethodReq.bFuncParamCount = paramTypes.size();
         jMethodReq.bParamTypes = paramTypes.toArray(new BType[0]);
 
-        BType returnType = typeBuilder.buildType(bFuncType.retType);
+        BType returnType = typeBuilder.build(bFuncType.retType);
         jMethodReq.bReturnType = returnType;
         if (returnType.tag == TypeTags.UNION) {
             for (BType bType : ((BUnionType) returnType).getMemberTypes()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
@@ -83,7 +83,7 @@ class JMethodRequest {
         jMethodReq.bFuncParamCount = paramTypes.size();
         jMethodReq.bParamTypes = paramTypes.toArray(new BType[0]);
 
-        BType returnType = typeBuilder.buildType(bFuncType.retType, bFuncType.tsymbol);
+        BType returnType = typeBuilder.buildType(bFuncType.retType);
         jMethodReq.bReturnType = returnType;
         if (returnType.tag == TypeTags.UNION) {
             for (BType bType : ((BUnionType) returnType).getMemberTypes()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
@@ -43,6 +44,8 @@ class JMethodRequest {
     BType bReturnType = null;
     boolean returnsBErrorType = false;
     boolean restParamExist = false;
+
+    private static ConcreteBTypeBuilder typeBuilder = new ConcreteBTypeBuilder();
 
     private JMethodRequest() {
 
@@ -80,7 +83,7 @@ class JMethodRequest {
         jMethodReq.bFuncParamCount = paramTypes.size();
         jMethodReq.bParamTypes = paramTypes.toArray(new BType[0]);
 
-        BType returnType = bFuncType.retType;
+        BType returnType = typeBuilder.buildType(bFuncType.retType, bFuncType.tsymbol);
         jMethodReq.bReturnType = returnType;
         if (returnType.tag == TypeTags.UNION) {
             for (BType bType : ((BUnionType) returnType).getMemberTypes()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -50,6 +50,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BPackageType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
@@ -188,6 +189,11 @@ public class BIRTypeWriter implements TypeVisitor {
     public void visit(BTypedescType typedescType) {
 
         writeTypeCpIndex(typedescType.constraint);
+    }
+
+    @Override
+    public void visit(BParameterizedType type) {
+        writeTypeCpIndex(type.paramValueType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -234,10 +234,10 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUnionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeDefBuilderHelper;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -313,7 +313,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangNode result;
     private NodeCloner nodeCloner;
     private SemanticAnalyzer semanticAnalyzer;
-    private ConcreteBTypeBuilder typeBuilder;
+    private ResolvedTypeBuilder typeBuilder;
 
     private BLangStatementLink currentLink;
     public Stack<BLangLockStmt> enclLocks = new Stack<>();
@@ -364,7 +364,7 @@ public class Desugar extends BLangNodeVisitor {
         this.serviceDesugar = ServiceDesugar.getInstance(context);
         this.nodeCloner = NodeCloner.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
-        this.typeBuilder = new ConcreteBTypeBuilder();
+        this.typeBuilder = new ResolvedTypeBuilder();
     }
 
     public BLangPackage perform(BLangPackage pkgNode) {
@@ -3565,7 +3565,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BInvokableSymbol invSym = (BInvokableSymbol) invocation.symbol;
         if (Symbols.isFlagOn(invSym.retType.flags, Flags.PARAMETERIZED)) {
-            BType retType = typeBuilder.buildType(invSym.retType);
+            BType retType = typeBuilder.build(invSym.retType);
             invocation.type = retType;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3563,6 +3563,12 @@ public class Desugar extends BLangNodeVisitor {
         invocation.expr = rewriteExpr(invocation.expr);
         result = invRef;
 
+        BInvokableSymbol invSym = (BInvokableSymbol) invocation.symbol;
+        if (Symbols.isFlagOn(invSym.retType.flags, Flags.PARAMETERIZED)) {
+            BType retType = typeBuilder.buildType(invSym.retType);
+            invocation.type = retType;
+        }
+
         if (invocation.expr == null) {
             fixTypeCastInTypeParamInvocation(invocation, invRef);
             if (invocation.exprSymbol == null) {
@@ -3607,12 +3613,10 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private void fixTypeCastInTypeParamInvocation(BLangInvocation iExpr, BLangInvocation genIExpr) {
-        BType retType = ((BInvokableSymbol) iExpr.symbol).retType;
-        if (iExpr.langLibInvocation || TypeParamAnalyzer.containsTypeParam(retType)
-                || Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
+
+        if (iExpr.langLibInvocation || TypeParamAnalyzer.containsTypeParam(((BInvokableSymbol) iExpr.symbol).retType)) {
             BType originalInvType = genIExpr.type;
-            BInvokableSymbol invokableSymbol = (BInvokableSymbol) genIExpr.symbol;
-            genIExpr.type = typeBuilder.buildType(invokableSymbol.retType, genIExpr);
+            genIExpr.type = ((BInvokableSymbol) genIExpr.symbol).retType;
             BLangExpression expr = addConversionExprIfRequired(genIExpr, originalInvType);
 
             // Prevent adding another type conversion

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -234,6 +234,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUnionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -312,6 +313,7 @@ public class Desugar extends BLangNodeVisitor {
     private BLangNode result;
     private NodeCloner nodeCloner;
     private SemanticAnalyzer semanticAnalyzer;
+    private ConcreteBTypeBuilder typeBuilder;
 
     private BLangStatementLink currentLink;
     public Stack<BLangLockStmt> enclLocks = new Stack<>();
@@ -362,6 +364,7 @@ public class Desugar extends BLangNodeVisitor {
         this.serviceDesugar = ServiceDesugar.getInstance(context);
         this.nodeCloner = NodeCloner.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
+        this.typeBuilder = new ConcreteBTypeBuilder();
     }
 
     public BLangPackage perform(BLangPackage pkgNode) {
@@ -3604,10 +3607,12 @@ public class Desugar extends BLangNodeVisitor {
     }
 
     private void fixTypeCastInTypeParamInvocation(BLangInvocation iExpr, BLangInvocation genIExpr) {
-
-        if (iExpr.langLibInvocation || TypeParamAnalyzer.containsTypeParam(((BInvokableSymbol) iExpr.symbol).retType)) {
+        BType retType = ((BInvokableSymbol) iExpr.symbol).retType;
+        if (iExpr.langLibInvocation || TypeParamAnalyzer.containsTypeParam(retType)
+                || Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
             BType originalInvType = genIExpr.type;
-            genIExpr.type = ((BInvokableSymbol) genIExpr.symbol).retType;
+            BInvokableSymbol invokableSymbol = (BInvokableSymbol) genIExpr.symbol;
+            genIExpr.type = typeBuilder.buildType(invokableSymbol.retType, (BLangInvocation) null);
             BLangExpression expr = addConversionExprIfRequired(genIExpr, originalInvType);
 
             // Prevent adding another type conversion

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3612,7 +3612,7 @@ public class Desugar extends BLangNodeVisitor {
                 || Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
             BType originalInvType = genIExpr.type;
             BInvokableSymbol invokableSymbol = (BInvokableSymbol) genIExpr.symbol;
-            genIExpr.type = typeBuilder.buildType(invokableSymbol.retType, (BLangInvocation) null);
+            genIExpr.type = typeBuilder.buildType(invokableSymbol.retType, genIExpr);
             BLangExpression expr = addConversionExprIfRequired(genIExpr, originalInvType);
 
             // Prevent adding another type conversion

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -285,6 +285,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
     public void visit(BLangFunction funcNode) {
         SymbolEnv funcEnv = SymbolEnv.createFunctionEnv(funcNode, funcNode.symbol.scope, env);
+
+        // TODO: Shouldn't this be done in symbol enter?
         //set function param flag to final
         funcNode.symbol.params.forEach(param -> param.flags |= Flags.FUNCTION_FINAL);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -37,6 +37,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BOperatorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
@@ -318,6 +319,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
             if (param.expr != null) {
                 funcNode.symbol.paramDefaultValTypes.put(param.symbol.name.value, param.expr.type);
+                ((BInvokableTypeSymbol) funcNode.type.tsymbol).paramDefaultValTypes.put(param.symbol.name.value,
+                                                                                        param.expr.type);
             }
         }
         if (funcNode.restParam != null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -315,6 +315,10 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         for (BLangSimpleVariable param : funcNode.requiredParams) {
             symbolEnter.defineExistingVarSymbolInEnv(param.symbol, funcNode.clonedEnv);
             this.analyzeDef(param, funcNode.clonedEnv);
+
+            if (param.expr != null) {
+                funcNode.symbol.paramDefaultValTypes.put(param.symbol.name.value, param.expr.type);
+            }
         }
         if (funcNode.restParam != null) {
             symbolEnter.defineExistingVarSymbolInEnv(funcNode.restParam.symbol, funcNode.clonedEnv);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1151,7 +1151,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         List<BType> fieldTypes = new ArrayList<>();
-        for (BField field : recordType.fields) {
+        for (BField field : recordType.fields.values()) {
             BType type = field.type;
             fieldTypes.add(type);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1149,7 +1149,14 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
+        List<BType> fieldTypes = new ArrayList<>();
+        for (BField field : recordType.fields) {
+            BType type = field.type;
+            fieldTypes.add(type);
+        }
+
         if (recordTypeNode.restFieldType == null) {
+            symResolver.markParameterizedType(recordType, fieldTypes);
             if (recordTypeNode.sealed) {
                 recordType.restFieldType = symTable.noType;
                 return;
@@ -1159,6 +1166,8 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         recordType.restFieldType = symResolver.resolveTypeNode(recordTypeNode.restFieldType, env);
+        fieldTypes.add(recordType.restFieldType);
+        symResolver.markParameterizedType(recordType, fieldTypes);
     }
 
     private Collector<BField, ?, LinkedHashMap<String, BField>> getFieldCollector() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1150,7 +1150,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        List<BType> fieldTypes = new ArrayList<>();
+        List<BType> fieldTypes = new ArrayList<>(recordType.fields.size());
         for (BField field : recordType.fields.values()) {
             BType type = field.type;
             fieldTypes.add(type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -904,6 +904,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         funcSymbol.markdownDocumentation = getMarkdownDocAttachment(funcNode.markdownDocumentationAttachment);
         SymbolEnv invokableEnv = SymbolEnv.createFunctionEnv(funcNode, funcSymbol.scope, env);
         defineInvokableSymbol(funcNode, funcSymbol, invokableEnv);
+        funcNode.type = funcSymbol.type;
 
         if (isDeprecated(funcNode.annAttachments)) {
             funcSymbol.flags |= Flags.DEPRECATED;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -90,11 +90,11 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FunctionalConstructorBuilder;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLogHelper;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -137,7 +137,7 @@ public class SymbolResolver extends BLangNodeVisitor {
     private SymbolEnter symbolEnter;
     private BLangAnonymousModelHelper anonymousModelHelper;
     private BLangMissingNodesHelper missingNodesHelper;
-    private ConcreteBTypeBuilder typeBuilder;
+    private ResolvedTypeBuilder typeBuilder;
 
     public static SymbolResolver getInstance(CompilerContext context) {
         SymbolResolver symbolResolver = context.get(SYMBOL_RESOLVER_KEY);
@@ -158,7 +158,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         this.symbolEnter = SymbolEnter.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.missingNodesHelper = BLangMissingNodesHelper.getInstance(context);
-        this.typeBuilder = new ConcreteBTypeBuilder();
+        this.typeBuilder = new ResolvedTypeBuilder();
     }
 
     public boolean checkForUniqueSymbol(DiagnosticPos pos, SymbolEnv env, BSymbol symbol) {
@@ -1142,7 +1142,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return;
         }
 
-        if (!TypeTags.isXMLTypeTag(constraintType.tag)) {
+        if (!TypeTags.isXMLTypeTag(constraintType.tag) && constraintType.tag != TypeTags.NEVER) {
             dlog.error(pos, DiagnosticCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType, constraintType);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -60,6 +60,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
+import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
@@ -1140,8 +1141,18 @@ public class SymbolResolver extends BLangNodeVisitor {
         //    If the package alias is not empty or null, then find the package scope,
         if (symbol == symTable.notFoundSymbol) {
             BSymbol tempSymbol = lookupMainSpaceSymbolInPackage(userDefinedTypeNode.pos, env, pkgAlias, typeName);
+
             if ((tempSymbol.tag & SymTag.TYPE) == SymTag.TYPE) {
                 symbol = tempSymbol;
+            }
+
+            if (env.node.getKind() == NodeKind.FUNCTION) {
+                BLangFunction func = (BLangFunction) env.node;
+                if (func.hasBody() && func.body.getKind() == NodeKind.EXTERN_FUNCTION_BODY) {
+                    symbol = tempSymbol;
+                } else {
+                    dlog.error(func.pos, DiagnosticCode.INVALID_RETURN_TYPE_PARAMETERIZATION);
+                }
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -90,6 +90,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FunctionalConstructorBuilder;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
@@ -137,6 +138,7 @@ public class SymbolResolver extends BLangNodeVisitor {
     private SymbolEnter symbolEnter;
     private BLangAnonymousModelHelper anonymousModelHelper;
     private BLangMissingNodesHelper missingNodesHelper;
+    private ConcreteBTypeBuilder typeBuilder;
 
     public static SymbolResolver getInstance(CompilerContext context) {
         SymbolResolver symbolResolver = context.get(SYMBOL_RESOLVER_KEY);
@@ -157,6 +159,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         this.symbolEnter = SymbolEnter.getInstance(context);
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.missingNodesHelper = BLangMissingNodesHelper.getInstance(context);
+        this.typeBuilder = new ConcreteBTypeBuilder();
     }
 
     public boolean checkForUniqueSymbol(DiagnosticPos pos, SymbolEnv env, BSymbol symbol) {
@@ -1116,16 +1119,14 @@ public class SymbolResolver extends BLangNodeVisitor {
         } else if (type.tag == TypeTags.TYPEDESC) {
             constrainedType = new BTypedescType(constraintType, null);
         } else if (type.tag == TypeTags.XML) {
-            if (constraintType.tag != TypeTags.UNION) {
-                if (!TypeTags.isXMLTypeTag(constraintType.tag) && constraintType.tag != TypeTags.NEVER) {
-                    dlog.error(constrainedTypeNode.pos, DiagnosticCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType,
-                            constraintType);
-                }
-                constrainedType = new BXMLType(constraintType, null);
+            if (constraintType.tag == TypeTags.PARAMETERIZED_TYPE) {
+                BType typedescType = ((BParameterizedType) constraintType).paramSymbol.type;
+                BType typedescConstraint = ((BTypedescType) typedescType).constraint;
+                validateXMLConstraintType(typedescConstraint, constrainedTypeNode.pos);
             } else {
-                checkUnionTypeForXMLSubTypes((BUnionType) constraintType, constrainedTypeNode.pos);
-                constrainedType = new BXMLType(constraintType, null);
+                validateXMLConstraintType(constraintType, constrainedTypeNode.pos);
             }
+            constrainedType = new BXMLType(constraintType, null);
         } else {
             return;
         }
@@ -1135,6 +1136,17 @@ public class SymbolResolver extends BLangNodeVisitor {
                                                            typeSymbol.pkgID, constrainedType, typeSymbol.owner);
         markParameterizedType(constrainedType, constraintType);
         resultType = constrainedType;
+    }
+
+    private void validateXMLConstraintType(BType constraintType, DiagnosticPos pos) {
+        if (constraintType.tag == TypeTags.UNION) {
+            checkUnionTypeForXMLSubTypes((BUnionType) constraintType, pos);
+            return;
+        }
+
+        if (!TypeTags.isXMLTypeTag(constraintType.tag)) {
+            dlog.error(pos, DiagnosticCode.INCOMPATIBLE_TYPE_CONSTRAINT, symTable.xmlType, constraintType);
+        }
     }
 
     private void checkUnionTypeForXMLSubTypes(BUnionType constraintUnionType, DiagnosticPos pos) {
@@ -1185,10 +1197,10 @@ public class SymbolResolver extends BLangNodeVisitor {
                         return;
                     }
 
-                    BTypeSymbol tSymbol = new BTypeSymbol(SymTag.TYPE, Flags.PARAMETERIZED, tempSymbol.name,
-                                                          tempSymbol.pkgID, null, func.symbol);
+                    BTypeSymbol tSymbol = new BTypeSymbol(SymTag.TYPE, Flags.PARAMETERIZED | tempSymbol.flags,
+                                                          tempSymbol.name, tempSymbol.pkgID, null, func.symbol);
                     this.resultType = tSymbol.type = new BParameterizedType(paramValType, (BVarSymbol) tempSymbol,
-                                                                            tSymbol);
+                                                                            tSymbol, tempSymbol.name);
                     this.resultType.flags |= Flags.PARAMETERIZED;
                     return;
                 } else {
@@ -1230,7 +1242,7 @@ public class SymbolResolver extends BLangNodeVisitor {
                 if (param.expr.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
                     Name varName = names.fromIdNode(((BLangSimpleVarRef) param.expr).variableName);
                     BSymbol typeRefSym = lookupSymbolInMainSpace(this.env, varName);
-                    return typeRefSym.type;
+                    return typeRefSym != symTable.notFoundSymbol ? typeRefSym.type : symTable.semanticError;
                 }
 
                 dlog.error(param.pos, DiagnosticCode.INVALID_TYPEDESC_PARAM);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1175,6 +1175,8 @@ public class SymbolResolver extends BLangNodeVisitor {
                 //  TODO: Check what happens when the same param is used in multiple places in the same return type
                 BLangFunction func = (BLangFunction) env.node;
                 if (func.hasBody() && func.body.getKind() == NodeKind.EXTERN_FUNCTION_BODY) {
+                    validateTypedescExprDefaultValue(func.requiredParams, tempSymbol.name.value);
+
                     BTypeSymbol tSymbol = new BTypeSymbol(SymTag.TYPE, Flags.PARAMETERIZED, tempSymbol.name,
                                                           tempSymbol.pkgID, null, func.symbol);
                     this.resultType = tSymbol.type = new BParameterizedType((BVarSymbol) tempSymbol, tSymbol);
@@ -1202,6 +1204,16 @@ public class SymbolResolver extends BLangNodeVisitor {
         }
 
         resultType = symbol.type;
+    }
+
+    private void validateTypedescExprDefaultValue(List<BLangSimpleVariable> params, String varName) {
+        for (BLangSimpleVariable param : params) {
+            if (param.name.value.equals(varName) && param.expr != null &&
+                    (param.expr.getKind() != NodeKind.TYPEDESC_EXPRESSION &&
+                            param.expr.getKind() != NodeKind.SIMPLE_VARIABLE_REF)) {
+                dlog.error(param.pos, DiagnosticCode.INVALID_TYPEDESC_PARAM);
+            }
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4790,7 +4790,8 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         BType retType = typeParamAnalyzer.getReturnTypeParams(env, bInvokableType.getReturnType());
-        if (Symbols.isFlagOn(invokableSymbol.flags, Flags.NATIVE) && !invokableSymbol.params.isEmpty()) {
+        if (Symbols.isFlagOn(invokableSymbol.flags, Flags.NATIVE)
+                && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
             retType = typeBuilder.buildType(retType, iExpr);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -161,12 +161,12 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.ClosureVarSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.NumericLiteralSupport;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeDefBuilderHelper;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLog;
@@ -223,7 +223,7 @@ public class TypeChecker extends BLangNodeVisitor {
     private TypeParamAnalyzer typeParamAnalyzer;
     private BLangAnonymousModelHelper anonymousModelHelper;
     private SemanticAnalyzer semanticAnalyzer;
-    private ConcreteBTypeBuilder typeBuilder;
+    private ResolvedTypeBuilder typeBuilder;
     private boolean nonErrorLoggingCheck = false;
     private int letCount = 0;
     private SymbolEnv narrowedQueryEnv;
@@ -269,7 +269,7 @@ public class TypeChecker extends BLangNodeVisitor {
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
         this.missingNodesHelper = BLangMissingNodesHelper.getInstance(context);
-        this.typeBuilder = new ConcreteBTypeBuilder();
+        this.typeBuilder = new ResolvedTypeBuilder();
     }
 
     public BType checkExpr(BLangExpression expr, SymbolEnv env) {
@@ -4792,7 +4792,7 @@ public class TypeChecker extends BLangNodeVisitor {
         BType retType = typeParamAnalyzer.getReturnTypeParams(env, bInvokableType.getReturnType());
         if (Symbols.isFlagOn(invokableSymbol.flags, Flags.NATIVE)
                 && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.buildType(retType, iExpr);
+            retType = typeBuilder.build(retType, iExpr);
         }
 
         if (iExpr instanceof ActionNode && ((BLangInvocation.BLangActionInvocation) iExpr).async) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -161,6 +161,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangValueType;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.ClosureVarSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.FieldKind;
 import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
@@ -222,6 +223,7 @@ public class TypeChecker extends BLangNodeVisitor {
     private TypeParamAnalyzer typeParamAnalyzer;
     private BLangAnonymousModelHelper anonymousModelHelper;
     private SemanticAnalyzer semanticAnalyzer;
+    private ConcreteBTypeBuilder typeBuilder;
     private boolean nonErrorLoggingCheck = false;
     private int letCount = 0;
     private SymbolEnv narrowedQueryEnv;
@@ -267,6 +269,7 @@ public class TypeChecker extends BLangNodeVisitor {
         this.anonymousModelHelper = BLangAnonymousModelHelper.getInstance(context);
         this.semanticAnalyzer = SemanticAnalyzer.getInstance(context);
         this.missingNodesHelper = BLangMissingNodesHelper.getInstance(context);
+        this.typeBuilder = new ConcreteBTypeBuilder();
     }
 
     public BType checkExpr(BLangExpression expr, SymbolEnv env) {
@@ -4787,6 +4790,9 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         BType retType = typeParamAnalyzer.getReturnTypeParams(env, bInvokableType.getReturnType());
+        if (Symbols.isFlagOn(invokableSymbol.flags, Flags.NATIVE) && !invokableSymbol.params.isEmpty()) {
+            retType = typeBuilder.buildType(retType, iExpr);
+        }
 
         if (iExpr instanceof ActionNode && ((BLangInvocation.BLangActionInvocation) iExpr).async) {
             return this.generateFutureType(invokableSymbol, retType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -69,9 +69,9 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
-import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.NumericLiteralSupport;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLogHelper;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
@@ -116,7 +116,7 @@ public class Types {
 
     private static final CompilerContext.Key<Types> TYPES_KEY =
             new CompilerContext.Key<>();
-    private final ConcreteBTypeBuilder typeBuilder;
+    private final ResolvedTypeBuilder typeBuilder;
 
     private SymbolTable symTable;
     private SymbolResolver symResolver;
@@ -144,7 +144,7 @@ public class Types {
         this.expandedXMLBuiltinSubtypes = BUnionType.create(null,
                                                             symTable.xmlElementType, symTable.xmlCommentType,
                                                             symTable.xmlPIType, symTable.xmlTextType);
-        this.typeBuilder = new ConcreteBTypeBuilder();
+        this.typeBuilder = new ResolvedTypeBuilder();
     }
 
     public List<BType> checkTypes(BLangExpression node,
@@ -646,8 +646,8 @@ public class Types {
         }
 
         if (sourceTag == TypeTags.PARAMETERIZED_TYPE) {
-            BType resolvedType = typeBuilder.buildType(source);
-            return isAssignable(resolvedType, target, unresolvedTypes, unresolvedReadonlyTypes);
+            BType resolvedType = typeBuilder.build(source);
+            return isAssignable(resolvedType, target, unresolvedTypes);
         }
 
         return sourceTag == TypeTags.ARRAY && targetTag == TypeTags.ARRAY &&

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -48,6 +48,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BReadonlyType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
@@ -2156,6 +2157,16 @@ public class Types {
         public Boolean visit(BFiniteType t, BType s) {
 
             return s == t;
+        }
+
+        @Override
+        public Boolean visit(BParameterizedType t, BType s) {
+            if (s.tag != TypeTags.PARAMETERIZED_TYPE) {
+                return false;
+            }
+
+            BParameterizedType sType = (BParameterizedType) s;
+            return isSameType(sType.paramValueType, t.paramValueType) && sType.paramSymbol.equals(t.paramSymbol);
         }
 
     };

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -69,6 +69,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypeConversionExpr;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.ConcreteBTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.NumericLiteralSupport;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -115,6 +116,7 @@ public class Types {
 
     private static final CompilerContext.Key<Types> TYPES_KEY =
             new CompilerContext.Key<>();
+    private final ConcreteBTypeBuilder typeBuilder;
 
     private SymbolTable symTable;
     private SymbolResolver symResolver;
@@ -140,7 +142,9 @@ public class Types {
         this.dlogHelper = BLangDiagnosticLogHelper.getInstance(context);
         this.names = Names.getInstance(context);
         this.expandedXMLBuiltinSubtypes = BUnionType.create(null,
-                symTable.xmlElementType, symTable.xmlCommentType, symTable.xmlPIType, symTable.xmlTextType);
+                                                            symTable.xmlElementType, symTable.xmlCommentType,
+                                                            symTable.xmlPIType, symTable.xmlTextType);
+        this.typeBuilder = new ConcreteBTypeBuilder();
     }
 
     public List<BType> checkTypes(BLangExpression node,
@@ -639,6 +643,11 @@ public class Types {
 
         if (sourceTag == TypeTags.INVOKABLE && targetTag == TypeTags.INVOKABLE) {
             return isFunctionTypeAssignable((BInvokableType) source, (BInvokableType) target, new HashSet<>());
+        }
+
+        if (sourceTag == TypeTags.PARAMETERIZED_TYPE) {
+            BType resolvedType = typeBuilder.buildType(source);
+            return isAssignable(resolvedType, target, unresolvedTypes, unresolvedReadonlyTypes);
         }
 
         return sourceTag == TypeTags.ARRAY && targetTag == TypeTags.ARRAY &&

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/TypeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/TypeVisitor.java
@@ -36,6 +36,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNoType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BPackageType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
@@ -77,6 +78,8 @@ public interface TypeVisitor {
     void visit(BStreamType bStreamType);
 
     void visit(BTypedescType bTypedescType);
+
+    void visit(BParameterizedType bTypedescType);
 
     void visit(BNeverType bNeverType);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableSymbol.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +40,7 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
     public BVarSymbol restParam;
     public BType retType;
     public Map<Integer, TaintRecord> taintTable;
+    public Map<String, BType> paramDefaultValTypes;
 
     // This field is only applicable for functions at the moment.
     public BVarSymbol receiverSymbol;
@@ -61,6 +63,7 @@ public class BInvokableSymbol extends BVarSymbol implements InvokableSymbol {
         this.tag = tag;
         this.params = new ArrayList<>();
         this.dependentGlobalVars = new HashSet<>();
+        this.paramDefaultValTypes = new HashMap<>();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
@@ -24,7 +24,9 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a function type symbol.
@@ -36,10 +38,12 @@ public class BInvokableTypeSymbol extends BTypeSymbol {
     public List<BVarSymbol> params;
     public BVarSymbol restParam;
     public BType returnType;
+    public Map<String, BType> paramDefaultValTypes;
 
     public BInvokableTypeSymbol(int symTag, int flags, PackageID pkgID, BType type, BSymbol owner) {
         super(symTag, flags, Names.EMPTY, pkgID, type, owner);
         this.params = new ArrayList<>();
+        this.paramDefaultValTypes = new HashMap<>();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -204,7 +204,7 @@ public class Symbols {
         return (sym.flags & Flags.INTERFACE) == Flags.INTERFACE;
     }
 
-    public static boolean isSymTagOn(BSymbol symbol, int symTag) {
+    public static boolean isTagOn(BSymbol symbol, int symTag) {
         return (symbol.tag & symTag) == symTag;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/Symbols.java
@@ -203,4 +203,8 @@ public class Symbols {
     public static boolean isFunctionDeclaration(BSymbol sym) {
         return (sym.flags & Flags.INTERFACE) == Flags.INTERFACE;
     }
+
+    public static boolean isSymTagOn(BSymbol symbol, int symTag) {
+        return (symbol.tag & symTag) == symTag;
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
@@ -29,7 +29,7 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
  * that parameter. This contains the symbol of the parameter referred, and if there is one, the default value of the
  * parameter.
  *
- * @since 2.0.0-Preview1
+ * @since 2.0.0
  */
 public class BParameterizedType extends BType {
 
@@ -45,8 +45,6 @@ public class BParameterizedType extends BType {
 
     @Override
     public boolean isNullable() {
-        // TODO: Check what the correct behaviour is for this
-//        return this.paramSymbol.type.isNullable();
         return false;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
@@ -1,0 +1,58 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.wso2.ballerinalang.compiler.semantics.model.types;
+
+import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
+
+/**
+ * Represents a parameterized type.
+ */
+public class BParameterizedType extends BType {
+
+    public BVarSymbol paramSymbol;
+    public BType paramValueType;
+
+    public BParameterizedType(BVarSymbol paramSymbol, BTypeSymbol tSymbol) {
+        super(TypeTags.PARAMETERIZED_TYPE, tSymbol);
+        this.paramSymbol = paramSymbol;
+        this.paramValueType = ((BTypedescType) this.paramSymbol.type).constraint;
+    }
+
+    @Override
+    public boolean isNullable() {
+        return this.paramSymbol.type.isNullable();
+    }
+
+    @Override
+    public String toString() {
+        return this.paramSymbol.type.toString();
+    }
+
+    @Override
+    public void accept(TypeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T, R> R accept(BTypeVisitor<T, R> visitor, T t) {
+        return visitor.visit(this, t);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.semantics.model.types;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 /**
@@ -30,15 +31,18 @@ public class BParameterizedType extends BType {
     public BVarSymbol paramSymbol;
     public BType paramValueType;
 
-    public BParameterizedType(BType valueType, BVarSymbol paramSymbol, BTypeSymbol tSymbol) {
+    public BParameterizedType(BType valueType, BVarSymbol paramSymbol, BTypeSymbol tSymbol, Name name) {
         super(TypeTags.PARAMETERIZED_TYPE, tSymbol);
         this.paramSymbol = paramSymbol;
         this.paramValueType = valueType;
+        this.name = name;
     }
 
     @Override
     public boolean isNullable() {
-        return this.paramSymbol.type.isNullable();
+        // TODO: Check what the correct behaviour is for this
+//        return this.paramSymbol.type.isNullable();
+        return false;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
@@ -24,7 +24,12 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 /**
- * Represents a parameterized type.
+ * This is a special type introduced to be used in the return type of an extern function. In extern function return
+ * types, typedesc typed parameters of the function can be referred. This type is basically a wrapper created around
+ * that parameter. This contains the symbol of the parameter referred, and if there is one, the default value of the
+ * parameter.
+ *
+ * @since 2.0.0-Preview1
  */
 public class BParameterizedType extends BType {
 
@@ -47,7 +52,7 @@ public class BParameterizedType extends BType {
 
     @Override
     public String toString() {
-        return "<T>" + this.paramValueType.toString();
+        return this.paramSymbol.name.toString();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BParameterizedType.java
@@ -30,10 +30,10 @@ public class BParameterizedType extends BType {
     public BVarSymbol paramSymbol;
     public BType paramValueType;
 
-    public BParameterizedType(BVarSymbol paramSymbol, BTypeSymbol tSymbol) {
+    public BParameterizedType(BType valueType, BVarSymbol paramSymbol, BTypeSymbol tSymbol) {
         super(TypeTags.PARAMETERIZED_TYPE, tSymbol);
         this.paramSymbol = paramSymbol;
-        this.paramValueType = ((BTypedescType) this.paramSymbol.type).constraint;
+        this.paramValueType = valueType;
     }
 
     @Override
@@ -43,7 +43,7 @@ public class BParameterizedType extends BType {
 
     @Override
     public String toString() {
-        return this.paramSymbol.type.toString();
+        return "<T>" + this.paramValueType.toString();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeVisitor.java
@@ -65,4 +65,5 @@ public interface BTypeVisitor<T, R> {
 
     R visit(BTypedescType t, T s);
 
+    R visit(BParameterizedType t, T s);
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
@@ -142,7 +142,7 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
 
         BArrayType newArrayType = new BArrayType(newElemType, null, originalType.size, originalType.state);
         newArrayType.flags = originalType.flags;
-        return originalType;
+        return newArrayType;
     }
 
     @Override
@@ -357,11 +357,16 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
             // This would return null if the calling function gets analyzed before the callee function. This only
             // happens when the invocation uses the default value of the param.
             type = paramValueTypes.get(paramVarName);
+
+            if (type.tag == TypeTags.SEMANTIC_ERROR) {
+                return type;
+            }
+
+            // TODO:
             type = type == null ? originalType.paramValueType : ((BTypedescType) type).constraint;
         } else {
             type = ((BTypedescType) originalType.paramSymbol.type).constraint;
         }
-        type.flags = originalType.flags;
         return type;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
@@ -159,8 +159,8 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
             return originalType;
         }
 
-        List<BField> newFields = new ArrayList<>();
-        for (BField field : originalType.fields) {
+        LinkedHashMap<String, BField> newFields = new LinkedHashMap();
+        for (BField field : originalType.fields.values()) {
             if (this.visitedTypes.contains(field.type)) {
                 continue;
             }
@@ -170,13 +170,13 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
             this.visitedTypes.remove(field.type);
 
             if (newFType == field.type) {
-                newFields.add(field);
+                newFields.put(field.name.value, field);
                 continue;
             }
 
             BField newField = new BField(field.name, field.pos, field.symbol);
             newField.type = newFType;
-            newFields.add(newField);
+            newFields.put(newField.name.value, newField);
         }
 
         BType newRestType = originalType.restFieldType.accept(this, null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
@@ -357,7 +357,10 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
         String paramVarName = originalType.paramSymbol.name.value;
         BType type;
         if (this.isInvocation) {
-            type = ((BTypedescType) paramValueTypes.get(paramVarName)).constraint;
+            // This would return null if the calling function gets analyzed before the callee function. This only
+            // happens when the invocation uses the default value of the param.
+            type = paramValueTypes.get(paramVarName);
+            type = type == null ? originalType.paramValueType : ((BTypedescType) type).constraint;
         } else if (this.funcTSymbol != null && !this.funcTSymbol.paramDefaultValTypes.isEmpty()) {
             type = ((BTypedescType) this.funcTSymbol.paramDefaultValTypes.get(paramVarName)).constraint;
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ConcreteBTypeBuilder.java
@@ -1,0 +1,337 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.util;
+
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BBuiltInRefType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeVisitor;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Util class for building concrete BType types from parameterized types.
+ *
+ * @since 2.0.0-preview1
+ */
+public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
+
+    private Map<String, BLangExpression> paramValues;
+    private boolean isInvocation;
+
+    public BType buildType(BType originalType, BLangInvocation invocation) {
+        this.isInvocation = invocation != null;
+        if (this.isInvocation) {
+            createParamMap(invocation);
+        }
+        return originalType.accept(this, null);
+    }
+
+    @Override
+    public BType visit(BType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BBuiltInRefType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BAnyType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BAnydataType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BMapType originalType, BType newType) {
+        BType newConstraint = originalType.constraint.accept(this, null);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BMapType newMType = new BMapType(originalType.tag, newConstraint, null);
+        newMType.flags = originalType.flags;
+        return newMType;
+    }
+
+    @Override
+    public BType visit(BXMLType originalType, BType newType) {
+        BType newConstraint = originalType.constraint.accept(this, null);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BXMLType newXMLType = new BXMLType(newConstraint, null);
+        newXMLType.flags = originalType.flags;
+        return newXMLType;
+    }
+
+    @Override
+    public BType visit(BJSONType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BArrayType originalType, BType newType) {
+        BType newElemType = originalType.eType.accept(this, null);
+
+        if (newElemType == originalType.eType) {
+            return originalType;
+        }
+
+        BArrayType newArrayType = new BArrayType(newElemType, null, originalType.size, originalType.state);
+        newArrayType.flags = originalType.flags;
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BObjectType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BRecordType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BTupleType originalType, BType newType) {
+        boolean hasNewType = false;
+        List<BType> members = new ArrayList<>();
+        for (BType member : originalType.tupleTypes) {
+            BType newMem = member.accept(this, null);
+            newMem.flags = member.flags;
+            members.add(newMem);
+
+            if (newMem != member) {
+                hasNewType = true;
+            }
+        }
+
+        BType rest = originalType.restType;
+        if (rest != null) {
+            rest = rest.accept(this, null);
+            rest.flags = originalType.restType.flags;
+
+            if (rest != originalType.restType) {
+                hasNewType = true;
+            }
+        }
+
+        if (!hasNewType) {
+            return originalType;
+        }
+
+        BTupleType type = new BTupleType(null, members);
+        type.restType = rest;
+        type.flags = originalType.flags;
+        return type;
+    }
+
+    @Override
+    public BType visit(BStreamType originalType, BType newType) {
+        BType newConstraint = originalType.constraint.accept(this, null);
+        BType newError = originalType.error != null ? originalType.error.accept(this, null) : null;
+
+        if (newConstraint == originalType.constraint && newError == originalType.error) {
+            return originalType;
+        }
+
+        BStreamType type = new BStreamType(originalType.tag, newConstraint, newError, null);
+        type.flags = originalType.flags;
+        return type;
+    }
+
+    @Override
+    public BType visit(BTableType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BInvokableType originalType, BType newType) {
+        boolean hasNewType = false;
+        List<BType> paramTypes = new ArrayList<>();
+        for (BType type : originalType.paramTypes) {
+            BType newT = type.accept(this, null);
+            newT.flags = type.flags;
+            paramTypes.add(newT);
+
+            if (newT != type) {
+                hasNewType = true;
+            }
+        }
+
+        BType rest = originalType.restType;
+        if (rest != null) {
+            rest = rest.accept(this, null);
+            rest.flags = originalType.restType.flags;
+
+            if (rest != originalType.restType) {
+                hasNewType = true;
+            }
+        }
+
+        BType retType = originalType.retType.accept(this, null);
+        retType.flags = originalType.retType.flags;
+
+        if (!hasNewType && retType != originalType.retType) {
+            return originalType;
+        }
+
+        BType type = new BInvokableType(paramTypes, rest, retType, null);
+        type.flags = originalType.flags;
+        return type;
+    }
+
+    @Override
+    public BType visit(BUnionType originalType, BType newType) {
+        boolean hasNewType = false;
+        LinkedHashSet<BType> newMemberTypes = new LinkedHashSet<>();
+
+        for (BType member : originalType.getMemberTypes()) {
+            BType newMember = member.accept(this, null);
+            newMemberTypes.add(newMember);
+
+            if (newMember != member) {
+                hasNewType = true;
+            }
+        }
+
+        if (!hasNewType) {
+            return originalType;
+        }
+
+        BUnionType type = BUnionType.create(null, newMemberTypes);
+        type.flags = originalType.flags;
+        return type;
+    }
+
+    @Override
+    public BType visit(BErrorType originalType, BType newType) {
+        BType newReason = originalType.reasonType.accept(this, null);
+        BType newDetail = originalType.detailType.accept(this, null);
+
+        if (newReason == originalType.reasonType && newDetail == originalType.detailType) {
+            return originalType;
+        }
+
+        BErrorType type = new BErrorType(null, newReason, newDetail);
+        type.flags = originalType.flags;
+        return type;
+    }
+
+    @Override
+    public BType visit(BFutureType originalType, BType newType) {
+        BType newConstraint = originalType.constraint.accept(this, null);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BFutureType newFutureType = new BFutureType(originalType.tag, newConstraint, null,
+                                                    originalType.workerDerivative);
+        newFutureType.flags = originalType.flags;
+        return newFutureType;
+    }
+
+    @Override
+    public BType visit(BFiniteType originalType, BType newType) {
+        // Not applicable for finite types since the descriptor has to be defined before using in the return type.
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BServiceType originalType, BType newType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BTypedescType originalType, BType newType) {
+        BType newConstraint = originalType.constraint.accept(this, null);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BTypedescType newTypedescType = new BTypedescType(newConstraint, null);
+        newTypedescType.flags = originalType.flags;
+        return newTypedescType;
+    }
+
+    @Override
+    public BType visit(BParameterizedType originalType, BType newType) {
+        String paramVarName = originalType.paramSymbol.name.value;
+        BType type;
+        if (this.isInvocation) {
+            type = ((BTypedescType) paramValues.get(paramVarName).type).constraint;
+        } else {
+            type = originalType.paramValueType;
+        }
+        type.flags = originalType.flags;
+        return type;
+    }
+
+    private void createParamMap(BLangInvocation invocation) {
+        paramValues = new LinkedHashMap<>();
+        BInvokableSymbol symbol = (BInvokableSymbol) invocation.symbol;
+        BVarSymbol param;
+
+        for (int i = 0; i < symbol.params.size(); i++) {
+            param = symbol.params.get(i);
+
+            if (param.defaultableParam) {
+                break;
+            }
+
+            paramValues.put(param.name.value, invocation.requiredArgs.get(i));
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ResolvedTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ResolvedTypeBuilder.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
@@ -58,15 +59,15 @@ import java.util.Set;
 /**
  * Util class for building concrete BType types from parameterized types.
  *
- * @since 2.0.0-preview1
+ * @since 2.0.0
  */
-public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
+public class ResolvedTypeBuilder implements BTypeVisitor<BType, BType> {
 
     private Map<String, BType> paramValueTypes;
     private Set<BType> visitedTypes;
     private boolean isInvocation;
 
-    public BType buildType(BType originalType, BLangInvocation invocation) {
+    public BType build(BType originalType, BLangInvocation invocation) {
         this.isInvocation = invocation != null;
         this.visitedTypes = new HashSet<>();
         if (this.isInvocation) {
@@ -77,8 +78,8 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
         return newType;
     }
 
-    public BType buildType(BType originalType) {
-        return buildType(originalType, null);
+    public BType build(BType originalType) {
+        return build(originalType, null);
     }
 
     @Override
@@ -308,6 +309,11 @@ public class ConcreteBTypeBuilder implements BTypeVisitor<BType, BType> {
         BUnionType type = BUnionType.create(null, newMemberTypes);
         type.flags = originalType.flags;
         return type;
+    }
+
+    @Override
+    public BType visit(BIntersectionType originalType, BType newType) {
+        return originalType;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/TypeTags.java
@@ -78,6 +78,7 @@ public class TypeTags {
     public static final int NEVER = XML_TEXT + 1;
 
     public static final int NULL_SET = XML_TEXT + 1;
+    public static final int PARAMETERIZED_TYPE = NULL_SET + 1;
 
     private TypeTags() {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -53,6 +53,7 @@ public class Flags {
     public static final int WORKER = LANG_LIB << 1;
     public static final int FORKED = WORKER << 1;
     public static final int TRANSACTIONAL = FORKED << 1;
+    public static final int PARAMETERIZED = FORKED << 1;
 
     public static int asMask(Set<Flag> flagSet) {
         int mask = 0;
@@ -86,7 +87,7 @@ public class Flags {
                     mask |= INTERFACE;
                     break;
                 case REQUIRED:
-                    mask |= REQUIRED;
+                    mask |= REQUIRED;assignment
                     break;
                 case RECORD:
                     mask |= RECORD;
@@ -145,7 +146,7 @@ public class Flags {
         int flagVal;
         for (Flag flag : Flag.values()) {
             switch (flag) {
-                case PUBLIC:
+                case PUBLIC:assignment
                     flagVal = PUBLIC;
                     break;
                 case PRIVATE:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -87,7 +87,7 @@ public class Flags {
                     mask |= INTERFACE;
                     break;
                 case REQUIRED:
-                    mask |= REQUIRED;assignment
+                    mask |= REQUIRED;
                     break;
                 case RECORD:
                     mask |= RECORD;
@@ -146,7 +146,7 @@ public class Flags {
         int flagVal;
         for (Flag flag : Flag.values()) {
             switch (flag) {
-                case PUBLIC:assignment
+                case PUBLIC:
                     flagVal = PUBLIC;
                     break;
                 case PRIVATE:

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1360,3 +1360,6 @@ error.invalid.return.type.parameterization=\
 
 error.invalid.typedesc.param=\
   only type references allowed as default values for 'typedesc' params used in the return type
+
+error.typedesc.param.not.found=\
+  expected ''{0}'' to be a parameter of the function

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1355,11 +1355,11 @@ error.illegal.function.change.list.size=\
 error.illegal.function.change.tuple.shape=\
   cannot call ''{0}'' on tuple(s) of type ''{1}'': cannot violate inherent type
 
-error.invalid.return.type.parameterization=\
-  return type parameterization only allowed for extern functions
+error.invalid.use.of.typedesc.param=\
+  use of 'typedesc' parameters as types only allowed for return types in external functions
 
 error.invalid.typedesc.param=\
-  only type references allowed as default values for 'typedesc' params used in the return type
+  default value for a 'typedesc' parameter used in the return type should be a reference to a type
 
 error.typedesc.param.not.found=\
   expected ''{0}'' to be a parameter of the function

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1356,10 +1356,10 @@ error.illegal.function.change.tuple.shape=\
   cannot call ''{0}'' on tuple(s) of type ''{1}'': cannot violate inherent type
 
 error.invalid.use.of.typedesc.param=\
-  use of 'typedesc' parameters as types only allowed for return types in external functions
+  use of ''typedesc'' parameters as types only allowed for return types in external functions
+
+error.invalid.param.type.for.return.type=\
+  invalid parameter reference: expected ''typedesc'', found ''{0}''
 
 error.invalid.typedesc.param=\
-  default value for a 'typedesc' parameter used in the return type should be a reference to a type
-
-error.typedesc.param.not.found=\
-  expected ''{0}'' to be a parameter of the function
+  default value for a ''typedesc'' parameter used in the return type should be a reference to a type

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1354,3 +1354,6 @@ error.illegal.function.change.list.size=\
 
 error.illegal.function.change.tuple.shape=\
   cannot call ''{0}'' on tuple(s) of type ''{1}'': cannot violate inherent type
+
+error.invalid.return.type.parameterization=\
+  return type parameterization only allowed for extern functions

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1357,3 +1357,6 @@ error.illegal.function.change.tuple.shape=\
 
 error.invalid.return.type.parameterization=\
   return type parameterization only allowed for extern functions
+
+error.invalid.typedesc.param=\
+  only type references allowed as default values for 'typedesc' params used in the return type

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.nativeimpl.jvm.tests;
+
+import org.ballerinalang.jvm.types.BMapType;
+import org.ballerinalang.jvm.types.BRecordType;
+import org.ballerinalang.jvm.types.BTupleType;
+import org.ballerinalang.jvm.types.BType;
+import org.ballerinalang.jvm.types.BTypes;
+import org.ballerinalang.jvm.values.ArrayValue;
+import org.ballerinalang.jvm.values.ArrayValueImpl;
+import org.ballerinalang.jvm.values.BmpStringValue;
+import org.ballerinalang.jvm.values.DecimalValue;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.jvm.values.MapValueImpl;
+import org.ballerinalang.jvm.values.TableValue;
+import org.ballerinalang.jvm.values.TupleValueImpl;
+import org.ballerinalang.jvm.values.api.BError;
+import org.ballerinalang.jvm.values.api.BFunctionPointer;
+import org.ballerinalang.jvm.values.api.BFuture;
+import org.ballerinalang.jvm.values.api.BStream;
+import org.ballerinalang.jvm.values.api.BString;
+import org.ballerinalang.jvm.values.api.BTypedesc;
+import org.ballerinalang.jvm.values.api.BValue;
+import org.ballerinalang.jvm.values.api.BXML;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.ballerinalang.jvm.types.TypeTags.BOOLEAN_TAG;
+import static org.ballerinalang.jvm.types.TypeTags.BYTE_TAG;
+import static org.ballerinalang.jvm.types.TypeTags.DECIMAL_TAG;
+import static org.ballerinalang.jvm.types.TypeTags.FLOAT_TAG;
+import static org.ballerinalang.jvm.types.TypeTags.INT_TAG;
+import static org.ballerinalang.jvm.types.TypeTags.RECORD_TYPE_TAG;
+import static org.ballerinalang.jvm.types.TypeTags.STRING_TAG;
+
+/**
+ * Native methods for testing functions with variable return types.
+ *
+ * @since 2.0.0-preview1
+ */
+public class VariableReturnType {
+
+    public static Object echo(BTypedesc td, BValue value) {
+        return value;
+    }
+
+    public static BXML getXML(BTypedesc td, BXML value) {
+        return value;
+    }
+
+    public static BStream getStream(BTypedesc td, BStream value) {
+        return value;
+    }
+
+    public static TableValue getTable(BTypedesc td, TableValue value) {
+        return value;
+    }
+
+    public static BFunctionPointer getFunction(BTypedesc param, BTypedesc ret, BFunctionPointer fp) {
+        return fp;
+    }
+
+    public static BTypedesc getTypedesc(BTypedesc td) {
+        return td;
+    }
+
+    public static BFuture getFuture(BTypedesc td, BFuture value) {
+        return value;
+    }
+
+    public static BError getFuture(BTypedesc reason, BTypedesc detail, BError value) {
+        return value;
+    }
+
+    public static Object getValue(BTypedesc td) {
+        return getValue(td.getDescribingType());
+    }
+
+    public static MapValue query(BString query, BTypedesc typedesc) {
+        BType type = typedesc.getDescribingType();
+        MapValue map;
+
+        if (type.getTag() == INT_TAG) {
+            map = new MapValueImpl(new BMapType(type));
+            map.put("one", 10);
+            map.put("two", 20);
+        } else if (type.getTag() == STRING_TAG) {
+            map = new MapValueImpl(new BMapType(type));
+            map.put("name", "Pubudu");
+            map.put("city", "Panadura");
+        } else {
+            map = new MapValueImpl(new BMapType(BTypes.typeAny));
+        }
+
+        return map;
+    }
+
+    public static ArrayValue getTuple(BTypedesc td1, BTypedesc td2, BTypedesc td3) {
+        List<BType> memTypes = new ArrayList<>();
+        memTypes.add(td1.getDescribingType());
+        memTypes.add(td2.getDescribingType());
+        memTypes.add(td3.getDescribingType());
+        BTupleType tupleType = new BTupleType(memTypes);
+
+        ArrayValue arr = new TupleValueImpl(tupleType);
+        arr.add(0, getValue(memTypes.get(0)));
+        arr.add(1, getValue(memTypes.get(1)));
+        arr.add(2, getValue(memTypes.get(2)));
+
+        return arr;
+    }
+
+    public static MapValue getRecord(BTypedesc td) {
+        BRecordType recType = (BRecordType) td.getDescribingType();
+        MapValueImpl person = new MapValueImpl(recType);
+
+        if (recType.getName().equals("Person")) {
+            person.put("name", "John Doe");
+            person.put("age", 20);
+        } else if (recType.getName().equals("Employee")) {
+            person.put("name", "Jane Doe");
+            person.put("age", 25);
+            person.put("designation", "Software Engineer");
+        } else {
+            throw new IllegalStateException();
+        }
+
+        return person;
+    }
+
+    public static Object getVariedUnion(long x, BTypedesc td1, BTypedesc td2) {
+        BType type1 = td1.getDescribingType();
+        BType type2 = td2.getDescribingType();
+
+        if (x == 0) {
+            switch (type1.getTag()) {
+                case INT_TAG:
+                    return 100L;
+                case STRING_TAG:
+                    return "Foo";
+            }
+        }
+
+        MapValueImpl rec = new MapValueImpl(type2);
+        if (type2.getName().equals("Person")) {
+            rec.put("name", "John Doe");
+            rec.put("age", 20);
+        } else {
+            rec.put("type", "Unknown");
+        }
+
+        return rec;
+    }
+
+    public static ArrayValue getArray(BTypedesc td) {
+        return new ArrayValueImpl(new long[]{10, 20, 30});
+    }
+
+    public static Object getInvalidValue(BTypedesc td1, BTypedesc td2) {
+        switch (td1.getDescribingType().getTag()) {
+            case INT_TAG:
+                return getRecord(td2);
+            case RECORD_TYPE_TAG:
+                return 200;
+        }
+        return null;
+    }
+
+    private static Object getValue(BType type) {
+        switch (type.getTag()) {
+            case INT_TAG:
+                return 150L;
+            case FLOAT_TAG:
+                return 12.34D;
+            case DECIMAL_TAG:
+                return new DecimalValue("23.45");
+            case BOOLEAN_TAG:
+                return true;
+            case STRING_TAG:
+                return new BmpStringValue("Hello World!");
+            case BYTE_TAG:
+                return 32;
+            case RECORD_TYPE_TAG:
+                BRecordType recType = (BRecordType) type;
+                MapValueImpl person = new MapValueImpl(recType);
+
+                if (recType.getName().equals("Person")) {
+                    person.put("name", "John Doe");
+                    person.put("age", 20);
+                } else if (recType.getName().equals("Employee")) {
+                    person.put("name", "Jane Doe");
+                    person.put("age", 25);
+                    person.put("designation", "Software Engineer");
+                } else {
+                    throw new IllegalStateException();
+                }
+
+                return person;
+        }
+        return null;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -57,6 +57,14 @@ import static org.ballerinalang.jvm.types.TypeTags.STRING_TAG;
  */
 public class VariableReturnType {
 
+    private static final BString NAME = new BmpStringValue("name");
+    private static final BString AGE = new BmpStringValue("age");
+    private static final BString DESIGNATION = new BmpStringValue("designation");
+    private static final BString CITY = new BmpStringValue("city");
+    private static final BString JOHN_DOE = new BmpStringValue("John Doe");
+    private static final BString JANE_DOE = new BmpStringValue("Jane Doe");
+    private static final BString SOFTWARE_ENGINEER = new BmpStringValue("Software Engineer");
+
     public static Object echo(BTypedesc td, BValue value) {
         return value;
     }
@@ -99,12 +107,12 @@ public class VariableReturnType {
 
         if (type.getTag() == INT_TAG) {
             map = new MapValueImpl(new BMapType(type));
-            map.put("one", 10);
-            map.put("two", 20);
+            map.put(new BmpStringValue("one"), 10);
+            map.put(new BmpStringValue("two"), 20);
         } else if (type.getTag() == STRING_TAG) {
             map = new MapValueImpl(new BMapType(type));
-            map.put("name", "Pubudu");
-            map.put("city", "Panadura");
+            map.put(NAME, new BmpStringValue("Pubudu"));
+            map.put(CITY, new BmpStringValue("Panadura"));
         } else {
             map = new MapValueImpl(new BMapType(BTypes.typeAny));
         }
@@ -132,12 +140,12 @@ public class VariableReturnType {
         MapValueImpl person = new MapValueImpl(recType);
 
         if (recType.getName().equals("Person")) {
-            person.put("name", "John Doe");
-            person.put("age", 20);
+            person.put(NAME, JOHN_DOE);
+            person.put(AGE, 20);
         } else if (recType.getName().equals("Employee")) {
-            person.put("name", "Jane Doe");
-            person.put("age", 25);
-            person.put("designation", "Software Engineer");
+            person.put(NAME, JANE_DOE);
+            person.put(AGE, 25);
+            person.put(DESIGNATION, SOFTWARE_ENGINEER);
         } else {
             throw new IllegalStateException();
         }
@@ -154,16 +162,16 @@ public class VariableReturnType {
                 case INT_TAG:
                     return 100L;
                 case STRING_TAG:
-                    return "Foo";
+                    return new BmpStringValue("Foo");
             }
         }
 
         MapValueImpl rec = new MapValueImpl(type2);
         if (type2.getName().equals("Person")) {
-            rec.put("name", "John Doe");
-            rec.put("age", 20);
+            rec.put(NAME, JOHN_DOE);
+            rec.put(AGE, 20);
         } else {
-            rec.put("type", "Unknown");
+            rec.put(new BmpStringValue("type"), new BmpStringValue("Unknown"));
         }
 
         return rec;
@@ -202,12 +210,12 @@ public class VariableReturnType {
                 MapValueImpl person = new MapValueImpl(recType);
 
                 if (recType.getName().equals("Person")) {
-                    person.put("name", "John Doe");
-                    person.put("age", 20);
+                    person.put(NAME, JOHN_DOE);
+                    person.put(AGE, 20);
                 } else if (recType.getName().equals("Employee")) {
-                    person.put("name", "Jane Doe");
-                    person.put("age", 25);
-                    person.put("designation", "Software Engineer");
+                    person.put(NAME, JANE_DOE);
+                    person.put(AGE, 25);
+                    person.put(DESIGNATION, SOFTWARE_ENGINEER);
                 } else {
                     throw new IllegalStateException();
                 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/VariableReturnTypesBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/VariableReturnTypesBaloTest.java
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *   Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -30,7 +30,7 @@ import org.testng.annotations.Test;
 /**
  * Test cases for variable return types in extern functions.
  *
- * @since 2.0.0-preview1
+ * @since 2.0.0
  */
 public class VariableReturnTypesBaloTest {
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/VariableReturnTypesBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/VariableReturnTypesBaloTest.java
@@ -1,0 +1,88 @@
+/*
+ *   Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.balo.functions;
+
+import org.ballerinalang.test.balo.BaloCreator;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for variable return types in extern functions.
+ *
+ * @since 2.0.0-preview1
+ */
+public class VariableReturnTypesBaloTest {
+
+    CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        BaloCreator.cleanCacheDirectories();
+        BaloCreator.createAndSetupBalo("test-src/balo/test_projects/test_project", "testorg", "returntypes");
+        result = BCompileUtil.compile("test-src/javainterop/variable_return_type_bir_test.bal");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'map' cannot be cast to " +
+                  "'map<anydata>.*")
+    public void testRuntimeCastError() {
+        BRunUtil.invoke(result, "testRuntimeCastError");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'Person' cannot be cast " +
+                  "to 'int'.*")
+    public void testCastingForInvalidValues() {
+        BRunUtil.invoke(result, "testCastingForInvalidValues");
+    }
+
+    @Test(dataProvider = "FunctionNames")
+    public void testVariableTypeAsReturnType(String funcName) {
+        BRunUtil.invoke(result, funcName);
+    }
+
+    @DataProvider(name = "FunctionNames")
+    public Object[][] getFuncNames() {
+        return new Object[][]{
+                {"testRecordVarRef"},
+                {"testVarRefInMapConstraint"},
+                {"testVarRefUseInMultiplePlaces"},
+                {"testSimpleTypes"},
+                {"testUnionTypes"},
+                {"testArrayTypes"},
+//                {"testXML"},
+                {"testStream"},
+                {"testTable"},
+                {"testFunctionPointers"},
+                {"testTypedesc"},
+                {"testFuture"},
+                {"testComplexTypes"}
+        };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "returntypes");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -67,7 +67,7 @@ public class VariableReturnTypeTest {
                 "in external functions", 93, 67);
         validateError(errors, indx++, "default value for a typedesc parameter used in the return type should be a " +
                 "reference to a type", 97, 29);
-        validateError(errors, indx++, "expected 'aTypeVar' to be a parameter of the function", 97, 81);
+        validateError(errors, indx++, "unknown type 'NonExistentParam'", 107, 77);
 
         Assert.assertEquals(errors.getErrorCount(), indx);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -55,7 +55,7 @@ public class VariableReturnTypeTest {
         validateError(errors, indx++, "incompatible types: expected 'float', found '(int|float)'", 61, 15);
         validateError(errors, indx++, "unknown type 'td'", 64, 73);
         validateError(errors, indx++, "unknown type 'td'", 72, 54);
-        validateError(errors, indx++, "unknown type 'td'", 74, 90);
+        validateError(errors, indx++, "unknown type 'td'", 74, 88);
         validateError(errors, indx++, "invalid error reason type 'other', expected a subtype of 'string'", 86, 83);
         validateError(errors, indx++, "unknown type 'reason'", 86, 83);
         validateError(errors, indx++, "invalid error detail type 'detail', expected a subtype of 'record {| " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -72,6 +72,11 @@ public class VariableReturnTypeTest {
         validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 119, 45);
         validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
                 "in external functions", 119, 45);
+        validateError(errors, indx++, "incompatible types: expected 'function (typedesc<(string|int)>) returns " +
+                "(string)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 130, 61);
+        validateError(errors, indx++, "unknown type 'td'", 131, 48);
+        validateError(errors, indx++, "incompatible types: expected 'function (typedesc<(string|int)>) returns " +
+                "(other)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 131, 57);
 
         Assert.assertEquals(errors.getErrorCount(), indx);
     }
@@ -88,6 +93,13 @@ public class VariableReturnTypeTest {
                   "to 'int'.*")
     public void testCastingForInvalidValues() {
         BRunUtil.invoke(result, "testCastingForInvalidValues");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'string' cannot be cast " +
+                  "to 'int'.*")
+    public void testFunctionAssignment() {
+        BRunUtil.invoke(result, "testFunctionAssignment");
     }
 
     @Test(dataProvider = "FunctionNames")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -30,7 +30,7 @@ import static org.ballerinalang.test.util.BAssertUtil.validateError;
 /**
  * Test cases for interop functions with variable return types through typedesc refs.
  *
- * @since 2.0.0-preview1
+ * @since 2.0.0
  */
 public class VariableReturnTypeTest {
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -21,8 +21,11 @@ import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.util.BAssertUtil.validateError;
 
 /**
  * Test cases for interop functions with variable return types through typedesc refs.
@@ -32,6 +35,35 @@ import org.testng.annotations.Test;
 public class VariableReturnTypeTest {
 
     private CompileResult result = BCompileUtil.compile("test-src/javainterop/variable_return_type_test.bal");
+
+    @Test
+    public void testNegatives() {
+        CompileResult errors = BCompileUtil.compile("test-src/javainterop/variable_return_type_negative.bal");
+        int indx = 0;
+        validateError(errors, indx++, "incompatible types: expected 'string', found 'int'", 27, 16);
+        validateError(errors, indx++, "incompatible types: expected 'int', found 'float'", 29, 13);
+        validateError(errors, indx++, "incompatible types: expected 'int', found 'decimal'", 30, 9);
+        validateError(errors, indx++, "incompatible types: expected 'int', found 'string'", 31, 9);
+        validateError(errors, indx++, "incompatible types: expected 'int', found 'boolean'", 32, 9);
+        validateError(errors, indx++, "incompatible types: expected 'boolean', found 'int'", 34, 17);
+        validateError(errors, indx++, "incompatible types: expected 'float', found 'int'", 36, 15);
+        validateError(errors, indx++, "incompatible types: expected 'typedesc<(int|float|decimal|string|boolean)>', " +
+                "found 'typedesc<json>'", 40, 23);
+        validateError(errors, indx++, "unknown type 'aTypeVar'", 43, 60);
+        validateError(errors, indx++, "incompatible types: expected 'map<int>', found 'map<other>'", 50, 18);
+        validateError(errors, indx++, "incompatible types: expected 'int', found '(int|float)'", 60, 13);
+        validateError(errors, indx++, "incompatible types: expected 'float', found '(int|float)'", 61, 15);
+        validateError(errors, indx++, "unknown type 'td'", 64, 73);
+        validateError(errors, indx++, "unknown type 'td'", 72, 54);
+        validateError(errors, indx++, "unknown type 'td'", 74, 90);
+        validateError(errors, indx++, "invalid error reason type 'other', expected a subtype of 'string'", 86, 83);
+        validateError(errors, indx++, "unknown type 'reason'", 86, 83);
+        validateError(errors, indx++, "invalid error detail type 'detail', expected a subtype of 'record {| " +
+                "string message?; error cause?; (anydata|error)...; |}'", 86, 91);
+        validateError(errors, indx++, "unknown type 'detail'", 86, 91);
+
+        Assert.assertEquals(errors.getErrorCount(), indx);
+    }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
           expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'map' cannot be cast to " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -61,13 +61,17 @@ public class VariableReturnTypeTest {
         validateError(errors, indx++, "invalid error detail type 'detail', expected a subtype of 'record {| " +
                 "string message?; error cause?; (anydata|error)...; |}'", 86, 91);
         validateError(errors, indx++, "unknown type 'detail'", 86, 91);
-        validateError(errors, indx++, "use of typedesc parameters as types only allowed for return types " +
+        validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
                 "in external functions", 93, 45);
-        validateError(errors, indx++, "use of typedesc parameters as types only allowed for return types " +
+        validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
                 "in external functions", 93, 67);
-        validateError(errors, indx++, "default value for a typedesc parameter used in the return type should be a " +
+        validateError(errors, indx++, "default value for a 'typedesc' parameter used in the return type should be a " +
                 "reference to a type", 97, 29);
         validateError(errors, indx++, "unknown type 'NonExistentParam'", 107, 77);
+        validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 113, 54);
+        validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 119, 45);
+        validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
+                "in external functions", 119, 45);
 
         Assert.assertEquals(errors.getErrorCount(), indx);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.test.javainterop;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.util.exceptions.BLangRuntimeException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for interop functions with variable return types through typedesc refs.
+ *
+ * @since 2.0.0-preview1
+ */
+public class VariableReturnTypeTest {
+
+    private CompileResult result = BCompileUtil.compile("test-src/javainterop/variable_return_type_test.bal");
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'map' cannot be cast to " +
+                  "'map<anydata>.*")
+    public void testRuntimeCastError() {
+        BRunUtil.invoke(result, "testRuntimeCastError");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+          expectedExceptionsMessageRegExp = ".*TypeCastError message=incompatible types: 'Person' cannot be cast " +
+                  "to 'int'.*")
+    public void testCastingForInvalidValues() {
+        BRunUtil.invoke(result, "testCastingForInvalidValues");
+    }
+
+    @Test(dataProvider = "FunctionNames")
+    public void testVariableTypeAsReturnType(String funcName) {
+        BRunUtil.invoke(result, funcName);
+    }
+
+    @DataProvider(name = "FunctionNames")
+    public Object[][] getFuncNames() {
+        return new Object[][]{
+                {"testRecordVarRef"},
+                {"testVarRefInMapConstraint"},
+                {"testVarRefUseInMultiplePlaces"},
+                {"testSimpleTypes"},
+                {"testUnionTypes"},
+                {"testArrayTypes"},
+//                {"testXML"},
+                {"testStream"},
+                {"testTable"},
+                {"testFunctionPointers"},
+                {"testTypedesc"},
+                {"testFuture"},
+                {"testComplexTypes"}
+        };
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -61,6 +61,13 @@ public class VariableReturnTypeTest {
         validateError(errors, indx++, "invalid error detail type 'detail', expected a subtype of 'record {| " +
                 "string message?; error cause?; (anydata|error)...; |}'", 86, 91);
         validateError(errors, indx++, "unknown type 'detail'", 86, 91);
+        validateError(errors, indx++, "use of typedesc parameters as types only allowed for return types " +
+                "in external functions", 93, 45);
+        validateError(errors, indx++, "use of typedesc parameters as types only allowed for return types " +
+                "in external functions", 93, 67);
+        validateError(errors, indx++, "default value for a typedesc parameter used in the return type should be a " +
+                "reference to a type", 97, 29);
+        validateError(errors, indx++, "expected 'aTypeVar' to be a parameter of the function", 97, 81);
 
         Assert.assertEquals(errors.getErrorCount(), indx);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/returntypes/interop_funcs.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/returntypes/interop_funcs.bal
@@ -1,0 +1,115 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/java;
+
+//type ItemType 'xml:Element|'xml:Comment|'xml:ProcessingInstruction|'xml:Text;
+
+public type Person record {
+    readonly string name;
+    int age;
+};
+
+public type Employee record {
+    *Person;
+    string designation;
+};
+
+public function getValue(public typedesc<int|float|decimal|string|boolean> td) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function getRecord(public typedesc<anydata> td = Person) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getRecord",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function query(string q, public typedesc<anydata> rowType = int) returns map<rowType> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "query",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BString", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function getTuple(public typedesc<int|string> td1, public typedesc<record {}> td2, public typedesc<float|boolean> td3 = float) returns [td1, td2, td3] = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getTuple",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function getVariedUnion(int x, public typedesc<int|string> td1, public typedesc<record{ string name; }> td2) returns (td1|td2) = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getVariedUnion",
+    paramTypes: ["long", "org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function getArray(public typedesc<anydata> td) returns td[] = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getArray",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function getInvalidValue(public typedesc<int|Person> td1, public typedesc<Person> td2) returns td1 = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getInvalidValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+//public function getXML(public typedesc<ItemType> td, xml value) returns xml<td> = @java:Method {
+//    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+//    name: "getXML",
+//    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BXML"]
+//} external;
+
+public function getStream(public typedesc<anydata> td, stream<anydata> value) returns stream<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getStream",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BStream"]
+} external;
+
+public function getTable(public typedesc<anydata> td, table<anydata> value) returns table<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getTable",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.TableValue"]
+} external;
+
+public function getFunction(public typedesc<anydata> param, public typedesc<anydata> ret, function (string|int) returns anydata fn)
+                                                                returns function (param) returns ret = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getFunction",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc",
+                    "org.ballerinalang.jvm.values.api.BFunctionPointer"]
+} external;
+
+public function getTypedesc(public typedesc<anydata> td) returns typedesc<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getTypedesc",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+public function getFuture(public typedesc<anydata> td, future<anydata> f) returns future<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getFuture",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BFuture"]
+} external;
+
+public function echo(public typedesc<any> td, any val) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "echo",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BValue"]
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_bir_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_bir_test.bal
@@ -143,7 +143,7 @@ type PersonObj object {
     string fname;
     string lname;
 
-    function __init(string fname, string lname) {
+    function init(string fname, string lname) {
         self.fname = fname;
         self.lname = lname;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_bir_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_bir_test.bal
@@ -1,0 +1,207 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.'xml;
+import testorg/returntypes as rt;
+
+type ItemType 'xml:Element|'xml:Comment|'xml:ProcessingInstruction|'xml:Text;
+
+type Person record {
+    readonly string name;
+    int age;
+};
+
+type Employee record {
+    *Person;
+    string designation;
+};
+
+Person expPerson = {name: "John Doe", age: 20};
+
+
+// Test functions
+
+function testSimpleTypes() {
+    int i = rt:getValue(int);
+    assert(150, i);
+
+    float f = rt:getValue(float);
+    assert(12.34, f);
+
+    decimal d = rt:getValue(decimal);
+    assert(23.45d, d);
+
+    string s = rt:getValue(string);
+    assert("Hello World!", s);
+
+    boolean b = rt:getValue(boolean);
+    assert(true, b);
+}
+
+function testRecordVarRef() {
+    Person p = rt:getRecord();
+    assert(expPerson, p);
+
+    Employee e = rt:getRecord(td = Employee);
+    assert(<Employee>{name: "Jane Doe", age: 25, designation: "Software Engineer"}, e);
+}
+
+function testVarRefInMapConstraint() {
+    map<int> m1 = rt:query("foo");
+    assert(<map<int>>{"one": 10, "two": 20}, m1);
+
+    map<string> m2 = rt:query("foo", rowType = string);
+    assert(<map<string>>{"name": "Pubudu", "city": "Panadura"}, m2);
+}
+
+function testRuntimeCastError() {
+    map<anydata> m1 = rt:query("foo", rowType = float);
+}
+
+function testVarRefUseInMultiplePlaces() {
+    [int, Person, float] tup1 = rt:getTuple(int, Person);
+    assert(<[int, Person, float]>[150, expPerson, 12.34], tup1);
+}
+
+function testUnionTypes() {
+    int|Person u = rt:getVariedUnion(1, int, Person);
+    assert(expPerson, u);
+}
+
+function testArrayTypes() {
+    int[] arr = rt:getArray(int);
+    assert(<int[]>[10, 20, 30], arr);
+}
+
+function testCastingForInvalidValues() {
+    int x = rt:getInvalidValue(int, Person);
+}
+
+//function testXML() {
+//    'xml:Element elem1 = xml `<hello>xml content</hello>`;
+//    xml<'xml:Element> x1 = rt:getXML('xml:Element, elem1);
+//    assert(elem1, x1);
+//}
+
+function testStream() {
+    string[] stringList = ["hello", "world", "from", "ballerina"];
+    stream<string> st = stringList.toStream();
+    stream<string> newSt = rt:getStream(string, st);
+    string s = "";
+
+    error? err = newSt.forEach(function (string x) { s += x; });
+    assert("helloworldfromballerina", s);
+}
+
+function testTable() {
+    table<Employee> key(name) tab = table [
+        { name: "Chiran", age: 33, designation: "SE" },
+        { name: "Mohan", age: 37, designation: "SE" },
+        { name: "Gima", age: 38, designation: "SE" },
+        { name: "Granier", age: 34, designation: "SE" }
+    ];
+
+    table<Person> newTab = rt:getTable(Person, tab);
+    assert(tab, newTab);
+}
+
+function testFunctionPointers() {
+    function (anydata) returns int fn = s => 10;
+    function (string) returns int newFn = rt:getFunction(string, int, fn);
+    assertSame(fn, newFn);
+    assert(fn("foo"), newFn("foo"));
+}
+
+function testTypedesc() {
+    typedesc<Person> tP = rt:getTypedesc(Person);
+    assert(Person.toString(), tP.toString());
+}
+
+function testFuture() {
+    var fn = function (string name) returns string => "Hello " + name;
+    future<string> f = start fn("Pubudu");
+    future<string> fNew = rt:getFuture(string, f);
+    string res = wait fNew;
+    assertSame(f, fNew);
+    assert("Hello Pubudu", res);
+}
+
+type PersonObj object {
+    string fname;
+    string lname;
+
+    function __init(string fname, string lname) {
+        self.fname = fname;
+        self.lname = lname;
+    }
+
+    function name() returns string => self.fname + " " + self.lname;
+};
+
+function testComplexTypes() {
+    json j = rt:echo(json, <json>{"name": "John Doe"});
+    assert(<json>{"name": "John Doe"}, j);
+
+    xml x = rt:echo(xml, xml `<hello>xml content</hello>`);
+    assert(xml `<hello>xml content</hello>`, x);
+
+    int[] ar = rt:echo(int[], <int[]>[20, 30, 40]);
+    assert(<int[]>[20, 30, 40], ar);
+
+    PersonObj pObj = new("John", "Doe");
+    PersonObj nObj = rt:echo(PersonObj, pObj);
+    assertSame(pObj, nObj);
+
+    int[] intList = [10, 20, 30, 40, 50];
+    stream<int> st = intList.toStream();
+    stream<int> newSt = rt:echo(stream<int>, st);
+    int tot = 0;
+
+    error? err = newSt.forEach(function (int x) { tot+= x; });
+    assert(150, tot);
+
+    table<Person> key(name) tab = table [
+        { name: "Chiran", age: 33},
+        { name: "Mohan", age: 37},
+        { name: "Gima", age: 38},
+        { name: "Granier", age: 34}
+    ];
+
+    table<Person> newTab = rt:echo(table<Person>, tab);
+    assert(tab, newTab);
+}
+
+
+// Util functions
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string detail = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}
+
+function assertSame(any expected, any actual) {
+    if (expected !== actual) {
+        typedesc<any> expT = typeof expected;
+        typedesc<any> actT = typeof actual;
+        string detail = "expected value of type [" + expT.toString() + "] is not the same as actual value" +
+                                " of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -103,3 +103,9 @@ function getNonTypedescExpr(typedesc<anydata> aTypeVar = getTypedesc()) returns 
 function getTypedesc() returns typedesc<anydata> {
     return float;
 }
+
+function referToANonExistingParam(typedesc<anydata> aTypeVar = int) returns NonExistentParam = @java:Method {
+    class: "xyz.pubudu.Hello",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -119,3 +119,14 @@ function referToNonTypedescParam(string str) returns str = @java:Method {
 function normalFunction(string str) returns str {
     return "foo";
 }
+
+function getValue2(typedesc<int|string> aTypeVar) returns aTypeVar = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function testInvalidFunctionAssignment() {
+    function (typedesc<string|int> td) returns string fn1 = getValue2;
+    function (typedesc<string|int> td) returns td fn2 = getValue2;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -109,3 +109,13 @@ function referToANonExistingParam(typedesc<anydata> aTypeVar = int) returns NonE
     name: "getValue",
     paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
 } external;
+
+function referToNonTypedescParam(string str) returns str = @java:Method {
+    class: "xyz.pubudu.Hello",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function normalFunction(string str) returns str {
+    return "foo";
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -1,0 +1,91 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+import ballerina/java;
+
+function getValue(typedesc<int|float|decimal|string|boolean> td) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function testParamToLHS() {
+    string s = getValue(int);
+
+    int i = getValue(float);
+    i = getValue(decimal);
+    i = getValue(string);
+    i = getValue(boolean);
+
+    boolean b = getValue(int);
+
+    float f = getValue(int);
+}
+
+function testIncompatibleArg() {
+    json j = getValue(json);
+}
+
+function getMap(typedesc<anydata>... aTypeVar) returns map<aTypeVar> = @java:Method {
+    class: "xyz.pubudu.Hello",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function testRestParamReference() {
+    map<int> m = getMap(int, float);
+}
+
+function funcWithDefaultableParam(typedesc<anydata> td = int|float) returns td = @java:Method {
+    class: "xyz.pubudu.Hello",
+    name: "funcWithDefaultableParam",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function testDefaultableParamRef() {
+    int i = funcWithDefaultableParam();
+    float f = funcWithDefaultableParam();
+}
+
+function getRecord(typedesc<anydata> td) returns record {| string name; td misc; |} = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getRecord",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getObject(typedesc<anydata> td) returns object {
+                                                     string name;
+                                                     td misc;
+
+                                                     public function __init(string name, td misc) {
+                                                         self.name = name;
+                                                         self.misc = misc;
+                                                     }
+                                                 } = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getObject",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getError(typedesc<string> reason, typedesc<record {}> detail,
+                    error<string, record {| string message?; error cause?; (anydata|error)...; |}> err)
+                                                                    returns error<reason, detail> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getError",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc",
+                    "org.ballerinalang.jvm.values.api.BError"]
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -89,3 +89,17 @@ function getError(typedesc<string> reason, typedesc<record {}> detail,
     paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc",
                     "org.ballerinalang.jvm.values.api.BError"]
 } external;
+
+function foo(typedesc<anydata> td = string, td s = "foo") returns td {
+    return "foo";
+}
+
+function getNonTypedescExpr(typedesc<anydata> aTypeVar = getTypedesc()) returns aTypeVar = @java:Method {
+    class: "xyz.pubudu.Hello",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getTypedesc() returns typedesc<anydata> {
+    return float;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -71,7 +71,7 @@ function getObject(typedesc<anydata> td) returns object {
                                                      string name;
                                                      td misc;
 
-                                                     public function __init(string name, td misc) {
+                                                     public function init(string name, td misc) {
                                                          self.name = name;
                                                          self.misc = misc;
                                                      }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -1,0 +1,295 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.'xml;
+import ballerina/java;
+
+type ItemType 'xml:Element|'xml:Comment|'xml:ProcessingInstruction|'xml:Text;
+
+type Person record {
+    readonly string name;
+    int age;
+};
+
+type Employee record {
+    *Person;
+    string designation;
+};
+
+Person expPerson = {name: "John Doe", age: 20};
+
+
+// Test functions
+
+function testSimpleTypes() {
+    int i = getValue(int);
+    assert(150, i);
+
+    float f = getValue(float);
+    assert(12.34, f);
+
+    decimal d = getValue(decimal);
+    assert(23.45d, d);
+
+    //string s = getValue(string);
+    //assert("Hello World!", s);
+
+    boolean b = getValue(boolean);
+    assert(true, b);
+}
+
+function testRecordVarRef() {
+    Person p = getRecord();
+    assert(expPerson, p);
+
+    Employee e = getRecord(td = Employee);
+    assert(<Employee>{name: "Jane Doe", age: 25, designation: "Software Engineer"}, e);
+}
+
+function testVarRefInMapConstraint() {
+    map<int> m1 = query("foo");
+    assert(<map<int>>{"one": 10, "two": 20}, m1);
+
+    map<string> m2 = query("foo", rowType = string);
+    assert(<map<string>>{"name": "Pubudu", "city": "Panadura"}, m2);
+}
+
+function testRuntimeCastError() {
+    map<anydata> m1 = query("foo", rowType = float);
+}
+
+function testVarRefUseInMultiplePlaces() {
+    [int, Person, float] tup1 = getTuple(int, Person);
+    assert(<[int, Person, float]>[150, expPerson, 12.34], tup1);
+}
+
+function testUnionTypes() {
+    int|Person u = getVariedUnion(1, int, Person);
+    assert(expPerson, u);
+}
+
+function testArrayTypes() {
+    int[] arr = getArray(int);
+    assert(<int[]>[10, 20, 30], arr);
+}
+
+function testCastingForInvalidValues() {
+    int x = getInvalidValue(int, Person);
+}
+
+//function testXML() {
+//    'xml:Element elem1 = xml `<hello>xml content</hello>`;
+//    xml<'xml:Element> x1 = getXML('xml:Element, elem1);
+//    assert(elem1, x1);
+//}
+
+function testStream() {
+    string[] stringList = ["hello", "world", "from", "ballerina"];
+    stream<string> st = stringList.toStream();
+    stream<string> newSt = getStream(string, st);
+    string s = "";
+
+    error? err = newSt.forEach(function (string x) { s += x; });
+    assert("helloworldfromballerina", s);
+}
+
+function testTable() {
+    table<Employee> key(name) tab = table [
+        { name: "Chiran", age: 33, designation: "SE" },
+        { name: "Mohan", age: 37, designation: "SE" },
+        { name: "Gima", age: 38, designation: "SE" },
+        { name: "Granier", age: 34, designation: "SE" }
+    ];
+
+    table<Person> newTab = getTable(Person, tab);
+    assert(tab, newTab);
+}
+
+function testFunctionPointers() {
+    function (anydata) returns int fn = s => 10;
+    function (string) returns int newFn = getFunction(string, int, fn);
+    assertSame(fn, newFn);
+    assert(fn("foo"), newFn("foo"));
+}
+
+function testTypedesc() {
+    typedesc<Person> tP = getTypedesc(Person);
+    assert(Person.toString(), tP.toString());
+}
+
+function testFuture() {
+    var fn = function (string name) returns string => "Hello " + name;
+    future<string> f = start fn("Pubudu");
+    future<string> fNew = getFuture(string, f);
+    string res = wait fNew;
+    assertSame(f, fNew);
+    assert("Hello Pubudu", res);
+}
+
+type PersonObj object {
+    string fname;
+    string lname;
+
+    function __init(string fname, string lname) {
+        self.fname = fname;
+        self.lname = lname;
+    }
+
+    function name() returns string => self.fname + " " + self.lname;
+};
+
+function testComplexTypes() {
+    json j = echo(json, <json>{"name": "John Doe"});
+    assert(<json>{"name": "John Doe"}, j);
+
+    xml x = echo(xml, xml `<hello>xml content</hello>`);
+    assert(xml `<hello>xml content</hello>`, x);
+
+    int[] ar = echo(int[], <int[]>[20, 30, 40]);
+    assert(<int[]>[20, 30, 40], ar);
+
+    PersonObj pObj = new("John", "Doe");
+    PersonObj nObj = echo(PersonObj, pObj);
+    assertSame(pObj, nObj);
+
+    int[] intList = [10, 20, 30, 40, 50];
+    stream<int> st = intList.toStream();
+    stream<int> newSt = echo(stream<int>, st);
+    int tot = 0;
+
+    error? err = newSt.forEach(function (int x) { tot+= x; });
+    assert(150, tot);
+
+    table<Person> key(name) tab = table [
+        { name: "Chiran", age: 33},
+        { name: "Mohan", age: 37},
+        { name: "Gima", age: 38},
+        { name: "Granier", age: 34}
+    ];
+
+    table<Person> newTab = echo(table<Person>, tab);
+    assert(tab, newTab);
+}
+
+
+// Interop functions
+function getValue(typedesc<int|float|decimal|string|boolean> td) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getRecord(typedesc<anydata> td = Person) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getRecord",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function query(string q, typedesc<anydata> rowType = int) returns map<rowType> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "query",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BString", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getTuple(typedesc<int|string> td1, typedesc<record {}> td2, typedesc<float|boolean> td3 = float) returns [td1, td2, td3] = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getTuple",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getVariedUnion(int x, typedesc<int|string> td1, typedesc<record{ string name; }> td2) returns (td1|td2) = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getVariedUnion",
+    paramTypes: ["long", "org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getArray(typedesc<anydata> td) returns td[] = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getArray",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getInvalidValue(typedesc<int|Person> td1, typedesc<Person> td2) returns td1 = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getInvalidValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getXML(typedesc<ItemType> td, xml value) returns xml<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getXML",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BXML"]
+} external;
+
+function getStream(typedesc<anydata> td, stream<anydata> value) returns stream<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getStream",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BStream"]
+} external;
+
+function getTable(typedesc<anydata> td, table<anydata> value) returns table<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getTable",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.TableValue"]
+} external;
+
+function getFunction(typedesc<anydata> param, typedesc<anydata> ret, function (string|int) returns anydata fn)
+                                                                returns function (param) returns ret = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getFunction",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BTypedesc",
+                    "org.ballerinalang.jvm.values.api.BFunctionPointer"]
+} external;
+
+function getTypedesc(typedesc<anydata> td) returns typedesc<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getTypedesc",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
+
+function getFuture(typedesc<anydata> td, future<anydata> f) returns future<td> = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getFuture",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BFuture"]
+} external;
+
+function echo(typedesc<any> td, any val) returns td = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "echo",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BValue"]
+} external;
+
+
+// Util functions
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string detail = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}
+
+function assertSame(any expected, any actual) {
+    if (expected !== actual) {
+        typedesc<any> expT = typeof expected;
+        typedesc<any> actT = typeof actual;
+        string detail = "expected value of type [" + expT.toString() + "] is not the same as actual value" +
+                                " of type [" + actT.toString() + "]";
+        panic error("{AssertionError}", message = detail);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -184,6 +184,17 @@ function testComplexTypes() {
     assert(tab, newTab);
 }
 
+function testFunctionAssignment() {
+    function (typedesc<string|int> td) returns int|string fn = getValue2;
+    int x = <int>fn(int);
+    assert(150, x);
+
+    string s = <string>fn(string);
+    assert("Hello World!", s);
+
+    x = <int>fn(string);
+}
+
 
 // Interop functions
 function getValue(typedesc<int|float|decimal|string|boolean> td) returns td = @java:Method {
@@ -272,6 +283,11 @@ function echo(typedesc<any> td, any val) returns td = @java:Method {
     paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc", "org.ballerinalang.jvm.values.api.BValue"]
 } external;
 
+function getValue2(typedesc<int|string> aTypeVar) returns aTypeVar = @java:Method {
+    class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+    name: "getValue",
+    paramTypes: ["org.ballerinalang.jvm.values.api.BTypedesc"]
+} external;
 
 // Util functions
 function assert(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -143,7 +143,7 @@ type PersonObj object {
     string fname;
     string lname;
 
-    function __init(string fname, string lname) {
+    function init(string fname, string lname) {
         self.fname = fname;
         self.lname = lname;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -44,8 +44,8 @@ function testSimpleTypes() {
     decimal d = getValue(decimal);
     assert(23.45d, d);
 
-    //string s = getValue(string);
-    //assert("Hello World!", s);
+    string s = getValue(string);
+    assert("Hello World!", s);
 
     boolean b = getValue(boolean);
     assert(true, b);


### PR DESCRIPTION
## Purpose
> This PR adds support for using typedesc variable references in the return type of an extern function. 
>Fixes #22930 

## Approach
> The approach taken was to introduce a new type called `BParameterizedType` for the var refs used in the return type. This type just simply captures the symbol of the parameter and its default value's (if there is one) type. 
>
> When type checking function calls, if the return type of the function is parameterized, a parameterized type resolver will walk through the return type and replace any var refs with the appropriate concrete type for that particular context, using the arguments provided by the user. In Desugar, the type gets replaced by the narrowest static concrete type that can be resolved for the function's return type. For example, in the sample below, this would be `map<anydata>`.
>
> When generating the function itself also the return type is generated as the narrowest possible concrete type that can be resolved for the return type. 
>
> `BParameterizedType` gets written to the BIR since we want the return type information to be persisted if the module will be used in other modules. But it doesn't have a runtime type since at runtime we will always be relying on concrete types and type casts to do the narrowing based on the contexts. 
>
> The name of the parameter is set as the name of the type. The default value type gets written to the BIR when visiting the `BParameterizedType`. Symbol info is not written. When reading it back, first the type gets created with the name and the default value type.After the invokable symbol's param symbols get defined, we walk through the return type recursively and if we come across a parameterized type, we lookup the param symbols using the type's name and fill the param symbol in the type.

## Samples
```ballerina
import ballerina/io;

public function main() {
    map<int> m = query("foo");
    io:println(m);
}

function query(string q, typedesc<anydata> rowType = int) returns map<rowType> = @java:Method {
    class: "xyz.pubudu.Hello",
    name: "query",
    paramTypes: ["org.ballerinalang.jvm.values.api.BString", "org.ballerinalang.jvm.values.api.BTypedesc"]
} external;
\
```

## Remarks
- [ ] Add support for object types
- [x] Complete the read/write from/to BIR 
- [x] Add test cases
- [x] Clean up the code

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
