### PR TITLE
Fix the test failures due to Ballerina type migrations from handle to string

### DIFF
--- a/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
+++ b/stdlib/email/src/main/java/org/ballerinalang/stdlib/email/util/SmtpUtil.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.stdlib.email.util;
 
+import org.ballerinalang.jvm.StringUtils;
 import org.ballerinalang.jvm.values.ArrayValue;
 import org.ballerinalang.jvm.values.HandleValue;
 import org.ballerinalang.jvm.values.MapValue;
@@ -212,7 +213,8 @@ public class SmtpUtil {
 
     private static void addHeadersToJavaMailBodyPart(ObjectValue mimeEntity, MimeBodyPart attachmentBodyPart)
             throws MessagingException {
-        ArrayValue headerNamesArrayValue = EntityHeaders.getHeaderNames(mimeEntity, MimeConstants.LEADING_HEADER);
+        ArrayValue headerNamesArrayValue = EntityHeaders.getHeaderNames(mimeEntity,
+                StringUtils.fromString(MimeConstants.LEADING_HEADER));
         HandleValue[] handleValues = (HandleValue[]) headerNamesArrayValue.getValues();
         String[] headerNames = new String[handleValues.length];
         for (int j = 0; j < handleValues.length; j++) {
@@ -220,7 +222,8 @@ public class SmtpUtil {
         }
         if (headerNames.length > 0) {
             for (String headerName : headerNames) {
-                String headerValue = EntityHeaders.getHeader(mimeEntity, headerName, MimeConstants.LEADING_HEADER);
+                String headerValue = EntityHeaders.getHeader(mimeEntity, headerName,
+                        StringUtils.fromString(MimeConstants.LEADING_HEADER));
                 if (isNotEmpty(headerValue)) {
                     log.debug("Added a MIME body part header " + headerName + " with value " + headerValue);
                     attachmentBodyPart.setHeader(headerName, headerValue);

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/SmtpComplexEmailSendTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/SmtpComplexEmailSendTest.java
@@ -104,7 +104,7 @@ public class SmtpComplexEmailSendTest {
         compileResult = BCompileUtil.compileOffline(true, sourceFilePath.toAbsolutePath().toString());
     }
 
-    @Test(description = "Test for sending an email with all the parameters", enabled = false)
+    @Test(description = "Test for sending an email with all the parameters")
     public void testSendComplexEmail() throws MessagingException, IOException {
         BValue[] args = { new BString(HOST_NAME), new BString(USER_NAME), new BString(USER_PASSWORD),
                 new BString(EMAIL_SUBJECT), new BString(EMAIL_TEXT), new BString(EMAIL_CONTENT_TYPE),
@@ -160,7 +160,7 @@ public class SmtpComplexEmailSendTest {
     private static void testAttachment3(MimeBodyPart bodyPart) throws IOException, MessagingException {
         InputStream input = bodyPart.getInputStream();
         assertEquals("<name>Ballerina xml file part</name>", convertInputStreamToString(input));
-        assertEquals("text/xml", bodyPart.getContentType());
+        assertTrue(bodyPart.getContentType().startsWith("text/xml"));
     }
 
     private static void testAttachment4(MimeBodyPart bodyPart) throws MessagingException, IOException {


### PR DESCRIPTION
## Purpose
Fix the Email Connector test failure, `SmtpComplexEmailSendTest` due to Ballerina type migration from `handle` to `string` type.

Fixes #23475

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
