### PR TITLE
Sanitize async call name before using as the wrapper func name

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -203,7 +203,7 @@ class JvmObservabilityGen {
                         .map(arg -> arg.variableDcl.type)
                         .collect(Collectors.toList());
                 Name lambdaName = new Name(String.format("$lambda$observability%d$%s", lambdaIndex++,
-                        asyncCallIns.name.value));
+                        asyncCallIns.name.value.replace(".", "_")));
                 BInvokableType bInvokableType = new BInvokableType(argTypes, null,
                         returnType, null);
                 BIRFunction desugaredFunc = new BIRFunction(asyncCallIns.pos, lambdaName, 0, bInvokableType,


### PR DESCRIPTION
## Purpose
> Sanitize async call name before using as the wrapper func name

## Approach
> Since async call name can have "." (eg:- Client.get), it had been removed