### PR TITLE
Fix the fromHandle() method call in field getters

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JField.java
@@ -28,6 +28,7 @@ import static org.ballerinalang.bindgen.utils.BindgenConstants.MUTATE_FIELD;
 import static org.ballerinalang.bindgen.utils.BindgenConstants.MUTATE_FIELD_INTEROP_TYPE;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getBallerinaHandleType;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getBallerinaParamType;
+import static org.ballerinalang.bindgen.utils.BindgenUtils.getJavaType;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.isStaticField;
 
 /**
@@ -41,6 +42,7 @@ public class JField {
     private String fieldType;
     private String interopType;
     private String externalType;
+    private String returnTypeJava;
     private String fieldMethodName;
 
     private boolean isArray;
@@ -78,6 +80,7 @@ public class JField {
         if (fieldKind.equals(ACCESS_FIELD)) {
             fieldMethodName = "get" + StringUtils.capitalize(fieldName);
             interopType = ACCESS_FIELD_INTEROP_TYPE;
+            returnTypeJava = getJavaType(type);
         } else if (fieldKind.equals(MUTATE_FIELD)) {
             fieldMethodName = "set" + StringUtils.capitalize(fieldName);
             interopType = MUTATE_FIELD_INTEROP_TYPE;

--- a/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
@@ -74,7 +74,7 @@ import ballerina/java;{{/if}}
     #
     # + return - The `{{fieldType}}` value of the field.
     {{accessModifier}}function {{fieldMethodName}}() returns {{fieldType}}{{#if isString}}?{{/if}}{{#if returnError}}|error{{/if}} {
-        return {{#if isString}}java:toString({{else if isArray}}<{{fieldType}}>check fromHandle({{/if}}{{prefix}}_{{fieldMethodName}}(self.jObj){{#if isString}}){{else if isArray}}){{/if}};
+        return {{#if isString}}java:toString({{else if isArray}}<{{fieldType}}>check fromHandle({{/if}}{{prefix}}_{{fieldMethodName}}(self.jObj){{#if isString}}){{else if isArray}}, "{{returnTypeJava}}"){{/if}};
     }{{/if}}{{/unless}}{{/fieldList}}
 };
 {{#initFunctionList}}
@@ -136,7 +136,7 @@ import ballerina/java;{{/if}}
     {{#if isObject}}
     {{fieldType}} obj = new({{#if handleException}}check {{/if}}{{#if isStringReturn}}java:toString({{/if}}{{prefix}}_{{fieldMethodName}}(){{#if isStringReturn}}){{/if}});
     return obj;{{else}}
-    return {{#if isString}}java:toString({{else if isArray}}<{{fieldType}}>check fromHandle({{/if}}{{prefix}}_{{fieldMethodName}}(){{#if isString}}){{else if isArray}}){{/if}};{{/if}}
+    return {{#if isString}}java:toString({{else if isArray}}<{{fieldType}}>check fromHandle({{/if}}{{prefix}}_{{fieldMethodName}}(){{#if isString}}){{else if isArray}}, "{{returnTypeJava}}"){{/if}};{{/if}}
 }
 {{/if}}{{/if}}{{/fieldList}}{{#if constructorList}}
 // External interop functions for mapping public constructors.


### PR DESCRIPTION
## Purpose
Fixes the incorrect `fromHandle()` function call in field getters returning an array value, in binding objects generated using the Ballerina bindgen tool.

Fixes #24046

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
