### PR TITLE
Add the public flag for bindgen command

### DIFF
--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-bindgen.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-bindgen.help
@@ -5,6 +5,7 @@ SYNOPSIS
        ballerina bindgen [(-cp|--classpath) <classpath>...]
                          [(-mvn|--maven) <groupId>:<artifactId>:<version>]
                          [(-o|--output) <output>]
+                         [--public]
                          (<class-name>...)
 
 
@@ -32,6 +33,9 @@ OPTIONS
        (-o|--output) <output>
            Location of the generated Ballerina bridge code. If this path is not specified,
            the output will be written onto the same directory from where the command is run.
+
+       --public
+           Set the visibility modifier of generated binding objects to public.
 
        <class-name>...
            One or more space separated fully qualified Java class names for which the bridge

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindgenCommand.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindgenCommand.java
@@ -74,12 +74,18 @@ public class BindgenCommand implements BLauncherCmd {
     )
     private String outputPath;
 
+    @CommandLine.Option(names = {"--public"},
+            description = "Set the visibility modifier of Ballerina bindings to public."
+    )
+    private boolean publicFlag;
+
     @CommandLine.Parameters
     private List<String> classNames;
 
     private static final String BINDGEN_CMD = "ballerina bindgen [(-cp|--classpath) <classpath>...]\n" +
             "                  [(-mvn|--maven) <groupId>:<artifactId>:<version>]\n" +
             "                  [(-o|--output) <output>]\n" +
+            "                  [--public]\n" +
             "                  (<class-name>...)";
 
     @Override
@@ -107,6 +113,10 @@ public class BindgenCommand implements BLauncherCmd {
                 targetOutputPath = Paths.get(targetOutputPath.toString(), outputPath);
             }
             setOutputPath(outputPath);
+        }
+
+        if (publicFlag) {
+            bindingsGenerator.setPublic();
         }
 
         if (!ProjectDirs.isProject(targetOutputPath)) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
@@ -73,6 +73,7 @@ public class BindingsGenerator {
     private String mvnGroupId;
     private String mvnArtifactId;
     private String mvnVersion;
+    private String accessModifier;
     private PrintStream errStream;
     private PrintStream outStream;
     private Set<String> classNames = new HashSet<>();
@@ -246,6 +247,7 @@ public class BindingsGenerator {
                     Class classInstance = classLoader.loadClass(c);
                     if (classInstance != null && isPublicClass(classInstance)) {
                         JClass jClass = new JClass(classInstance);
+                        jClass.setAccessModifier(accessModifier);
                         String outputFile = Paths.get(modulePath.toString(), jClass.getPackageName()).toString();
                         createDirectory(outputFile);
                         String filePath = Paths.get(outputFile, jClass.getShortClassName() + BAL_EXTENSION).toString();
@@ -307,5 +309,9 @@ public class BindingsGenerator {
 
     public static String getOutputPath() {
         return outputPath;
+    }
+
+    void setPublic() {
+        this.accessModifier = "public ";
     }
 }

--- a/misc/ballerina-bindgen/src/main/resources/templates/array_utils.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/array_utils.mustache
@@ -10,7 +10,7 @@ import ballerina/java.arrays as jarrays;
 # + jType - The `string` parameter provided to specify the Java array element type
 # + bType - The optional `string` parameter provided to specify the Ballerina array element type
 # + return - Ballerina `any[]|error` array for the provided handle
-public function fromHandle(handle array, string jType, string bType = "default") returns any[]|error {
+function fromHandle(handle array, string jType, string bType = "default") returns any[]|error {
     int count = jarrays:getLength(array);
     any[] returnArray = [];
     if (!java:isNull(array)) {

--- a/misc/ballerina-bindgen/src/main/resources/templates/jobject.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/jobject.mustache
@@ -12,7 +12,7 @@ type JObject abstract object {
 #
 # + jObj - The `handle` reference to the Java object.
 # + return - The `string` value of the Java object.
-public function jObjToString(handle jObj) returns string {
+function jObjToString(handle jObj) returns string {
     handle jStringValue = toStringInternal(jObj);
     return java:toString(jStringValue) ?: "null";
 }


### PR DESCRIPTION
## Purpose
Adds a flag `--public` to allow the generation of public Ballerina binding objects.

Fixes #23525

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
