### PR TITLE
Fix intermittent failures in worker tests

### DIFF
--- a/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/workers/workers.bal
@@ -484,7 +484,7 @@ public function workerWithFutureTest1() returns int {
     @strand{thread:"any"}
     worker w2 returns int {
       // Delay the execution of worker w2
-      runtime:sleep(200);
+      runtime:sleep(1000);
       int i = wait f1;
       return i;
     }
@@ -499,7 +499,7 @@ public function workerWithFutureTest2() returns int {
     worker w1 {
       int i = 40;
       // Delay the execution of worker w1
-      runtime:sleep(200);
+      runtime:sleep(1000);
       f1.cancel();
     }
 
@@ -523,7 +523,7 @@ public function workerWithFutureTest3() returns int {
     @strand{thread:"any"}
     worker w2 returns int {
       // Delay the execution of worker w1
-      runtime:sleep(5);
+      runtime:sleep(1000);
       int i = wait f1;
       return i;
     }


### PR DESCRIPTION
## Purpose
> At the moment worker tests are failing intermittently. One example is below,

![image](https://user-images.githubusercontent.com/6178058/83249549-5b8f4780-a1c4-11ea-9a14-6cb1577e588b.png)

I think the main reason for this is the use of runtime:sleep(). The time intervals provided in the test cases are very low and often fails in CI environments which usually have only 2 cores. I have increased the time interval here.

Ideally, we should try to write them without runtime:sleep() if possible.

