### PR TITLE
Create BmpStringValue instead of NonBmpStringValue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -38,6 +38,8 @@ public class JvmConstants {
     public static final String REF_VALUE = "org/ballerinalang/jvm/values/RefValue";
     public static final String ERROR_VALUE = "org/ballerinalang/jvm/values/ErrorValue";
     public static final String STRING_VALUE = "java/lang/String";
+    public static final String B_STRING_VALUE = "org/ballerinalang/jvm/values/api/BString";
+    public static final String NON_BMP_STRING_VALUE = "org/ballerinalang/jvm/values/NonBmpStringValue";
     public static final String BMP_STRING_VALUE = "org/ballerinalang/jvm/values/BmpStringValue";
     public static final String LONG_VALUE = "java/lang/Long";
     public static final String BYTE_VALUE = "java/lang/Byte";
@@ -238,7 +240,4 @@ public class JvmConstants {
     public static final String CLASS_TOO_LARGE = "ClassTooLarge";
 
     public static final String GLOBAL_LOCK_NAME = "lock";
-    public static final String I_STRING_VALUE = "org/ballerinalang/jvm/values/StringValue";
-    public static final String B_STRING_VALUE = "org/ballerinalang/jvm/values/api/BString";
-    public static final String NON_BMP_STRING_VALUE = "org/ballerinalang/jvm/values/NonBmpStringValue";
 }


### PR DESCRIPTION
## Purpose
> Improve code by reducing creation of extra int array for strings with non high surrogate characters

## Approach
> String with high surrogate characters are created as BmpStringValue instead of NonBmpStringValue.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
