### PR TITLE
Make command line formatter use the old parser

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/testng.xml
+++ b/language-server/modules/langserver-core/src/test/resources/testng.xml
@@ -30,7 +30,7 @@ under the License.
 <!--            <package name="org.ballerinalang.langserver.highlighting.*"/>-->
             <package name="org.ballerinalang.langserver.definition.*"/>
 <!--            <package name="org.ballerinalang.langserver.docsymbol.*"/>-->
-<!--            <package name="org.ballerinalang.langserver.hover.*"/>-->
+            <package name="org.ballerinalang.langserver.hover.*"/>
 <!--            <package name="org.ballerinalang.langserver.implementation.*"/>-->
 <!--            <package name="org.ballerinalang.langserver.references.*"/>-->
 <!--            <package name="org.ballerinalang.langserver.rename.*"/>-->

--- a/misc/ballerina-formatter/src/main/java/org/ballerinalang/format/FormatUtil.java
+++ b/misc/ballerina-formatter/src/main/java/org/ballerinalang/format/FormatUtil.java
@@ -51,6 +51,7 @@ import java.util.regex.Pattern;
 import static org.ballerinalang.compiler.CompilerOptionName.COMPILER_PHASE;
 import static org.ballerinalang.compiler.CompilerOptionName.EXPERIMENTAL_FEATURES_ENABLED;
 import static org.ballerinalang.compiler.CompilerOptionName.LOCK_ENABLED;
+import static org.ballerinalang.compiler.CompilerOptionName.NEW_PARSER_ENABLED;
 import static org.ballerinalang.compiler.CompilerOptionName.OFFLINE;
 import static org.ballerinalang.compiler.CompilerOptionName.PRESERVE_WHITESPACE;
 import static org.ballerinalang.compiler.CompilerOptionName.PROJECT_DIR;
@@ -323,6 +324,7 @@ public class FormatUtil {
         options.put(LOCK_ENABLED, Boolean.toString(false));
         options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(true));
         options.put(PRESERVE_WHITESPACE, Boolean.toString(true));
+        options.put(NEW_PARSER_ENABLED, Boolean.toString(false));
 
         return context;
     }


### PR DESCRIPTION
## Purpose
> With this, enable the hover tests and Make command line formatter use the old parser.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
