### PR TITLE
[Streams]Match iterator's next function's return type with completion type of the stream

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -425,6 +425,7 @@ public enum DiagnosticCode {
 
     // Streaming related codes
     INVALID_STREAM_CONSTRUCTOR("invalid.stream.constructor"),
+    INVALID_STREAM_CONSTRUCTOR_EXP_TYPE("invalid.stream.constructor.expected.type"),
     NOT_ALLOWED_STREAM_USAGE_WITH_FROM("invalid.stream.usage.with.from"),
     ERROR_TYPE_EXPECTED("error.type.expected"),
     MISSING_REQUIRED_METHOD_NEXT("missing.required.method.next"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2729,7 +2729,12 @@ public class TypeChecker extends BLangNodeVisitor {
                     resultType = symTable.semanticError;
                     return;
                 }
-
+                if (types.getErrorType(nextReturnType) == null && (types.getErrorType(expectedReturnType) != null)) {
+                    dlog.error(iteratorExpr.pos, DiagnosticCode.INVALID_STREAM_CONSTRUCTOR_EXP_TYPE,
+                            iteratorExpr);
+                    resultType = symTable.semanticError;
+                    return;
+                }
                 types.checkType(iteratorExpr.pos, nextReturnType, expectedReturnType,
                         DiagnosticCode.INCOMPATIBLE_TYPES);
                 resultType = actualType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2730,11 +2730,11 @@ public class TypeChecker extends BLangNodeVisitor {
                     return;
                 }
                 if (types.getErrorType(nextReturnType) == null && (types.getErrorType(expectedReturnType) != null)) {
-                    dlog.error(iteratorExpr.pos, DiagnosticCode.INVALID_STREAM_CONSTRUCTOR_EXP_TYPE,
-                            iteratorExpr);
+                    dlog.error(iteratorExpr.pos, DiagnosticCode.INVALID_STREAM_CONSTRUCTOR_EXP_TYPE, iteratorExpr);
                     resultType = symTable.semanticError;
                     return;
                 }
+
                 types.checkType(iteratorExpr.pos, nextReturnType, expectedReturnType,
                         DiagnosticCode.INCOMPATIBLE_TYPES);
                 resultType = actualType;

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1079,6 +1079,9 @@ error.unnecessary.condition=\
 error.invalid.stream.constructor=\
   ''{0}'' is not a valid constructor for streams type
 
+error.invalid.stream.constructor.expected.type=\
+  invalid expected stream type. ''{0}'' does not return an error
+
 error.invalid.stream.usage.with.from = \
   type 'stream' not allowed here; to use from on a type 'stream', it should be the first from clause in the query.
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -157,8 +157,12 @@ public class BStreamValueTest {
                 " next() returns (record {| string value; |}|CustomError)?'.", 205, 47);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(record {| string value; " +
                 "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 227, 52);
-        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected '(record {| string value; " +
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected '(record {| string value; " +
                 "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 228, 48);
+        BAssertUtil.validateError(negativeResult, i++, "invalid expected stream type. 'itr' does not " +
+                "return an error", 239, 48);
+        BAssertUtil.validateError(negativeResult, i, "invalid expected stream type. 'itr' does not " +
+                "return an error", 240, 44);
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
@@ -227,3 +227,15 @@ function testIteratorWithMismatchedError() {
     var streamE = new stream<string, CustomError1>(itr);
     stream<string, CustomError1> streamF = new(itr);
 }
+
+function testInvalidStreamConstructor() {
+    IteratorWithOutError itr = new();
+
+    // correct
+    var streamA = new stream<int>(itr);
+    stream<int> streamB = new(itr);
+
+    // incorrect (`IteratorWithOutError` does not return an error from next() method)
+    var streamC = new stream<int, CustomError>(itr);
+    stream<int, CustomError> streamD = new(itr);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
@@ -95,7 +95,7 @@ function testStreamConstruct() returns boolean {
 function testStreamConstructWithFilter() returns boolean {
     boolean testPassed = true;
     NumberGenerator numGen = new NumberGenerator();
-    var intStream = new stream<int,error>(numGen);
+    var intStream = new stream<int>(numGen);
 
     stream<int,error> oddNumberStream = intStream.filter(function (int intVal) returns boolean {
         return intVal % 2 == 1;


### PR DESCRIPTION
## Purpose
> Check iterator's next function's return type with completion type of the stream

Fixes #22385

## Approach
> n/a

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
