### PR TITLE
Fix BString cast issue in JSONParser

### DIFF
--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -209,7 +209,8 @@ public class LangLibValueTest {
                 { "testCloneWithTypeNumeric4" },
                 { "testCloneWithTypeNumeric5" },
                 { "testCloneWithTypeNumeric6" },
-                { "testCloneWithTypeNumeric7" }
+                { "testCloneWithTypeNumeric7" },
+                { "testCloneWithTypeStringArray" }
         };
     }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -516,6 +516,19 @@ function testCloneWithTypeNumeric7() {
     assert(a2d[2], <decimal> 3);
 }
 
+type StringArray string[];
+function testCloneWithTypeStringArray() {
+   string anArray = "[\"hello\", \"world\"]";
+   json j = <json> anArray.fromJsonString();
+    string[]|error cloned = j.cloneWithType(StringArray);
+    assert(cloned is string[], true);
+
+    string[]  clonedArr= <string[]> a2;
+    assert(clonedArr.length(), anArray.length());
+    assert(clonedArr[0], "Hello");
+    assert(clonedArr[1], "World");
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected != actual) {
         typedesc<anydata> expT = typeof expected;


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-platform/ballerina-lang/issues/23915

## Approach
> The JSONParser called ArrayValue.append() without any type checking which caused java String to be added to the ArrayValueImpl instead of BString. Also removes the overhead of creating ArrayValueImpl and MapValueImpl in the `changeForBString` method in JSONParser which is unnecessary.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
