### PR TITLE
Add functionality to generate docs to/from json, move templates to directory and exclude index

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -124,7 +124,7 @@ public class DocCommand implements BLauncherCmd {
         this.sourceRootPath = null != this.sourceRoot ?
                 Paths.get(this.sourceRoot).toAbsolutePath() : this.sourceRootPath;
         // Generating API Docs through a JSON file
-        if (null != this.jsonLoc) {
+        if (this.jsonLoc != null) {
             this.jsonPath = Paths.get(this.jsonLoc).toAbsolutePath();
             if (Files.notExists(jsonPath)) {
                 CommandUtil.printError(this.errStream,
@@ -161,7 +161,6 @@ public class DocCommand implements BLauncherCmd {
             CommandUtil.exitError(true);
             return;
         }
-
         // when -a or --all flag is provided. check if the command is executed within a ballerina project. update source
         // root path if command executed inside a project.
         if (this.buildAll) {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -32,7 +32,6 @@ import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
-import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -82,6 +82,10 @@ public class DocCommand implements BLauncherCmd {
     @CommandLine.Option(names = {"--o", "-o"}, description = "Location to save API Docs.")
     private String outputLoc;
 
+    @CommandLine.Option(names = {"--excludeIndex", "-excludeIndex"}, description = "Prevents project index from " +
+            "being generated.")
+    private boolean excludeIndex;
+
     @CommandLine.Option(names = {"--offline"}, description = "Compiles offline without downloading " +
                                                               "dependencies.")
     private boolean offline;
@@ -139,7 +143,7 @@ public class DocCommand implements BLauncherCmd {
             buildContext.setErr(errStream);
             TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                     .addTask(new CreateTargetDirTask()) // create target directory.
-                    .addTask(new CreateDocsTask(toJson, jsonPath)) // creates API documentation
+                    .addTask(new CreateDocsTask(toJson, jsonPath, excludeIndex)) // creates API documentation
                     .build();
 
             taskExecutor.executeTasks(buildContext);
@@ -264,7 +268,7 @@ public class DocCommand implements BLauncherCmd {
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CreateTargetDirTask()) // create target directory.
                 .addTask(new CompileTask()) // compile the modules
-                .addTask(new CreateDocsTask(toJson, jsonPath)) // creates API documentation
+                .addTask(new CreateDocsTask(toJson, jsonPath, excludeIndex)) // creates API documentation
                 .build();
         
         taskExecutor.executeTasks(buildContext);

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -32,6 +32,7 @@ import org.wso2.ballerinalang.compiler.util.ProjectDirs;
 import org.wso2.ballerinalang.util.RepoUtils;
 import picocli.CommandLine;
 
+import java.io.File;
 import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -57,6 +58,8 @@ public class DocCommand implements BLauncherCmd {
     private final PrintStream outStream;
     private final PrintStream errStream;
     private Path sourceRootPath;
+    private Path jsonPath;
+    private Path outputPath;
 
     public DocCommand() {
         this.sourceRootPath = Paths.get(System.getProperty("user.dir"));
@@ -70,6 +73,15 @@ public class DocCommand implements BLauncherCmd {
 
     @CommandLine.Option(names = {"--all", "-a"}, description = "Generate docs for all the modules of the project.")
     private boolean buildAll;
+
+    @CommandLine.Option(names = {"--toJSON", "-toJSON"}, description = "Generate JSON containing doc data.")
+    private boolean toJson;
+
+    @CommandLine.Option(names = {"--fromJSON", "-fromJSON"}, description = "Generate API Docs from a JSON.")
+    private String jsonLoc;
+
+    @CommandLine.Option(names = {"--o", "-o"}, description = "Location to save API Docs.")
+    private String outputLoc;
 
     @CommandLine.Option(names = {"--offline"}, description = "Compiles offline without downloading " +
                                                               "dependencies.")
@@ -104,6 +116,38 @@ public class DocCommand implements BLauncherCmd {
             CommandUtil.exitError(true);
             return;
         }
+        Path sourcePath = null;
+        Path targetPath;
+        // validation and decide source root and source full path
+        this.sourceRootPath = null != this.sourceRoot ?
+                Paths.get(this.sourceRoot).toAbsolutePath() : this.sourceRootPath;
+        // Generating API Docs through a JSON file
+        if (null != this.jsonLoc) {
+            this.jsonPath = Paths.get(this.jsonLoc).toAbsolutePath();
+            if (Files.notExists(jsonPath)) {
+                CommandUtil.printError(this.errStream,
+                        "cannot find json file",
+                        null,
+                        false);
+                CommandUtil.exitError(true);
+                return;
+            }
+            targetPath = null != this.outputLoc ?
+                    Paths.get(this.outputLoc).toAbsolutePath() : this.sourceRootPath.
+                    resolve(ProjectDirConstants.TARGET_DIR_NAME);
+            BuildContext buildContext = new BuildContext(this.sourceRootPath, targetPath, null);
+            buildContext.setOut(outStream);
+            buildContext.setErr(errStream);
+            TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
+                    .addTask(new CreateTargetDirTask()) // create target directory.
+                    .addTask(new CreateDocsTask(toJson, jsonPath)) // creates API documentation
+                    .build();
+
+            taskExecutor.executeTasks(buildContext);
+            Runtime.getRuntime().exit(0);
+        } else {
+            this.jsonPath = null;
+        }
     
         // if -a or --all flag is not given, then it is mandatory to give a module name.
         if (!this.buildAll && (this.argList == null || this.argList.size() == 0)) {
@@ -115,13 +159,7 @@ public class DocCommand implements BLauncherCmd {
             CommandUtil.exitError(true);
             return;
         }
-        
-        // validation and decide source root and source full path
-        this.sourceRootPath = null != this.sourceRoot ?
-                Paths.get(this.sourceRoot).toAbsolutePath() : this.sourceRootPath;
-        Path sourcePath = null;
-        Path targetPath;
-        
+
         // when -a or --all flag is provided. check if the command is executed within a ballerina project. update source
         // root path if command executed inside a project.
         if (this.buildAll) {
@@ -227,7 +265,7 @@ public class DocCommand implements BLauncherCmd {
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CreateTargetDirTask()) // create target directory.
                 .addTask(new CompileTask()) // compile the modules
-                .addTask(new CreateDocsTask()) // creates API documentation
+                .addTask(new CreateDocsTask(toJson, jsonPath)) // creates API documentation
                 .build();
         
         taskExecutor.executeTasks(buildContext);

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -59,7 +59,6 @@ public class DocCommand implements BLauncherCmd {
     private final PrintStream errStream;
     private Path sourceRootPath;
     private Path jsonPath;
-    private Path outputPath;
 
     public DocCommand() {
         this.sourceRootPath = Paths.get(System.getProperty("user.dir"));

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateDocsTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateDocsTask.java
@@ -41,10 +41,12 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.TARGET_AP
  */
 public class CreateDocsTask implements Task {
 
+    private boolean excludeIndex;
     private boolean toJson;
     private Path jsonPath;
 
-    public CreateDocsTask(boolean toJson, Path jsonPath) {
+    public CreateDocsTask(boolean toJson, Path jsonPath, boolean excludeIndex) {
+        this.excludeIndex = excludeIndex;
         this.toJson = toJson;
         this.jsonPath = jsonPath;
     }
@@ -57,7 +59,7 @@ public class CreateDocsTask implements Task {
         buildContext.out().println();
         if (jsonPath != null) {
             buildContext.out().println("Generating API Documentation using data in JSON");
-            BallerinaDocGenerator.writeAPIDocsForModulesFromJson(jsonPath, outputPath.toString());
+            BallerinaDocGenerator.writeAPIDocsForModulesFromJson(jsonPath, outputPath.toString(), excludeIndex);
             buildContext.out().println("\t" + sourceRootPath.relativize(outputPath).toString());
         } else {
             buildContext.out().println("Generating API Documentation");
@@ -73,8 +75,7 @@ public class CreateDocsTask implements Task {
                     buildContext.out().println("\t" + "data saved as a JSON in: " +
                             sourceRootPath.relativize(outputPath).toString());
                 } else {
-                    BallerinaDocGenerator.writeAPIDocsForModules(moduleDocMap,
-                            outputPath.toString());
+                    BallerinaDocGenerator.writeAPIDocsForModules(moduleDocMap, outputPath.toString(), excludeIndex);
                     buildContext.out().println("\t" + sourceRootPath.relativize(outputPath).toString());
                 }
             } catch (IOException e) {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateDocsTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateDocsTask.java
@@ -84,10 +84,6 @@ public class CreateDocsTask implements Task {
         }
     }
 
-    public void execute(){
-
-    }
-
     static class EmptyPrintStream extends PrintStream {
         EmptyPrintStream() throws UnsupportedEncodingException {
             super(new OutputStream() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateDocsTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CreateDocsTask.java
@@ -41,29 +41,50 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.TARGET_AP
  */
 public class CreateDocsTask implements Task {
 
+    private boolean toJson;
+    private Path jsonPath;
 
-    public CreateDocsTask() { }
+    public CreateDocsTask(boolean toJson, Path jsonPath) {
+        this.toJson = toJson;
+        this.jsonPath = jsonPath;
+    }
 
     @Override
     public void execute(BuildContext buildContext) {
         Path sourceRootPath = buildContext.get(BuildContextField.SOURCE_ROOT);
         Path targetDir = buildContext.get(BuildContextField.TARGET_DIR);
         Path outputPath = targetDir.resolve(TARGET_API_DOC_DIRECTORY);
-        List<BLangPackage> modules = buildContext.getModules();
         buildContext.out().println();
-        buildContext.out().println("Generating API Documentation");
-        try {
-            // disable deprecated verbose logs from docerina
-            BallerinaDocGenerator.setPrintStream(new EmptyPrintStream());
-            Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator
-                    .generateModuleDocs(sourceRootPath.toString(), modules);
-            Files.createDirectories(outputPath);
-            BallerinaDocGenerator.writeAPIDocsForModules(moduleDocMap,
-                    outputPath.toString());
+        if (jsonPath != null) {
+            buildContext.out().println("Generating API Documentation using data in JSON");
+            BallerinaDocGenerator.writeAPIDocsForModulesFromJson(jsonPath, outputPath.toString());
             buildContext.out().println("\t" + sourceRootPath.relativize(outputPath).toString());
-        } catch (IOException e) {
-            throw createLauncherException("Unable to generate API Documentation.");
+        } else {
+            buildContext.out().println("Generating API Documentation");
+            List<BLangPackage> modules = buildContext.getModules();
+            try {
+                // disable deprecated verbose logs from docerina
+                BallerinaDocGenerator.setPrintStream(new EmptyPrintStream());
+                Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator
+                        .generateModuleDocs(sourceRootPath.toString(), modules);
+                Files.createDirectories(outputPath);
+                if (toJson) {
+                    BallerinaDocGenerator.writeAPIDocsToJSON(moduleDocMap, outputPath.toString());
+                    buildContext.out().println("\t" + "data saved as a JSON in: " +
+                            sourceRootPath.relativize(outputPath).toString());
+                } else {
+                    BallerinaDocGenerator.writeAPIDocsForModules(moduleDocMap,
+                            outputPath.toString());
+                    buildContext.out().println("\t" + sourceRootPath.relativize(outputPath).toString());
+                }
+            } catch (IOException e) {
+                throw createLauncherException("Unable to generate API Documentation.");
+            }
         }
+    }
+
+    public void execute(){
+
     }
 
     static class EmptyPrintStream extends PrintStream {

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-doc.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-doc.help
@@ -4,7 +4,8 @@ NAME
 SYNOPSIS
        ballerina doc [<options>] <module-name>
        ballerina doc -a | --all [<options>]
-
+       ballerina doc -a | <module-name> -toJSON | --toJSON
+       ballerina doc -fromJSON | --fromJSON [path to json]
 
 DESCRIPTION
        Doc builds documentation for a given module or a ballerina file.
@@ -14,6 +15,11 @@ DESCRIPTION
 
        This command writes the module documentation to the 'target/apidocs'
        directory inside the project.
+
+       Using the -toJSON option will create a JSON containing all the data
+       used to generate the documentation.
+
+       The command -fromJSON generates documentation using the specified JSON.
 
 
 
@@ -35,6 +41,15 @@ OPTIONS
        -a, --all
            Build documentation for all the modules of a project.
 
+       -toJSON, --toJSON
+           Generates a JSON containing all the documentation data.
+
+       -fromJSON, --fromJSON
+           Generates documentation from a specified JSON.
+
+       -excludeIndex, --excludeIndex
+           Prevents project index from being generated.
+
 
 EXAMPLES
        Generate API documentation for all modules in the current project.
@@ -42,3 +57,9 @@ EXAMPLES
 
        Generate API documentation for a single module.
           $ ballerina doc hello
+
+       Generate a JSON containing all API documentation data.
+          $ ballerina doc -a -toJSON
+
+       Generate API documentation using a JSON.
+          $ ballerina doc -fromJSON target/apidocs/api-doc-data.json

--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -271,6 +271,13 @@ def copyStaticSpec = {
     }
 }
 
+def copyTemplatesSpec = {
+    path -> copySpec {
+        from project(':docerina').file('src/main/resources/template/html')
+        into(path + 'lib/templates')
+    }
+}
+
 def copyResourceSpec = {
     path -> copySpec {
         from configurations.resourceFiles
@@ -448,6 +455,7 @@ task createZip(type: Zip) {
     with copyDebugAdapterLauncher(basePath)
     with apiDocsSpec(basePath)
     with copyStaticSpec(basePath)
+    with copyTemplatesSpec(basePath)
     with copyResourceSpec(basePath)
 //    with copySrcBaloSpec(basePath)
     with copyKraalLib(basePath)
@@ -471,6 +479,7 @@ task updateBalHome(type: Copy) {
     with copyDebugAdapterLauncher(installDir)
     with apiDocsSpec(installDir)
     with copyStaticSpec(installDir)
+    with copyTemplatesSpec(installDir)
     with copyResourceSpec(installDir)
     with copyKraalLib(installDir)
     with copyJaCoCoAgent(installDir)
@@ -497,6 +506,7 @@ task createDistribution(type: Copy) {
     with copyDebugAdapterLauncher("")
     with apiDocsSpec("")
     with copyStaticSpec("")
+    with copyTemplatesSpec("")
     with copyResourceSpec("")
 //    with copySrcBaloSpec("")
     with copyKraalLib("")

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
@@ -54,15 +54,15 @@ public class Writer {
      */
     public static void writeHtmlDocument(Object object, String packageTemplateName, String filePath) throws
             IOException {
-        String templatesFolderPath = System.getProperty(BallerinaDocConstants.TEMPLATES_FOLDER_PATH_KEY, File
-                .separator + "template" + File.separator + "html");
+        String templatesFolderPath = System.getProperty("ballerina.home") + File.separator + "lib" + File.separator +
+                "templates";
 
         String templatesClassPath = System.getProperty(BallerinaDocConstants.TEMPLATES_FOLDER_PATH_KEY,
                 "/template/html");
         PrintWriter writer = null;
         try {
-            Handlebars handlebars = new Handlebars().with(new ClassPathTemplateLoader(templatesClassPath), new
-                    FileTemplateLoader(templatesFolderPath));
+            Handlebars handlebars = new Handlebars().with(new FileTemplateLoader(templatesFolderPath),
+                    new ClassPathTemplateLoader(templatesClassPath));
             handlebars.registerHelpers(StringHelpers.class);
             handlebars.registerHelper("paramSummary", (Helper<List<DefaultableVariable>>)
                     (varList, options) -> varList.stream()

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -84,11 +84,11 @@ public class BallerinaDocGenerator {
     private static final String HTML = ".html";
     private static final String DOC_JSON = "api-doc-data.json";
     private static final String JSON = ".json";
-    private static Gson gson = new GsonBuilder().registerTypeHierarchyAdapter(Path.class, new PathToJson())
-            .excludeFieldsWithoutExposeAnnotation().setPrettyPrinting().create();
     private static final String MODULE_SEARCH = "search";
     private static final String SEARCH_DATA = "search-data.js";
     private static final String SEARCH_DIR = "doc-search";
+    private static Gson gson = new GsonBuilder().registerTypeHierarchyAdapter(Path.class, new PathToJson())
+            .excludeFieldsWithoutExposeAnnotation().setPrettyPrinting().create();
 
     /**
      * API to merge multiple api docs.
@@ -179,10 +179,9 @@ public class BallerinaDocGenerator {
 
         // Generate project model
         Project project = getDocsGenModel(moduleDocList);
-
         writeAPIDocs(project, output, excludeIndex);
-
     }
+
     public static void writeAPIDocs(Project project, String output, boolean excludeIndex) {
         String moduleTemplateName = System.getProperty(BallerinaDocConstants.MODULE_TEMPLATE_NAME_KEY, "module");
         String recordTemplateName = System.getProperty(BallerinaDocConstants.RECORD_TEMPLATE_NAME_KEY, "record");
@@ -351,7 +350,6 @@ public class BallerinaDocGenerator {
                     out.println("docerina: successfully copied project resources into " + resourcesDir);
                 }
             }
-
         }
 
         if (!excludeIndex) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -140,7 +140,7 @@ public class BallerinaDocGenerator {
         }
     }
 
-    public static void writeAPIDocsToJSON(Map<String, ModuleDoc> docsMap, String output){
+    public static void writeAPIDocsToJSON(Map<String, ModuleDoc> docsMap, String output) {
         // Sort modules by module path
         List<ModuleDoc> moduleDocList = new ArrayList<>(docsMap.values());
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -152,8 +152,8 @@ public class BallerinaDocGenerator {
             String json = gson.toJson(project);
             writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
         } catch (IOException e) {
-            out.println(String.format("docerina: failed to create the module.json. Cause: %s", e.getMessage()));
-            log.error("Failed to create module.json file.", e);
+            out.println(String.format("docerina: failed to create the " + DOC_JSON + ". Cause: %s", e.getMessage()));
+            log.error("Failed to create " + DOC_JSON + " file.", e);
         }
     }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/utils/PathToJson.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/utils/PathToJson.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.docgen.docs.utils;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+import java.lang.reflect.Type;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Used to convert Path objects to JSON.
+ */
+public class PathToJson implements JsonDeserializer<Path>, JsonSerializer<Path> {
+    @Override
+    public Path deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext)
+            throws JsonParseException {
+        return Paths.get(jsonElement.getAsString());
+    }
+
+    @Override
+    public JsonElement serialize(Path path, Type type, JsonSerializationContext jsonSerializationContext) {
+        return new JsonPrimitive(path.toString());
+    }
+}

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/utils/PathToJson.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/utils/PathToJson.java
@@ -32,6 +32,8 @@ import java.nio.file.Paths;
 
 /**
  * Used to convert Path objects to JSON.
+ *
+ * @since 2.0.0
  */
 public class PathToJson implements JsonDeserializer<Path>, JsonSerializer<Path> {
     @Override

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Annotation.java
@@ -15,11 +15,15 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 /**
  * Represent documentation for an Annotation.
  */
 public class Annotation extends Construct {
+    @Expose
     public Type type;
+    @Expose
     public String attachmentPoints;
 
     public Annotation(String name, String description, boolean isDeprecated, Type type, String attachmentPoints) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Client.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
  */
 public class Client extends Object {
 
+    @Expose
     public List<Function> remoteMethods;
 
     public Client(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Constant.java
@@ -15,11 +15,15 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 /**
  * Represent documentation for a Constant.
  */
 public class Constant extends Construct {
+    @Expose
     public Type type;
+    @Expose
     public String value;
 
     public Constant(String name, String description, boolean isDeprecated, Type type, String value) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Construct.java
@@ -15,12 +15,17 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 /**
  * Represents a language construct in a Ballerina module.
  */
 public class Construct {
+    @Expose
     public String name;
+    @Expose
     public String description;
+    @Expose
     public boolean isDeprecated;
 
     public Construct(String name, String description, boolean isDeprecated) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/DefaultableVariable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/DefaultableVariable.java
@@ -15,10 +15,13 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 /**
  * Represents a defaultable variable.
  */
 public class DefaultableVariable extends Variable {
+    @Expose
     public String defaultValue;
 
     public DefaultableVariable(String name, String description, boolean isDeprecated, Type type, String defaultValue) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Error.java
@@ -15,10 +15,13 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 /**
  * Represent documentation for an Error.
  */
 public class Error extends Construct {
+    @Expose
     public Type detailType;
 
     public Error(String name, String description, boolean isDeprecated, Type detailType) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FiniteType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/FiniteType.java
@@ -15,13 +15,15 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 
 /**
  * Represents a finite type.
  */
 public class FiniteType extends Type {
-
+    @Expose
     public List<String> valueSpace;
 
     public FiniteType(String name, String description, boolean isDeprecated,  List<String> valueSpace) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Function.java
@@ -15,15 +15,21 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 
 /**
  * Represent documentation for a Function.
  */
 public class Function extends Construct {
+    @Expose
     public boolean isRemote;
+    @Expose
     public boolean isExtern;
+    @Expose
     public List<DefaultableVariable> parameters;
+    @Expose
     public List<Variable> returnParameters;
 
     public Function(String name, String description, boolean isRemote, boolean isExtern, boolean isDeprecated,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Listener.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -23,6 +25,7 @@ import java.util.stream.Collectors;
  */
 public class Listener extends Object {
 
+    @Expose
     public List<Function> lifeCycleMethods;
 
     public Listener(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
@@ -17,6 +17,7 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,7 +25,6 @@ import java.util.List;
  * Represents a Ballerina Module.
  */
 public class Module {
-
     @Expose
     public String id;
     @Expose
@@ -57,4 +57,7 @@ public class Module {
     public List<FiniteType> finiteTypes = new ArrayList<>();
     @Expose
     public List<UnionType> unionTypes = new ArrayList<>();
+
+    @Expose
+    public List<Path> resources = new ArrayList<>();
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
@@ -37,14 +37,24 @@ public class Module {
     public String version;
 
     // constructs
+    @Expose
     public List<Record> records = new ArrayList<>();
+    @Expose
     public List<Object> objects = new ArrayList<>();
+    @Expose
     public List<Client> clients = new ArrayList<>();
+    @Expose
     public List<Listener> listeners = new ArrayList<>();
+    @Expose
     public List<Function> functions = new ArrayList<>();
+    @Expose
     public List<Constant> constants = new ArrayList<>();
+    @Expose
     public List<Annotation> annotations = new ArrayList<>();
+    @Expose
     public List<Error> errors = new ArrayList<>();
+    @Expose
     public List<FiniteType> finiteTypes = new ArrayList<>();
+    @Expose
     public List<UnionType> unionTypes = new ArrayList<>();
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Object.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Object.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -24,9 +26,13 @@ import java.util.stream.Collectors;
  */
 public class Object extends Construct {
 
+    @Expose
     public List<DefaultableVariable> fields;
+    @Expose
     public List<Function> methods;
+    @Expose
     public Function initMethod;
+    @Expose
     public List<Function> otherMethods;
 
     public Object(String name, String description, boolean isDeprecated, List<DefaultableVariable> fields,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Project.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Project.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 
 /**
@@ -22,8 +24,12 @@ import java.util.List;
  */
 public class Project {
     public boolean isSingleFile;
+    @Expose
     public String sourceFileName;
+    @Expose
     public String name;
+    @Expose
     public String description;
+    @Expose
     public List<Module> modules;
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Project.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Project.java
@@ -23,6 +23,7 @@ import java.util.List;
  * Represents a Ballerina Project.
  */
 public class Project {
+    @Expose
     public boolean isSingleFile;
     @Expose
     public String sourceFileName;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Record.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Record.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 import java.util.List;
 
 /**
@@ -22,7 +24,9 @@ import java.util.List;
  */
 public class Record extends Construct {
 
+    @Expose
     public List<DefaultableVariable> fields;
+    @Expose
     public boolean isAnonymous = false;
 
     public Record(String name, String description, boolean isDeprecated, boolean isAnonymous,

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
 import org.ballerinalang.docgen.docs.BallerinaDocDataHolder;
 import org.ballerinalang.model.elements.Flag;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
@@ -46,22 +47,39 @@ import java.util.stream.Collectors;
  * Represents a Ballerina Type.
  */
 public class Type {
+    @Expose
     public String orgName;
+    @Expose
     public String moduleName;
+    @Expose
     public String name;
+    @Expose
     public String description;
+    @Expose
     public String category;
+    @Expose
     public boolean isAnonymousUnionType;
+    @Expose
     public boolean isArrayType;
+    @Expose
     public boolean isNullable;
+    @Expose
     public boolean isTuple;
+    @Expose
     public boolean isLambda;
+    @Expose
     public boolean isDeprecated;
+    @Expose
     public boolean generateUserDefinedTypeLink = true;
+    @Expose
     public List<Type> memberTypes = new ArrayList<>();
+    @Expose
     public List<Type> paramTypes = new ArrayList<>();
+    @Expose
     public int arrayDimensions;
+    @Expose
     public Type elementType;
+    @Expose
     public Type returnType;
 
     private Type() {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Variable.java
@@ -15,10 +15,13 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
+import com.google.gson.annotations.Expose;
+
 /**
  * Represents a variable.
  */
 public class Variable extends Construct {
+    @Expose
     public Type type;
 
     public Variable(String name, String description, boolean isDeprecated, Type type) {

--- a/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/GenerateBalo.java
+++ b/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/GenerateBalo.java
@@ -158,7 +158,7 @@ public class GenerateBalo {
                                                          docModuleFilter);
         String apiDocPath = "./build/generated-apidocs/";
         Files.createDirectories(Paths.get(apiDocPath));
-        BallerinaDocGenerator.writeAPIDocsForModules(moduleDocMap, apiDocPath);
+        BallerinaDocGenerator.writeAPIDocsForModules(moduleDocMap, apiDocPath, false);
     }
 
     private static void printErrors(boolean reportWarnings, CompileResult.CompileResultDiagnosticListener diagListner,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DeprecatedAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DeprecatedAnnotationTest.java
@@ -42,11 +42,9 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -70,9 +68,8 @@ public class DeprecatedAnnotationTest {
                 Paths.get("src/test/resources", sourceRoot).toAbsolutePath().toString(), modules);
         List<ModuleDoc> moduleDocList = new ArrayList<>(docsMap.values());
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
-        Map<String, List<Path>> resources = new HashMap<>();
 
-        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList, resources);
+        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList);
         testModule = project.modules.get(0);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/FieldLevelDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/FieldLevelDocsTest.java
@@ -34,11 +34,9 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -78,9 +76,8 @@ public class FieldLevelDocsTest {
                 Paths.get("src", "test", "resources", sourceRoot).toAbsolutePath().toString(), modules);
         List<ModuleDoc> moduleDocList = new ArrayList<>(docsMap.values());
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
-        Map<String, List<Path>> resources = new HashMap<>();
 
-        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList, resources);
+        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList);
         Module testModule = project.modules.get(0);
 
         for (Record record : testModule.records) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
@@ -32,11 +32,9 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +76,6 @@ public class MultilineDocsTest {
                 Paths.get("src/test/resources", sourceRoot).toAbsolutePath().toString(), modules);
         List<ModuleDoc> moduleDocList = new ArrayList<>(docsMap.values());
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
-        Map<String, List<Path>> resources = new HashMap<>();
 
         Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList);
         Module testModule = project.modules.get(0);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
@@ -80,7 +80,7 @@ public class MultilineDocsTest {
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
         Map<String, List<Path>> resources = new HashMap<>();
 
-        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList, resources);
+        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList);
         Module testModule = project.modules.get(0);
 
         for (Function function : testModule.functions) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ObjectFieldDefaultValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ObjectFieldDefaultValueTest.java
@@ -63,7 +63,7 @@ public class ObjectFieldDefaultValueTest {
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
         Map<String, List<Path>> resources = new HashMap<>();
 
-        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList, resources);
+        Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList);
         testModule = project.modules.get(0);
         objects = testModule.objects;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ObjectFieldDefaultValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ObjectFieldDefaultValueTest.java
@@ -33,11 +33,9 @@ import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -61,7 +59,6 @@ public class ObjectFieldDefaultValueTest {
                 Paths.get("src/test/resources", sourceRoot).toAbsolutePath().toString(), modules);
         List<ModuleDoc> moduleDocList = new ArrayList<>(docsMap.values());
         moduleDocList.sort(Comparator.comparing(pkg -> pkg.bLangPackage.packageID.toString()));
-        Map<String, List<Path>> resources = new HashMap<>();
 
         Project project = BallerinaDocGenerator.getDocsGenModel(moduleDocList);
         testModule = project.modules.get(0);


### PR DESCRIPTION
## Purpose
Adds functionality to

1. Create a JSON contatining all the data required to generate documentation..
2. Generate documentation using a given JSON.
3. Move templates used for documentation generation to lib/templates
4. Exclude generation of project index.html
Fixes #22721
Fixes #19853

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
