### PR TITLE
Fix for undefined symbol for array type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
@@ -44,8 +44,8 @@ public class SymTag {
     public static final int FINITE_TYPE = 1 << 20 | TYPE | VARIABLE_NAME;
     public static final int UNION_TYPE = 1 << 21 | TYPE | VARIABLE_NAME;
     public static final int INTERSECTION_TYPE = 1 << 22 | TYPE | VARIABLE_NAME;
-    public static final int TUPLE_TYPE = 1 << 23 | TYPE | VARIABLE_NAME;
-    public static final int ARRAY_TYPE = 1 << 24 | TYPE | VARIABLE_NAME;
+    public static final int TUPLE_TYPE = 1 << 23 | TYPE_DEF;
+    public static final int ARRAY_TYPE = 1 << 24 | TYPE_DEF;
     public static final int CONSTANT = 1 << 25 | VARIABLE_NAME | TYPE;
     public static final int FUNCTION_TYPE = 1 << 26 | TYPE | VARIABLE_NAME;
     public static final int CONSTRUCTOR = 1 << 27 | INVOKABLE;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
@@ -137,4 +137,14 @@ public class TypeDefinitionsTest {
     public void testAnonExclusiveRecordUnionTypeDef() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testAnonExclusiveRecordUnionTypeDef");
     }
+
+    @Test
+    public void testIntArrayTypeDef() {
+        BRunUtil.invoke(compileResult, "testIntArrayTypeDef");
+    }
+
+    @Test
+    public void testTupleTypeDef() {
+        BRunUtil.invoke(compileResult, "testTupleTypeDef");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
@@ -175,3 +175,51 @@ function testAnonExclusiveRecordUnionTypeDef() {
         panic error("Error in union with anonymous record type definitions");
     }
 }
+
+// ---------------------------------------------------------------------------------------------------------------------
+type IntArray int[];
+type Int_String [int, string];
+
+function testIntArrayTypeDef() {
+    IntArray s = [1, 2];
+    anydata y = s;
+    IntArray|error b = y.cloneWithType(IntArray);
+    if (b is IntArray) {
+        assertEquality(s[0], b[0]);
+        assertEquality(s[1], b[1]);
+    } else {
+        assertFalse(true);
+    }
+}
+
+function testTupleTypeDef() {
+    Int_String x = [10, "XX"];
+    anydata y = x;
+    Int_String|error z = y.cloneWithType(Int_String);
+    if (z is Int_String) {
+        assertEquality(z[0], x[0]);
+        assertEquality(z[1], x[1]);
+    } else {
+        assertFalse(true);
+    }
+}
+
+type AssertionError error<ASSERTION_ERROR_REASON>;
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertFalse(any|error actual) {
+    assertEquality(false, actual);
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    panic AssertionError(message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}


### PR DESCRIPTION
## Purpose
Fixes #23984 

## Approach
Fixed by adding TYPE_DEF syn tags to the tuple and array symbol tags.

## Samples
> Provide high-level details about the samples related to this feature.
```Ballerina
import ballerina/io;

type IntArray int[];

function foo(anydata x) {
    int[] b =  checkpanic x.cloneWithType(IntArray); // (b)
    io:println(b);
}

public function main() {
    IntArray s = [ 1,2,3,4 ];
    foo(s);
}
```


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.
May need to refactor this area
https://github.com/ballerina-platform/ballerina-lang/blob/21aa54f9a09f98b3ea95bc0a2fc0bea7f613d8ef/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java#L1840

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
