### PR TITLE
Consider the requirement of a field to be readonly for record/object subtyping

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -939,8 +939,7 @@ public class TypeChecker {
                 return false;
             }
 
-            if (Flags.isFlagOn(targetField.flags, Flags.READONLY) &&
-                    !Flags.isFlagOn(sourceField.flags, Flags.READONLY)) {
+            if (hasIncompatibleReadOnlyFlags(targetField, sourceField)) {
                 return false;
             }
 
@@ -972,6 +971,10 @@ public class TypeChecker {
             }
         }
         return true;
+    }
+
+    private static boolean hasIncompatibleReadOnlyFlags(BField targetField, BField sourceField) {
+        return Flags.isFlagOn(targetField.flags, Flags.READONLY) && !Flags.isFlagOn(sourceField.flags, Flags.READONLY);
     }
 
     private static boolean checkIsArrayType(BType sourceType, BArrayType targetType, List<TypePair> unresolvedTypes) {
@@ -1133,8 +1136,7 @@ public class TypeChecker {
                     !isInSameVisibilityRegion(Optional.ofNullable(lhsField.type.getPackage()).map(BPackage::getName)
                         .orElse(""), Optional.ofNullable(rhsField.type.getPackage()).map(BPackage::getName)
                         .orElse(""), lhsField.flags, rhsField.flags) ||
-                    (Flags.isFlagOn(lhsField.flags, Flags.READONLY) &&
-                             !Flags.isFlagOn(rhsField.flags, Flags.READONLY)) ||
+                    hasIncompatibleReadOnlyFlags(lhsField, rhsField) ||
                     !checkIsType(rhsField.type, lhsField.type, new ArrayList<>())) {
                 return false;
             }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/TypeChecker.java
@@ -939,6 +939,11 @@ public class TypeChecker {
                 return false;
             }
 
+            if (Flags.isFlagOn(targetField.flags, Flags.READONLY) &&
+                    !Flags.isFlagOn(sourceField.flags, Flags.READONLY)) {
+                return false;
+            }
+
             // If the target field is required, the source field should be required as well.
             if (!Flags.isFlagOn(targetField.flags, Flags.OPTIONAL)
                     && Flags.isFlagOn(sourceField.flags, Flags.OPTIONAL)) {
@@ -1125,9 +1130,11 @@ public class TypeChecker {
         for (BField lhsField : targetFields.values()) {
             BField rhsField = sourceFields.get(lhsField.name);
             if (rhsField == null ||
-                !isInSameVisibilityRegion(Optional.ofNullable(lhsField.type.getPackage()).map(BPackage::getName)
+                    !isInSameVisibilityRegion(Optional.ofNullable(lhsField.type.getPackage()).map(BPackage::getName)
                         .orElse(""), Optional.ofNullable(rhsField.type.getPackage()).map(BPackage::getName)
                         .orElse(""), lhsField.flags, rhsField.flags) ||
+                    (Flags.isFlagOn(lhsField.flags, Flags.READONLY) &&
+                             !Flags.isFlagOn(rhsField.flags, Flags.READONLY)) ||
                     !checkIsType(rhsField.type, lhsField.type, new ArrayList<>())) {
                 return false;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -754,8 +754,7 @@ public class Types {
                 return false;
             }
 
-            if (Symbols.isFlagOn(field.symbol.flags, Flags.READONLY) &&
-                    !Symbols.isFlagOn(sourceMapType.flags, Flags.READONLY)) {
+            if (hasIncompatibleReadOnlyFlags(field.symbol.flags, sourceMapType.flags)) {
                 return false;
             }
 
@@ -765,6 +764,10 @@ public class Types {
         }
 
         return isAssignable(sourceMapType.constraint, targetRecType.restFieldType);
+    }
+
+    private boolean hasIncompatibleReadOnlyFlags(int targetFlags, int sourceFlags) {
+        return Symbols.isFlagOn(targetFlags, Flags.READONLY) && !Symbols.isFlagOn(sourceFlags, Flags.READONLY);
     }
 
     private boolean isErrorTypeAssignable(BErrorType source, BErrorType target, Set<TypePair> unresolvedTypes) {
@@ -1195,8 +1198,7 @@ public class Types {
             BField rhsField = rhsType.fields.get(lhsField.name.value);
             if (rhsField == null ||
                     !isInSameVisibilityRegion(lhsField.symbol, rhsField.symbol) ||
-                    (Symbols.isFlagOn(lhsField.symbol.flags, Flags.READONLY) &&
-                             !Symbols.isFlagOn(rhsField.symbol.flags, Flags.READONLY)) ||
+                    hasIncompatibleReadOnlyFlags(lhsField.symbol.flags, rhsField.symbol.flags) ||
                     !isAssignable(rhsField.type, lhsField.type, unresolvedTypes)) {
                 return false;
             }
@@ -2232,8 +2234,7 @@ public class Types {
                 return false;
             }
 
-            if (Symbols.isFlagOn(lhsField.symbol.flags, Flags.READONLY) &&
-                    !Symbols.isFlagOn(rhsField.symbol.flags, Flags.READONLY)) {
+            if (hasIncompatibleReadOnlyFlags(lhsField.symbol.flags, rhsField.symbol.flags)) {
                 return false;
             }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ReadonlyObjectFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ReadonlyObjectFieldTest.java
@@ -34,13 +34,13 @@ import static org.testng.Assert.assertEquals;
 public class ReadonlyObjectFieldTest {
 
     @Test
-    public void testReadonlyRecordFields() {
+    public void testReadonlyObjectFields() {
         CompileResult result = BCompileUtil.compile("test-src/object/readonly_object_fields.bal");
         BRunUtil.invoke(result, "testReadonlyObjectFields");
     }
 
     @Test(groups = { "brokenOnNewParser" }) // Syntax kind is not supported: READONLY_KEYWORD
-    public void testReadonlyRecordFieldsNegative() {
+    public void testReadonlyObjectFieldsNegative() {
         CompileResult result = BCompileUtil.compile("test-src/object/readonly_object_fields_negative.bal");
         int index = 0;
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ReadonlyObjectFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ReadonlyObjectFieldTest.java
@@ -33,7 +33,7 @@ import static org.testng.Assert.assertEquals;
  */
 public class ReadonlyObjectFieldTest {
 
-    @Test
+    @Test(groups = { "brokenOnNewParser" })
     public void testReadonlyObjectFields() {
         CompileResult result = BCompileUtil.compile("test-src/object/readonly_object_fields.bal");
         BRunUtil.invoke(result, "testReadonlyObjectFields");
@@ -52,6 +52,9 @@ public class ReadonlyObjectFieldTest {
         validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Bar'", 115, 25);
         validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Baz'", 116, 25);
         validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Qux'", 117, 25);
+        validateError(result, index++, "incompatible types: expected 'Person', found 'Undergraduate'", 160, 17);
+        validateError(result, index++, "incompatible types: expected 'Person', found 'Graduate'", 163, 17);
+        validateError(result, index++, "incompatible types: expected 'Person', found 'AbstractPerson'", 166, 17);
         assertEquals(result.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
@@ -54,6 +54,10 @@ public class ReadonlyRecordFieldTest {
         validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Bar'", 106, 25);
         validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Baz'", 107, 25);
         validateError(result, index++, "incompatible types: expected '(Foo & readonly)', found 'Qux'", 108, 25);
+        validateError(result, index++, "incompatible types: expected 'Person', found 'Undergraduate'", 142, 17);
+        validateError(result, index++, "incompatible types: expected 'Person', found 'Graduate'", 150, 17);
+        validateError(result, index++, "incompatible types: expected 'OptionalId', found 'map<(map<int>|boolean)>'",
+                      159, 23);
         assertEquals(result.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableCastTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableCastTest.java
@@ -60,7 +60,7 @@ public class TableCastTest {
         Assert.assertTrue(((BBoolean) results[0]).booleanValue());
     }
 
-    @Test
+    @Test(enabled = false) // https://github.com/ballerina-platform/ballerina-lang/issues/24105#issuecomment-643760140
     public void testKeyConstraintCastToString4() {
         BValue[] results = BRunUtil.invoke(result, "testKeyConstraintCastToString4");
         Assert.assertTrue(((BBoolean) results[0]).booleanValue());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_object_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_object_fields.bal
@@ -24,6 +24,9 @@ function testReadonlyObjectFields() {
     testObjectWithStructuredReadonlyFields();
     testReadOnlyFieldWithDefaultValue();
     testTypeReadOnlyFlagForAllReadOnlyFields();
+    testSubTypingWithReadOnlyFields();
+    testSubTypingWithReadOnlyFieldsViaReadOnlyType();
+    testSubTypingWithReadOnlyFieldsNegative();
 }
 
 public type Student object {
@@ -249,10 +252,126 @@ function testTypeReadOnlyFlagForAllReadOnlyFields() {
     assertTrue(rd is Bar);
 }
 
+type Person object {
+    readonly Particulars particulars;
+    int id;
+
+    function init(Particulars & readonly particulars) {
+        self.particulars = particulars;
+        self.id = 1021;
+    }
+};
+
+type Undergraduate object {
+    Particulars & readonly particulars;
+    int id = 1234;
+
+    function init(Particulars & readonly particulars) {
+        self.particulars = particulars;
+    }
+};
+
+type Graduate object {
+    Particulars particulars;
+    int id;
+
+    function init(Particulars particulars, int id) {
+        self.particulars = particulars;
+        self.id = id;
+    }
+};
+
+type Particulars record {|
+    string name;
+|};
+
+function testSubTypingWithReadOnlyFields() {
+    Person p1 = new ({name: "Jo"});
+    Undergraduate u = p1;
+    assertTrue(u is Person);
+
+    var fn1 = function () {
+        u.particulars = {name: "May"};
+    };
+    error? res = trap fn1();
+    assertTrue(res is error);
+    error err = <error> res;
+    assertEquality("cannot update 'readonly' field 'particulars' in object of type 'Person'", err.detail()["message"]);
+
+    Person p2 = new ({name: "Amy"});
+    Graduate g = p2;
+
+    var fn2 = function () {
+        u.particulars = {name: "May"};
+    };
+    res = trap fn2();
+    assertTrue(res is error);
+    err = <error> res;
+    assertEquality("cannot update 'readonly' field 'particulars' in object of type 'Person'", err.detail()["message"]);
+
+    assertTrue(g is Person);
+    var fn3 = function () {
+        g.particulars.name = "Anne";
+    };
+    res = trap fn3();
+    assertTrue(res is error);
+    err = <error> res;
+    assertEquality("cannot update 'readonly' field 'name' in record of type '(Particulars & readonly)'",
+                   err.detail()["message"]);
+}
+
+type AbstractPerson abstract object {
+    Particulars particulars;
+    int id;
+};
+
+type ReadOnlyPerson readonly object {
+    Particulars particulars;
+    int id;
+
+    function init() {
+        self.particulars = {name: "Rob"};
+        self.id = 1234;
+    }
+};
+
+function testSubTypingWithReadOnlyFieldsViaReadOnlyType() {
+    object {
+        readonly Particulars particulars = {
+            name: "Jo"
+        };
+        readonly int id = 1234;
+    } lrp = new ();
+
+    AbstractPerson & readonly ap = lrp;
+    Person p1 = ap;
+    assertTrue(p1 is AbstractPerson & readonly);
+
+    Person p2 = new ReadOnlyPerson();
+    assertTrue(p2 is ReadOnlyPerson);
+}
+
+function testSubTypingWithReadOnlyFieldsNegative() {
+    Undergraduate u = new ({name: "Jo"});
+    any undergrad = u;
+
+    Graduate g = new ({name: "Amy"}, 1121);
+    any grad = g;
+
+    assertTrue(undergrad is Undergraduate);
+    assertTrue(grad is Graduate);
+    assertFalse(undergrad is Person);
+    assertFalse(grad is Person);
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
+}
+
+function assertFalse(any|error actual) {
+    assertEquality(false, actual);
 }
 
 function assertEquality(any|error expected, any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_object_fields_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_object_fields_negative.bal
@@ -116,3 +116,52 @@ function testInvalidImmutableTypeAssignmentForNotAllReadOnlyFields() {
     Foo & readonly f2 = new Baz();
     Foo & readonly f3 = new Qux();
 }
+
+type Person object {
+    readonly Particulars particulars;
+    int id;
+
+    function init(Particulars & readonly particulars) {
+        self.particulars = particulars;
+        self.id = 1021;
+    }
+};
+
+type Undergraduate object {
+    Particulars & readonly particulars;
+    int id = 1234;
+
+    function init(Particulars & readonly particulars) {
+        self.particulars = particulars;
+    }
+};
+
+type Graduate object {
+    Particulars particulars;
+    int id;
+
+    function init(Particulars particulars, int id) {
+        self.particulars = particulars;
+        self.id = id;
+    }
+};
+
+type Particulars record {|
+    string name;
+|};
+
+type AbstractPerson abstract object {
+    Particulars particulars;
+    int id;
+};
+
+function testSubTypingWithReadOnlyFieldsNegative() {
+    Undergraduate u = new ({name: "Jo"});
+    Person p1 = u;
+
+    Graduate g = new ({name: "Amy"}, 1121);
+    Person p2 = g;
+
+    AbstractPerson ap = g;
+    Person p3 = ap;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields_negative.bal
@@ -107,3 +107,54 @@ function testInvalidImmutableTypeAssignmentForNotAllReadOnlyFields() {
     Foo & readonly f2 = baz;
     Foo & readonly f3 = qux;
 }
+
+type Person record {|
+    readonly Particulars particulars;
+    int id;
+|};
+
+type Undergraduate record {|
+    readonly & Particulars particulars;
+    int id;
+|};
+
+type Graduate record {|
+    Particulars particulars;
+    int id;
+|};
+
+type Particulars record {|
+    string name;
+|};
+
+type OptionalId record {|
+    readonly map<int>|boolean id?;
+    map<int>|boolean...;
+|};
+
+function testSubTypingWithReadOnlyFieldsNegative() {
+    Undergraduate u = {
+        particulars: {
+            name: "Jo"
+        },
+        id: 1234
+    };
+    Person p1 = u;
+
+    Graduate g = {
+        particulars: {
+          name: "Amy"
+        },
+        id: 1121
+    };
+    Person p2 = g;
+
+    map<map<int>|boolean> mp = {
+        a: true,
+        b: {
+            x: 1,
+            y: 2
+        }
+    };
+    OptionalId opId = mp;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/tables-cast.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/tables-cast.bal
@@ -40,10 +40,10 @@ CustomerTable tab3 = table key(name) [
     { id: 13 , name: "Bar" , lname: "UYOR" }
     ];
 
-PersonTable3 tab4 = table key(age) [
-    { name: "AAA", age: 31, country: "LK" },
-    { name: "BBB", age: 34, country: "US" }
-    ];
+//PersonTable3 tab4 = table key(age) [
+//    { name: "AAA", age: 31, country: "LK" },
+//    { name: "BBB", age: 34, country: "US" }
+//    ];
 
 function testKeyConstraintCastToString1() returns boolean {
     table<Person> key<string> tab = <table<Person> key<string>> tab1;
@@ -60,7 +60,8 @@ function testKeyConstraintCastToString3() returns boolean {
     return tab[31]["name"] == "AAA";
 }
 
-function testKeyConstraintCastToString4() returns boolean {
-    table<Person> key<int> tab =<table<Person> key<int>> tab4;
-    return tab[31]["name"] == "AAA";
-}
+// See https://github.com/ballerina-platform/ballerina-lang/issues/24105#issuecomment-643760140
+//function testKeyConstraintCastToString4() returns boolean {
+//    table<Person> key<int> tab =<table<Person> key<int>> tab4;
+//    return tab[31]["name"] == "AAA";
+//}


### PR DESCRIPTION
## Purpose
$title - if the field in the target type is a `readonly` field, the relevant field in the source type should also be `readonly` either explicitly or due to the source type itself having its read-only bit set.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/23468

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
