### PR TITLE
Minor improvements & Update help sections of --with-choreo flag

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -181,8 +181,8 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--code-coverage", description = "enable code coverage")
     private boolean coverage;
 
-    @CommandLine.Option(names = "--with-choreo", description = "package Choreo observability extension " +
-            "in the executable jars.")
+    @CommandLine.Option(names = "--with-choreo", description = "package the Choreo observability extension " +
+            "in the executable JAR file(s).")
     private boolean withChoreo;
 
     public void execute() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -181,7 +181,8 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--code-coverage", description = "enable code coverage")
     private boolean coverage;
 
-    @CommandLine.Option(names = "--with-choreo", description = "package Choreo extension in the executable jar")
+    @CommandLine.Option(names = "--with-choreo", description = "package Choreo observability extension " +
+            "in the executable jars.")
     private boolean withChoreo;
 
     public void execute() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
@@ -119,8 +119,8 @@ public class RunCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--old-parser", description = "Enable new parser.", hidden = true)
     private boolean useOldParser;
 
-    @CommandLine.Option(names = "--with-choreo", description = "package Choreo observability extension " +
-            "in the executable jars created while building.")
+    @CommandLine.Option(names = "--with-choreo", description = "package the Choreo observability extension " +
+            "in the executable when run is used with a source file or a module.")
     private boolean withChoreo;
 
     public RunCommand() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
@@ -119,7 +119,8 @@ public class RunCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--old-parser", description = "Enable new parser.", hidden = true)
     private boolean useOldParser;
 
-    @CommandLine.Option(names = "--with-choreo", description = "package Choreo extension in the executable jar")
+    @CommandLine.Option(names = "--with-choreo", description = "package Choreo observability extension " +
+            "in the executable jars created while building.")
     private boolean withChoreo;
 
     public RunCommand() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
@@ -154,8 +154,8 @@ public class TestCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--code-coverage", description = "enable code coverage")
     private boolean coverage;
 
-    @CommandLine.Option(names = "--with-choreo", description = "package Choreo observability extension " +
-            "in the executable jars created while building.")
+    @CommandLine.Option(names = "--with-choreo", description = "package the Choreo observability extension " +
+            "in the executable.")
     private boolean withChoreo;
 
     public void execute() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
@@ -154,7 +154,8 @@ public class TestCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--code-coverage", description = "enable code coverage")
     private boolean coverage;
 
-    @CommandLine.Option(names = "--with-choreo", description = "package Choreo extension in the executable jar")
+    @CommandLine.Option(names = "--with-choreo", description = "package Choreo observability extension " +
+            "in the executable jars created while building.")
     private boolean withChoreo;
 
     public void execute() {

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CopyChoreoExtensionTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CopyChoreoExtensionTask.java
@@ -30,6 +30,8 @@ import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BLANG_COM
 
 /**
  * Package the Choreo extension.
+ *
+ * @since 2.0.0
  */
 public class CopyChoreoExtensionTask implements Task {
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CopyObservabilitySymbolsTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/CopyObservabilitySymbolsTask.java
@@ -40,6 +40,8 @@ import static org.ballerinalang.tool.LauncherUtils.createLauncherException;
 
 /**
  * Copy collected observability symbol to module jar.
+ *
+ * @since 2.0.0
  */
 public class CopyObservabilitySymbolsTask implements Task {
 

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-build.help
@@ -66,11 +66,11 @@ OPTIONS
            Run tests in remote debugging mode, only when the '--skip-tests' flag is not used.
 
        --with-choreo
-           Package Choreo observability extension in the executable jars.
+           Package the Choreo observability extension in the executable JAR file(s).
 
 CONFIG PROPERTIES
        (--key=value)...
-           Set Ballerina environment parameters as key/value pairs.
+           Set the Ballerina environment parameters as key/value pairs.
            If multiple parameters need to be provided, each parameter
            has to be prefixed with '--'. Details of the environment parameters
            supported by the Ballerina standard library modules are specified

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-build.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-build.help
@@ -65,6 +65,9 @@ OPTIONS
        --debug
            Run tests in remote debugging mode, only when the '--skip-tests' flag is not used.
 
+       --with-choreo
+           Package Choreo observability extension in the executable jars.
+
 CONFIG PROPERTIES
        (--key=value)...
            Set Ballerina environment parameters as key/value pairs.

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-run.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-run.help
@@ -44,11 +44,12 @@ OPTIONS
            Run in remote debugging mode.
 
        --with-choreo
-           Package Choreo observability extension in the executable jars created while building.
+           Package the Choreo observability extension in the executable
+           when run is used with a source file or a module.
 
 CONFIG PROPERTIES
        (--key=value)...
-           Set Ballerina environment parameters as key/value pairs.
+           Set the Ballerina environment parameters as key/value pairs.
            If multiple parameters need to be provided, each parameter
            has to be prefixed with '--'. Details of the environment parameters
            supported by the Ballerina standard library modules are specified

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-run.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-run.help
@@ -43,6 +43,9 @@ OPTIONS
        --debug
            Run in remote debugging mode.
 
+       --with-choreo
+           Package Choreo observability extension in the executable jars created while building.
+
 CONFIG PROPERTIES
        (--key=value)...
            Set Ballerina environment parameters as key/value pairs.

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-test.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-test.help
@@ -76,6 +76,9 @@ OPTIONS
        --debug
            Run tests in remote debugging mode.
 
+       --with-choreo
+           Package Choreo observability extension in the executable jars created while building.
+
 CONFIG PROPERTIES
        (--key=value)...
            Set Ballerina environment parameters as key/value pairs.

--- a/cli/ballerina-tool/src/main/resources/cli-help/ballerina-test.help
+++ b/cli/ballerina-tool/src/main/resources/cli-help/ballerina-test.help
@@ -77,11 +77,11 @@ OPTIONS
            Run tests in remote debugging mode.
 
        --with-choreo
-           Package Choreo observability extension in the executable jars created while building.
+           Package the Choreo observability extension in the executable.
 
 CONFIG PROPERTIES
        (--key=value)...
-           Set Ballerina environment parameters as key/value pairs.
+           Set the Ballerina environment parameters as key/value pairs.
            If multiple parameters need to be provided, each parameter
            has to be prefixed with '--'. Details of the environment parameters
            supported by the Ballerina standard library modules are specified

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/toml/model/BuildOptions.java
@@ -21,7 +21,7 @@ package org.ballerinalang.toml.model;
 /**
  * Model for Build Options config in Ballerina.toml.
  *
- * @since 1.0
+ * @since 2.0.0
  */
 public class BuildOptions {
     private boolean withChoreo;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/NullObservabiltySymbolCollector.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/NullObservabiltySymbolCollector.java
@@ -27,7 +27,7 @@ import java.nio.file.Path;
 /**
  * Null Object for ObserverbilitySymbolCollector interface.
  *
- * @since 1.3.0
+ * @since 2.0.0
  */
 public class NullObservabiltySymbolCollector implements ObservabilitySymbolCollector {
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ObserverbilitySymbolCollectorRunner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/ObserverbilitySymbolCollectorRunner.java
@@ -27,6 +27,8 @@ import java.util.ServiceLoader;
 
 /**
  * Used to analyze ballerina code and store observabilty symbols in the Ballerina program artifact.
+ *
+ * @since 2.0.0
  */
 public class ObserverbilitySymbolCollectorRunner {
     private static final CompilerContext.Key<ObservabilitySymbolCollector> OBSERVARBILITY_SYMBOL_COLLECTOR_KEY =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/spi/ObservabilitySymbolCollector.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/spi/ObservabilitySymbolCollector.java
@@ -28,6 +28,8 @@ import java.security.NoSuchAlgorithmException;
 /**
  * Implementation of this interface analyze the AST of the Ballerina program
  * and generate symbol data to be used for observability purposes.
+ *
+ * @since 2.0.0
  */
 public interface ObservabilitySymbolCollector {
     void init(CompilerContext context);

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
@@ -55,6 +55,8 @@ import java.util.stream.Collectors;
 
 /**
  * Default implementation of ObserverbilitySymbolCollector.
+ *
+ * @since 2.0.0
  */
 public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolCollector {
 

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/JsonASTHolder.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/JsonASTHolder.java
@@ -25,6 +25,8 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Hold AST JSON data for later storage.
+ *
+ * @since 2.0.0
  */
 public class JsonASTHolder {
 

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/JsonCanonicalizer.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/JsonCanonicalizer.java
@@ -25,6 +25,8 @@ import java.util.regex.Pattern;
 
 /**
  * JSON Canonicalizer.
+ *
+ * @since 2.0.0
  */
 public class JsonCanonicalizer {
 

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/JsonCanonicalizer.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/JsonCanonicalizer.java
@@ -25,8 +25,6 @@ import java.util.regex.Pattern;
 
 /**
  * JSON Canonicalizer.
- *
- * @author Anders Rundgren
  */
 public class JsonCanonicalizer {
 

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/NumberToJSON.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/NumberToJSON.java
@@ -24,6 +24,8 @@ import java.math.BigInteger;
 /**
  * An implementation of Ryu for serializing IEEE-754 double precision values for
  * JSON as specified by ES6.
+ *
+ * @since 2.0.0
  */
 public final class NumberToJSON {
     private static final boolean DEBUG = false;

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/model/CUnitASTHolder.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/model/CUnitASTHolder.java
@@ -22,6 +22,8 @@ import com.google.gson.JsonElement;
 
 /**
  * Holds a compilation unit holding an AST JSON.
+ *
+ * @since 2.0.0
  */
 public class CUnitASTHolder {
     private String name;

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/model/PkgASTHolder.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/model/PkgASTHolder.java
@@ -24,6 +24,8 @@ import java.util.Map;
 
 /**
  * Holds a package of a list of compilation units holding the AST JSONs.
+ *
+ * @since 2.0.0
  */
 public class PkgASTHolder {
     private String name;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/BallerinaPackageResourceReader.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/BallerinaPackageResourceReader.java
@@ -20,6 +20,8 @@ import java.io.InputStream;
 
 /**
  * Handle resource files in Ballerina program packages.
+ *
+ * @since 2.0.0
  */
 public class BallerinaPackageResourceReader {
 

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
@@ -42,6 +42,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Custom Jaeger tracing reporter for publishing stats to Choreo cloud.
+ *
+ * @since 2.0.0
  */
 public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
     private static final int PUBLISH_INTERVAL_SECS = 10;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/Constants.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/Constants.java
@@ -20,6 +20,8 @@ package org.ballerinalang.observe.trace.extension.choreo;
 /**
  * This is the constants class that defines all the constants
  * that are used by the {@link OpenTracerExtension}.
+ *
+ * @since 2.0.0
  */
 public class Constants {
 

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/MetricsReporterExtension.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/MetricsReporterExtension.java
@@ -49,6 +49,8 @@ import static org.ballerinalang.observe.trace.extension.choreo.Constants.CHOREO_
 
 /**
  * Ballerina MetricReporter extension for Choreo cloud.
+ *
+ * @since 2.0.0
  */
 public class MetricsReporterExtension implements MetricReporter, AutoCloseable {
     private static final Logger LOGGER = LogFactory.getLogger();

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/OpenTracerExtension.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/OpenTracerExtension.java
@@ -32,6 +32,8 @@ import static org.ballerinalang.observe.trace.extension.choreo.Constants.CHOREO_
 
 /**
  * This is the open tracing extension class for {@link OpenTracer}.
+ *
+ * @since 2.0.0
  */
 public class OpenTracerExtension implements OpenTracer {
     private static volatile Reporter reporterInstance;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClient.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClient.java
@@ -40,6 +40,8 @@ import java.util.concurrent.TimeUnit;
 
 /**
  * Manages the communication with Choreo cloud.
+ *
+ * @since 2.0.0
  */
 public class ChoreoClient implements AutoCloseable {
     private static final Logger LOGGER = LogFactory.getLogger();

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClientHolder.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClientHolder.java
@@ -45,6 +45,8 @@ import static org.ballerinalang.observe.trace.extension.choreo.Constants.REPORTE
 
 /**
  * Manages the Choreo Client used to communicate with the Choreo cloud.
+ *
+ * @since 2.0.0
  */
 public class ChoreoClientHolder {
     private static final Logger LOGGER = LogFactory.getLogger();

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoConfigHelper.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoConfigHelper.java
@@ -24,6 +24,8 @@ import java.nio.file.Paths;
 
 /**
  * Manages Choreo tracing extension's configs in local machine.
+ *
+ * @since 2.0.0
  */
 public class ChoreoConfigHelper {
     public static Path getGlobalChoreoConfigDir() {

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/MetadataReader.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/MetadataReader.java
@@ -31,6 +31,8 @@ import java.util.Properties;
 
 /**
  * Read AST metadata from a Ballerina program package.
+ *
+ * @since 2.0.0
  */
 public class MetadataReader {
     private static final Logger LOGGER = LogFactory.getLogger();

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/error/ChoreoClientException.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/error/ChoreoClientException.java
@@ -20,6 +20,8 @@ package org.ballerinalang.observe.trace.extension.choreo.client.error;
 
 /**
  * Choreo Client specific exception class.
+ *
+ * @since 2.0.0
  */
 public class ChoreoClientException extends Exception {
 

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/error/ChoreoError.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/error/ChoreoError.java
@@ -22,6 +22,8 @@ import java.io.Serializable;
 
 /**
  * Holds information about an error occurred in the client.
+ *
+ * @since 2.0.0
  */
 public class ChoreoError implements Serializable {
     private static final long serialVersionUID = -1L;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/error/ChoreoErrors.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/error/ChoreoErrors.java
@@ -20,6 +20,8 @@ package org.ballerinalang.observe.trace.extension.choreo.client.error;
 
 /**
  * Collection of helper methods to create Choreo specific exceptions.
+ *
+ * @since 2.0.0
  */
 public class ChoreoErrors {
 

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/secret/AnonymousAppSecretHandler.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/secret/AnonymousAppSecretHandler.java
@@ -37,6 +37,8 @@ import java.util.UUID;
 
 /**
  * Manages storage and retrieval of app secret for anonymous apps.
+ *
+ * @since 2.0.0
  */
 public class AnonymousAppSecretHandler implements AppSecretHandler {
     public static final String PROJECT_OBSERVABILITY_ID_CONFIG_KEY = "PROJECT_OBSERVABILITY_ID";

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/secret/AppSecretHandler.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/secret/AppSecretHandler.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 
 /**
  * Mangers an application secret.
+ *
+ * @since 2.0.0
  */
 public interface AppSecretHandler {
     String getAppSecret();

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/secret/LinkedAppSecretHandler.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/secret/LinkedAppSecretHandler.java
@@ -20,6 +20,8 @@ package org.ballerinalang.observe.trace.extension.choreo.client.secret;
 
 /**
  * Manages app secret for linked applications.
+ *
+ * @since 2.0.0
  */
 public class LinkedAppSecretHandler implements AppSecretHandler {
     private String appSecret;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/logging/ConsoleLogger.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/logging/ConsoleLogger.java
@@ -20,6 +20,8 @@ import java.io.PrintStream;
 
 /**
  * Logger that logs everything to console.
+ *
+ * @since 2.0.0
  */
 public class ConsoleLogger implements Logger {
     private static final PrintStream console = System.out;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/logging/LogFactory.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/logging/LogFactory.java
@@ -18,6 +18,8 @@ package org.ballerinalang.observe.trace.extension.choreo.logging;
 
 /**
  * Used to create a instance of loggers.
+ *
+ * @since 2.0.0
  */
 public class LogFactory {
 

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/logging/Logger.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/logging/Logger.java
@@ -18,6 +18,8 @@ package org.ballerinalang.observe.trace.extension.choreo.logging;
 
 /**
  * Used for logging requirements.
+ *
+ * @since 2.0.0
  */
 public interface Logger {
     void debug(String format, Object... args);

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/model/ChoreoMetric.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/model/ChoreoMetric.java
@@ -20,6 +20,8 @@ import java.util.Map;
 
 /**
  * Represents a Metric published to Choreo.
+ *
+ * @since 2.0.0
  */
 public class ChoreoMetric {
     private long timestamp;

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/model/ChoreoTraceSpan.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/model/ChoreoTraceSpan.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 /**
  * Represents a Trace Span published to Choreo.
+ *
+ * @since 2.0.0
  */
 public class ChoreoTraceSpan {
     private long traceId;


### PR DESCRIPTION
## Purpose
> Minor improvements & Update help sections of --with-choreo flag. This is a followup PR for #23518 & #24212

## Approach
* author javadoc tag which had been added mistakenly was removed
* since javadoc tag had which was missing in previous PRs were added (the updated since tags were tags added mistakenly while copying a class from another part of the repo itself)
* CLI help sections for `--with-choreo` flag had been added