### PR TITLE
Add tests for failOnErrors attribute in openapi annotation [1.2.x]

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -115,6 +115,7 @@ include(':ballerina-jsonutils')
 include(':testerina:testerina-runtime')
 include(':testerina:report-tools')
 include(':testerina-integration-test')
+include(':openapi-integration-tests')
 include(':jballerina-debugger-integration-test')
 //include(':examples-test')
 // TODO: enable at 'dependsOn' of tools-intergration-tests
@@ -257,6 +258,8 @@ project(':testerina:testerina-runtime').projectDir = file('misc/testerina/module
 project(':testerina:report-tools').projectDir = file('misc/testerina/modules/report-tools')
 project(':testerina-integration-test').projectDir = file('tests/testerina-integration-test')
 project(':jballerina-debugger-integration-test').projectDir = file('tests/jballerina-debugger-integration-test')
+project(':openapi-integration-tests').projectDir = file('tests/openapi-integration-tests')
+
 
 project(':debug-adapter:debug-adapter-core').projectDir = file('misc/debug-adapter/modules/debug-adapter-core')
 project(':debug-adapter:debug-adapter-cli').projectDir = file('misc/debug-adapter/modules/debug-adapter-cli')

--- a/tests/openapi-integration-tests/build.gradle
+++ b/tests/openapi-integration-tests/build.gradle
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+apply plugin: 'base'
+apply from: "$rootDir/gradle/javaProject.gradle"
+
+description = 'Ballerina - Openapi Test'
+
+def extractedDist = "$buildDir/extractedDistribution/jballerina-tools-${project.version}"
+
+configurations {
+    jballerinaTools
+}
+
+dependencies {
+    jballerinaTools project(path: ':jballerina-tools', configuration: 'zip')
+    testCompile 'org.testng:testng'
+    testCompile 'org.slf4j:slf4j-jdk14'
+    implementation 'info.picocli:picocli'
+
+    implementation project(path: ':ballerina-test-utils')
+}
+
+task extractDistribution(type: Copy) {
+    dependsOn ':jballerina-tools:build'
+    from zipTree(configurations.jballerinaTools.asPath)
+    into "$buildDir/extractedDistribution"
+
+}
+
+// Integration tests for Openapi
+test {
+    mustRunAfter ':jballerina-integration-test:test'
+    dependsOn extractDistribution
+    systemProperty 'enableOpenapiTests', 'true'
+
+    maxParallelForks = 1
+    systemProperty 'basedir', "$buildDir"
+    systemProperty 'libdir', "$buildDir"
+    systemProperty 'server.zip', configurations.jballerinaTools.asPath
+    systemProperty 'jballerina.server.zip', configurations.jballerinaTools.asPath
+    systemProperty 'java.util.logging.config.file', "$buildDir/src/test/resources/logging.properties"
+    systemProperty 'java.util.logging.manager', 'org.ballerinalang.logging.BLogManager'
+
+    useTestNG() {
+        suites 'src/test/resources/testng.xml'
+    }
+}

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/BaseTestCase.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/BaseTestCase.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.openapi.test;
+
+
+import org.ballerinalang.openapi.test.utils.FileUtils;
+import org.ballerinalang.test.context.BalServer;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class BaseTestCase {
+    public static BalServer balServer;
+    Path tempProjectDirectory;
+    static Path basicTestsProjectPath;
+
+    @BeforeSuite(alwaysRun = true)
+    public void initialize() throws BallerinaTestException, IOException {
+        balServer = new BalServer();
+        tempProjectDirectory = Files.createTempDirectory("bal-test-integration-openapi-project");
+
+        // copy TestProject validator off  to a temp directory
+        Path OpenapiValidatorProj = Paths.get("src", "test", "resources",
+                "project-based-tests/openapi-validator").toAbsolutePath();
+
+        basicTestsProjectPath = tempProjectDirectory.resolve("openapi-validator");
+        FileUtils.copyFolder(OpenapiValidatorProj, basicTestsProjectPath);
+
+
+    }
+    @AfterSuite(alwaysRun = true)
+    public void destroy() {
+        balServer.cleanup();
+    }
+
+}

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/BaseTestCase.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/BaseTestCase.java
@@ -49,8 +49,6 @@ public class BaseTestCase {
 
         basicTestsProjectPath = tempProjectDirectory.resolve("openapi-validator");
         FileUtils.copyFolder(openapiValidatorProj, basicTestsProjectPath);
-
-
     }
     @AfterSuite(alwaysRun = true)
     public void destroy() {

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/BaseTestCase.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/BaseTestCase.java
@@ -30,6 +30,9 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+/**
+ * Parent test class for all integration test cases. This will provide basic functionality for integration tests.
+ */
 public class BaseTestCase {
     public static BalServer balServer;
     Path tempProjectDirectory;
@@ -41,11 +44,11 @@ public class BaseTestCase {
         tempProjectDirectory = Files.createTempDirectory("bal-test-integration-openapi-project");
 
         // copy TestProject validator off  to a temp directory
-        Path OpenapiValidatorProj = Paths.get("src", "test", "resources",
+        Path openapiValidatorProj = Paths.get("src", "test", "resources",
                 "project-based-tests/openapi-validator").toAbsolutePath();
 
         basicTestsProjectPath = tempProjectDirectory.resolve("openapi-validator");
-        FileUtils.copyFolder(OpenapiValidatorProj, basicTestsProjectPath);
+        FileUtils.copyFolder(openapiValidatorProj, basicTestsProjectPath);
 
 
     }

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOff.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOff.java
@@ -24,6 +24,9 @@ import org.ballerinalang.test.context.LogLeecher;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Test class to test openapi annotation disable validating.
+ */
 public class OpenapiValidatorOff extends BaseTestCase {
 
     private BMainInstance balClient;

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOff.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOff.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.openapi.test;
+
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class OpenapiValidatorOff extends BaseTestCase {
+
+    private BMainInstance balClient;
+    private String projectPath;
+
+    @BeforeClass
+    public void setup() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+        projectPath = basicTestsProjectPath.toString();
+    }
+    @Test
+    public void testOpenapiValidatorOff() throws BallerinaTestException {
+        String msg1 = "warning: openapi-test/openapi-validator-off:0.0.0::openapi-validator-off.bal:15:17:" +
+                " Couldn't find a Ballerina service resource for the path '/{param1}/{param2}'" +
+                " which is documented in the OpenAPI contract";
+        String msg2 = "warning: openapi-test/openapi-validator-off:0.0.0::openapi-validator-off.bal:19:9:" +
+                " Ballerina service contains a Resource that is not documented in the OpenAPI contract." +
+                " Error Resource path '/{param1}/{param3}'";
+
+        LogLeecher clientLeecher1 = new LogLeecher(msg1, LogLeecher.LeecherType.ERROR);
+        LogLeecher clientLeecher2 = new LogLeecher(msg2, LogLeecher.LeecherType.ERROR);
+        balClient.runMain("test", new String[]{ "openapi-validator-off"}, null, new String[]{},
+                new LogLeecher[]{clientLeecher1, clientLeecher2}, projectPath);
+        clientLeecher1.waitForText(20000);
+        clientLeecher2.waitForText(20000);
+    }
+}

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOff.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOff.java
@@ -36,18 +36,11 @@ public class OpenapiValidatorOff extends BaseTestCase {
     }
     @Test
     public void testOpenapiValidatorOff() throws BallerinaTestException {
-        String msg1 = "warning: openapi-test/openapi-validator-off:0.0.0::openapi-validator-off.bal:15:17:" +
-                " Couldn't find a Ballerina service resource for the path '/{param1}/{param2}'" +
-                " which is documented in the OpenAPI contract";
-        String msg2 = "warning: openapi-test/openapi-validator-off:0.0.0::openapi-validator-off.bal:19:9:" +
-                " Ballerina service contains a Resource that is not documented in the OpenAPI contract." +
-                " Error Resource path '/{param1}/{param3}'";
+        String msg1 = "warning: openapi-test/openapi-validator-off:";
 
         LogLeecher clientLeecher1 = new LogLeecher(msg1, LogLeecher.LeecherType.ERROR);
-        LogLeecher clientLeecher2 = new LogLeecher(msg2, LogLeecher.LeecherType.ERROR);
-        balClient.runMain("test", new String[]{ "openapi-validator-off"}, null, new String[]{},
-                new LogLeecher[]{clientLeecher1, clientLeecher2}, projectPath);
+        balClient.runMain("build", new String[]{"openapi-validator-off"}, null, new String[]{},
+                new LogLeecher[]{clientLeecher1}, projectPath);
         clientLeecher1.waitForText(20000);
-        clientLeecher2.waitForText(20000);
     }
 }

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOn.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOn.java
@@ -24,7 +24,10 @@ import org.ballerinalang.test.context.LogLeecher;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class OpenapiValidatorOn extends BaseTestCase{
+/**
+ * Test class to test openapi annotation enable validating.
+ */
+public class OpenapiValidatorOn extends BaseTestCase {
     private BMainInstance balClient;
     private String projectPath;
 

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOn.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOn.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.openapi.test;
+
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class OpenapiValidatorOn extends BaseTestCase{
+    private BMainInstance balClient;
+    private String projectPath;
+
+    @BeforeClass
+    public void setup() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+        projectPath = basicTestsProjectPath.toString();
+    }
+    @Test
+    public void testOpenapiValidatorOn() throws BallerinaTestException {
+
+        String msg1 = "error: openapi-test/openapi-validator-on:0.0.0::openapi-validator-on.bal:14:17:" +
+                " Couldn't find a Ballerina service resource for the path '/{param1}/{param2}' which" +
+                " is documented in the OpenAPI contract";
+        String msg2 = "error: openapi-test/openapi-validator-on:0.0.0::openapi-validator-on.bal:18:9:" +
+                " Ballerina service contains a Resource that is not documented in the OpenAPI contract." +
+                " Error Resource path '/{param1}/{param3}'";
+        LogLeecher clientLeecher1 = new LogLeecher(msg1, LogLeecher.LeecherType.ERROR);
+        LogLeecher clientLeecher2 = new LogLeecher(msg2, LogLeecher.LeecherType.ERROR);
+
+        balClient.runMain("test", new String[]{ "openapi-validator-on"}, null, new String[]{},
+                new LogLeecher[]{clientLeecher1, clientLeecher2}, projectPath);
+        clientLeecher1.waitForText(20000);
+        clientLeecher2.waitForText(20000);
+
+    }
+}

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOn.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/OpenapiValidatorOn.java
@@ -36,16 +36,16 @@ public class OpenapiValidatorOn extends BaseTestCase{
     @Test
     public void testOpenapiValidatorOn() throws BallerinaTestException {
 
-        String msg1 = "error: openapi-test/openapi-validator-on:0.0.0::openapi-validator-on.bal:14:17:" +
+        String msg1 = "error: openapi-test/openapi-validator-on:0.0.0::openapi-validator-on.bal:14:9:" +
                 " Couldn't find a Ballerina service resource for the path '/{param1}/{param2}' which" +
                 " is documented in the OpenAPI contract";
-        String msg2 = "error: openapi-test/openapi-validator-on:0.0.0::openapi-validator-on.bal:18:9:" +
+        String msg2 = "error: openapi-test/openapi-validator-on:0.0.0::openapi-validator-on.bal:17:9:" +
                 " Ballerina service contains a Resource that is not documented in the OpenAPI contract." +
                 " Error Resource path '/{param1}/{param3}'";
         LogLeecher clientLeecher1 = new LogLeecher(msg1, LogLeecher.LeecherType.ERROR);
         LogLeecher clientLeecher2 = new LogLeecher(msg2, LogLeecher.LeecherType.ERROR);
 
-        balClient.runMain("test", new String[]{ "openapi-validator-on"}, null, new String[]{},
+        balClient.runMain("build", new String[]{ "openapi-validator-on"}, null, new String[]{},
                 new LogLeecher[]{clientLeecher1, clientLeecher2}, projectPath);
         clientLeecher1.waitForText(20000);
         clientLeecher2.waitForText(20000);

--- a/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/utils/FileUtils.java
+++ b/tests/openapi-integration-tests/src/test/java/org/ballerinalang/openapi/test/utils/FileUtils.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.openapi.test.utils;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
+
+/**
+ * Util class for file operations.
+ */
+public class FileUtils {
+
+    /**
+     * Recursively copy a directory from a source to destination.
+     *
+     * @param src source path
+     * @param dest destination path
+     * @throws IOException thrown when as error occurs when copying from src to dest
+     */
+    public static void copyFolder(Path src, Path dest) throws IOException {
+        Files.walk(src).forEach(source -> copy(source, dest.resolve(src.relativize(source))));
+    }
+
+    private static void copy(Path source, Path dest) {
+        try {
+            Files.copy(source, dest, REPLACE_EXISTING);
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Returns the content of a given file as a string.
+     *
+     * @param filepath filepath to read content from
+     * @return file content string
+     */
+    public static String getFileContent(Path filepath) {
+        try {
+            return new String(Files.readAllBytes(filepath));
+        } catch (Exception e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+}

--- a/tests/openapi-integration-tests/src/test/resources/logging.properties
+++ b/tests/openapi-integration-tests/src/test/resources/logging.properties
@@ -1,0 +1,37 @@
+#
+# Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+####################### HANDLERS #######################
+# Configurations for console logging
+java.util.logging.ConsoleHandler.level=ALL
+java.util.logging.ConsoleHandler.formatter=org.ballerinalang.logging.formatters.BallerinaLogFormatter
+org.ballerinalang.logging.formatters.BallerinaLogFormatter.format=%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL %2$s [%3$s] - %4$s %n
+
+org.ballerinalang.openapi.test.utils.TestLogHandler.level=INFO
+org.ballerinalang.openapi.test.utils.TestLogHandler.formatter=org.ballerinalang.logging.formatters.DefaultLogFormatter
+org.ballerinalang.logging.formatters.DefaultLogFormatter.format=[%1$tY-%1$tm-%1$td %1$tH:%1$tM:%1$tS,%1$tL] %2$s [%3$s] - %4$s %5$s %n
+
+####################### LOGGERS #######################
+# Ballerina user level root logger
+ballerina.handlers=java.util.logging.ConsoleHandler
+ballerina.level=ALL
+ballerina.useParentHandlers=false
+
+# JUL root logger
+.handlers=java.util.logging.ConsoleHandler
+.level=SEVERE

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/Ballerina.toml
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/Ballerina.toml
@@ -1,0 +1,3 @@
+[project]
+org-name= "openapi-test"
+version= "0.0.0"

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/openapi-validator-off.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/openapi-validator-off.bal
@@ -12,19 +12,16 @@ import ballerina/openapi;
         basePath: "/api/v1"
         }
 
-        service openapi_validator_off on ep0 {
-
-@http:ResourceConfig {
+service openapi_validator_off on ep0 {
+    @http:ResourceConfig {
         methods:["GET"],
         path:"/{param1}/{param3}"
+    }
+    resource function test2Params (http:Caller caller, http:Request req,  string param1,  string param3) returns error? {
+        string msg = "Hello, " + param1 + " " + param3 ;
+        var result = caller->respond(<@untained> msg);
+        if (result is error) {
+            log:printError("Error sending response", result);
         }
-        resource function test2Params (http:Caller caller, http:Request req,  string param1,  string param3) returns error? {
-            string msg = "Hello, " + param1 + " " + param3 ;
-            var result = caller->respond(<@untained> msg);
-            if (result is error) {
-                log:printError("Error sending response", result);
-            }
-
-        }
-
-        }
+    }
+}

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/openapi-validator-off.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/openapi-validator-off.bal
@@ -1,0 +1,30 @@
+import ballerina/http;
+import ballerina/log;
+import ballerina/openapi;
+
+        listener http:Listener ep0 = new(9091, config = {host: "localhost"});
+
+@openapi:ServiceInfo {
+        contract: "src/openapi-validator-off/resources/openapi_validator_off.yaml",
+        failOnErrors: false
+        }
+@http:ServiceConfig {
+        basePath: "/api/v1"
+        }
+
+        service openapi_validator_off on ep0 {
+
+@http:ResourceConfig {
+        methods:["GET"],
+        path:"/{param1}/{param3}"
+        }
+        resource function test2Params (http:Caller caller, http:Request req,  string param1,  string param3) returns error? {
+            string msg = "Hello, " + param1 + " " + param3 ;
+            var result = caller->respond(<@untained> msg);
+            if (result is error) {
+                log:printError("Error sending response", result);
+            }
+
+        }
+
+        }

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/resources/openapi_validator_off.yaml
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/resources/openapi_validator_off.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+info:
+  title: Openapi validator off
+  description: test 2 or more uri parameters
+  version: 1.0.0
+servers:
+  - url: http://localhost/api/v1
+paths:
+  /{param1}/{param2}:
+    get:
+      operationId: test2Params
+      parameters:
+        - name: param1
+          in: path
+          required: true
+          schema:
+            type: string
+            description: param1
+        - name: param2
+          in: path
+          required: true
+          schema:
+            type: string
+            description: param2
+      responses:
+        '200':
+          description: test

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/tests/openapi-validator-off-test.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/tests/openapi-validator-off-test.bal
@@ -1,0 +1,24 @@
+import ballerina/http;
+import ballerina/test;
+import ballerina/io;
+
+# Test service
+@test:Config {
+
+}
+function testFunction() {
+    http:Client clientModule = new ("http://localhost:9091");
+    var respModule = clientModule->get("/api/v1/Test/Parametes");
+
+    if (respModule is http:Response) {
+        var payload = respModule.getTextPayload();
+        if (payload is string) {
+            io:println(payload);
+        } else {
+            io:println(payload.detail());
+        }
+    } else {
+        io:println(respModule.detail());
+    }
+}
+

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/tests/openapi-validator-off-test.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-off/tests/openapi-validator-off-test.bal
@@ -8,7 +8,7 @@ import ballerina/io;
 }
 function testFunction() {
     http:Client clientModule = new ("http://localhost:9091");
-    var respModule = clientModule->get("/api/v1/Test/Parametes");
+    var respModule = clientModule->get("/api/v1/Test/Parameters");
 
     if (respModule is http:Response) {
         var payload = respModule.getTextPayload();

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/openapi-validator-on.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/openapi-validator-on.bal
@@ -11,19 +11,16 @@ import ballerina/openapi;
         basePath: "/api/v1"
         }
 
-        service openapi_validator_off on ep0 {
-
-@http:ResourceConfig {
+service openapi_validator_on on ep0 {
+    @http:ResourceConfig {
         methods:["GET"],
         path:"/{param1}/{param3}"
+    }
+    resource function test2Params (http:Caller caller, http:Request req,  string param1,  string param3) returns error? {
+        string msg = "Hello, " + param1 + " " + param3 ;
+        var result = caller->respond(<@untained> msg);
+        if (result is error) {
+            log:printError("Error sending response", result);
         }
-        resource function test2Params (http:Caller caller, http:Request req,  string param1,  string param3) returns error? {
-            string msg = "Hello, " + param1 + " " + param3 ;
-            var result = caller->respond(<@untained> msg);
-            if (result is error) {
-                log:printError("Error sending response", result);
-            }
-
-        }
-
-        }
+    }
+}

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/openapi-validator-on.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/openapi-validator-on.bal
@@ -1,0 +1,29 @@
+import ballerina/http;
+import ballerina/log;
+import ballerina/openapi;
+
+        listener http:Listener ep0 = new(9091, config = {host: "localhost"});
+
+@openapi:ServiceInfo {
+        contract: "src/openapi-validator-on/resources/openapi_validator_on.yaml"
+        }
+@http:ServiceConfig {
+        basePath: "/api/v1"
+        }
+
+        service openapi_validator_off on ep0 {
+
+@http:ResourceConfig {
+        methods:["GET"],
+        path:"/{param1}/{param3}"
+        }
+        resource function test2Params (http:Caller caller, http:Request req,  string param1,  string param3) returns error? {
+            string msg = "Hello, " + param1 + " " + param3 ;
+            var result = caller->respond(<@untained> msg);
+            if (result is error) {
+                log:printError("Error sending response", result);
+            }
+
+        }
+
+        }

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/resources/openapi_validator_on.yaml
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/resources/openapi_validator_on.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.1
+info:
+  title: Openapi validator off
+  description: test 2 or more uri parameters
+  version: 1.0.0
+servers:
+  - url: http://localhost/api/v1
+paths:
+  /{param1}/{param2}:
+    get:
+      operationId: test2Params
+      parameters:
+        - name: param1
+          in: path
+          required: true
+          schema:
+            type: string
+            description: param1
+        - name: param2
+          in: path
+          required: true
+          schema:
+            type: string
+            description: param2
+      responses:
+        '200':
+          description: test

--- a/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/tests/openapi-validator-on-test.bal
+++ b/tests/openapi-integration-tests/src/test/resources/project-based-tests/openapi-validator/src/openapi-validator-on/tests/openapi-validator-on-test.bal
@@ -1,0 +1,24 @@
+import ballerina/http;
+import ballerina/test;
+import ballerina/io;
+
+# Test service
+@test:Config {
+
+}
+function testFunction() {
+    http:Client clientModule = new ("http://localhost:9091");
+    var respModule = clientModule->get("/api/v1/Test/Parametes");
+
+    if (respModule is http:Response) {
+        var payload = respModule.getTextPayload();
+        if (payload is string) {
+            io:println(payload);
+        } else {
+            io:println(payload.detail());
+        }
+    } else {
+        io:println(respModule.detail());
+    }
+}
+

--- a/tests/openapi-integration-tests/src/test/resources/testng.xml
+++ b/tests/openapi-integration-tests/src/test/resources/testng.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+
+WSO2 Inc. licenses this file to you under the Apache License,
+Version 2.0 (the "License"); you may not use this file except
+in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="openapi-intg-test-suite">
+
+    <test name="openapi-ballerina-test-suite" preserve-order="true"
+          parallel="false">
+        <groups>
+            <run>
+                <exclude name="brokenOnJBallerina"/>
+            </run>
+        </groups>
+        <classes>
+            <class name="org.ballerinalang.openapi.test.OpenapiValidatorOff"></class>
+            <class name="org.ballerinalang.openapi.test.OpenapiValidatorOn"></class>
+        </classes>
+    </test>
+</suite>


### PR DESCRIPTION
## Purpose
> Add integration tests for failOnErrors attribute in openapi annotations.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
