### PR TITLE
Add version awareness to the stdlib cache in LS

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/LSStandardLibCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/LSStandardLibCache.java
@@ -86,7 +86,12 @@ public class LSStandardLibCache {
                     public List<TopLevelNode> load(@Nonnull String module) throws UnsupportedEncodingException,
                             LSStdlibCacheException {
                         // If the content is not in the cache then we need to extract the source content and compile
-                        LSStdLibCacheUtil.extractSourceForCacheableKey(module);
+                        int versionSeparator = module.lastIndexOf("_");
+                        int modNameSeparator = module.indexOf("_");
+                        String version = module.substring(versionSeparator + 1);
+                        String moduleName = module.substring(modNameSeparator + 1, versionSeparator);
+                        String orgName = module.substring(0, modNameSeparator);
+                        LSStdLibCacheUtil.extractSourceForModule(orgName, moduleName, version);
                         return getNodesForModule(module);
                     }
                 });
@@ -182,8 +187,12 @@ public class LSStandardLibCache {
         new Thread(() -> {
             try {
                 for (String langLib : langLibs) {
-                    String cacheableKey = "ballerina_lang." + langLib + "_0.0.0";
-                    LSStdLibCacheUtil.extractSourceForCacheableKey(cacheableKey);
+                    String orgName = "ballerina";
+                    String moduleName = "lang." + langLib;
+                    Path modulePath = LSStdLibCacheUtil.STD_LIB_SOURCE_ROOT.resolve(orgName).resolve(moduleName);
+                    String version = LSStdLibCacheUtil.readModuleVersionFromDir(modulePath);
+                    String cacheableKey = orgName + "_" + moduleName + "_" + version;
+                    LSStdLibCacheUtil.extractSourceForModule(orgName, moduleName, version);
                     topLevelNodeCache.put(cacheableKey, getNodesForModule(cacheableKey));
                 }
             } catch (LSStdlibCacheException | UnsupportedEncodingException e) {


### PR DESCRIPTION
## Purpose
> With this, Add version awareness to the stdlib cache in LS. Standard library cache will read the versions from the distribution instead of depending on the default version.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
