### PR TITLE
Add support for error type inferring - error<*>

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -1354,6 +1354,9 @@ public class BLangPackageBuilder {
             var.isDeclaredWithVar = true;
         } else {
             var.setTypeNode(this.typeNodeStack.pop());
+            if (var.getTypeNode().getKind() == NodeKind.ERROR_TYPE) {
+                var.isDeclaredWithVar = ((BLangErrorType) var.typeNode).inferErrorType;
+            }
         }
         if (isExpressionAvailable) {
             var.setInitialExpression(this.exprNodeStack.pop());
@@ -2529,6 +2532,9 @@ public class BLangPackageBuilder {
             if (!isTypeNameProvided) {
                 var.isDeclaredWithVar = true;
             }
+        }
+        if (var.typeNode.getKind() == NodeKind.ERROR_TYPE) {
+            var.isDeclaredWithVar = ((BLangErrorType) var.typeNode).inferErrorType;
         }
 
         attachAnnotations(var);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangErrorType.java
@@ -54,6 +54,9 @@ public class BLangErrorType extends BLangType implements ErrorTypeNode {
             val.append(detailType.toString());
             val.append(">");
         }
+        if (this.inferErrorType) {
+            val.append("<*>");
+        }
         return val.toString();
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -410,4 +410,19 @@ public class ErrorTest {
         BError bError = (BError) returns[0];
         Assert.assertEquals(bError.getReason(), "panic now");
     }
+
+    @Test
+    public void testErrorTypeDescriptionInferring() {
+        BRunUtil.invoke(errorTestResult, "testErrorTypeDescriptionInferring");
+    }
+
+    @Test
+    public void testDefaultErrorTypeDescriptionInferring() {
+        BRunUtil.invoke(errorTestResult, "testDefaultErrorTypeDescriptionInferring");
+    }
+
+    @Test
+    public void testUnionErrorTypeDescriptionInferring() {
+        BRunUtil.invoke(errorTestResult, "testUnionErrorTypeDescriptionInferring");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -354,3 +354,37 @@ function testStackOverFlow() returns [runtime:CallStackElement[], string]? {
         return [e.stackTrace().callStack, e.message()];
     }
 }
+
+function testErrorTypeDescriptionInferring() {
+    TrxError e = TrxError("IAmAInferedErr");
+    error<*> err = e;
+    TrxError errSecondRef = err;
+    assertEquality(errSecondRef.detail().toString(), e.detail().toString());
+}
+
+function testDefaultErrorTypeDescriptionInferring() {
+    error e = error("IAmAInferedDefaultErr");
+    error<*> err = e;
+    assertEquality(err.detail().toString(), e.detail().toString());
+}
+
+function testUnionErrorTypeDescriptionInferring() {
+    error|TrxError e = error("IAmAInferedUnionErr");
+    error<*> err = e;
+    assertEquality(err.detail().toString(), e.detail().toString());
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(any|error actual, any|error expected) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}


### PR DESCRIPTION
## Purpose

Fixes #18007

## Approach

This is handled the same way the compiler handles `var`

## Samples
We now support type inferring

```Ballerina
TrxError e = TrxError("IAmAInferedErr");
error<*> err = e;	// infer type from context
TrxError errSecondRef = err;
```

## Testing
`./gradlew :jballerina-unit-test:test --tests 'org.ballerinalang.test.error.ErrorTest.testErrorTypeDescriptionInferring'`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
