### PR TITLE
Limit usage of on-conflict to tables with key specifiers

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -447,6 +447,7 @@ public enum DiagnosticCode {
             ("key.constraint.not.supported.for.table.with.map.constraint"),
     CANNOT_INFER_MEMBER_TYPE_FOR_TABLE_DUE_AMBIGUITY("cannot.infer.member.type.for.table.due.ambiguity"),
     CANNOT_INFER_MEMBER_TYPE_FOR_TABLE("cannot.infer.member.type.for.table"),
+    ON_CONFLICT_ONLY_WORKS_WITH_TABLES_WITH_KEY_SPECIFIER("on.conflict.only.works.with.tables.with.key.specifier"),
 
 
     // Taint checking related codes

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -266,6 +266,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private boolean commitRollbackAllowed;
     private int commitCountWithinBlock;
     private int rollbackCountWithinBlock;
+    private boolean queryToTableWithKey;
 
     public static CodeAnalyzer getInstance(CompilerContext context) {
         CodeAnalyzer codeGenerator = context.get(CODE_ANALYZER_KEY);
@@ -2642,6 +2643,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangQueryExpr queryExpr) {
+        queryToTableWithKey = queryExpr.isTable() && !queryExpr.fieldNameIdentifierList.isEmpty();
         int fromCount = 0;
         for (BLangNode clause : queryExpr.getQueryClauses()) {
             if (clause.getKind() == NodeKind.FROM) {
@@ -2712,6 +2714,9 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangOnConflictClause onConflictClause) {
         analyzeExpr(onConflictClause.expression);
+        if (!queryToTableWithKey) {
+            dlog.error(onConflictClause.pos, DiagnosticCode.ON_CONFLICT_ONLY_WORKS_WITH_TABLES_WITH_KEY_SPECIFIER);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1136,6 +1136,9 @@ error.cannot.infer.member.type.for.table.due.ambiguity = \
 error.cannot.infer.member.type.for.table = \
   cannot infer the member type from table constructor; no values are provided in table constructor
 
+error.on.conflict.only.works.with.tables.with.key.specifier = \
+  on conflict can only be used with queries which produce tables with key specifiers
+
 error.arrow.expression.mismatched.parameter.length=\
   invalid number of parameters used in arrow expression. expected: ''{0}'' but found ''{1}''
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExprWithQueryConstructTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExprWithQueryConstructTypeTest.java
@@ -36,13 +36,14 @@ import static org.ballerinalang.test.util.BAssertUtil.validateError;
  */
 public class QueryExprWithQueryConstructTypeTest {
 
-    private CompileResult result;
-    private CompileResult negativeResult;
+    private CompileResult result, negativeResult, semanticsNegativeResult;
 
     @BeforeClass
     public void setup() {
         result = BCompileUtil.compile("test-src/query/query-expr-with-query-construct-type.bal");
         negativeResult = BCompileUtil.compile("test-src/query/query-expr-query-construct-type-negative.bal");
+        semanticsNegativeResult = BCompileUtil.compile("test-src/query/query-expr-query-construct-type-semantics" +
+                "-negative.bal");
     }
 
     @Test(description = "Test query expr returning a stream ")
@@ -181,5 +182,13 @@ public class QueryExprWithQueryConstructTypeTest {
                 91, 21);
         validateError(negativeResult, index, "type 'error' not allowed here; expected " +
                 "an 'error' or a subtype of 'error'.", 91, 21);
+    }
+
+    @Test(description = "Test semantic negative scenarios for query expr with query construct type")
+    public void testSemanticNegativeScenarios() {
+        Assert.assertEquals(semanticsNegativeResult.getErrorCount(), 1);
+        validateError(semanticsNegativeResult, 0, "on conflict can only be used with queries which produce tables " +
+                        "with key specifiers",
+                39, 13);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-query-construct-type-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-query-construct-type-semantics-negative.bal
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Person record {|
+    string firstName;
+    string lastName;
+    int age;
+|};
+
+function testOnConflictClauseWithNonTableTypes() {
+    error onConflictError = error("Key Conflict", message = "cannot insert.");
+    Person p1 = {firstName: "Alex", lastName: "George", age: 33};
+    Person p2 = {firstName: "John", lastName: "David", age: 35};
+    Person p3 = {firstName: "Max", lastName: "Gomaz", age: 33};
+    Person[] personList = [p1, p2, p3];
+
+    Person[] outputPersonList =
+            from var person in personList
+            let int newAge = 34
+            where person.age == 33
+            select {
+                   firstName: person.firstName,
+                   lastName: person.lastName,
+                   age: newAge
+            }
+            on conflict onConflictError;
+}


### PR DESCRIPTION
## Purpose
$title.

Fixes #24323

## Approach
n/a

## Samples
n/a

## Remarks
n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
