### PR TITLE
Increase timeout value of the HTTP client

### DIFF
--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/HttpClientRequest.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/HttpClientRequest.java
@@ -43,7 +43,7 @@ import java.util.Map;
  */
 public class HttpClientRequest {
     private static final Logger LOG = LoggerFactory.getLogger(HttpClientRequest.class);
-    private static final int DEFAULT_READ_TIMEOUT = 30000;
+    private static final int DEFAULT_READ_TIMEOUT = 60000;
 
     /**
      * Sends an HTTP GET request to a url.


### PR DESCRIPTION
## Purpose
> Having 30s timeout is not enough when running in 2 core containers with parallel test.
