### PR TITLE
Add exclude tags and operations attributes to openapi annotation [1.2.x]

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -21,25 +21,25 @@ package org.ballerinalang.openapi.validator;
  * Container for Constants used in validator plugin.
  */
 public class Constants {
-    static final String PACKAGE = "openapi";
-    static final String ANNOTATION_NAME = "ServiceInfo";
-    static final String CONTRACT = "contract";
-    static final String HTTP = "http";
-    static final String RESOURCE_CONFIG = "ResourceConfig";
-    static final String PATH = "path";
-    static final String METHODS = "methods";
-    static final String GET = "get";
-    static final String POST = "post";
-    static final String PUT = "put";
-    static final String DELETE = "delete";
-    static final String HEAD = "head";
-    static final String PATCH = "patch";
-    static final String OPTIONS = "options";
-    static final String TRACE = "trace";
-    static final String TAGS = "tags";
-    static final String OPERATIONS = "operations";
-    static final String BODY = "body";
-    static final String FAILONERRORS = "failOnErrors";
-    static final String EXCLUDETAGS = "excludeTags";
-    static final String EXCLUDEOPERATIONS = "excludeOperations";
+    public static final String PACKAGE = "openapi";
+    public static final String ANNOTATION_NAME = "ServiceInfo";
+    public static final String CONTRACT = "contract";
+    public static final String HTTP = "http";
+    public static final String RESOURCE_CONFIG = "ResourceConfig";
+    public static final String PATH = "path";
+    public static final String METHODS = "methods";
+    public static final String GET = "get";
+    public static final String POST = "post";
+    public static final String PUT = "put";
+    public static final String DELETE = "delete";
+    public static final String HEAD = "head";
+    public static final String PATCH = "patch";
+    public static final String OPTIONS = "options";
+    public static final String TRACE = "trace";
+    public static final String TAGS = "tags";
+    public static final String OPERATIONS = "operations";
+    public static final String BODY = "body";
+    public static final String FAILONERRORS = "failOnErrors";
+    public static final String EXCLUDETAGS = "excludeTags";
+    public static final String EXCLUDEOPERATIONS = "excludeOperations";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -40,4 +40,6 @@ public class Constants {
     static final String OPERATIONS = "operations";
     static final String BODY = "body";
     static final String FAILONERRORS = "failOnErrors";
+    static final String EXCLUDETAGS = "excludeTags";
+    static final String EXCLUDEOPERATIONS = "excludeOperations";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
@@ -79,12 +79,12 @@ class ErrorMessages {
     }
 
     static String tagFilterEnable() {
-        return String.format("Both Tags and excludeTags fields include the same tag(s). Make sure to use one"+
+        return String.format("Both Tags and excludeTags fields include the same tag(s). Make sure to use one" +
                 " field when using the openapi annotation. ");
     }
 
     static String operationFilterEnable() {
-        return String.format("Both Operations and excludeOperations fields include"+
+        return String.format("Both Operations and excludeOperations fields include" +
                 " the same operation(s). Make sure to use one field when using the openapi annotation.");
     }
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
@@ -77,4 +77,14 @@ class ErrorMessages {
                         "for the method '%s' of the path '%s' which is documented in the OpenAPI contract",
                 fieldName, paramName, operation, path);
     }
+
+    static String tagFilterEnable() {
+        return String.format("Both Tags and excludeTags fields include the same tag(s). Make sure to use one"+
+                " field when using the openapi annotation. ");
+    }
+
+    static String operationFilterEnable() {
+        return String.format("Both Operations and excludeOperations fields include"+
+                " the same operation(s). Make sure to use one field when using the openapi annotation.");
+    }
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
@@ -80,11 +80,12 @@ class ErrorMessages {
 
     static String tagFilterEnable() {
         return String.format("Both Tags and excludeTags fields include the same tag(s). Make sure to use one" +
-                " field when using the openapi annotation. ");
+                " field of tag filtering when using the openapi annotation. ");
     }
 
     static String operationFilterEnable() {
         return String.format("Both Operations and excludeOperations fields include" +
-                " the same operation(s). Make sure to use one field when using the openapi annotation.");
+                " the same operation(s). Make sure to use one field of operation filtering" +
+                " when using the openapi annotation.");
     }
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
@@ -23,10 +23,8 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 
 /**
  * Summary of the OpenAPI documentation for a API path.
@@ -67,7 +65,17 @@ class OpenAPIPathSummary {
         if (operation == null) {
             return false;
         }
-        return operation.getTags().containsAll(tags);
+//        return tags.containsAll(operation.getTags());
+        return !Collections.disjoint(tags, operation.getTags());
+    }
+
+    boolean hasOperations( List<String> operationslist, String method){
+        Operation operation = operations.get(method);
+        if (operation == null) {
+            return false;
+        }
+        return operationslist.contains(operation.getOperationId());
+
     }
 
     List<OpenAPIParameter> getParamNamesForOperation(String operation) {

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
@@ -23,7 +23,6 @@ import io.swagger.v3.oas.models.media.MediaType;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
@@ -24,8 +24,11 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 
 
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 /**
  * Summary of the OpenAPI documentation for a API path.
  */
@@ -69,7 +72,7 @@ class OpenAPIPathSummary {
         return !Collections.disjoint(tags, operation.getTags());
     }
 
-    boolean hasOperations( List<String> operationslist, String method){
+    boolean hasOperations(List<String> operationslist, String method) {
         Operation operation = operations.get(method);
         if (operation == null) {
             return false;

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
@@ -68,7 +68,6 @@ class OpenAPIPathSummary {
         if (operation == null) {
             return false;
         }
-//        return tags.containsAll(operation.getTags());
         return !Collections.disjoint(tags, operation.getTags());
     }
 

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
@@ -228,12 +228,12 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
             }
 
 //            Checking both tags and excludeTags include same tags and operations
-            if (!Collections.disjoint(tags,excludeTags)) {
+            if (!Collections.disjoint(tags, excludeTags)) {
                 dLog.logDiagnostic(Diagnostic.Kind.WARNING, annotation.getPosition(),
                         ErrorMessages.tagFilterEnable());
                 excludeTags.clear();
 
-            }else if (!Collections.disjoint(operations, excludeOperations)) {
+            } else if (!Collections.disjoint(operations, excludeOperations)) {
                 dLog.logDiagnostic(Diagnostic.Kind.WARNING, annotation.getPosition(),
                         ErrorMessages.operationFilterEnable());
                 excludeOperations.clear();

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIValidatorPlugin.java
@@ -143,37 +143,10 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                                 }
                             }
                         } else if (key.equals(Constants.TAGS)) {
-                            if (valueExpr instanceof BLangListConstructorExpr) {
-                                BLangListConstructorExpr bLangListConstructorExpr =
-                                        (BLangListConstructorExpr) valueExpr;
-                                for (BLangExpression bLangExpression : bLangListConstructorExpr.getExpressions()) {
-                                    if (bLangExpression instanceof BLangLiteral) {
-                                        BLangLiteral expression = (BLangLiteral) bLangExpression;
-                                        if (expression.getValue() instanceof String) {
-                                            tags.add((String) expression.getValue());
-                                        } else {
-                                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
-                                                    "Tags should be applied as string values");
-                                        }
-                                    }
-                                }
-                            }
+                            extractValues(annotation, tags, valueExpr, "Tags should be applied as string values");
                         } else if (key.equals(Constants.OPERATIONS)) {
-                            if (valueExpr instanceof BLangListConstructorExpr) {
-                                BLangListConstructorExpr bLangListConstructorExpr =
-                                        (BLangListConstructorExpr) valueExpr;
-                                for (BLangExpression bLangExpression : bLangListConstructorExpr.getExpressions()) {
-                                    if (bLangExpression instanceof BLangLiteral) {
-                                        BLangLiteral expression = (BLangLiteral) bLangExpression;
-                                        if (expression.getValue() instanceof String) {
-                                            operations.add((String) expression.getValue());
-                                        } else {
-                                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
-                                                    "Operations should be applied as string values");
-                                        }
-                                    }
-                                }
-                            }
+                            extractValues(annotation, operations, valueExpr,
+                                    "Operations should be applied as string values");
                         }  else if (key.equals(Constants.FAILONERRORS)) {
                             if (valueExpr instanceof BLangLiteral) {
                                 BLangLiteral value = (BLangLiteral) valueExpr;
@@ -185,37 +158,11 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                                 }
                             }
                         } else if (key.equals(Constants.EXCLUDETAGS)) {
-                            if (valueExpr instanceof  BLangListConstructorExpr) {
-                                BLangListConstructorExpr bLangListConstructorExpr =
-                                        (BLangListConstructorExpr) valueExpr;
-                                for (BLangExpression bLangExpression: bLangListConstructorExpr.getExpressions()) {
-                                    if (bLangExpression instanceof BLangLiteral) {
-                                        BLangLiteral expression = (BLangLiteral) bLangExpression;
-                                        if (expression.getValue() instanceof String) {
-                                            excludeTags.add((String) expression.getValue());
-                                        } else {
-                                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
-                                                    "ExcludeTags should be applied as string values");
-                                        }
-                                    }
-                                }
-                            }
+                            extractValues(annotation, excludeTags, valueExpr,
+                                    "ExcludeTags should be applied as string values");
                         } else if (key.equals(Constants.EXCLUDEOPERATIONS)) {
-                            if (valueExpr instanceof  BLangListConstructorExpr) {
-                                BLangListConstructorExpr bLangListConstructorExpr =
-                                        (BLangListConstructorExpr) valueExpr;
-                                for (BLangExpression bLangExpression: bLangListConstructorExpr.getExpressions()) {
-                                    if (bLangExpression instanceof BLangLiteral) {
-                                        BLangLiteral expression = (BLangLiteral) bLangExpression;
-                                        if (expression.getValue() instanceof String) {
-                                            excludeOperations.add((String) expression.getValue());
-                                        } else {
-                                            dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
-                                                    "ExcludeOperations should be applied as string values");
-                                        }
-                                    }
-                                }
-                            }
+                            extractValues(annotation, excludeOperations, valueExpr,
+                                    "ExcludeOperations should be applied as string values");
                         }
                     }
                 }
@@ -256,6 +203,24 @@ public class OpenAPIValidatorPlugin extends AbstractCompilerPlugin {
                 } catch (OpenApiValidatorException e) {
                     dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(),
                             e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void extractValues(AnnotationAttachmentNode annotation, List<String> operations,
+                               BLangExpression valueExpr, String s) {
+        if (valueExpr instanceof BLangListConstructorExpr) {
+            BLangListConstructorExpr bLangListConstructorExpr =
+                    (BLangListConstructorExpr) valueExpr;
+            for (BLangExpression bLangExpression : bLangListConstructorExpr.getExpressions()) {
+                if (bLangExpression instanceof BLangLiteral) {
+                    BLangLiteral expression = (BLangLiteral) bLangExpression;
+                    if (expression.getValue() instanceof String) {
+                        operations.add((String) expression.getValue());
+                    } else {
+                        dLog.logDiagnostic(Diagnostic.Kind.ERROR, annotation.getPosition(), s);
+                    }
                 }
             }
         }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -830,10 +830,7 @@ class ValidatorUtil {
         }
         dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                 ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
-
-
     }
-
 
     private static void validateUnmatchedMethods(List<String> unmatchedMethods, ServiceNode serviceNode,
                                                  Diagnostic.Kind kind, OpenAPIPathSummary openApiSummary,

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -344,18 +344,18 @@ class ValidatorUtil {
                 if (tagFilteringEnabled || operationFilteringEnabled || excludeTagsFilteringEnabled
                         || excludeOperationFilterEnabled) {
                     if (operationFilteringEnabled) {
-                        OperationsFilter(serviceNode, openApiSummary, operations, kind, Diagnostic.Kind.ERROR,
+                        operationsFilter(serviceNode, openApiSummary, operations, kind, Diagnostic.Kind.ERROR,
                                 Diagnostic.Kind.WARNING, dLog);
-                    } else if (excludeOperationFilterEnabled){
-                        OperationsFilter(serviceNode, openApiSummary, excludeOperations, kind, Diagnostic.Kind.WARNING,
+                    } else if (excludeOperationFilterEnabled) {
+                        operationsFilter(serviceNode, openApiSummary, excludeOperations, kind, Diagnostic.Kind.WARNING,
                                 Diagnostic.Kind.ERROR, dLog);
                     }
 
                     if (tagFilteringEnabled) {
-                        TagsFilter(serviceNode, openApiSummary, tags, kind, Diagnostic.Kind.ERROR,
+                        tagsFilter(serviceNode, openApiSummary, tags, kind, Diagnostic.Kind.ERROR,
                                 Diagnostic.Kind.WARNING, dLog);
                     } else if (excludeTagsFilteringEnabled) {
-                        TagsFilter(serviceNode, openApiSummary, excludeTags, kind, Diagnostic.Kind.WARNING,
+                        tagsFilter(serviceNode, openApiSummary, excludeTags, kind, Diagnostic.Kind.WARNING,
                                 Diagnostic.Kind.ERROR, dLog);;
                     }
 
@@ -387,7 +387,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     } else if (excludeTagsFilteringEnabled) {
                         for (String method : openApiSummary.getAvailableOperations()) {
@@ -400,7 +400,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     } else {
                         for (String method : openApiSummary.getAvailableOperations()) {
@@ -412,7 +412,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     }
                 } else if (excludeOperationFilterEnabled) {
@@ -433,7 +433,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     } else if (tagFilteringEnabled) {
                         for (String method : openApiSummary.getAvailableOperations()) {
@@ -446,7 +446,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     } else {
                         for (String method : openApiSummary.getAvailableOperations()) {
@@ -458,7 +458,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     }
                     // If exclude tag filtering available proceed to validate all the operations grouped by tags which
@@ -476,7 +476,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
                         }
                     }  else if (tagFilteringEnabled) {
                         // If tag filtering available proceed to validate all the operations grouped by given tags.
@@ -490,7 +490,7 @@ class ValidatorUtil {
                         }
 
                         if (unmatchedMethods.size() > 0) {
-                            validateUnmatchedMethods( unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
+                            validateUnmatchedMethods(unmatchedMethods, serviceNode, kind, openApiSummary, dLog);
 
                         }
                         // If Exclude operation filtering available proceed.
@@ -796,19 +796,18 @@ class ValidatorUtil {
         return serviceNode.getName().getPosition();
     }
 
-    private static void TagsFilter (ServiceNode serviceNode,
+    private static void tagsFilter (ServiceNode serviceNode,
                                     OpenAPIPathSummary openApiSummary,
                                     List<String> tags,
                                     Diagnostic.Kind kind,
                                     Diagnostic.Kind kind1,
                                     Diagnostic.Kind kind2,
                                     DiagnosticLog dLog) {
-        for (String method : openApiSummary.getAvailableOperations()){
-            if (openApiSummary.hasTags(tags, method)){
+        for (String method : openApiSummary.getAvailableOperations()) {
+            if (openApiSummary.hasTags(tags, method)) {
                 kind = kind1;
                 break;
-            }
-            else {
+            } else {
                 kind = kind2;
             }
         }
@@ -816,7 +815,7 @@ class ValidatorUtil {
                 ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
     }
     //for Operation Filter
-    private static void OperationsFilter (ServiceNode serviceNode,
+    private static void operationsFilter (ServiceNode serviceNode,
                                           OpenAPIPathSummary openApiSummary,
                                           List<String> operations,
                                           Diagnostic.Kind kind,

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -322,7 +322,8 @@ class ValidatorUtil {
      * @param openAPIComponentSummary openAPI component summary
      * @param dLog                    diagnostic logger
      */
-    public static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags, List<String> operations,
+    public static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags,
+                                                List<String> operations,
                                                 Diagnostic.Kind kind,
                                                 List<String> excludeTags,
                                                 List<String> excludeOperations,

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.openapi.validator;
 
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.ObjectSchema;
 import io.swagger.v3.oas.models.media.Schema;
@@ -93,43 +94,35 @@ class ValidatorUtil {
 
                 PathItem operations = (PathItem) pathItem.getValue();
                 if (operations.getGet() != null) {
-                    openAPISummary.addAvailableOperation(Constants.GET);
-                    openAPISummary.addOperation(Constants.GET, operations.getGet());
+                    addOpenapiSummary(openAPISummary, Constants.GET, operations.getGet());
                 }
 
                 if (operations.getPost() != null) {
-                    openAPISummary.addAvailableOperation(Constants.POST);
-                    openAPISummary.addOperation(Constants.POST, operations.getPost());
+                    addOpenapiSummary(openAPISummary, Constants.POST, operations.getPost());
                 }
 
                 if (operations.getPut() != null) {
-                    openAPISummary.addAvailableOperation(Constants.PUT);
-                    openAPISummary.addOperation(Constants.PUT, operations.getPut());
+                    addOpenapiSummary(openAPISummary, Constants.PUT, operations.getPut());
                 }
 
                 if (operations.getDelete() != null) {
-                    openAPISummary.addAvailableOperation(Constants.DELETE);
-                    openAPISummary.addOperation(Constants.DELETE, operations.getDelete());
+                    addOpenapiSummary(openAPISummary, Constants.DELETE, operations.getDelete());
                 }
 
                 if (operations.getHead() != null) {
-                    openAPISummary.addAvailableOperation(Constants.HEAD);
-                    openAPISummary.addOperation(Constants.HEAD, operations.getHead());
+                    addOpenapiSummary(openAPISummary, Constants.HEAD, operations.getHead());
                 }
 
                 if (operations.getPatch() != null) {
-                    openAPISummary.addAvailableOperation(Constants.PATCH);
-                    openAPISummary.addOperation(Constants.PATCH, operations.getPatch());
+                    addOpenapiSummary(openAPISummary, Constants.PATCH, operations.getPatch());
                 }
 
                 if (operations.getOptions() != null) {
-                    openAPISummary.addAvailableOperation(Constants.OPTIONS);
-                    openAPISummary.addOperation(Constants.OPTIONS, operations.getOptions());
+                    addOpenapiSummary(openAPISummary, Constants.OPTIONS, operations.getOptions());
                 }
 
                 if (operations.getTrace() != null) {
-                    openAPISummary.addAvailableOperation(Constants.TRACE);
-                    openAPISummary.addOperation(Constants.TRACE, operations.getTrace());
+                    addOpenapiSummary(openAPISummary, Constants.TRACE, operations.getTrace());
                 }
             }
 
@@ -137,6 +130,11 @@ class ValidatorUtil {
         }
 
         openAPIComponentSummary.setComponents(contract.getComponents());
+    }
+
+    private static void addOpenapiSummary(OpenAPIPathSummary openAPISummary, String get, Operation get2) {
+        openAPISummary.addAvailableOperation(get);
+        openAPISummary.addOperation(get, get2);
     }
 
     /**

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -57,7 +57,7 @@ class ValidatorUtil {
      * @return {@link OpenAPI} OpenAPI model
      * @throws OpenApiValidatorException in case of exception
      */
-    static OpenAPI parseOpenAPIFile(String definitionURI) throws OpenApiValidatorException {
+    public static OpenAPI parseOpenAPIFile(String definitionURI) throws OpenApiValidatorException {
         Path contractPath = Paths.get(definitionURI);
         if (!Files.exists(contractPath)) {
             throw new OpenApiValidatorException(ErrorMessages.invalidFilePath(definitionURI));
@@ -82,7 +82,7 @@ class ValidatorUtil {
      * @param contract                openAPI contract
      * @param openAPIComponentSummary list of openAPI components
      */
-    static void summarizeOpenAPI(List<OpenAPIPathSummary> openAPISummaries, OpenAPI contract
+    public static void summarizeOpenAPI(List<OpenAPIPathSummary> openAPISummaries, OpenAPI contract
             , OpenAPIComponentSummary openAPIComponentSummary) {
         io.swagger.v3.oas.models.Paths paths = contract.getPaths();
         for (Map.Entry pathItem : paths.entrySet()) {
@@ -143,7 +143,7 @@ class ValidatorUtil {
      * @param resourceSummaryList list of resource summaries
      * @param serviceNode         service node
      */
-    static void summarizeResources(List<ResourceSummary> resourceSummaryList, ServiceNode serviceNode) {
+    public static void summarizeResources(List<ResourceSummary> resourceSummaryList, ServiceNode serviceNode) {
         // Iterate resources available in a service and extract details to be validated.
         for (FunctionNode resource : serviceNode.getResources()) {
             AnnotationAttachmentNode annotation = null;
@@ -223,7 +223,7 @@ class ValidatorUtil {
         }
     }
 
-    static void validateResourcesAgainstOpenApi(List<String> tags, List<String> operations,
+    public static void validateResourcesAgainstOpenApi(List<String> tags, List<String> operations,
                                                 Diagnostic.Kind kind,
                                                 List<String> excludeTags,
                                                 List<String> excludeOperations,
@@ -322,7 +322,7 @@ class ValidatorUtil {
      * @param openAPIComponentSummary openAPI component summary
      * @param dLog                    diagnostic logger
      */
-    static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags, List<String> operations,
+    public static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags, List<String> operations,
                                                 Diagnostic.Kind kind,
                                                 List<String> excludeTags,
                                                 List<String> excludeOperations,

--- a/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
+++ b/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
@@ -15,30 +15,34 @@
 // under the License.
 
 # Service validation codee
-# + contract - OpenApi Contract link
-# + tags - OpenApi Tags
-# + operations - OpenApi Operations
-# + failOnErrors - OpenApi Validator Enable
+        # + contract - OpenApi Contract link
+        # + tags - OpenApi Tags
+        # + operations - OpenApi Operations
+        # + failOnErrors - OpenApi Validator Enable
+        # + excludeTags - Openapi Validator Off for these tags
+        # + excludeOperations - Openapi Validator Off for these operations
 public type ServiceInformation record {|
-    string contract = "";
-    string[]? tags = [];
-    string[]? operations = [];
-    boolean failOnErrors = true;
-|};
+        string contract = "";
+        string[]? tags = [];
+        string[]? operations = [];
+        boolean failOnErrors = true;
+        string[]? excludeTags = [];
+        string[]? excludeOperations = [];
+        |};
 
-# Configuration elements for client code generation.
-#
-# + generate - generates client code if set to true
+        # Configuration elements for client code generation.
+        #
+        # + generate - generates client code if set to true
 public type ClientInformation record {|
-    boolean generate = true;
-|};
+        boolean generate = true;
+        |};
 
-# Presence of this annotation will mark this endpoint to be used as a service endpoint for client generation
+        # Presence of this annotation will mark this endpoint to be used as a service endpoint for client generation
 public const annotation ClientEndpoint on source listener;
 
-# Annotation to configure client code generation.
+        # Annotation to configure client code generation.
 public annotation ClientInformation ClientConfig on service;
 
-# Annotation for additional OpenAPI information of a Ballerina service.
+        # Annotation for additional OpenAPI information of a Ballerina service.
 public annotation ServiceInformation ServiceInfo on service;
 


### PR DESCRIPTION
## Purpose
> Fix issues with tag and operation filtering. Add the extra fields excludeTags and excludeOperations to Opeanapi annotation. This use to filter the tags and operations that exclude validating. 


## Samples
>@openapi:ServiceInfo {
    contract: "resources/petstore.yaml",
      excludeTags: ["user"]
      excludeOperations: ["getOrderById"]
    }

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
