### PR TITLE
Add project api to compiler context

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/InvalidModuleException.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/InvalidModuleException.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.project;
+
+/**
+ * Invalid module is provided as input
+ *
+ * @since 2.0.0
+ */
+public class InvalidModuleException extends Exception {
+}

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/InvalidModuleException.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/InvalidModuleException.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.project;
 
 /**
- * Invalid module is provided as input
+ * Invalid module is provided as input.
  *
  * @since 2.0.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/Project.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/Project.java
@@ -17,7 +17,6 @@
  */
 package org.ballerinalang.project;
 
-import org.ballerinalang.compiler.JarResolver;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
@@ -33,7 +32,7 @@ public interface Project {
     CompilerContext.Key<Project> PROJECT_KEY = new CompilerContext.Key<>();
 
     /**
-     * Return true is module exists in the project.
+     * Returns true if the module exists in the project.
      *
      * @param moduleId Module Id
      * @return

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/Project.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/project/Project.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.project;
+
+import org.ballerinalang.compiler.JarResolver;
+import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.nio.file.Path;
+
+/**
+ * Defines functionality of the Project.
+ *
+ * @since 2.0.0
+ */
+public interface Project {
+
+    CompilerContext.Key<Project> PROJECT_KEY = new CompilerContext.Key<>();
+
+    /**
+     * Return true is module exists in the project.
+     *
+     * @param moduleId Module Id
+     * @return
+     */
+    public boolean isModuleExists(PackageID moduleId);
+
+    /**
+     * Returns the .balo path.
+     *
+     * @param moduleId Module Id
+     * @return
+     */
+    public Path getBaloPath(PackageID moduleId) throws InvalidModuleException;
+}

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
@@ -54,7 +54,6 @@ public class SourceDirectoryManagerTest {
     public void testListSourceFilesAndPackages() {
         Names names = Names.getInstance(context);
         List<PackageID> expectedPackageIds = new ArrayList<>();
-        // expectedPackageIds.add(new PackageID(names.fromString("abc"), "main.bal", names.fromString("0.0.1")));
         expectedPackageIds.add(new PackageID(names.fromString("abc"),
                                              names.fromString("fruits"),
                                              names.fromString("0.0.1"))

--- a/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
+++ b/compiler/ballerina-lang/src/test/java/org/wso2/ballerinalang/compiler/SourceDirectoryManagerTest.java
@@ -17,13 +17,17 @@ package org.wso2.ballerinalang.compiler;
 
 import org.ballerinalang.compiler.CompilerOptionName;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.project.InvalidModuleException;
+import org.ballerinalang.project.Project;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.programfile.ProgramFileConstants;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Stream;
@@ -50,7 +54,7 @@ public class SourceDirectoryManagerTest {
     public void testListSourceFilesAndPackages() {
         Names names = Names.getInstance(context);
         List<PackageID> expectedPackageIds = new ArrayList<>();
-        expectedPackageIds.add(new PackageID(names.fromString("abc"), "main.bal", names.fromString("0.0.1")));
+        // expectedPackageIds.add(new PackageID(names.fromString("abc"), "main.bal", names.fromString("0.0.1")));
         expectedPackageIds.add(new PackageID(names.fromString("abc"),
                                              names.fromString("fruits"),
                                              names.fromString("0.0.1"))
@@ -68,5 +72,55 @@ public class SourceDirectoryManagerTest {
                                                     names.fromString("fruits"),
                                                     names.fromString("0.0.1"));
         Assert.assertEquals(fruits, expectedPackageId);
+    }
+
+    @Test(description = "Test if module exist in the project")
+    public void testIsModuleExists() {
+        Project project = context.get(Project.PROJECT_KEY);
+        Names names = Names.getInstance(context);
+        PackageID expectedPackageId = new PackageID(names.fromString("abc"),
+                names.fromString("fruits"),
+                names.fromString("0.0.1"));
+        Assert.assertTrue(project.isModuleExists(expectedPackageId));
+        PackageID invalidName = new PackageID(names.fromString("abc"),
+                names.fromString("invalid"),
+                names.fromString("0.0.1"));
+        Assert.assertFalse(project.isModuleExists(invalidName));
+        PackageID invalidOrg = new PackageID(names.fromString("invalid"),
+                names.fromString("fruits"),
+                names.fromString("0.0.1"));
+        Assert.assertFalse(project.isModuleExists(invalidOrg));
+        PackageID invalidVersion = new PackageID(names.fromString("abc"),
+                names.fromString("fruits"),
+                names.fromString("0.1.1"));
+        Assert.assertFalse(project.isModuleExists(invalidVersion));
+    }
+
+    @Test(description = "Test if get balo path")
+    public void getBaloPath() throws InvalidModuleException {
+        Project project = context.get(Project.PROJECT_KEY);
+        Names names = Names.getInstance(context);
+        PackageID moduleId = new PackageID(names.fromString("abc"),
+                names.fromString("fruits"),
+                names.fromString("0.0.1"));
+        // valid module
+        String baloName =  "fruits-"
+                + ProgramFileConstants.IMPLEMENTATION_VERSION + "-any-0.0.1.balo";
+        Path baloPath = directoryManager.getSourceDirectory().getPath()
+                .resolve("target").resolve("balo").resolve(baloName);
+        Assert.assertEquals(project.getBaloPath(moduleId), baloPath);
+        // valid module with a diffrent platform
+
+        // invalid module
+        try {
+            PackageID invalidModuleId = new PackageID(names.fromString("invalid"),
+                    names.fromString("fruits"),
+                    names.fromString("0.0.1"));
+            // invalid valid module
+            project.getBaloPath(invalidModuleId);
+            throw new AssertionError("Failed to identify invalid module");
+        } catch (InvalidModuleException e) {
+            // catch works
+        }
     }
 }

--- a/compiler/ballerina-lang/src/test/resources/testng.xml
+++ b/compiler/ballerina-lang/src/test/resources/testng.xml
@@ -23,6 +23,7 @@ under the License.
     <test name="ballerina-blang-node-transformer-test-suite" preserve-order="true" parallel="false">
         <classes>
             <class name="org.wso2.ballerinalang.compiler.BLangNodeTransformerTest"/>
+            <class name="org.wso2.ballerinalang.compiler.SourceDirectoryManagerTest"/>
         </classes>
     </test>
     <test name="ballerina-toml-parser-test-suite" preserve-order="true" parallel="false">


### PR DESCRIPTION
## Purpose
Add a Project API to compiler context. This can be use by compiler plugins and other components to retrieve information about the project.

Fixes #24441

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
