### PR TITLE
Fix the issue with duplicate field methods

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
@@ -153,10 +153,19 @@ public class JClass {
     }
 
     private void populateFields(Field[] fields) {
+        boolean addField = true;
         for (Field field : fields) {
-            fieldList.add(new JField(field, ACCESS_FIELD));
-            if (!isFinalField(field) && isPublicField(field)) {
-                fieldList.add(new JField(field, MUTATE_FIELD));
+            // To prevent the duplication of fields resulting from super classes.
+            for (JField jField : fieldList) {
+                if (jField.getFieldName().equals(field.getName())) {
+                    addField = false;
+                }
+            }
+            if (addField) {
+                fieldList.add(new JField(field, ACCESS_FIELD));
+                if (!isFinalField(field) && isPublicField(field)) {
+                    fieldList.add(new JField(field, MUTATE_FIELD));
+                }
             }
         }
     }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
@@ -100,4 +100,8 @@ public class JField {
     public boolean isSetter() {
         return isSetter;
     }
+
+    public String getFieldName() {
+        return fieldName;
+    }
 }


### PR DESCRIPTION
## Purpose
Fix the duplication of field methods when a superclass has a public field with the same name as that of the class for which bindings are generated.

Fixes #24029

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
