### PR TITLE
Change the name of exception objects generated

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JClass.java
@@ -66,6 +66,14 @@ public class JClass {
         shortClassName = c.getSimpleName();
         packageName = c.getPackage().getName();
 
+        // Append the prefix "J" in front of bindings generated for Java exceptions.
+        try {
+            if (this.getClass().getClassLoader().loadClass(Exception.class.getCanonicalName()).isAssignableFrom(c)) {
+                shortClassName = "J" + shortClassName;
+            }
+        } catch (ClassNotFoundException ignore) {
+        }
+
         setAllClasses(shortClassName);
         if (c.isInterface()) {
             isInterface = true;
@@ -121,6 +129,7 @@ public class JClass {
         constructorList.sort(Comparator.comparing(JConstructor::getParamTypes));
         for (JConstructor jConstructor:constructorList) {
             jConstructor.setConstructorName("new" + shortClassName + i);
+            jConstructor.setShortClassName(shortClassName);
             i++;
         }
     }
@@ -147,6 +156,7 @@ public class JClass {
         for (Method method : declaredMethods) {
             if (isPublicMethod(method)) {
                 JMethod jMethod = new JMethod(method);
+                jMethod.setShortClassName(shortClassName);
                 methodList.add(jMethod);
             }
         }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
@@ -99,11 +99,15 @@ public class JConstructor implements Cloneable {
         return super.clone();
     }
 
-    public String getConstructorName() {
+    String getConstructorName() {
         return constructorName;
     }
 
     String getParamTypes() {
         return paramTypes.toString();
+    }
+
+    void setShortClassName(String shortClassName) {
+        this.shortClassName = shortClassName;
     }
 }

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JMethod.java
@@ -134,6 +134,14 @@ public class JMethod {
                 objectReturn = false;
             } else {
                 returnComponentType = returnTypeClass.getComponentType().getSimpleName();
+                // Append the prefix "J" in front of bindings generated for Java exceptions.
+                try {
+                    if (this.getClass().getClassLoader().loadClass(Exception.class.getCanonicalName())
+                            .isAssignableFrom(returnTypeClass)) {
+                        returnComponentType = "J" + returnComponentType;
+                    }
+                } catch (ClassNotFoundException ignore) {
+                }
                 objectReturn = true;
             }
         } else if (returnTypeClass.isPrimitive()) {
@@ -228,5 +236,9 @@ public class JMethod {
 
     public boolean isReturnError() {
         return returnError;
+    }
+
+    public void setShortClassName(String shortClassName) {
+        this.shortClassName = shortClassName;
     }
 }


### PR DESCRIPTION
## Purpose
Change the name of Java exception objects generated using the bindgen tool. When generating an exception class the letter `J` is prepended in front of the simple class name, in order to prevent the naming conflict with autogenerated Ballerina errors and to give the idea that it is a mapping for a Java exception.

Fixes #24127

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples