### PR TITLE
Fix the issue of Leecher exiting before logs are read

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/LogLeecher.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/LogLeecher.java
@@ -107,6 +107,15 @@ public class LogLeecher {
                 }
             }
 
+            // Makes it graceful. Otherwise Leecher could exit before the printed logs are read.
+            if (forcedExit) {
+                try {
+                    this.wait(5000);
+                } catch (InterruptedException e) {
+                    throw new BallerinaTestException("Error while graceful exit of Leecher", e);
+                }
+            }
+
             if (!textFound) {
                 throw new BallerinaTestException("Matching log not found prior to server shutdown for: " + text);
             }


### PR DESCRIPTION
## Purpose
> At the moment some of the HTTP tests are intermittently failing as the LogLeecher exists before the actual logs are printed and read. Following is example test failures,

![image](https://user-images.githubusercontent.com/6178058/83219181-4fd45e80-a18d-11ea-8ca7-d86d9589b282.png)

This PR is intended to fix this. Five seconds wait time is something decided thinking that it should be okay when running a gradle build on 2-core machine with max-parallel threads set to 2. 
