### PR TITLE
 Fix intersection type issues due to constituent type ordering

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -62,6 +62,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
@@ -105,6 +106,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangArrayType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangConstrainedType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangErrorType;
 import org.wso2.ballerinalang.compiler.tree.types.BLangFiniteTypeNode;
+import org.wso2.ballerinalang.compiler.tree.types.BLangIntersectionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangObjectTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangRecordTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangStructureTypeNode;
@@ -350,6 +352,10 @@ public class SymbolEnter extends BLangNodeVisitor {
         // Define type def members (if any)
         defineMembers(pkgNode.typeDefinitions, pkgEnv);
 
+        // Intersection type nodes need to look at the member fields of a structure too.
+        // Once all the fields and members of other types are set revisit intersection type definitions to validate
+        // them and set the fields and members of the relevant immutable type.
+        validateReadOnlyIntersectionTypeDefinitions(pkgNode.typeDefinitions);
         defineUndefinedReadOnlyTypes(pkgNode.typeDefinitions, pkgEnv);
 
         // Define service and resource nodes.
@@ -620,6 +626,12 @@ public class SymbolEnter extends BLangNodeVisitor {
                 // If the current type node is a union type node, we need to check all member nodes.
                 memberTypeNodes = ((BLangUnionTypeNode) currentTypeNode).memberTypeNodes;
                 // Recursively check all members.
+                for (BLangType memberTypeNode : memberTypeNodes) {
+                    checkErrors(unresolvedType, memberTypeNode, visitedNodes);
+                }
+                break;
+            case INTERSECTION_TYPE_NODE:
+                memberTypeNodes = ((BLangIntersectionTypeNode) currentTypeNode).constituentTypeNodes;
                 for (BLangType memberTypeNode : memberTypeNodes) {
                     checkErrors(unresolvedType, memberTypeNode, visitedNodes);
                 }
@@ -1548,6 +1560,81 @@ public class SymbolEnter extends BLangNodeVisitor {
                         defineReferencedFunction(typeDef, objMethodsEnv, typeRef, function, includedFunctionNames);
                     }
                 }
+            }
+        }
+    }
+
+    private void validateReadOnlyIntersectionTypeDefinitions(List<BLangTypeDefinition> typeDefNodes) {
+        List<BType> loggedTypes = new ArrayList<>();
+
+        for (BLangTypeDefinition typeDefNode : typeDefNodes) {
+            BLangType typeNode = typeDefNode.typeNode;
+            NodeKind kind = typeNode.getKind();
+            if (kind == NodeKind.INTERSECTION_TYPE_NODE) {
+                BType currentType = typeNode.type;
+
+                if (currentType.tag != TypeTags.INTERSECTION) {
+                    continue;
+                }
+
+                BIntersectionType intersectionType = (BIntersectionType) currentType;
+
+                BType effectiveType = intersectionType.effectiveType;
+                if (loggedTypes.contains(effectiveType)) {
+                    continue;
+                }
+
+                loggedTypes.add(effectiveType);
+
+                boolean hasNonReadOnlyElement = false;
+                for (BType constituentType : intersectionType.getConstituentTypes()) {
+                    if (constituentType == symTable.readonlyType) {
+                        continue;
+                    }
+
+                    if (!types.isSelectivelyImmutableType(constituentType, true, true)) {
+                        hasNonReadOnlyElement = true;
+                        break;
+                    }
+                }
+
+                if (hasNonReadOnlyElement) {
+                    dlog.error(typeDefNode.typeNode.pos, DiagnosticCode.INVALID_INTERSECTION_TYPE, typeNode);
+                    typeNode.type = symTable.semanticError;
+                }
+
+                continue;
+            }
+
+            BStructureType immutableType;
+            BStructureType mutableType;
+
+            if (kind == NodeKind.OBJECT_TYPE) {
+                BObjectType currentType = (BObjectType) typeNode.type;
+                mutableType = currentType.mutableType;
+                if (mutableType == null) {
+                    continue;
+                }
+                immutableType = currentType;
+            } else if (kind == NodeKind.RECORD_TYPE) {
+                BRecordType currentType = (BRecordType) typeNode.type;
+                mutableType = currentType.mutableType;
+                if (mutableType == null) {
+                    continue;
+                }
+                immutableType = currentType;
+            } else {
+                continue;
+            }
+
+            if (loggedTypes.contains(immutableType)) {
+                continue;
+            }
+            loggedTypes.add(immutableType);
+
+            if (!types.isSelectivelyImmutableType(mutableType, false, true)) {
+                dlog.error(typeDefNode.typeNode.pos, DiagnosticCode.INVALID_INTERSECTION_TYPE, immutableType);
+                typeNode.type = symTable.semanticError;
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1588,11 +1588,19 @@ public class SymbolResolver extends BLangNodeVisitor {
 
         BLangType bLangTypeOne = constituentTypeNodes.get(0);
         BType typeOne = resolveTypeNode(bLangTypeOne, env);
+
+        if (typeOne == symTable.noType) {
+            return symTable.noType;
+        }
         typeBLangTypeMap.put(typeOne, bLangTypeOne);
 
 
         BLangType bLangTypeTwo = constituentTypeNodes.get(1);
         BType typeTwo = resolveTypeNode(bLangTypeTwo, env);
+
+        if (typeTwo == symTable.noType) {
+            return symTable.noType;
+        }
         typeBLangTypeMap.put(typeTwo, bLangTypeTwo);
 
         boolean hasReadOnlyType = typeOne == symTable.readonlyType || typeTwo == symTable.readonlyType;
@@ -1609,6 +1617,10 @@ public class SymbolResolver extends BLangNodeVisitor {
 
                 if (!hasReadOnlyType) {
                     hasReadOnlyType = type == symTable.readonlyType;
+                }
+
+                if (type == symTable.noType) {
+                    return symTable.noType;
                 }
 
                 potentialIntersectionType = getPotentialReadOnlyIntersection(potentialIntersectionType, type);
@@ -1634,7 +1646,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return potentialIntersectionType;
         }
 
-        if (!types.isSelectivelyImmutableType(potentialIntersectionType, true)) {
+        if (!types.isSelectivelyImmutableType(potentialIntersectionType, true, false)) {
             if (types.isSelectivelyImmutableType(potentialIntersectionType)) {
                 // This intersection would have been valid if not for `readonly object`s.
                 dlog.error(intersectionTypeNode.pos, DiagnosticCode.INVALID_READONLY_OBJECT_INTERSECTION_TYPE);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -964,24 +964,25 @@ public class Types {
     }
 
     boolean isSelectivelyImmutableType(BType type) {
-        return isSelectivelyImmutableType(type, false, new HashSet<>());
+        return isSelectivelyImmutableType(type, false, new HashSet<>(), false);
     }
 
-    boolean isSelectivelyImmutableType(BType type, boolean disallowReadOnlyObjects) {
-        return isSelectivelyImmutableType(type, disallowReadOnlyObjects, new HashSet<>());
+    boolean isSelectivelyImmutableType(BType type, boolean disallowReadOnlyObjects, boolean forceCheck) {
+        return isSelectivelyImmutableType(type, disallowReadOnlyObjects, new HashSet<>(), forceCheck);
     }
 
     public boolean isSelectivelyImmutableType(BType type, Set<BType> unresolvedTypes) {
-        return isSelectivelyImmutableType(type, false, unresolvedTypes);
+        return isSelectivelyImmutableType(type, false, unresolvedTypes, false);
     }
 
-    boolean isSelectivelyImmutableType(BType type, boolean disallowReadOnlyObjects, Set<BType> unresolvedTypes) {
+    boolean isSelectivelyImmutableType(BType type, boolean disallowReadOnlyObjects, Set<BType> unresolvedTypes,
+                                       boolean forceCheck) {
         if (isInherentlyImmutableType(type) || !(type instanceof SelectivelyImmutableReferenceType)) {
             // Always immutable.
             return false;
         }
 
-        if (((SelectivelyImmutableReferenceType) type).getImmutableType() != null) {
+        if (!forceCheck && ((SelectivelyImmutableReferenceType) type).getImmutableType() != null) {
             return true;
         }
 
@@ -1063,7 +1064,8 @@ public class Types {
                 boolean readonlyIntersectionExists = false;
                 for (BType memberType : ((BUnionType) type).getMemberTypes()) {
                     if (isInherentlyImmutableType(memberType) ||
-                            isSelectivelyImmutableType(memberType, disallowReadOnlyObjects, unresolvedTypes)) {
+                            isSelectivelyImmutableType(memberType, disallowReadOnlyObjects, unresolvedTypes,
+                                                       forceCheck)) {
                         readonlyIntersectionExists = true;
                     }
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -975,8 +975,12 @@ public class Types {
         return isSelectivelyImmutableType(type, false, unresolvedTypes, false);
     }
 
-    boolean isSelectivelyImmutableType(BType type, boolean disallowReadOnlyObjects, Set<BType> unresolvedTypes,
-                                       boolean forceCheck) {
+    private boolean isSelectivelyImmutableType(BType type, Set<BType> unresolvedTypes, boolean forceCheck) {
+        return isSelectivelyImmutableType(type, false, unresolvedTypes, forceCheck);
+    }
+
+    private boolean isSelectivelyImmutableType(BType type, boolean disallowReadOnlyObjects, Set<BType> unresolvedTypes,
+                                               boolean forceCheck) {
         if (isInherentlyImmutableType(type) || !(type instanceof SelectivelyImmutableReferenceType)) {
             // Always immutable.
             return false;
@@ -1002,12 +1006,12 @@ public class Types {
             case TypeTags.ARRAY:
                 BType elementType = ((BArrayType) type).eType;
                 return isInherentlyImmutableType(elementType) ||
-                        isSelectivelyImmutableType(elementType, unresolvedTypes);
+                        isSelectivelyImmutableType(elementType, unresolvedTypes, forceCheck);
             case TypeTags.TUPLE:
                 BTupleType tupleType = (BTupleType) type;
                 for (BType tupMemType : tupleType.tupleTypes) {
                     if (!isInherentlyImmutableType(tupMemType) &&
-                            !isSelectivelyImmutableType(tupMemType, unresolvedTypes)) {
+                            !isSelectivelyImmutableType(tupMemType, unresolvedTypes, forceCheck)) {
                         return false;
                     }
                 }
@@ -1018,13 +1022,13 @@ public class Types {
                 }
 
                 return isInherentlyImmutableType(tupRestType) ||
-                        isSelectivelyImmutableType(tupRestType, unresolvedTypes);
+                        isSelectivelyImmutableType(tupRestType, unresolvedTypes, forceCheck);
             case TypeTags.RECORD:
                 BRecordType recordType = (BRecordType) type;
                 for (BField field : recordType.fields.values()) {
                     BType fieldType = field.type;
                     if (!isInherentlyImmutableType(fieldType) &&
-                            !isSelectivelyImmutableType(fieldType, unresolvedTypes)) {
+                            !isSelectivelyImmutableType(fieldType, unresolvedTypes, forceCheck)) {
                         return false;
                     }
                 }
@@ -1035,11 +1039,11 @@ public class Types {
                 }
 
                 return isInherentlyImmutableType(recordRestType) ||
-                        isSelectivelyImmutableType(recordRestType, unresolvedTypes);
+                        isSelectivelyImmutableType(recordRestType, unresolvedTypes, forceCheck);
             case TypeTags.MAP:
                 BType constraintType = ((BMapType) type).constraint;
                 return isInherentlyImmutableType(constraintType) ||
-                        isSelectivelyImmutableType(constraintType, unresolvedTypes);
+                        isSelectivelyImmutableType(constraintType, unresolvedTypes, forceCheck);
             case TypeTags.OBJECT:
                 BObjectType objectType = (BObjectType) type;
 
@@ -1051,7 +1055,7 @@ public class Types {
                 for (BField field : objectType.fields.values()) {
                     BType fieldType = field.type;
                     if (!isInherentlyImmutableType(fieldType) &&
-                            !isSelectivelyImmutableType(fieldType, unresolvedTypes)) {
+                            !isSelectivelyImmutableType(fieldType, unresolvedTypes, forceCheck)) {
                         return false;
                     }
                 }
@@ -1059,7 +1063,7 @@ public class Types {
             case TypeTags.TABLE:
                 BType tableConstraintType = ((BTableType) type).constraint;
                 return isInherentlyImmutableType(tableConstraintType) ||
-                        isSelectivelyImmutableType(tableConstraintType, unresolvedTypes);
+                        isSelectivelyImmutableType(tableConstraintType, unresolvedTypes, forceCheck);
             case TypeTags.UNION:
                 boolean readonlyIntersectionExists = false;
                 for (BType memberType : ((BUnionType) type).getMemberTypes()) {
@@ -1070,6 +1074,9 @@ public class Types {
                     }
                 }
                 return readonlyIntersectionExists;
+            case TypeTags.INTERSECTION:
+                return isSelectivelyImmutableType(((BIntersectionType) type).effectiveType, false, unresolvedTypes,
+                                                  forceCheck);
         }
         return false;
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -54,6 +54,8 @@ public class IntersectionTypeTest {
                 "'readonly'", 19, 5);
         validateError(result, index++, "invalid intersection type 'json & int', intersection types are currently " +
                 "supported only with 'readonly'", 23, 5);
+        validateError(result, index++, "invalid intersection type '(Bar & readonly)': no intersection", 26, 45);
+        validateError(result, index++, "invalid intersection type '(Baz & readonly)': no intersection", 32, 45);
 
         assertEquals(result.getErrorCount(), index);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -88,6 +88,9 @@ public class SelectivelyImmutableTypeTest {
         validateError(result, index++, "cannot update 'readonly' value of type '(Config & readonly)'", 194, 5);
         validateError(result, index++, "cannot update 'readonly' value of type 'MyConfig'", 197, 5);
 
+        validateError(result, index++, "invalid intersection type '(DEF & readonly)': no intersection", 201, 5);
+        validateError(result, index++, "invalid intersection type '(JKL & readonly)': no intersection", 209, 5);
+
         assertEquals(result.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_object_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_object_fields.bal
@@ -20,7 +20,7 @@ function testReadonlyObjectFields() {
     testObjectWithSimpleReadonlyFields();
     testInvalidObjectSimpleReadonlyFieldUpdate();
     testValidUpdateOfPossiblyReadonlyFieldInUnion();
-    //testInvalidUpdateOfPossiblyReadonlyFieldInUnion(); https://github.com/ballerina-platform/ballerina-lang/issues/23551
+    testInvalidUpdateOfPossiblyReadonlyFieldInUnion();
     testObjectWithStructuredReadonlyFields();
     testReadOnlyFieldWithDefaultValue();
     testTypeReadOnlyFlagForAllReadOnlyFields();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -15,8 +15,28 @@
 // under the License.
 
 function testIntersectionTypes() {
+    testIntersectionWithMemberTypeDefinedAfter();
     testIntersectionInUnion();
     testComplexIntersectionsInUnions();
+}
+
+type ReadOnlyFoo readonly & Foo;
+
+function testIntersectionWithMemberTypeDefinedAfter() {
+    ReadOnlyFoo rf = {i: 100, "j": "hello world"};
+    Foo f = rf;
+    assertTrue(f is Foo & readonly);
+    assertTrue(f is ReadOnlyFoo);
+    assertEquality(<Foo> {i: 100, "j": "hello world"}, f);
+
+    var fn = function () {
+        f.i = 200;
+    };
+    error? res = trap fn();
+    assertTrue(res is error);
+
+    error err = <error> res;
+    assertEquality("cannot update 'readonly' field 'i' in record of type '(Foo & readonly)'", err.detail()["message"]);
 }
 
 type Foo record {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type_negative.bal
@@ -22,3 +22,15 @@ function testInvalidIntersection() {
 function testUnsupportedIntersection() {
     json & int x = 1;
 }
+
+type IntersectionWithInvalidRecordTypeAfter Bar & readonly;
+
+type Bar record {
+    future<int> ft;
+};
+
+type IntersectionWithInvalidObjectTypeAfter Baz & readonly;
+
+type Baz abstract object {
+    future<int> ft;
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type_negative.bal
@@ -196,3 +196,23 @@ function testInvalidObjectUpdate() {
     MyConfig myConfig = new MyConfig("client config");
     myConfig.name = "new name";
 }
+
+type ABC record {|
+    DEF & readonly d;
+|};
+
+type DEF record {|
+    future<int> fr;
+|};
+
+type GHI object {
+    JKL & readonly j;
+
+    function init(JKL & readonly j) {
+        self.j = j;
+    }
+};
+
+type JKL abstract object {
+    future<int> fr;
+};


### PR DESCRIPTION
## Purpose
$title.

Fixes #24167 - No type-checking error for invalid readonly intersection field where the invalid member type is defined after

Fixes #24116 Error when defining an intersection type definition with a type defined after the type definition 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
