### PR TITLE
Add exclude tags and operations attributes to openapi annotation 

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -21,25 +21,25 @@ package org.ballerinalang.openapi.validator;
  * Container for Constants used in validator plugin.
  */
 public class Constants {
-    static final String PACKAGE = "openapi";
-    static final String ANNOTATION_NAME = "ServiceInfo";
-    static final String CONTRACT = "contract";
-    static final String HTTP = "http";
-    static final String RESOURCE_CONFIG = "ResourceConfig";
-    static final String PATH = "path";
-    static final String METHODS = "methods";
-    static final String GET = "get";
-    static final String POST = "post";
-    static final String PUT = "put";
-    static final String DELETE = "delete";
-    static final String HEAD = "head";
-    static final String PATCH = "patch";
-    static final String OPTIONS = "options";
-    static final String TRACE = "trace";
-    static final String TAGS = "tags";
-    static final String OPERATIONS = "operations";
-    static final String BODY = "body";
-    static final String FAILONERRORS = "failOnErrors";
-    static final String EXCLUDETAGS = "excludeTags";
-    static final String EXCLUDEOPERATIONS = "excludeOperations";
+    public static final String PACKAGE = "openapi";
+    public static final String ANNOTATION_NAME = "ServiceInfo";
+    public static final String CONTRACT = "contract";
+    public static final String HTTP = "http";
+    public static final String RESOURCE_CONFIG = "ResourceConfig";
+    public static final String PATH = "path";
+    public static final String METHODS = "methods";
+    public static final String GET = "get";
+    public static final String POST = "post";
+    public static final String PUT = "put";
+    public static final String DELETE = "delete";
+    public static final String HEAD = "head";
+    public static final String PATCH = "patch";
+    public static final String OPTIONS = "options";
+    public static final String TRACE = "trace";
+    public static final String TAGS = "tags";
+    public static final String OPERATIONS = "operations";
+    public static final String BODY = "body";
+    public static final String FAILONERRORS = "failOnErrors";
+    public static final String EXCLUDETAGS = "excludeTags";
+    public static final String EXCLUDEOPERATIONS = "excludeOperations";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/Constants.java
@@ -40,4 +40,6 @@ public class Constants {
     static final String OPERATIONS = "operations";
     static final String BODY = "body";
     static final String FAILONERRORS = "failOnErrors";
+    static final String EXCLUDETAGS = "excludeTags";
+    static final String EXCLUDEOPERATIONS = "excludeOperations";
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ErrorMessages.java
@@ -77,4 +77,15 @@ class ErrorMessages {
                         "for the method '%s' of the path '%s' which is documented in the OpenAPI contract",
                 fieldName, paramName, operation, path);
     }
+
+    static String tagFilterEnable() {
+        return String.format("Both Tags and excludeTags fields include the same tag(s). Make sure to use one" +
+                " field of tag filtering when using the openapi annotation. ");
+    }
+
+    static String operationFilterEnable() {
+        return String.format("Both Operations and excludeOperations fields include" +
+                " the same operation(s). Make sure to use one field of operation filtering" +
+                " when using the openapi annotation.");
+    }
 }

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/OpenAPIPathSummary.java
@@ -24,6 +24,7 @@ import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,7 +68,16 @@ class OpenAPIPathSummary {
         if (operation == null) {
             return false;
         }
-        return operation.getTags().containsAll(tags);
+        return !Collections.disjoint(tags, operation.getTags());
+    }
+
+    boolean hasOperations(List<String> operationslist, String method) {
+        Operation operation = operations.get(method);
+        if (operation == null) {
+            return false;
+        }
+        return operationslist.contains(operation.getOperationId());
+
     }
 
     List<OpenAPIParameter> getParamNamesForOperation(String operation) {

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -57,7 +57,7 @@ class ValidatorUtil {
      * @return {@link OpenAPI} OpenAPI model
      * @throws OpenApiValidatorException in case of exception
      */
-    static OpenAPI parseOpenAPIFile(String definitionURI) throws OpenApiValidatorException {
+    public static OpenAPI parseOpenAPIFile(String definitionURI) throws OpenApiValidatorException {
         Path contractPath = Paths.get(definitionURI);
         if (!Files.exists(contractPath)) {
             throw new OpenApiValidatorException(ErrorMessages.invalidFilePath(definitionURI));
@@ -82,7 +82,7 @@ class ValidatorUtil {
      * @param contract                openAPI contract
      * @param openAPIComponentSummary list of openAPI components
      */
-    static void summarizeOpenAPI(List<OpenAPIPathSummary> openAPISummaries, OpenAPI contract
+    public static void summarizeOpenAPI(List<OpenAPIPathSummary> openAPISummaries, OpenAPI contract
             , OpenAPIComponentSummary openAPIComponentSummary) {
         io.swagger.v3.oas.models.Paths paths = contract.getPaths();
         for (Map.Entry pathItem : paths.entrySet()) {
@@ -143,7 +143,7 @@ class ValidatorUtil {
      * @param resourceSummaryList list of resource summaries
      * @param serviceNode         service node
      */
-    static void summarizeResources(List<ResourceSummary> resourceSummaryList, ServiceNode serviceNode) {
+    public static void summarizeResources(List<ResourceSummary> resourceSummaryList, ServiceNode serviceNode) {
         // Iterate resources available in a service and extract details to be validated.
         for (FunctionNode resource : serviceNode.getResources()) {
             AnnotationAttachmentNode annotation = null;
@@ -234,7 +234,7 @@ class ValidatorUtil {
      * @param openAPIComponentSummary component summaries
      * @param dLog                    diagnostic logger
      */
-    static void validateResourcesAgainstOpenApi(List<String> tags, List<String> operations,
+    public static void validateResourcesAgainstOpenApi(List<String> tags, List<String> operations,
                                                 Diagnostic.Kind kind,
                                                 List<String> excludeTags,
                                                 List<String> excludeOperations,
@@ -333,7 +333,8 @@ class ValidatorUtil {
      * @param openAPIComponentSummary openAPI component summary
      * @param dLog                    diagnostic logger
      */
-    static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags, List<String> operations,
+    public static void validateOpenApiAgainstResources(ServiceNode serviceNode, List<String> tags,
+                                                List<String> operations,
                                                 Diagnostic.Kind kind,
                                                 List<String> excludeTags,
                                                 List<String> excludeOperations,

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -839,10 +839,7 @@ class ValidatorUtil {
         }
         dLog.logDiagnostic(kind, getServiceNamePosition(serviceNode),
                 ErrorMessages.unimplementedOpenAPIPath(openApiSummary.getPath()));
-
-
     }
-
 
     private static void validateUnmatchedMethods(List<String> unmatchedMethods, ServiceNode serviceNode,
                                                  Diagnostic.Kind kind, OpenAPIPathSummary openApiSummary,

--- a/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-validator/src/main/java/org/ballerinalang/openapi/validator/ValidatorUtil.java
@@ -803,7 +803,7 @@ class ValidatorUtil {
     private static Diagnostic.DiagnosticPosition getServiceNamePosition(ServiceNode serviceNode) {
         return serviceNode.getName().getPosition();
     }
-
+// For tag filter
     private static void tagsFilter (ServiceNode serviceNode,
                                     OpenAPIPathSummary openApiSummary,
                                     List<String> tags,

--- a/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
+++ b/stdlib/openapi/src/main/ballerina/src/openapi/annotation.bal
@@ -18,12 +18,17 @@
 # + contract - OpenApi Contract link
 # + tags - OpenApi Tags
 # + operations - OpenApi Operations
+# + excludeTags - Openapi Validator Off for these tags
+# + excludeOperations - Openapi Validator Off for these operations
 # + failOnErrors - OpenApi Validator Enable
 public type ServiceInformation record {|
     string contract = "";
     string[]? tags = [];
     string[]? operations = [];
+    string[]? excludeTags = [];
+    string[]? excludeOperations = [];
     boolean failOnErrors = true;
+
 |};
 
 # Configuration elements for client code generation.


### PR DESCRIPTION
## Purpose
> Fix issues with tag and operation filtering. Add the extra fields excludeTags and excludeOperations to Opeanapi annotation. This use to filter the tags and operations that exclude validating.

## Samples
> @openapi:ServiceInfo {
contract: "resources/petstore.yaml",
excludeTags: ["user"]
excludeOperations: ["getOrderById"]
}

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
