### PR TITLE
Remove appending JWT custom claims when empty [1.2.x]

### DIFF
--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -272,7 +272,9 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
             }
         }
     }
-    jwtPayload.customClaims = customClaims;
+    if (customClaims.length() > 0) {
+        jwtPayload.customClaims = customClaims;
+    }
     return jwtPayload;
 }
 
@@ -414,7 +416,7 @@ function getJwk(string kid, JwksConfig jwksConfig) returns @tainted (json|Error)
             }
         }
     } else {
-        return prepareError("JWK retrieval failed", response);
+        return prepareError("Failed to call JWKs endpoint.", response);
     }
 }
 


### PR DESCRIPTION
## Purpose
Remove appending JWT custom claims into `jwt:JwtPayload` when there are no claims.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24352

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
