### PR TITLE
Disable `ListenerImapReceiveTest` due to intermittent test failures

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
@@ -8,5 +8,5 @@ target = "java8"
     [[platform.libraries]]
         artifactId = "mock"
         version = "0.0.0"
-        path = "./lib/testerina-core-2.0.0-Preview1.jar"
+        path = "./lib/testerina-core-2.0.0-Preview2-SNAPSHOT.jar"
         groupId = "ballerina"

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
@@ -8,5 +8,5 @@ target = "java8"
     [[platform.libraries]]
         artifactId = "mock"
         version = "0.0.0"
-        path = "./lib/testerina-core-2.0.0-Preview2-SNAPSHOT.jar"
+        path = "./lib/testerina-core-2.0.0-Preview1.jar"
         groupId = "ballerina"

--- a/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/ListenerImapReceiveTest.java
+++ b/stdlib/email/src/test/java/org/ballerinalang/stdlib/email/ListenerImapReceiveTest.java
@@ -70,7 +70,7 @@ public class ListenerImapReceiveTest {
         startServer();
     }
 
-    @Test(description = "Test for receiving an email with simple parameters")
+    @Test(description = "Test for receiving an email with simple parameters", enabled = false)
     public void testReceiveSimpleEmail() throws MessagingException, InterruptedException {
         compileBallerinaScript();
         sendEmail();
@@ -80,7 +80,8 @@ public class ListenerImapReceiveTest {
 
     @Test(
             description = "Test for receiving an email with simple parameters",
-            dependsOnMethods = "testReceiveSimpleEmail"
+            dependsOnMethods = "testReceiveSimpleEmail",
+            enabled = false
     )
     public void testReceiveError() throws InterruptedException {
         compileBallerinaScript();


### PR DESCRIPTION
## Purpose
Disable `ListenerImapReceiveTest` due to intermittent test failures

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
