### PR TITLE
Move JWT caching operations to validation logic [1.2.x]

### DIFF
--- a/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -15,10 +15,7 @@
 // under the License.
 
 import ballerina/auth;
-import ballerina/cache;
-import ballerina/log;
 import ballerina/stringutils;
-import ballerina/time;
 
 # Represents the inbound JWT auth provider, which authenticates by validating a JWT.
 # The `jwt:InboundJwtAuthProvider` is another implementation of the `auth:InboundAuthProvider` interface.
@@ -42,14 +39,12 @@ public type InboundJwtAuthProvider object {
     *auth:InboundAuthProvider;
 
     public JwtValidatorConfig jwtValidatorConfig;
-    cache:Cache inboundJwtCache;
 
     # Provides authentication based on the provided JWT.
     #
     # + jwtValidatorConfig - JWT validator configurations
     public function __init(JwtValidatorConfig jwtValidatorConfig) {
         self.jwtValidatorConfig = jwtValidatorConfig;
-        self.inboundJwtCache = jwtValidatorConfig.jwtCache;
     }
 
 # Authenticates provided JWT against `jwt:JwtValidatorConfig`.
@@ -65,71 +60,16 @@ public type InboundJwtAuthProvider object {
             return false;
         }
 
-        if (self.inboundJwtCache.hasKey(credential)) {
-            JwtPayload? payload = authenticateFromCache(self.inboundJwtCache, credential);
-            if (payload is JwtPayload) {
-                auth:setAuthenticationContext("jwt", credential);
-                setPrincipal(payload);
-                return true;
-            }
-        }
-
         JwtPayload|Error validationResult = validateJwt(credential, self.jwtValidatorConfig);
         if (validationResult is JwtPayload) {
             auth:setAuthenticationContext("jwt", credential);
             setPrincipal(validationResult);
-            addToAuthenticationCache(self.inboundJwtCache, credential, <@untainted> validationResult?.exp,
-                <@untainted> validationResult);
             return true;
         } else {
             return prepareAuthError("JWT validation failed.", validationResult);
         }
     }
 };
-
-function authenticateFromCache(cache:Cache jwtCache, string jwt) returns JwtPayload? {
-    if (jwtCache.hasKey(jwt)) {
-        InboundJwtCacheEntry jwtCacheEntry = <InboundJwtCacheEntry>jwtCache.get(jwt);
-        int? expTime = jwtCacheEntry.expTime;
-        // convert to current time and check the expiry time
-        if (expTime is () || expTime > (time:currentTime().time / 1000)) {
-            JwtPayload payload = jwtCacheEntry.jwtPayload;
-            string? sub = payload?.sub;
-            if (sub is string) {
-                string printMsg = sub;
-                log:printDebug(function() returns string {
-                    return "Authenticate user :" + printMsg + " from the cache";
-                });
-            }
-            return payload;
-        } else {
-            cache:Error? result = jwtCache.invalidate(jwt);
-            if (result is cache:Error) {
-                log:printDebug(function() returns string {
-                    return "Failed to invalidate JWT from the cache.";
-                });
-            }
-        }
-    }
-}
-
-function addToAuthenticationCache(cache:Cache jwtCache, string jwt, int? exp, JwtPayload payload) {
-    InboundJwtCacheEntry jwtCacheEntry = {jwtPayload : payload, expTime : exp };
-    cache:Error? result = jwtCache.put(jwt, jwtCacheEntry);
-    if (result is cache:Error) {
-        log:printDebug(function() returns string {
-            return "Failed to add JWT to the cache";
-        });
-        return;
-    }
-    string? sub = payload?.sub;
-    if (sub is string) {
-        string printMsg = sub;
-        log:printDebug(function() returns string {
-            return "Add authenticated user :" + printMsg + " to the cache";
-        });
-    }
-}
 
 function setPrincipal(JwtPayload jwtPayload) {
     string? iss = jwtPayload?.iss;

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -48,7 +48,8 @@ public type JwtTrustStoreConfig record {|
     string certificateAlias;
 |};
 
-// TODO: Remove since not used anymore.
+// Deprecated: This record was used for JWT caching and with the new cache API v2.0.0 this record no longer used
+// and will be removed in next major version.
 # Represents an entry of JWT cache.
 #
 # + jwtPayload - Parsed JWT payload

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -66,7 +66,7 @@ public type InboundJwtCacheEntry record {|
 # + jwt - JWT that needs to be validated
 # + config - JWT validator config record
 # + return - JWT payload or else a `jwt:Error` if token validation fails
-public function validateJwt(string jwt, @tainted JwtValidatorConfig config) returns @tainted (JwtPayload|Error) {
+public function validateJwt(string jwt, JwtValidatorConfig config) returns @tainted (JwtPayload|Error) {
     if (config.jwtCache.hasKey(jwt)) {
         JwtPayload? payload = validateFromCache(config.jwtCache, jwt);
         if (payload is JwtPayload) {
@@ -99,7 +99,7 @@ function validateFromCache(cache:Cache jwtCache, string jwt) returns JwtPayload?
 }
 
 function addToCache(cache:Cache jwtCache, string jwt, JwtPayload payload) {
-    cache:Error? result = jwtCache.put(jwt, payload);
+    cache:Error? result = jwtCache.put(<@untainted> jwt, <@untainted> payload);
     if (result is cache:Error) {
         log:printDebug(function() returns string {
             return "Failed to add JWT to the cache. JWT payload: " + payload.toString();

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -20,6 +20,7 @@ import ballerina/encoding;
 import ballerina/io;
 import ballerina/lang.'int as langint;
 import ballerina/lang.'string as strings;
+import ballerina/log;
 import ballerina/stringutils;
 import ballerina/time;
 
@@ -47,6 +48,7 @@ public type JwtTrustStoreConfig record {|
     string certificateAlias;
 |};
 
+// TODO: Remove since not used anymore.
 # Represents an entry of JWT cache.
 #
 # + jwtPayload - Parsed JWT payload
@@ -64,9 +66,49 @@ public type InboundJwtCacheEntry record {|
 # + jwt - JWT that needs to be validated
 # + config - JWT validator config record
 # + return - JWT payload or else a `jwt:Error` if token validation fails
-public function validateJwt(string jwt, JwtValidatorConfig config) returns @tainted (JwtPayload|Error) {
+public function validateJwt(string jwt, @tainted JwtValidatorConfig config) returns @tainted (JwtPayload|Error) {
+    if (config.jwtCache.hasKey(jwt)) {
+        JwtPayload? payload = validateFromCache(config.jwtCache, jwt);
+        if (payload is JwtPayload) {
+            return payload;
+        }
+    }
     [JwtHeader, JwtPayload] [header, payload] = check decodeJwt(jwt);
-    return validateJwtRecords(jwt, header, payload, config) ?: payload;
+    _ = check validateJwtRecords(jwt, header, payload, config);
+    addToCache(config.jwtCache, jwt, payload);
+    return payload;
+}
+
+function validateFromCache(cache:Cache jwtCache, string jwt) returns JwtPayload? {
+    JwtPayload payload = <JwtPayload>jwtCache.get(jwt);
+    int? expTime = payload?.exp;
+    // convert to current time and check the expiry time
+    if (expTime is () || expTime > (time:currentTime().time / 1000)) {
+        log:printDebug(function() returns string {
+            return "JWT validated from the cache. JWT payload: " + payload.toString();
+        });
+        return payload;
+    } else {
+        cache:Error? result = jwtCache.invalidate(jwt);
+        if (result is cache:Error) {
+            log:printDebug(function() returns string {
+                return "Failed to invalidate JWT from the cache. JWT payload: " + payload.toString();
+            });
+        }
+    }
+}
+
+function addToCache(cache:Cache jwtCache, string jwt, JwtPayload payload) {
+    cache:Error? result = jwtCache.put(jwt, payload);
+    if (result is cache:Error) {
+        log:printDebug(function() returns string {
+            return "Failed to add JWT to the cache. JWT payload: " + payload.toString();
+        });
+        return;
+    }
+    log:printDebug(function() returns string {
+        return "JWT added to the cache. JWT payload: " + payload.toString();
+    });
 }
 
 # Decodes the given JWT string.


### PR DESCRIPTION
## Purpose
This PR moves the JWT caching operations (`addToCache` & `validateFromCache`) into `jwt:validateJwt` API since the caching operations should be engaged for both direct and indirect API calls of `jwt:validateJwt` API.

This is a duplicate of https://github.com/ballerina-platform/ballerina-lang/pull/22909 which is sent to `master` branch.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
