### PR TITLE
Change __init to init in the Bindgen object template file

### DIFF
--- a/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
@@ -23,7 +23,7 @@ import ballerina/java;{{/if}}
     # The init function of the Ballerina object mapping `{{#replace className "." "/"}}{{/replace}}` Java class.
     #
     # + obj - The `handle` value containing the Java reference of the object.
-    {{accessModifier}}function __init(handle obj) {
+    {{accessModifier}}function init(handle obj) {
         self.jObj = obj;
     }
 


### PR DESCRIPTION
## Purpose
To change `__init` to `init` in the Ballerina binding object template of the Bindgen tool according to 2020R2 specification.

Fixes #https://github.com/ballerina-platform/ballerina-lang/issues/23358

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples