### PR TITLE
Add OAuth2 introspection response optional parameters to InvocationContext [master]

### DIFF
--- a/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
+++ b/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
@@ -22,6 +22,8 @@ import ballerina/mime;
 import ballerina/stringutils;
 import ballerina/time;
 
+type JsonMap map<json>;
+
 # Represents the inbound OAuth2 provider, which calls the introspection server, validates the received credentials,
 # and performs authentication and authorization. The `oauth2:InboundOAuth2Provider` is an implementation of the
 # `auth:InboundAuthProvider` interface.
@@ -62,6 +64,10 @@ public type InboundOAuth2Provider object {
                 auth:setAuthenticationContext("oauth2", credential);
                 auth:setPrincipal(validationResult?.username, validationResult?.username,
                                   getScopes(validationResult?.scopes));
+                map<json>|error introspectionResponseMap = validationResult.cloneWithType(JsonMap);
+                if (introspectionResponseMap is map<json>) {
+                    auth:setPrincipal(claims = introspectionResponseMap);
+                }
             }
             return validationResult.active;
         } else {


### PR DESCRIPTION
## Purpose
Add OAuth2 introspection response parameters as claims of `runtime:Principal` of `runtime:InvocationContext`.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24331

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
