### PR TITLE
Fix issue with optional fields in record using openapi gen-service [1.2.x]

### DIFF
--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
@@ -302,13 +302,19 @@ public class TypeExtractorUtil {
             } else if ((schema.getType() != null && schema.getType().equals("object")) ||
                     schema.getProperties() != null) {
                 if (schema.getProperties() != null) {
+                    List<String> required_block = new ArrayList<>();
+                    required_block = schema.getRequired();
                     final Iterator<Map.Entry<String, Schema>> propertyIterator = schema.getProperties()
                             .entrySet().iterator();
                     List<BallerinaOpenApiSchema> propertyList = new ArrayList<>();
 
                     while (propertyIterator.hasNext()) {
                         final Map.Entry<String, Schema> nextProp = propertyIterator.next();
-                        final String propName = nextProp.getKey();
+                        String propName = nextProp.getKey();
+                        if (required_block == null || (!required_block.isEmpty() &&
+                                !required_block.contains(propName))) {
+                            propName += "?";
+                        }
                         final Schema propValue = nextProp.getValue();
                         BallerinaOpenApiSchema propertySchema = new BallerinaOpenApiSchema();
 
@@ -380,8 +386,12 @@ public class TypeExtractorUtil {
      */
     public static String escapeIdentifier(String identifier) {
         if (!identifier.matches("[a-zA-Z0-9]+") || BAL_KEYWORDS.stream().anyMatch(identifier::equals)) {
-            identifier = identifier.replaceAll("([\\\\?!<>*\\-=^+()_{}|.$])", "\\\\$1");
-            identifier = "'" + identifier;
+            identifier = identifier.replaceAll("([\\\\?!<>*\\-=^+()_{}|.$])", "$1");
+            if (identifier.endsWith("?")) {
+                return identifier;
+            } else {
+                identifier = "'" + identifier;
+            }
         }
         return identifier;
     }

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
@@ -42,6 +42,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.ballerinalang.openapi.OpenApiMesseges.BAL_KEYWORDS;
 
@@ -387,7 +388,14 @@ public class TypeExtractorUtil {
         if (!identifier.matches("[a-zA-Z0-9]+") || BAL_KEYWORDS.stream().anyMatch(identifier::equals)) {
             identifier = identifier.replaceAll("([\\\\?!<>*\\-=^+()_{}|.$])", "$1");
             if (identifier.endsWith("?")) {
-                return identifier;
+                if (BAL_KEYWORDS.stream().anyMatch(Optional.ofNullable(identifier)
+                        .filter(sStr -> sStr.length() != 0)
+                        .map(sStr -> sStr.substring(0, sStr.length() - 1))
+                        .orElse(identifier)::equals)) {
+                    identifier = "'" + identifier;
+                } else {
+                    return identifier;
+                }
             } else {
                 identifier = "'" + identifier;
             }

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
@@ -302,8 +302,8 @@ public class TypeExtractorUtil {
             } else if ((schema.getType() != null && schema.getType().equals("object")) ||
                     schema.getProperties() != null) {
                 if (schema.getProperties() != null) {
-                    List<String> required_block = new ArrayList<>();
-                    required_block = schema.getRequired();
+                    List<String> requiredBlock = new ArrayList<>();
+                    requiredBlock = schema.getRequired();
                     final Iterator<Map.Entry<String, Schema>> propertyIterator = schema.getProperties()
                             .entrySet().iterator();
                     List<BallerinaOpenApiSchema> propertyList = new ArrayList<>();
@@ -311,8 +311,8 @@ public class TypeExtractorUtil {
                     while (propertyIterator.hasNext()) {
                         final Map.Entry<String, Schema> nextProp = propertyIterator.next();
                         String propName = nextProp.getKey();
-                        if (required_block == null || (!required_block.isEmpty() &&
-                                !required_block.contains(propName))) {
+                        if (requiredBlock == null || (!requiredBlock.isEmpty() &&
+                                !requiredBlock.contains(propName))) {
                             propName += "?";
                         }
                         final Schema propValue = nextProp.getValue();

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/main/java/org/ballerinalang/openapi/utils/TypeExtractorUtil.java
@@ -302,8 +302,7 @@ public class TypeExtractorUtil {
             } else if ((schema.getType() != null && schema.getType().equals("object")) ||
                     schema.getProperties() != null) {
                 if (schema.getProperties() != null) {
-                    List<String> requiredBlock = new ArrayList<>();
-                    requiredBlock = schema.getRequired();
+                    List<String> requiredBlock = schema.getRequired();
                     final Iterator<Map.Entry<String, Schema>> propertyIterator = schema.getProperties()
                             .entrySet().iterator();
                     List<BallerinaOpenApiSchema> propertyList = new ArrayList<>();

--- a/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/test/resources/expected_gen/allOf-schema-petstore.bal
+++ b/misc/openapi-ballerina/modules/openapi-to-ballerina-generator/src/test/resources/expected_gen/allOf-schema-petstore.bal
@@ -2,12 +2,12 @@
 type Pet record { 
      int id;
      string name;
-     string tag;
-     string 'type;
+     string tag?;
+     string 'type?;
 };
 type Dog record { 
     *Pet;
-     boolean bark;
+     boolean bark?;
 };
 type Error record { 
      int code;


### PR DESCRIPTION
## Purpose
> Fix issue with optional fields in the record using `openapi gen-service`. Check the fields whether it is in the required block in the contract and generate schema record 

Fixes #24479 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
