### PR TITLE
Add support for cyclic dependency in union type definitions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -709,6 +709,14 @@ public class TypeChecker {
     }
 
     private static boolean checkIsUnionType(BType sourceType, BUnionType targetType, List<TypePair> unresolvedTypes) {
+        // If we encounter two types that we are still resolving, then skip it.
+        // This is done to avoid recursive checking of the same type.
+        TypePair pair = new TypePair(sourceType, targetType);
+        if (unresolvedTypes.contains(pair)) {
+            return true;
+        }
+        unresolvedTypes.add(pair);
+
         switch (sourceType.getTag()) {
             case TypeTags.UNION_TAG:
                 return isUnionTypeMatch((BUnionType) sourceType, targetType, unresolvedTypes);
@@ -2283,42 +2291,46 @@ public class TypeChecker {
                 BTupleType tupleType = (BTupleType) type;
                 return tupleType.getTupleTypes().stream().allMatch(TypeChecker::hasFillerValue);
             case TypeTags.UNION_TAG:
-                return checkFillerValue((BUnionType) type);
+                return checkFillerValue((BUnionType) type, unanalyzedTypes);
             default:
                 return false;
         }
     }
 
-    private static boolean checkFillerValue(BUnionType type) {
-        // NIL is a member.
-        if (type.isNullable()) {
-            return true;
-        }
-        // All members are of same type.
-        Iterator<BType> iterator = type.getMemberTypes().iterator();
-        BType firstMember;
-        for (firstMember = iterator.next(); iterator.hasNext(); ) {
-            if (!isSameType(firstMember, iterator.next())) {
-                return false;
-            }
-        }
-        // Control reaching this point means there is only one type in the union.
-        return BTypes.isValueType(firstMember) && hasFillerValue(firstMember);
-    }
-
-    private static boolean checkFillerValue(BRecordType type, List<BType> unAnalyzedTypes) {
+    private static boolean checkFillerValue(BType type, List<BType> unAnalyzedTypes) {
         if (unAnalyzedTypes.contains(type)) {
             return true;
         }
         unAnalyzedTypes.add(type);
-        for (BField field : type.getFields().values()) {
-            if (Flags.isFlagOn(field.flags, Flags.OPTIONAL)) {
-                continue;
-            }
-            if (!Flags.isFlagOn(field.flags, Flags.REQUIRED)) {
-                continue;
-            }
-            return false;
+        switch (type.getTag()) {
+            case TypeTags.RECORD_TYPE_TAG:
+                BRecordType recordType = (BRecordType) type;
+                for (BField field : recordType.getFields().values()) {
+                    if (Flags.isFlagOn(field.flags, Flags.OPTIONAL)) {
+                        continue;
+                    }
+                    if (!Flags.isFlagOn(field.flags, Flags.REQUIRED)) {
+                        continue;
+                    }
+                    return false;
+                }
+                break;
+            case TypeTags.UNION_TAG:
+                BUnionType unionType = (BUnionType) type;
+                // NIL is a member.
+                if (unionType.isNullable()) {
+                    return true;
+                }
+                // All members are of same type.
+                Iterator<BType> iterator = unionType.getMemberTypes().iterator();
+                BType firstMember;
+                for (firstMember = iterator.next(); iterator.hasNext(); ) {
+                    if (!isSameType(firstMember, iterator.next())) {
+                        return false;
+                    }
+                }
+                // Control reaching this point means there is only one type in the union.
+                return BTypes.isValueType(firstMember) && hasFillerValue(firstMember);
         }
         return true;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1061,10 +1061,11 @@ public class BIRPackageSymbolEnter {
                     BUnionType unionType = BUnionType.create(unionTypeSymbol,
                             new LinkedHashSet<>()); //TODO improve(useless second param)
                     int unionMemberCount = inputStream.readInt();
+                    unionType.flags = flags;
+                    addShapeCP(unionType, cpI);
                     for (int i = 0; i < unionMemberCount; i++) {
                         unionType.add(readTypeFromCp());
                     }
-                    unionType.flags = flags;
                     return unionType;
                 case TypeTags.INTERSECTION:
                     BTypeSymbol intersectionTypeSymbol = Symbols.createTypeSymbol(SymTag.INTERSECTION_TYPE,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -923,7 +923,8 @@ public class SymbolResolver extends BLangNodeVisitor {
         LinkedHashSet<BType> memberTypes = unionTypeNode.memberTypeNodes.stream()
                 .map(memTypeNode -> resolveTypeNode(memTypeNode, env))
                 .flatMap(memBType ->
-                        memBType.tag == TypeTags.UNION && !Symbols.isFlagOn(memBType.tsymbol.flags, Flags.TYPE_PARAM) ?
+                        memBType.tag == TypeTags.UNION && memBType.tsymbol != null &&
+                                !Symbols.isFlagOn(memBType.tsymbol.flags, Flags.TYPE_PARAM) ?
                                 ((BUnionType) memBType).getMemberTypes().stream() :
                                 Stream.of(memBType))
                 .collect(Collectors.toCollection(LinkedHashSet::new));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTypeDefinition.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangTypeDefinition.java
@@ -45,6 +45,7 @@ public class BLangTypeDefinition extends BLangNode implements TypeDefinition {
     public Set<Flag> flagSet;
     public int precedence;
     public boolean isBuiltinTypeDef;
+    public boolean hasCyclicReference = false;
 
     public BTypeSymbol symbol;
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ResolvedTypeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ResolvedTypeBuilder.java
@@ -290,7 +290,12 @@ public class ResolvedTypeBuilder implements BTypeVisitor<BType, BType> {
         LinkedHashSet<BType> newMemberTypes = new LinkedHashSet<>();
 
         for (BType member : originalType.getMemberTypes()) {
+            if (this.visitedTypes.contains(member)) {
+                continue;
+            }
+            this.visitedTypes.add(member);
             BType newMember = member.accept(this, null);
+            this.visitedTypes.remove(member);
             newMemberTypes.add(newMember);
 
             if (newMember != member) {
@@ -421,7 +426,7 @@ public class ResolvedTypeBuilder implements BTypeVisitor<BType, BType> {
     }
 
     private void reset() {
-        this.visitedTypes = null;
+        this.visitedTypes = new HashSet<>();
         this.paramValueTypes = null;
         this.isInvocation = false;
     }

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -99,7 +99,7 @@ error.uninitialized.variable=\
     uninitialized variable ''{0}''
 
 error.cyclic.type.reference=\
-  cyclic type reference in ''{0}''
+  invalid cyclic type reference in ''{0}''
 
 error.attempt.refer.non.accessible.symbol=\
   attempt to refer to non-accessible symbol ''{0}''

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTest.java
@@ -441,7 +441,8 @@ public class ObjectTest {
     public void testSelfReferenceType() {
         CompileResult result = BCompileUtil.compile("test-src/object/object_cyclic_self_reference.bal");
         Assert.assertEquals(result.getErrorCount(), 1);
-        BAssertUtil.validateError(result, 0, "cyclic type reference in " + "'[Person, Employee, Foo, Bar]'", 32, 5);
+        BAssertUtil.validateError(result, 0, "invalid cyclic type reference in " + "'[Person, Employee, Foo, Bar]'",
+                32, 5);
     }
 
     @Test(description = "Negative test to test self reference types")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectTypeReferenceTest.java
@@ -50,27 +50,27 @@ public class ObjectTypeReferenceTest {
                 6);
         BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'salary'", 48, 6);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[Foo, Foo]'", 52, 1);
+                                  "invalid cyclic type reference in '[Foo, Foo]'", 52, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[A, B, C, D, A]'", 57, 1);
+                                  "invalid cyclic type reference in '[A, B, C, D, A]'", 57, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[C, E, C]'", 57, 1);
+                                  "invalid cyclic type reference in '[C, E, C]'", 57, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[B, C, D, A, B]'", 61, 1);
+                                  "invalid cyclic type reference in '[B, C, D, A, B]'", 61, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                "cyclic type reference in '[C, E, C]'", 61, 1);
+                                "invalid cyclic type reference in '[C, E, C]'", 61, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[C, D, A, B, C]'", 65, 1);
+                                  "invalid cyclic type reference in '[C, D, A, B, C]'", 65, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[C, E, C]'", 65, 1);
+                                  "invalid cyclic type reference in '[C, E, C]'", 65, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[C, E, C]'", 70, 1);
+                                  "invalid cyclic type reference in '[C, E, C]'", 70, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[D, A, B, C, D]'", 70, 1);
+                                  "invalid cyclic type reference in '[D, A, B, C, D]'", 70, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[C, D, A, B, C]'", 74, 1);
+                                  "invalid cyclic type reference in '[C, D, A, B, C]'", 74, 1);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "cyclic type reference in '[E, C, E]'", 74, 1);
+                                  "invalid cyclic type reference in '[E, C, E]'", 74, 1);
         BAssertUtil.validateError(negativeResult, i++,
                                   "no implementation found for the function 'getName' of non-abstract object " +
                                           "'Manager2'", 96, 5);
@@ -111,17 +111,17 @@ public class ObjectTypeReferenceTest {
         CompileResult negativeResult = BCompileUtil.compile("test-src/object/object-type-reference-cyclic-dependency" +
                                                                     "-negative.bal");
         int i = 0;
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[Foo, Foo]'", 18, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[A, B, C, D, A]'", 23, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 23, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[B, C, D, A, B]'", 27, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 27, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 31, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 31, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, E, C]'", 36, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[D, A, B, C, D]'", 36, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[C, D, A, B, C]'", 40, 1);
-        BAssertUtil.validateError(negativeResult, i++, "cyclic type reference in '[E, C, E]'", 40, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[Foo, Foo]'", 18, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[A, B, C, D, A]'", 23, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[C, E, C]'", 23, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[B, C, D, A, B]'", 27, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[C, E, C]'", 27, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[C, D, A, B, C]'", 31, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[C, E, C]'", 31, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[C, E, C]'", 36, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[D, A, B, C, D]'", 36, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[C, D, A, B, C]'", 40, 1);
+        BAssertUtil.validateError(negativeResult, i++, "invalid cyclic type reference in '[E, C, E]'", 40, 1);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.typedefs;
+
+import org.ballerinalang.test.util.BAssertUtil;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Cyclic type definition test cases.
+ */
+public class CyclicTypeDefinitionsTest {
+
+    private static CompileResult compileResult, negativeResult;
+    private static final String INVALID_CYCLIC_MESSAGE = "invalid cyclic type reference in '[%s]'";
+
+    @BeforeClass
+    public void setup() {
+        compileResult = BCompileUtil.compile("test-src/typedefs/type-definitions-cyclic.bal");
+        negativeResult = BCompileUtil.compile("test-src/typedefs/type-definitions-cyclic-negative.bal");
+    }
+
+    @Test(description = "Positive tests for cyclic type definitions", dataProvider = "FunctionList")
+    public void testCyclicTypeDef(String funcName) {
+        BRunUtil.invoke(compileResult, funcName);
+    }
+
+    @DataProvider(name = "FunctionList")
+    public Object[][] getTestFunctions() {
+        return new Object[][]{
+                {"testCycleTypeArray"},
+                {"testCycleTypeMap"},
+                {"testCycleTypeTable"},
+                {"testCyclicAsFunctionParams"},
+                {"testCyclicTypeDefInRecord"},
+                {"testCyclicTypeDefInTuple"},
+                {"testComplexCyclicUnion"},
+                {"testCyclicUserDefinedType"},
+        };
+    }
+
+    @Test(description = "Negative test cases for cyclic type definitions")
+    public void testCyclicTypeDefNegative() {
+        int i = 0;
+        BAssertUtil.validateError(negativeResult, i++, String.format(INVALID_CYCLIC_MESSAGE, "A, A"), 1, 1);
+        BAssertUtil.validateError(negativeResult, i++, String.format(INVALID_CYCLIC_MESSAGE, "B, B"), 3, 1);
+        BAssertUtil.validateError(negativeResult, i++, String.format(INVALID_CYCLIC_MESSAGE, "C, D, C"), 5, 1);
+        BAssertUtil.validateError(negativeResult, i++, String.format(INVALID_CYCLIC_MESSAGE, "D, C, D"), 6, 1);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected " +
+                "'(int|record {| E a; anydata...; |})', found 'string'", 8, 25);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantNegativeTest.java
@@ -32,7 +32,7 @@ public class SimpleConstantNegativeTest {
     public void testNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/constant/" +
                 "simple-literal-constant-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 61);
+        Assert.assertEquals(compileResult.getErrorCount(), 58);
 
         int index = 0;
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected 'boolean', found 'int'",
@@ -70,43 +70,40 @@ public class SimpleConstantNegativeTest {
                 73, 12);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected '(E|F)', found '(D|E)'",
                 91, 11);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[UVW, UVW]'", 98, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[IJK, IJK]'", 103, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[UVW, UVW]'", 98, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[IJK, IJK]'", 103, 1);
         BAssertUtil.validateError(compileResult, index++, "unknown type 'SSS'", 103, 18);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[LMN, OPQ, LMN]'", 108, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[LMN, OPQ, LMN]'", 108, 1);
         BAssertUtil.validateError(compileResult, index++, "unknown type 'RST'", 108, 20);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[OPQ, LMN, OPQ]'", 110, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[OPQ, LMN, OPQ]'", 110, 1);
         BAssertUtil.validateError(compileResult, index++, "unknown type 'RST'", 110, 20);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[ACE, BDF, CEG, ACE]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[ACE, BDF, CEG, ACE]'",
                 115, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[ACE, BDF, CEG, EGI, ACE]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[ACE, BDF, CEG, EGI," +
+                        " ACE]'", 115, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[BDF, CEG, EGI, BDF]'",
                 115, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[BDF, CEG, EGI, BDF]'",
-                115, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[BDF, CEG, ACE, BDF]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[BDF, CEG, ACE, BDF]'",
                 117, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[BDF, CEG, EGI, ACE, BDF]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[BDF, CEG, EGI, ACE," +
+                        " BDF]'", 117, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[BDF, CEG, EGI, BDF]'",
                 117, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[BDF, CEG, EGI, BDF]'",
-                117, 1);
-        BAssertUtil.validateError(compileResult, index++, "unknown type 'DFH'", 117, 26);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[CEG, ACE, BDF, CEG]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[CEG, ACE, BDF, CEG]'",
                 119, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[CEG, EGI, ACE, BDF, CEG]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[CEG, EGI, ACE, BDF," +
+                        " CEG]'", 119, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[CEG, EGI, BDF, CEG]'",
                 119, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[CEG, EGI, BDF, CEG]'",
-                119, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[ACE, BDF, CEG, ACE]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[ACE, BDF, CEG, ACE]'",
                 123, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[BDF, CEG, ACE, BDF]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[BDF, CEG, ACE, BDF]'",
                 123, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[EGI, ACE, BDF, CEG, EGI]'",
-                123, 1);
-        BAssertUtil.validateError(compileResult, index++, "cyclic type reference in '[EGI, BDF, CEG, EGI]'",
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[EGI, ACE, BDF," +
+                        " CEG, EGI]'", 123, 1);
+        BAssertUtil.validateError(compileResult, index++, "invalid cyclic type reference in '[EGI, BDF, CEG, EGI]'",
                 123, 1);
         BAssertUtil.validateError(compileResult, index++, "unknown type 'PQ'", 128, 10);
-        BAssertUtil.validateError(compileResult, index++, "unknown type 'J'", 133, 10);
-        BAssertUtil.validateError(compileResult, index++, "unknown type 'S'", 137, 10);
         BAssertUtil.validateError(compileResult, index++, "unknown type 'T'", 137, 12);
         BAssertUtil.validateError(compileResult, index++, "unknown type 'U'", 137, 14);
         BAssertUtil.validateError(compileResult, index++, "incompatible types: expected 'false', found 'boolean'",

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions-cyclic-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions-cyclic-negative.bal
@@ -1,0 +1,8 @@
+type A A;
+
+type B map<B>;
+
+type C D|map<C>|int;
+type D C|int;
+
+type E int|record{E a = "";};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions-cyclic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions-cyclic.bal
@@ -1,0 +1,188 @@
+type A int|A[];
+
+public function testCycleTypeArray() {
+    A a = 1;
+    A b = [1];
+    A c = [a];
+
+    assert(a is int, true);
+    assert(<int> a, 1);
+
+    int m = 0;
+    int n = 0;
+
+    if b is A[] {
+        m = <int> b[0];
+    }
+
+    if c is A[] {
+       n = <int> c[0];
+    }
+
+    assert(m, 1);
+    assert(n, 1);
+}
+
+type B int|map<B>;
+
+public function testCycleTypeMap() {
+    B number = 1;
+    B mapping = {
+        one: number,
+        two: 2
+    };
+
+    int numberResult = 0;
+    if(mapping is map<B>) {
+        numberResult = <int> mapping.get("one");
+    }
+    assert(numberResult, 1);
+}
+
+type Person record {
+    int id;
+    string name;
+};
+
+type C Person|table<map<C>>;
+
+public function testCycleTypeTable() {
+    table<map<C>> tb = table [
+            {
+                one: { id: 1, name: "Jane"}
+            },
+            {
+                one: { id: 1, name: "Anne"}
+            }
+    ];
+
+    string names = "";
+    foreach var x in tb {
+        var  a = x.get("one");
+        if(a is Person) {
+            names = names + a.name;
+        }
+     }
+    assert(names, "JaneAnne");
+}
+
+type D map<D>|int;
+
+public function testCyclicAsFunctionParams() {
+    D d = {
+        elem: 2
+    };
+
+    map<D> c = <map<D>> takeCyclicTyDef(d);
+    assert(<int> c.get("elem"), 5);
+}
+
+function takeCyclicTyDef(D d) returns D {
+   if(d is map<D>) {
+       d["elem"] = 5;
+   }
+   return d;
+}
+
+type E int|record{E a = 1;};
+
+public function testCyclicTypeDefInRecord() {
+    E a = 3;
+    E rec = { a : a};
+    int result = 0;
+    if (rec is record{}) {
+        result = <int> rec.a;
+    }
+    assert(result, 3);
+}
+
+type F int|string|F[]|map<F>;
+
+public function testCyclicTypeDefInTuple() {
+    [F, F, F] values = [1, "hello", [2, "hi"]];
+    assert(<int> values[0], 1);
+    assert(<string> values[1], "hello");
+    var arr = values[2];
+
+    int x = 0;
+    string y = "";
+    if (arr is F[]) {
+        x = <int> arr[0];
+        y = <string> arr[1];
+    }
+    assert(x, 2);
+    assert(y, "hi");
+}
+
+type G int|string|object { G g = "hi"; };
+
+public function testCyclicTypeDefInObject() {
+    G g = new;
+    string str = "";
+    int val = 0;
+    if (g is object{}) {
+        str = <string> g.g;
+        g.g = 1;
+        val = <int> g.g;
+    }
+    assert(str, "hi");
+    assert(val, 1);
+}
+
+type H int|string|H[]|map<H>|table<map<H>>|record { H a = "rec"; float x = 1.0; }|object { public H b = "obj"; }|error;
+
+public function testComplexCyclicUnion() {
+     H num = 1;
+     H str = "hello";
+     H mapping = {
+         first: num,
+         second: str
+     };
+     H rec = { a : "rec2", x: 2.0};
+     H obj = new;
+     H err = error("Simple error occurred");
+     H array = [
+        1, "hello", mapping, rec, obj, err
+     ];
+
+     int x = 0;
+     string y = "";
+     string mapVal = "";
+     string objVal = "";
+     if (array is H[]) {
+        x = <int> array[0];
+        y = <string> array[1];
+
+        var m = array[2];
+        if (m is map<H>) {
+            mapVal = <string> m.get("second");
+        }
+
+        var o = array[4];
+        if (o is object{}) {
+            objVal = <string> o.b;
+        }
+     }
+     assert(x, 1);
+     assert(y, "hello");
+     assert(mapVal, "hello");
+     assert(objVal, "obj");
+}
+
+type I H;
+
+function testCyclicUserDefinedType() {
+    I i = 1;
+    assert(<int> i, 1);
+}
+
+function assert(anydata expected, anydata actual) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}


### PR DESCRIPTION
## Purpose
This PR adds support for cyclic dependency in union type definitions

Fixes #23690

Note: Opening as a Draft PR, more tests needs to be added. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
