### PR TITLE
Make sure ServerLogReader reads everything

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/LogLeecher.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/LogLeecher.java
@@ -107,15 +107,6 @@ public class LogLeecher {
                 }
             }
 
-            // Makes it graceful. Otherwise Leecher could exit before the printed logs are read.
-            if (forcedExit) {
-                try {
-                    this.wait(10000);
-                } catch (InterruptedException e) {
-                    throw new BallerinaTestException("Error while graceful exit of Leecher", e);
-                }
-            }
-
             if (!textFound) {
                 throw new BallerinaTestException("Matching log not found prior to server shutdown for: " + text);
             }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/ServerLogReader.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/context/ServerLogReader.java
@@ -124,16 +124,14 @@ public class ServerLogReader implements Runnable {
                     if (s == null) {
                         break;
                     }
-                    if (STREAM_TYPE_IN.equals(streamType)) {
-                        feedLeechers(s);
-                        log.info(s);
-                    } else if (STREAM_TYPE_ERROR.equals(streamType)) {
-                        feedLeechers(s);
-                        log.error(s);
-                    }
+                    feedAndPrint(s);
                 } else {
                     TimeUnit.MILLISECONDS.sleep(1);
                 }
+            }
+            String s = bufferedReader.readLine();
+            if (s != null) {
+                feedAndPrint(s);
             }
         } catch (Exception ex) {
             log.error("Problem reading the [" + streamType + "] due to: " + ex.getMessage(), ex);
@@ -153,6 +151,16 @@ public class ServerLogReader implements Runnable {
                     log.error("Error occurred while closing the server log stream: " + e.getMessage(), e);
                 }
             }
+        }
+    }
+
+    private void feedAndPrint(String s) {
+        if (STREAM_TYPE_IN.equals(streamType)) {
+            feedLeechers(s);
+            log.info(s);
+        } else if (STREAM_TYPE_ERROR.equals(streamType)) {
+            feedLeechers(s);
+            log.error(s);
         }
     }
 }


### PR DESCRIPTION
## Purpose
>  Due to the nature of concurrency the loop inside the ServerLogReader could exit before reading what is left in the buffer. Which actually causes intermittent test failures. This PR fixes that issue.
