### PR TITLE
Support distinct error type in balo and jvm codegen

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -1900,6 +1900,9 @@ public class TypeChecker {
         }
         unresolvedTypes.add(pair);
         BErrorType bErrorType = (BErrorType) sourceType;
+        if (!((BErrorType) sourceType).typeIdSet.containsAll(targetType.typeIdSet)) {
+            return false;
+        }
 
         return  checkIsType(bErrorType.detailType, targetType.detailType, unresolvedTypes);
     }
@@ -1908,6 +1911,9 @@ public class TypeChecker {
                                                 List<TypeValuePair> unresolvedValues, boolean allowNumericConversion) {
         BType sourceType = getType(sourceValue);
         if (sourceValue == null || sourceType.getTag() != TypeTags.ERROR_TAG) {
+            return false;
+        }
+        if (!((BErrorType) sourceType).typeIdSet.containsAll(targetType.typeIdSet)) {
             return false;
         }
         return checkIsLikeType(((ErrorValue) sourceValue).getDetails(), targetType.detailType, unresolvedValues,

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BErrorType.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BErrorType.java
@@ -27,6 +27,7 @@ import org.ballerinalang.jvm.values.ErrorValue;
 public class BErrorType extends AnnotatableType {
 
     public BType detailType;
+    public BTypeIdSet typeIdSet;
 
     public BErrorType(String typeName, BPackage pkg, BType detailType) {
         super(typeName, pkg, ErrorValue.class);
@@ -37,9 +38,8 @@ public class BErrorType extends AnnotatableType {
         super(typeName, pkg, ErrorValue.class);
     }
 
-    public BErrorType(BType reasonType) {
-        super(TypeConstants.ERROR, null, ErrorValue.class);
-        this.detailType = detailType;
+    public void setTypeIdSet(BTypeIdSet typeIdSet) {
+        this.typeIdSet = typeIdSet;
     }
 
     @Override

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BPackage.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BPackage.java
@@ -35,18 +35,20 @@ public class BPackage {
     public String org;
     public String name;
     public String version;
-    private int hashCode = Objects.hash(org, name, version);
+    private int hashCode;
 
     public BPackage(String org, String name, String version) {
         this.org = org;
         this.name = name;
         this.version = version;
+        hashCode = Objects.hash(org, name, version);
     }
 
     public BPackage(String org, String name) {
         this.org = org;
         this.name = name;
         this.version = "";
+        hashCode = Objects.hash(org, name);
     }
 
     public String getOrg() {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BTypeIdSet.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/types/BTypeIdSet.java
@@ -1,0 +1,85 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.jvm.types;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represent Ballerina distinct types type-ids in the runtime.
+ *
+ * @since 2.0
+ */
+public class BTypeIdSet {
+    List<TypeId> ids;
+
+    public BTypeIdSet() {
+        this.ids = new ArrayList<>();
+    }
+
+    public void add(BPackage pkg, String name, boolean isPrimary) {
+        ids.add(new TypeId(pkg, name, isPrimary));
+    }
+
+    public boolean containsAll(BTypeIdSet other) {
+        // All items in other set is present in current.
+        for (TypeId id : other.ids) {
+            boolean found = false;
+            for (TypeId otherTypeId : ids) {
+                if (id.name.equals(otherTypeId.name) && id.pkg.equals(otherTypeId.pkg)) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    public static class TypeId {
+        final BPackage pkg;
+        final String name;
+        final boolean isPrimary;
+
+        public TypeId(BPackage pkg, String name, boolean isPrimary) {
+            this.pkg = pkg;
+            this.name = name;
+            this.isPrimary = isPrimary;
+        }
+
+        @Override
+        public int hashCode() {
+            return pkg.hashCode() * 31 + name.hashCode() + (isPrimary ? 0 : 1);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (obj == this) {
+                return true;
+            }
+
+            if (obj instanceof TypeId) {
+                TypeId that = (TypeId) obj;
+                return this.name.equals(that.name) && this.pkg.equals(that.pkg);
+            }
+            return false;
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -94,6 +94,8 @@ public class JvmConstants {
     public static final String FINITE_TYPE = "org/ballerinalang/jvm/types/BFiniteType";
     public static final String FUTURE_TYPE = "org/ballerinalang/jvm/types/BFutureType";
     public static final String PACKAGE_TYPE = "org/ballerinalang/jvm/types/BPackage";
+    public static final String TYPE_ID_SET = "org/ballerinalang/jvm/types/BTypeIdSet";
+    public static final String TYPE_ID = "org/ballerinalang/jvm/types/BTypeIdSet$TypeId";
 
     // other jvm-specific classes
     public static final String TYPE_CHECKER = "org/ballerinalang/jvm/TypeChecker";
@@ -158,6 +160,7 @@ public class JvmConstants {
     public static final String PANIC_FIELD = "panic";
     public static final String PRINT_STACK_TRACE_METHOD = "printStackTrace";
     public static final String SET_DETAIL_TYPE_METHOD = "setDetailType";
+    public static final String SET_TYPEID_SET_METHOD = "setTypeIdSet";
     public static final String ERROR_REASON_METHOD_TOO_LARGE = "MethodTooLarge";
     public static final String ERROR_REASON_CLASS_TOO_LARGE = "ClassTooLarge";
     public static final String TRAP_ERROR_METHOD = "trapError";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -55,6 +55,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BStructureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeIdSet;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
@@ -125,8 +126,30 @@ public class BIRTypeWriter implements TypeVisitor {
         int pkgIndex = cp.addCPEntry(new PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
         buff.writeInt(pkgIndex);
         buff.writeInt(addStringCPEntry(bErrorType.tsymbol.name.value));
-        // Write reason and detail types.
+        // Write detail types.
         writeTypeCpIndex(bErrorType.detailType);
+        writeTypeIds(bErrorType.typeIdSet);
+    }
+
+    private void writeTypeIds(BTypeIdSet typeIdSet) {
+        buff.writeInt(typeIdSet.primary.size());
+        for (BTypeIdSet.BTypeId bTypeId : typeIdSet.primary) {
+            writeTypeId(bTypeId);
+        }
+        buff.writeInt(typeIdSet.secondary.size());
+        for (BTypeIdSet.BTypeId bTypeId : typeIdSet.secondary) {
+            writeTypeId(bTypeId);
+        }
+    }
+
+    private void writeTypeId(BTypeIdSet.BTypeId bTypeId) {
+        int orgCPIndex = addStringCPEntry(bTypeId.packageID.orgName.value);
+        int nameCPIndex = addStringCPEntry(bTypeId.packageID.name.value);
+        int versionCPIndex = addStringCPEntry(bTypeId.packageID.version.value);
+        int pkgIndex = cp.addCPEntry(new PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
+        buff.writeInt(pkgIndex);
+        buff.writeInt(addStringCPEntry(bTypeId.name));
+        buff.writeBoolean(bTypeId.publicId);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
@@ -45,6 +45,7 @@ public class BLangAnonymousModelHelper {
     private static final String BUILTIN_ANON_TYPE = "$anonType$builtin$";
     private static final String BUILTIN_LAMBDA = "$lambda$builtin$";
     private static final String FORK = "$fork$";
+    private static final String ANON_TYPE_ID = "$anonTypeid$";
 
     private static final CompilerContext.Key<BLangAnonymousModelHelper> ANONYMOUS_MODEL_HELPER_KEY =
             new CompilerContext.Key<>();
@@ -102,7 +103,7 @@ public class BLangAnonymousModelHelper {
     public String getNextDistinctErrorId(PackageID packageID) {
         Integer nextValue = Optional.ofNullable(errorTypeIdCount.get(packageID)).orElse(0);
         anonFunctionCount.put(packageID, nextValue + 1);
-        return String.valueOf(nextValue);
+        return ANON_TYPE_ID + String.valueOf(nextValue);
     }
 
     public boolean isAnonymousType(BSymbol symbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeIdSet.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeIdSet.java
@@ -98,6 +98,18 @@ public class BTypeIdSet {
         return this.primary.equals(that.primary) && this.secondary.equals(that.secondary);
     }
 
+    @Override
+    public int hashCode() {
+        int hashCode = 1;
+        for (BTypeId bTypeId : primary) {
+            hashCode = hashCode * 31 + bTypeId.hashCode();
+        }
+        for (BTypeId bTypeId : secondary) {
+            hashCode = hashCode * 31 + bTypeId.hashCode();
+        }
+        return hashCode;
+    }
+
     public static class BTypeId {
         public final PackageID packageID;
         public final String name;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeIdSet.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTypeIdSet.java
@@ -53,9 +53,13 @@ public class BTypeIdSet {
     }
 
     public static BTypeIdSet from(PackageID packageID, String typeId, boolean publicId, BTypeIdSet secondary) {
-        HashSet<BTypeId> set = new HashSet<>();
-        set.add(new BTypeId(packageID, typeId, publicId));
-        return new BTypeIdSet(set, secondary.primary);
+        HashSet<BTypeId> primarySet = new HashSet<>();
+        primarySet.add(new BTypeId(packageID, typeId, publicId));
+
+        HashSet<BTypeId> secondarySet = new HashSet<>(secondary.primary);
+        secondarySet.addAll(secondary.secondary);
+
+        return new BTypeIdSet(primarySet, secondarySet);
     }
 
     public static BTypeIdSet emptySet() {
@@ -108,6 +112,13 @@ public class BTypeIdSet {
             hashCode = hashCode * 31 + bTypeId.hashCode();
         }
         return hashCode;
+    }
+
+    public boolean isEmpty() {
+        if (primary == emptySet && secondary == emptySet) {
+            return true;
+        }
+        return primary.isEmpty() && secondary.isEmpty();
     }
 
     public static class BTypeId {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
@@ -49,12 +49,11 @@ public class BLangErrorType extends BLangType implements ErrorTypeNode {
     @Override
     public String toString() {
         StringBuilder val = new StringBuilder(this.type.toString());
-        val.append("<");
         if (this.detailType != null) {
-            val.append(",");
+            val.append("<");
             val.append(detailType.toString());
+            val.append(">");
         }
-        val.append(">");
         return val.toString();
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.balo.types;
 import org.ballerinalang.model.values.BError;
 import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.balo.BaloCreator;
+import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
 import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
@@ -35,15 +36,17 @@ import org.testng.annotations.Test;
 public class ErrorTypeTest {
 
     private CompileResult result;
+    private CompileResult negativeResult;
 
     @BeforeClass
     public void setup() {
         BaloCreator.cleanCacheDirectories();
         BaloCreator.createAndSetupBalo("test-src/balo/test_projects/test_project", "testorg", "errors");
         result = BCompileUtil.compile("test-src/balo/test_balo/types/error_type_test.bal");
+        negativeResult = BCompileUtil.compile("test-src/balo/test_balo/types/error_type_negative_test.bal");
     }
 
-    @Test()
+    @Test
     public void errorFromAnotherPkg() {
         BValue[] returns = BRunUtil.invoke(result, "getApplicationError");
         Assert.assertEquals(returns.length, 1);
@@ -53,7 +56,7 @@ public class ErrorTypeTest {
                 "{ballerina/sql}ApplicationError {message:\"Client has been stopped\"}");
     }
 
-    @Test()
+    @Test
     public void indirectErrorCtorFromAnotherPkg() {
         BValue[] returns = BRunUtil.invoke(result, "getApplicationErrorIndirectCtor");
         Assert.assertEquals(returns.length, 1);
@@ -61,6 +64,35 @@ public class ErrorTypeTest {
         Assert.assertTrue(returns[0] instanceof BError);
         Assert.assertEquals(returns[0].stringValue(),
                 "{ballerina/sql}ApplicationError {message:\"Client has been stopped\"}");
+    }
+
+    @Test
+    public void testUsageOfDistinctTypeFromAnotherPackage() {
+        BValue[] returns = BRunUtil.invoke(result, "getDistinctError");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BError);
+        Assert.assertEquals(returns[0].stringValue(),
+                "OrderCreationError2-msg {message:\"Client has been stopped\"}");
+    }
+
+    @Test
+    public void testDistinctTypeFromAnotherPackageInATypeDef() {
+        BValue[] returns = BRunUtil.invoke(result, "testDistinctTypeFromAnotherPackageInATypeDef");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BError);
+        Assert.assertEquals(returns[0].stringValue(),
+                "Our error message {message:\"Client has been stopped\"}");
+    }
+    
+    @Test
+    public void testDistinctErrorTypeNegative() {
+        int i = 0;
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: expected 'testorg/errors:1.0.0:OrderCreationError2', " +
+                        "found 'testorg/errors:1.0.0:OrderCreationError'", 23, 9);
+        Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
@@ -85,6 +85,27 @@ public class ErrorTypeTest {
         Assert.assertEquals(returns[0].stringValue(),
                 "Our error message {message:\"Client has been stopped\"}");
     }
+
+    @Test
+    public void testDistinctTypeFromAnotherPackageInATypeDefWithACast() {
+        BValue[] returns = BRunUtil.invoke(result, "testDistinctTypeFromAnotherPackageInATypeDefWithACast");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BError);
+        Assert.assertEquals(returns[0].stringValue(),
+                "Our error message {message:\"Client has been stopped\"}");
+    }
+
+    @Test
+    public void testPerformInvalidCastWithDistinctErrorType() {
+        BValue[] returns = BRunUtil.invoke(result, "performInvalidCastWithDistinctErrorType");
+        Assert.assertEquals(returns.length, 1);
+        Assert.assertNotNull(returns[0]);
+        Assert.assertTrue(returns[0] instanceof BError);
+        Assert.assertEquals(returns[0].stringValue(),
+                "{ballerina}TypeCastError {message:\"incompatible types: 'OurProccessingError' cannot be cast to " +
+                        "'errors:OrderProcessingError'\"}");
+    }
     
     @Test
     public void testDistinctErrorTypeNegative() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_negative_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_negative_test.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/errors as er;
+
+function getDistinctError() returns error {
+    er:OrderCreationError e = er:OrderCreationError("order creation failed", message = "Client has been stopped");
+    er:OrderCreationError2 k = er:OrderCreationError2("failed", message = "Client has been stopped");
+    er:OrderCreationError f = k;
+    k = f; // expected 'testorg/errors:1.0.0:OrderCreationError2', found 'testorg/errors:1.0.0:OrderCreationError'
+    return f;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
@@ -40,3 +40,25 @@ function testDistinctTypeFromAnotherPackageInATypeDef() returns error {
     er:OrderCreationError f = e;
     return f;
 }
+
+type OurProccessingError distinct er:OrderCreationError2;
+
+function testDistinctTypeFromAnotherPackageInATypeDefWithACast() returns error {
+    OurProccessingError e = OurProccessingError("Our error message", message = "Client has been stopped");
+    error f = e;
+
+    er:OrderCreationError k = <er:OrderCreationError> f; // casting to distinct super type
+    return k;
+}
+
+function testDistinctTypeFromAnotherPackageInATypeDefWithACastNegative() returns error {
+    OurProccessingError e = OurProccessingError("Our error message", message = "Client has been stopped");
+    error f = e;
+    er:OrderProcessingError k = <er:OrderProcessingError> f; // casting to unrelated, yet same shaped type.
+    return k;
+}
+
+function performInvalidCastWithDistinctErrorType() returns error? {
+    error? e = trap testDistinctTypeFromAnotherPackageInATypeDefWithACastNegative();
+    return e;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
@@ -17,7 +17,7 @@
 import testorg/errors as er;
 
 function getApplicationError() returns error {
-    er:ApplicationError e = error(er:APPLICATION_ERROR_REASON, message = "Client has been stopped");
+    er:ApplicationError e = er:ApplicationError(er:APPLICATION_ERROR_REASON, message = "Client has been stopped");
     return e;
 }
 
@@ -25,4 +25,18 @@ function getApplicationErrorIndirectCtor() returns error {
     er:ApplicationError e = er:ApplicationError(er:APPLICATION_ERROR_REASON, message = "Client has been stopped");
     error e1 = er:ApplicationError(er:APPLICATION_ERROR_REASON, message = "Client has been stopped");
     return e;
+}
+
+function getDistinctError() returns error {
+    er:OrderCreationError2 k = er:OrderCreationError2("OrderCreationError2-msg", message = "Client has been stopped");
+    er:OrderCreationError f = k;
+    return f;
+}
+
+type OurError distinct er:OrderCreationError;
+
+function testDistinctTypeFromAnotherPackageInATypeDef() returns error {
+    OurError e = OurError("Our error message", message = "Client has been stopped");
+    er:OrderCreationError f = e;
+    return f;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/errors/errors.bal
@@ -9,3 +9,7 @@ public type ApplicationErrorData record {|
 |};
 
 public type ApplicationError error<ApplicationErrorData>;
+
+public type OrderCreationError distinct ApplicationError;
+public type OrderProcessingError distinct ApplicationError;
+public type OrderCreationError2 distinct OrderCreationError;


### PR DESCRIPTION
## Purpose
$subject.

Support exporting distinct error type information in balo format and add preliminary runtime typechecking support to distinct error types.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
