### PR TITLE
Fix intermittent test failuers

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -333,7 +333,7 @@ public class BServerInstance implements BServer {
      * @return The service URL without scheme.
      */
     private String getServiceUrl(int port, String servicePath) {
-        return "localhost:" + port + "/" + servicePath;
+        return "host.docker.internal:" + port + "/" + servicePath;
     }
 
     /**

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -534,7 +534,7 @@ public class BServerInstance implements BServer {
             //TODO: Need to reduce the timeout after build time improvements
             Utils.waitForPortsToOpen(new int[]{agentPort}, 1000 * 60 * 10, false, agentHost);
             log.info("Server Started Successfully.");
-        } catch (IOException|RuntimeException e) {
+        } catch (IOException | RuntimeException e) {
             throw new BallerinaTestException("Error starting services", e);
         }
     }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/BServerInstance.java
@@ -417,7 +417,7 @@ public class BServerInstance implements BServer {
     }
 
     private void makeContainerFriendly(File commandDir) throws IOException {
-        Path path = Paths.get(commandDir + "bin/ballerina");
+        Path path = Paths.get(commandDir + "/bin/ballerina");
         Charset charset = StandardCharsets.UTF_8;
 
         String content = new String(Files.readAllBytes(path), charset);


### PR DESCRIPTION
## Purpose
> Containers are killing the ballerina runtime which is created for testing because of excessive memory usage. This PR adjust the heap size to fit Containers. 

Following is an exert of the log file.

```
    [2020-06-02 10:47:55,828] INFO {org.ballerinalang.test.context.ServerLogReader} - Compiling source 
    [2020-06-02 10:47:56,021] INFO {org.ballerinalang.test.context.ServerLogReader} - 	ballerina-test/filterservices:0.0.1 
    [2020-06-02 10:48:01,136] INFO {org.ballerinalang.test.context.ServerLogReader} -  
    [2020-06-02 10:48:01,137] INFO {org.ballerinalang.test.context.ServerLogReader} - Creating balos 
    [2020-06-02 10:48:01,220] INFO {org.ballerinalang.test.context.ServerLogReader} - 	target/balo/filterservices-2020r1-any-0.0.1.balo 
    [2020-06-02 10:48:01,385] INFO {org.ballerinalang.test.context.ServerLogReader} -  
    [2020-06-02 10:48:01,385] INFO {org.ballerinalang.test.context.ServerLogReader} - Running Tests 
    [2020-06-02 10:48:01,385] INFO {org.ballerinalang.test.context.ServerLogReader} -  
    [2020-06-02 10:48:01,385] INFO {org.ballerinalang.test.context.ServerLogReader} - 	ballerina-test/filterservices:0.0.1 
    [2020-06-02 10:48:01,385] INFO {org.ballerinalang.test.context.ServerLogReader} - 	No tests found 
    [2020-06-02 10:48:01,385] INFO {org.ballerinalang.test.context.ServerLogReader} -  
    [2020-06-02 10:48:01,386] INFO {org.ballerinalang.test.context.ServerLogReader} -  
    [2020-06-02 10:48:01,386] INFO {org.ballerinalang.test.context.ServerLogReader} - Generating executables 
    [2020-06-02 10:48:02,479] SEVERE {org.ballerinalang.test.context.ServerLogReader} - bin/ballerina: line 288: 50000 Killed                  
$JAVACMD -Xbootclasspath/a:"$BALLERINA_XBOOTCLASSPATH" -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="$BALLERINA_HOME/heap-dump.hprof" $JAVA_OPTS -classpath "$BALLERINA_CLASSPATH" -Dballerina.home="$BALLERINA_HOME" -Dballerina.version=2.0.0-SNAPSHOT -Djava.util.logging.config.class="org.ballerinalang.logging.util.LogConfigReader" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager" -Denable.nonblocking=false -Djava.security.egd=file:/dev/./urandom -Dfile.encoding=UTF8 -DballeJAVACMDrina.target=jvm -Djava.command=$ org.ballerinalang.tool.Main "$@" 
```  