### PR TITLE
Enable HTTP caching by default

### DIFF
--- a/stdlib/http/src/main/ballerina/src/http/caching/http_caching_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/caching/http_caching_client.bal
@@ -51,7 +51,7 @@ public const RFC_7234 = "RFC_7234";
 
 # Provides a set of configurations for controlling the caching behaviour of the endpoint.
 #
-# + enabled - Specifies whether HTTP caching is enabled. Caching is disabled by default.
+# + enabled - Specifies whether HTTP caching is enabled. Caching is enabled by default.
 # + isShared - Specifies whether the HTTP caching layer should behave as a public cache or a private cache
 # + capacity - The capacity of the cache
 # + evictionFactor - The fraction of entries to be removed when the cache is full. The value should be
@@ -60,7 +60,7 @@ public const RFC_7234 = "RFC_7234";
 #            `CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`
 #            header and either the `etag` or `last-modified` header are present.
 public type CacheConfig record {|
-    boolean enabled = false;
+    boolean enabled = true;
     boolean isShared = false;
     int capacity = 8388608; // 8MB
     float evictionFactor = 0.2;

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/34_http_caching.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/34_http_caching.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 
-http:Client cachingEP = new("http://localhost:9240", { cache: { enabled: true, isShared: true } });
+http:Client cachingEP = new("http://localhost:9240", { cache: { isShared: true } });
 int cachingProxyHitcount = 0;
 
 @http:ServiceConfig {

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/37_no_cache_service.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/37_no_cache_service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 
-http:Client cachingEP1 = new("http://localhost:9243", { cache: { enabled: true, isShared: true } });
+http:Client cachingEP1 = new("http://localhost:9243", { cache: { isShared: true } });
 
 @http:ServiceConfig {
     basePath: "/nocache"

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/38_max_age_cache_service.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/38_max_age_cache_service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 
-http:Client maxAgeCacheEp = new("http://localhost:9246", { cache: { enabled: true, isShared: true } });
+http:Client maxAgeCacheEp = new("http://localhost:9246", { cache: { isShared: true } });
 
 @http:ServiceConfig {
     basePath: "/maxAge"

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/39_must_revalidate_cache_service.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/39_must_revalidate_cache_service.bal
@@ -16,7 +16,7 @@
 
 import ballerina/http;
 
-http:Client cachingEP3 = new("http://localhost:9248", { cache: { enabled: true, isShared: true } });
+http:Client cachingEP3 = new("http://localhost:9248", { cache: { isShared: true } });
 int numberOfProxyHits = 0;
 
 @http:ServiceConfig {


### PR DESCRIPTION
## Purpose
This PR enables the HTTP caching by default. Since the log improvements are done now [1], the performance drop, which caused to disable HTTP caching is fixed. 

[1] https://github.com/ballerina-platform/ballerina-lang/pull/23540

This is a revert PR of https://github.com/ballerina-platform/ballerina-lang/pull/21836

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
