### PR TITLE
Add OAuth2 introspection response optional parameters to InvocationContext [1.2.x]

### DIFF
--- a/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
+++ b/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
@@ -111,11 +111,40 @@ public type InboundOAuth2Provider object {
                     exp = self.defaultTokenExpTimeInSeconds +  (time:currentTime().time / 1000);
                 }
 
+                map<json> claims = {};
+                if (payload.client_id is string) {
+                    claims["clientId"] = <@untainted> <string>payload.client_id;
+                }
+                if (payload.token_type is string) {
+                    claims["tokenType"] = <@untainted> <string>payload.token_type;
+                }
+                if (payload.exp is int) {
+                    claims["exp"] = <@untainted> <int>payload.exp;
+                }
+                if (payload.iat is int) {
+                    claims["iat"] = <@untainted> <int>payload.iat;
+                }
+                if (payload.nbf is int) {
+                    claims["nbf"] = <@untainted> <int>payload.nbf;
+                }
+                if (payload.sub is string) {
+                    claims["sub"] = <@untainted> <string>payload.sub;
+                }
+                if (payload.aud is string) {
+                    claims["aud"] = <@untainted> <string>payload.aud;
+                }
+                if (payload.iss is string) {
+                    claims["iss"] = <@untainted> <string>payload.iss;
+                }
+                if (payload.jti is string) {
+                    claims["jti"] = <@untainted> <string>payload.jti;
+                }
+
                 if (oauth2Cache is cache:Cache) {
                     addToAuthenticationCache(oauth2Cache, credential, username, scopes, exp);
                 }
                 auth:setAuthenticationContext("oauth2", credential);
-                auth:setPrincipal(username, username, getScopes(scopes ?: ""));
+                auth:setPrincipal(username, username, getScopes(scopes ?: ""), claims);
                 return true;
             }
             return false;


### PR DESCRIPTION
## Purpose
Add OAuth2 introspection response parameters as claims of `runtime:Principal` of `runtime:InvocationContext`.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24331

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
