### PR TITLE
Fix NPE thrown when generating AST json fails

### DIFF
--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
@@ -150,7 +150,9 @@ public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolC
         List<BLangCompilationUnit> compilationUnits = module.getCompilationUnits();
         for (BLangCompilationUnit cUnit : compilationUnits) {
             CUnitASTHolder jsonCUnit = getCUnitASTHolder(visibleEPsByNode, cUnit);
-            pkgASTHolder.addCompilationUnit(cUnit.name, jsonCUnit);
+            if (jsonCUnit.getAst() != null) {
+                pkgASTHolder.addCompilationUnit(cUnit.name, jsonCUnit);
+            }
         }
         return pkgASTHolder;
     }


### PR DESCRIPTION
## Purpose
> Omit packaging compilation units for which generating AST json fails (Related to #24341)

## Approach
> Without this check a null pointer is thrown and the compilation fails completely. So a null check had been added.