### PR TITLE
Refactor and use switch statements

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -154,28 +154,30 @@ public class JvmCastGen {
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
             mv.visitInsn(I2B);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    // do nothing
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2I);
-                    mv.visitInsn(I2B);
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
-                            false);
-                    mv.visitInsn(I2B);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java byte'",
-                            sourceType));
-            }
+            return;
         }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                // do nothing
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2I);
+                mv.visitInsn(I2B);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
+                        false);
+                mv.visitInsn(I2B);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java byte'",
+                        sourceType));
+        }
+
     }
 
     private static void generateCheckCastBToJChar(MethodVisitor mv, BType sourceType) {
@@ -183,27 +185,28 @@ public class JvmCastGen {
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
             mv.visitInsn(I2C);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2C);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2I);
-                    mv.visitInsn(I2C);
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
-                    mv.visitInsn(L2I);
-                    mv.visitInsn(I2C);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java char'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2C);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2I);
+                mv.visitInsn(I2C);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                mv.visitInsn(L2I);
+                mv.visitInsn(I2C);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java char'",
+                        sourceType));
         }
     }
 
@@ -212,27 +215,28 @@ public class JvmCastGen {
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
             mv.visitInsn(I2S);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2S);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2I);
-                    mv.visitInsn(I2S);
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
-                    mv.visitInsn(L2I);
-                    mv.visitInsn(I2S);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java short'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2S);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2I);
+                mv.visitInsn(I2S);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                mv.visitInsn(L2I);
+                mv.visitInsn(I2S);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java short'",
+                        sourceType));
         }
     }
 
@@ -240,50 +244,51 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    // do nothing
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2I);
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
-                    mv.visitInsn(L2I);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java int'",
-                            sourceType));
-            }
+            return;
         }
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                // do nothing
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2I);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                mv.visitInsn(L2I);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java int'",
+                        sourceType));
+        }
+
     }
 
     private static void generateCheckCastBToJLong(MethodVisitor mv, BType sourceType) {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
-            // do nothing
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2L);
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java long'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2L);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java long'",
+                        sourceType));
         }
     }
 
@@ -291,26 +296,27 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2F);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2F);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2F);
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
-                            false);
-                    mv.visitInsn(D2F);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java float'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2F);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2F);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                        false);
+                mv.visitInsn(D2F);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java float'",
+                        sourceType));
         }
     }
 
@@ -318,25 +324,26 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2D);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2D);
-                    break;
-                case TypeTags.FLOAT:
-                    // do nothing
-                    break;
-                case TypeTags.HANDLE:
-                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-                    break;
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
-                            "to 'java double'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2D);
+                break;
+            case TypeTags.FLOAT:
+                // do nothing
+                break;
+            case TypeTags.HANDLE:
+                mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                break;
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                        "to 'java double'", sourceType));
         }
     }
 
@@ -372,64 +379,65 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(targetType.tag)) {
             generateCheckCastJToBInt(mv, sourceType);
-        } else {
-            switch (targetType.tag) {
-                case TypeTags.FLOAT:
-                    generateCheckCastJToBFloat(mv, sourceType);
-                    break;
-                case TypeTags.DECIMAL:
-                    generateCheckCastJToBDecimal(mv, sourceType);
-                    break;
-                case TypeTags.BOOLEAN:
-                    generateCheckCastJToBBoolean(mv, sourceType);
-                    break;
-                case TypeTags.BYTE:
-                    generateCheckCastJToBByte(mv, sourceType);
-                    break;
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                    // Do nothing
-                    break;
-                default:
-                    switch (targetType.tag) {
-                        case TypeTags.UNION:
-                            generateCheckCastJToBUnionType(mv, indexMap, sourceType, (BUnionType) targetType);
-                            break;
-                        case TypeTags.ANYDATA:
-                            generateCheckCastJToBAnyData(mv, indexMap, sourceType);
-                            break;
-                        case TypeTags.HANDLE:
-                            generateJCastToBHandle(mv, sourceType);
-                            break;
-                        case TypeTags.ANY:
-                            generateJCastToBAny(mv, indexMap, sourceType, targetType);
-                            break;
-                        case TypeTags.JSON:
-                            generateCheckCastJToBJSON(mv, indexMap, sourceType);
-                            break;
-                        case TypeTags.FINITE:
-                            generateCheckCastJToBFiniteType(mv, indexMap, sourceType, targetType);
-                            // TODO fix below properly - rajith
-                            //} else if (sourceType is bir:BXMLType && targetType is bir:BMapType) {
-                            //    generateXMLToAttributesMap(mv, sourceType);
-                            //    return;
-                            //} else if (targetType is bir:BFiniteType) {
-                            //    generateCheckCastToFiniteType(mv, sourceType, targetType);
-                            //    return;
-                            //} else if (sourceType is bir:BRecordType && (targetType is bir:BMapType &&
-                            // targetType.constraint
-                            // is bir:BTypeAny)) {
-                            //    // do nothing
-                            break;
-                    }
+            return;
+        }
 
-                    checkCast(mv, targetType);
-                    String targetTypeClass = getTargetClass(targetType);
-                    if (targetTypeClass != null) {
-                        mv.visitTypeInsn(CHECKCAST, targetTypeClass);
-                    }
-                    break;
-            }
+        switch (targetType.tag) {
+            case TypeTags.FLOAT:
+                generateCheckCastJToBFloat(mv, sourceType);
+                break;
+            case TypeTags.DECIMAL:
+                generateCheckCastJToBDecimal(mv, sourceType);
+                break;
+            case TypeTags.BOOLEAN:
+                generateCheckCastJToBBoolean(mv, sourceType);
+                break;
+            case TypeTags.BYTE:
+                generateCheckCastJToBByte(mv, sourceType);
+                break;
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+                // Do nothing
+                break;
+            default:
+                switch (targetType.tag) {
+                    case TypeTags.UNION:
+                        generateCheckCastJToBUnionType(mv, indexMap, sourceType, (BUnionType) targetType);
+                        break;
+                    case TypeTags.ANYDATA:
+                        generateCheckCastJToBAnyData(mv, indexMap, sourceType);
+                        break;
+                    case TypeTags.HANDLE:
+                        generateJCastToBHandle(mv, sourceType);
+                        break;
+                    case TypeTags.ANY:
+                        generateJCastToBAny(mv, indexMap, sourceType, targetType);
+                        break;
+                    case TypeTags.JSON:
+                        generateCheckCastJToBJSON(mv, indexMap, sourceType);
+                        break;
+                    case TypeTags.FINITE:
+                        generateCheckCastJToBFiniteType(mv, indexMap, sourceType, targetType);
+                        // TODO fix below properly - rajith
+                        //} else if (sourceType is bir:BXMLType && targetType is bir:BMapType) {
+                        //    generateXMLToAttributesMap(mv, sourceType);
+                        //    return;
+                        //} else if (targetType is bir:BFiniteType) {
+                        //    generateCheckCastToFiniteType(mv, sourceType, targetType);
+                        //    return;
+                        //} else if (sourceType is bir:BRecordType && (targetType is bir:BMapType &&
+                        // targetType.constraint
+                        // is bir:BTypeAny)) {
+                        //    // do nothing
+                        break;
+                }
+
+                checkCast(mv, targetType);
+                String targetTypeClass = getTargetClass(targetType);
+                if (targetTypeClass != null) {
+                    mv.visitTypeInsn(CHECKCAST, targetTypeClass);
+                }
+                break;
         }
     }
 
@@ -829,29 +837,29 @@ public class JvmCastGen {
     private static void generateCheckCastToInt(MethodVisitor mv, BType sourceType) {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
-            // do nothing
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToInt", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToInt", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
+                        sourceType));
         }
     }
 
@@ -859,29 +867,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned32", "(J)J", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned32", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned32", String.format("(L%s;)J", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
-                            "to 'int:Signed32'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned32", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned32", String.format("(L%s;)J", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                        "to 'int:Signed32'", sourceType));
         }
     }
 
@@ -889,29 +898,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned16", "(J)J", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned16", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned16", String.format("(L%s;)J", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
-                            "to 'int:Signed16'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned16", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned16", String.format("(L%s;)J", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                        "to 'int:Signed16'", sourceType));
         }
     }
 
@@ -919,30 +929,31 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned8", "(J)J", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned8", "(J)J", false);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned8", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned8", String.format("(L%s;)J", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s'" +
-                            " to 'int:Signed8'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned8", "(J)J", false);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned8", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned8", String.format("(L%s;)J", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s'" +
+                        " to 'int:Signed8'", sourceType));
         }
     }
 
@@ -950,29 +961,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToUnsigned32", "(J)J", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned32", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned32", String.format("(L%s;)J", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to " +
-                            "'int:Unsigned32'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned32", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned32", String.format("(L%s;)J", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to " +
+                        "'int:Unsigned32'", sourceType));
         }
     }
 
@@ -980,29 +992,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToUnsigned16", "(J)J", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned16", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned16", String.format("(L%s;)J", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
-                                    "to 'int:Unsigned16'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned16", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned16", String.format("(L%s;)J", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                                "to 'int:Unsigned16'", sourceType));
         }
     }
 
@@ -1010,29 +1023,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToUnsigned8", "(J)J", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned8", "(D)J", false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned8", String.format("(L%s;)J", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
-                                    "to 'int:Unsigned8'", sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned8", "(D)J", false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned8", String.format("(L%s;)J", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                                "to 'int:Unsigned8'", sourceType));
         }
     }
 
@@ -1040,27 +1054,28 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2D);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.FLOAT:
-                    // do nothing
-                    break;
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2D);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.DECIMAL:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.FLOAT:
+                // do nothing
+                break;
+            case TypeTags.BYTE:
+                mv.visitInsn(I2D);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.DECIMAL:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
+                        sourceType));
         }
     }
 
@@ -1068,31 +1083,32 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(J)L%s;", DECIMAL_VALUE), false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.DECIMAL:
-                    // do nothing
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
-                            String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE),
-                            false);
-                    break;
-                case TypeTags.BYTE:
-                    mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(I)L%s;", DECIMAL_VALUE),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.DECIMAL:
+                // do nothing
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
+                        String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case TypeTags.BYTE:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(I)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
+                        sourceType));
         }
     }
 
@@ -1190,30 +1206,31 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToByte", "(J)I", false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToByte", "(D)I", false);
-                    break;
-                case TypeTags.DECIMAL:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
-                            false);
-                    break;
-                case TypeTags.BYTE:
-                    // do nothing
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.FINITE:
-                case TypeTags.JSON:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
-                            false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'byte'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToByte", "(D)I", false);
+                break;
+            case TypeTags.DECIMAL:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
+                        false);
+                break;
+            case TypeTags.BYTE:
+                // do nothing
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.FINITE:
+            case TypeTags.JSON:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
+                        false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'byte'",
+                        sourceType));
         }
     }
 
@@ -1368,25 +1385,25 @@ public class JvmCastGen {
     private static void generateCastToInt(MethodVisitor mv, BType sourceType) {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
-            // do nothing
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(I2L);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(D2L);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.JSON:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(I2L);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(D2L);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.JSON:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
+                        sourceType));
         }
     }
 
@@ -1410,29 +1427,30 @@ public class JvmCastGen {
     private static void generateCastToString(MethodVisitor mv, BType sourceType) {
 
         if (TypeTags.isStringTypeTag(sourceType.tag)) {
-            // do nothing
+            return;
         } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "toString", String.format("(J)L%s;", STRING_VALUE), false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "toString", String.format("(D)L%s;", STRING_VALUE),
-                            false);
-                    break;
-                case TypeTags.BOOLEAN:
-                    mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "toString", String.format("(Z)L%s;", STRING_VALUE),
-                            false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.JSON:
-                    mv.visitTypeInsn(CHECKCAST, B_STRING_VALUE);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'string'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "toString", String.format("(D)L%s;", STRING_VALUE),
+                        false);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "toString", String.format("(Z)L%s;", STRING_VALUE),
+                        false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.JSON:
+                mv.visitTypeInsn(CHECKCAST, B_STRING_VALUE);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'string'",
+                        sourceType));
         }
     }
 
@@ -1440,26 +1458,27 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(J)L%s;", DECIMAL_VALUE), false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.DECIMAL:
-                    // do nothing
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE),
-                            false);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.JSON:
-                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
-                            String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
-                    break;
-                default:
-                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
-                            sourceType));
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.DECIMAL:
+                // do nothing
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.JSON:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
+                        String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
+                        sourceType));
         }
     }
 
@@ -1499,20 +1518,21 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
-        } else {
-            switch (sourceType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE),
-                            false);
-                    break;
-                case TypeTags.BOOLEAN:
-                    mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "valueOf", String.format("(Z)L%s;", BOOLEAN_VALUE),
-                            false);
-                    break;
-            }
+            return;
+        }
+
+        switch (sourceType.tag) {
+            case TypeTags.BYTE:
+                mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE),
+                        false);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "valueOf", String.format("(Z)L%s;", BOOLEAN_VALUE),
+                        false);
+                break;
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -391,29 +391,36 @@ public class JvmCastGen {
                     // Do nothing
                     break;
                 default:
-                    if (targetType.tag == TypeTags.UNION) {
-                        generateCheckCastJToBUnionType(mv, indexMap, sourceType, (BUnionType) targetType);
-                    } else if (targetType.tag == TypeTags.ANYDATA) {
-                        generateCheckCastJToBAnyData(mv, indexMap, sourceType);
-                    } else if (targetType.tag == TypeTags.HANDLE) {
-                        generateJCastToBHandle(mv, sourceType);
-                    } else if (targetType.tag == TypeTags.ANY) {
-                        generateJCastToBAny(mv, indexMap, sourceType, targetType);
-                    } else if (targetType.tag == TypeTags.JSON) {
-                        generateCheckCastJToBJSON(mv, indexMap, sourceType);
-                    } else if (targetType.tag == TypeTags.FINITE) {
-                        generateCheckCastJToBFiniteType(mv, indexMap, sourceType, targetType);
-                        // TODO fix below properly - rajith
-                        //} else if (sourceType is bir:BXMLType && targetType is bir:BMapType) {
-                        //    generateXMLToAttributesMap(mv, sourceType);
-                        //    return;
-                        //} else if (targetType is bir:BFiniteType) {
-                        //    generateCheckCastToFiniteType(mv, sourceType, targetType);
-                        //    return;
-                        //} else if (sourceType is bir:BRecordType && (targetType is bir:BMapType &&
-                        // targetType.constraint
-                        // is bir:BTypeAny)) {
-                        //    // do nothing
+                    switch (targetType.tag) {
+                        case TypeTags.UNION:
+                            generateCheckCastJToBUnionType(mv, indexMap, sourceType, (BUnionType) targetType);
+                            break;
+                        case TypeTags.ANYDATA:
+                            generateCheckCastJToBAnyData(mv, indexMap, sourceType);
+                            break;
+                        case TypeTags.HANDLE:
+                            generateJCastToBHandle(mv, sourceType);
+                            break;
+                        case TypeTags.ANY:
+                            generateJCastToBAny(mv, indexMap, sourceType, targetType);
+                            break;
+                        case TypeTags.JSON:
+                            generateCheckCastJToBJSON(mv, indexMap, sourceType);
+                            break;
+                        case TypeTags.FINITE:
+                            generateCheckCastJToBFiniteType(mv, indexMap, sourceType, targetType);
+                            // TODO fix below properly - rajith
+                            //} else if (sourceType is bir:BXMLType && targetType is bir:BMapType) {
+                            //    generateXMLToAttributesMap(mv, sourceType);
+                            //    return;
+                            //} else if (targetType is bir:BFiniteType) {
+                            //    generateCheckCastToFiniteType(mv, sourceType, targetType);
+                            //    return;
+                            //} else if (sourceType is bir:BRecordType && (targetType is bir:BMapType &&
+                            // targetType.constraint
+                            // is bir:BTypeAny)) {
+                            //    // do nothing
+                            break;
                     }
 
                     checkCast(mv, targetType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -115,166 +115,228 @@ public class JvmCastGen {
 
     public static void generateBToJCheckCast(MethodVisitor mv, BType sourceType, JType targetType) {
 
-        if (targetType.jTag == JTypeTags.JBYTE) {
-            generateCheckCastBToJByte(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JCHAR) {
-            generateCheckCastBToJChar(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JSHORT) {
-            generateCheckCastBToJShort(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JINT) {
-            generateCheckCastBToJInt(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JLONG) {
-            generateCheckCastBToJLong(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JFLOAT) {
-            generateCheckCastBToJFloat(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JDOUBLE) {
-            generateCheckCastBToJDouble(mv, sourceType);
-        } else if (targetType.jTag == JTypeTags.JREF) {
-            generateCheckCastBToJRef(mv, sourceType, targetType);
-        } else if (targetType.jTag == JTypeTags.JARRAY) {
-            generateCheckCastBToJRef(mv, sourceType, targetType);
-        } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java %s'",
-                    sourceType, targetType));
+        switch (targetType.jTag) {
+            case JTypeTags.JBYTE:
+                generateCheckCastBToJByte(mv, sourceType);
+                break;
+            case JTypeTags.JCHAR:
+                generateCheckCastBToJChar(mv, sourceType);
+                break;
+            case JTypeTags.JSHORT:
+                generateCheckCastBToJShort(mv, sourceType);
+                break;
+            case JTypeTags.JINT:
+                generateCheckCastBToJInt(mv, sourceType);
+                break;
+            case JTypeTags.JLONG:
+                generateCheckCastBToJLong(mv, sourceType);
+                break;
+            case JTypeTags.JFLOAT:
+                generateCheckCastBToJFloat(mv, sourceType);
+                break;
+            case JTypeTags.JDOUBLE:
+                generateCheckCastBToJDouble(mv, sourceType);
+                break;
+            case JTypeTags.JREF:
+                generateCheckCastBToJRef(mv, sourceType, targetType);
+                break;
+            case JTypeTags.JARRAY:
+                generateCheckCastBToJRef(mv, sourceType, targetType);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java %s'",
+                        sourceType, targetType));
         }
     }
 
     private static void generateCheckCastBToJByte(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            // do nothing
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
             mv.visitInsn(I2B);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2I);
-            mv.visitInsn(I2B);
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT), false);
-            mv.visitInsn(I2B);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java byte'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    // do nothing
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2I);
+                    mv.visitInsn(I2B);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
+                            false);
+                    mv.visitInsn(I2B);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java byte'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastBToJChar(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2C);
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
-            mv.visitInsn(L2I);
-            mv.visitInsn(I2C);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2I);
-            mv.visitInsn(I2C);
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
             mv.visitInsn(I2C);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java char'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2C);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2I);
+                    mv.visitInsn(I2C);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                    mv.visitInsn(L2I);
+                    mv.visitInsn(I2C);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java char'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastBToJShort(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2S);
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
-            mv.visitInsn(L2I);
-            mv.visitInsn(I2S);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2I);
-            mv.visitInsn(I2S);
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
             mv.visitInsn(I2S);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java short'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2S);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2I);
+                    mv.visitInsn(I2S);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                    mv.visitInsn(L2I);
+                    mv.visitInsn(I2S);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java short'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastBToJInt(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            // do nothing
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
-            mv.visitInsn(L2I);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2I);
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2I);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java int'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    // do nothing
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2I);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                    mv.visitInsn(L2I);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java int'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastBToJLong(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2L);
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             // do nothing
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2L);
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java long'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2L);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java long'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastBToJFloat(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2F);
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2F);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2F);
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT), false);
-            mv.visitInsn(D2F);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java float'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2F);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2F);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                            false);
+                    mv.visitInsn(D2F);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java float'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastBToJDouble(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2D);
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2D);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            // do nothing
-        } else if (sourceType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
-        } else if (sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'java double'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2D);
+                    break;
+                case TypeTags.FLOAT:
+                    // do nothing
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, "getValue", "()Ljava/lang/Object;", false);
+                    break;
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                            "to 'java double'", sourceType));
+            }
         }
     }
 
@@ -310,122 +372,166 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(targetType.tag)) {
             generateCheckCastJToBInt(mv, sourceType);
-        } else if (targetType.tag == TypeTags.FLOAT) {
-            generateCheckCastJToBFloat(mv, sourceType);
-        } else if (targetType.tag == TypeTags.DECIMAL) {
-            generateCheckCastJToBDecimal(mv, sourceType);
-        } else if (targetType.tag == TypeTags.BOOLEAN) {
-            generateCheckCastJToBBoolean(mv, sourceType);
-        } else if (targetType.tag == TypeTags.BYTE) {
-            generateCheckCastJToBByte(mv, sourceType);
-        } else if (targetType.tag == TypeTags.NIL || targetType.tag == TypeTags.NEVER) {
-            // Do nothing
         } else {
-            if (targetType.tag == TypeTags.UNION) {
-                generateCheckCastJToBUnionType(mv, indexMap, sourceType, (BUnionType) targetType);
-            } else if (targetType.tag == TypeTags.ANYDATA) {
-                generateCheckCastJToBAnyData(mv, indexMap, sourceType);
-            } else if (targetType.tag == TypeTags.HANDLE) {
-                generateJCastToBHandle(mv, sourceType);
-            } else if (targetType.tag == TypeTags.ANY) {
-                generateJCastToBAny(mv, indexMap, sourceType, targetType);
-            } else if (targetType.tag == TypeTags.JSON) {
-                generateCheckCastJToBJSON(mv, indexMap, sourceType);
-            } else if (targetType.tag == TypeTags.FINITE) {
-                generateCheckCastJToBFiniteType(mv, indexMap, sourceType, targetType);
-                // TODO fix below properly - rajith
-                //} else if (sourceType is bir:BXMLType && targetType is bir:BMapType) {
-                //    generateXMLToAttributesMap(mv, sourceType);
-                //    return;
-                //} else if (targetType is bir:BFiniteType) {
-                //    generateCheckCastToFiniteType(mv, sourceType, targetType);
-                //    return;
-                //} else if (sourceType is bir:BRecordType && (targetType is bir:BMapType && targetType.constraint
-                // is bir:BTypeAny)) {
-                //    // do nothing
-            }
+            switch (targetType.tag) {
+                case TypeTags.FLOAT:
+                    generateCheckCastJToBFloat(mv, sourceType);
+                    break;
+                case TypeTags.DECIMAL:
+                    generateCheckCastJToBDecimal(mv, sourceType);
+                    break;
+                case TypeTags.BOOLEAN:
+                    generateCheckCastJToBBoolean(mv, sourceType);
+                    break;
+                case TypeTags.BYTE:
+                    generateCheckCastJToBByte(mv, sourceType);
+                    break;
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    // Do nothing
+                    break;
+                default:
+                    if (targetType.tag == TypeTags.UNION) {
+                        generateCheckCastJToBUnionType(mv, indexMap, sourceType, (BUnionType) targetType);
+                    } else if (targetType.tag == TypeTags.ANYDATA) {
+                        generateCheckCastJToBAnyData(mv, indexMap, sourceType);
+                    } else if (targetType.tag == TypeTags.HANDLE) {
+                        generateJCastToBHandle(mv, sourceType);
+                    } else if (targetType.tag == TypeTags.ANY) {
+                        generateJCastToBAny(mv, indexMap, sourceType, targetType);
+                    } else if (targetType.tag == TypeTags.JSON) {
+                        generateCheckCastJToBJSON(mv, indexMap, sourceType);
+                    } else if (targetType.tag == TypeTags.FINITE) {
+                        generateCheckCastJToBFiniteType(mv, indexMap, sourceType, targetType);
+                        // TODO fix below properly - rajith
+                        //} else if (sourceType is bir:BXMLType && targetType is bir:BMapType) {
+                        //    generateXMLToAttributesMap(mv, sourceType);
+                        //    return;
+                        //} else if (targetType is bir:BFiniteType) {
+                        //    generateCheckCastToFiniteType(mv, sourceType, targetType);
+                        //    return;
+                        //} else if (sourceType is bir:BRecordType && (targetType is bir:BMapType &&
+                        // targetType.constraint
+                        // is bir:BTypeAny)) {
+                        //    // do nothing
+                    }
 
-            checkCast(mv, targetType);
-            String targetTypeClass = getTargetClass(targetType);
-            if (targetTypeClass != null) {
-                mv.visitTypeInsn(CHECKCAST, targetTypeClass);
+                    checkCast(mv, targetType);
+                    String targetTypeClass = getTargetClass(targetType);
+                    if (targetTypeClass != null) {
+                        mv.visitTypeInsn(CHECKCAST, targetTypeClass);
+                    }
+                    break;
             }
         }
     }
 
     private static void generateCheckCastJToBInt(MethodVisitor mv, JType sourceType) {
 
-        if (sourceType.jTag == JTypeTags.JBYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.jTag == JTypeTags.JCHAR) {
-            mv.visitInsn(I2L);
-        } else if (sourceType.jTag == JTypeTags.JSHORT) {
-            mv.visitInsn(I2L);
-        } else if (sourceType.jTag == JTypeTags.JINT) {
-            mv.visitInsn(I2L);
-        } else if (sourceType.jTag == JTypeTags.JLONG) {
-            // do nothing
-            // According to the spec doc, below two are not needed
-            // } else if (sourceType is jvm:JFloat) {
-            //     mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "jFloatToBInt", "(F)J", false);
-            // } else if (sourceType is jvm:JDouble) {
-            //     mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "jDoubleToBInt", "(D)J", false);
-        } else if (sourceType.jTag == JTypeTags.JREF) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJLong", String.format("(L%s;)J", OBJECT), false);
-        } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'", sourceType));
+        switch (sourceType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2L);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitInsn(I2L);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitInsn(I2L);
+                break;
+            case JTypeTags.JINT:
+                mv.visitInsn(I2L);
+                break;
+            case JTypeTags.JLONG:
+                // do nothing
+                // According to the spec doc, below two are not needed
+                // } else if (sourceType is jvm:JFloat) {
+                //     mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "jFloatToBInt", "(F)J", false);
+                // } else if (sourceType is jvm:JDouble) {
+                //     mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "jDoubleToBInt", "(D)J", false);
+                break;
+            case JTypeTags.JREF:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJLong", String.format("(L%s;)J", OBJECT), false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
+                        sourceType));
         }
     }
 
     private static void generateCheckCastJToBFloat(MethodVisitor mv, JType sourceType) {
 
-        if (sourceType.jTag == JTypeTags.JBYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2D);
-        } else if (sourceType.jTag == JTypeTags.JCHAR) {
-            mv.visitInsn(I2D);
-        } else if (sourceType.jTag == JTypeTags.JSHORT) {
-            mv.visitInsn(I2D);
-        } else if (sourceType.jTag == JTypeTags.JINT) {
-            mv.visitInsn(I2D);
-        } else if (sourceType.jTag == JTypeTags.JLONG) {
-            mv.visitInsn(L2D);
-        } else if (sourceType.jTag == JTypeTags.JFLOAT) {
-            mv.visitInsn(F2D);
-        } else if (sourceType.jTag == JTypeTags.JDOUBLE) {
-            // do nothing
-        } else if (sourceType.jTag == JTypeTags.JREF) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJDouble", String.format("(L%s;)D", OBJECT), false);
-        } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
-                    sourceType));
+        switch (sourceType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                mv.visitInsn(I2D);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitInsn(I2D);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitInsn(I2D);
+                break;
+            case JTypeTags.JINT:
+                mv.visitInsn(I2D);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitInsn(L2D);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitInsn(F2D);
+                break;
+            case JTypeTags.JDOUBLE:
+                // do nothing
+                break;
+            case JTypeTags.JREF:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJDouble", String.format("(L%s;)D", OBJECT), false);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
+                        sourceType));
         }
     }
 
     private static void generateCheckCastJToBDecimal(MethodVisitor mv, JType sourceType) {
 
-        if (sourceType.jTag == JTypeTags.JBYTE) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(B)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JCHAR) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(C)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JSHORT) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(S)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JINT) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(I)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JLONG) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(J)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JFLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(F)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(D)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JREF) {
-            mv.visitTypeInsn(CHECKCAST, DECIMAL_VALUE);
-        } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
-                    sourceType));
+        switch (sourceType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(B)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(C)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(S)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JINT:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(I)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(J)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(F)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOfJ", String.format("(D)L%s;", DECIMAL_VALUE),
+                        false);
+                break;
+            case JTypeTags.JREF:
+                mv.visitTypeInsn(CHECKCAST, DECIMAL_VALUE);
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
+                        sourceType));
         }
     }
 
@@ -506,83 +612,100 @@ public class JvmCastGen {
     private static void generateJCastToBAny(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, JType sourceType,
                                             BType targetType) {
 
-        if (sourceType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "valueOf", String.format("(Z)L%s;", BOOLEAN_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JBYTE) {
-            mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JCHAR) {
-            mv.visitInsn(I2L);
-            mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JSHORT) {
-            mv.visitInsn(I2L);
-            mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JINT) {
-            mv.visitInsn(I2L);
-            mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JLONG) {
-            mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JFLOAT) {
-            mv.visitInsn(F2D);
-            mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE), false);
-        } else if (sourceType.jTag == JTypeTags.JREF) {
-            Label afterHandle = new Label();
-            if (((JType.JRefType) sourceType).typeValue.equals(OBJECT)) {
+        switch (sourceType.jTag) {
+            case JTypeTags.JBOOLEAN:
+                mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "valueOf", String.format("(Z)L%s;", BOOLEAN_VALUE),
+                        false);
+                break;
+            case JTypeTags.JBYTE:
+                mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitInsn(I2L);
+                mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitInsn(I2L);
+                mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
+                break;
+            case JTypeTags.JINT:
+                mv.visitInsn(I2L);
+                mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitInsn(F2D);
+                mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE),
+                        false);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE),
+                        false);
+                break;
+            case JTypeTags.JREF:
+                Label afterHandle = new Label();
+                if (((JType.JRefType) sourceType).typeValue.equals(OBJECT)) {
+                    mv.visitInsn(DUP);
+                    mv.visitTypeInsn(INSTANCEOF, ERROR_VALUE);
+                    mv.visitJumpInsn(IFNE, afterHandle);
+
+                    mv.visitInsn(DUP);
+                    mv.visitTypeInsn(INSTANCEOF, NUMBER);
+                    mv.visitJumpInsn(IFNE, afterHandle);
+
+                    mv.visitInsn(DUP);
+                    mv.visitTypeInsn(INSTANCEOF, BOOLEAN_VALUE);
+                    mv.visitJumpInsn(IFNE, afterHandle);
+
+                    mv.visitInsn(DUP);
+                    mv.visitTypeInsn(INSTANCEOF, SIMPLE_VALUE);
+                    mv.visitJumpInsn(IFNE, afterHandle);
+                }
+
+                if (isNillable(targetType)) {
+                    mv.visitInsn(DUP);
+                    mv.visitJumpInsn(IFNULL, afterHandle);
+                }
+
                 mv.visitInsn(DUP);
-                mv.visitTypeInsn(INSTANCEOF, ERROR_VALUE);
+                mv.visitTypeInsn(INSTANCEOF, REF_VALUE);
                 mv.visitJumpInsn(IFNE, afterHandle);
 
+                BIRVariableDcl retJObjectVarDcl = new BIRVariableDcl(null, symbolTable.anyType,
+                        new Name("$_ret_jobject_val_$"), VarScope.FUNCTION, VarKind.LOCAL, "");
+                int returnJObjectVarRefIndex = indexMap.getIndex(retJObjectVarDcl);
+                mv.visitVarInsn(ASTORE, returnJObjectVarRefIndex);
+                mv.visitTypeInsn(NEW, HANDLE_VALUE);
                 mv.visitInsn(DUP);
-                mv.visitTypeInsn(INSTANCEOF, NUMBER);
-                mv.visitJumpInsn(IFNE, afterHandle);
-
-                mv.visitInsn(DUP);
-                mv.visitTypeInsn(INSTANCEOF, BOOLEAN_VALUE);
-                mv.visitJumpInsn(IFNE, afterHandle);
-
-                mv.visitInsn(DUP);
-                mv.visitTypeInsn(INSTANCEOF, SIMPLE_VALUE);
-                mv.visitJumpInsn(IFNE, afterHandle);
-            }
-
-            if (isNillable(targetType)) {
-                mv.visitInsn(DUP);
-                mv.visitJumpInsn(IFNULL, afterHandle);
-            }
-
-            mv.visitInsn(DUP);
-            mv.visitTypeInsn(INSTANCEOF, REF_VALUE);
-            mv.visitJumpInsn(IFNE, afterHandle);
-
-            BIRVariableDcl retJObjectVarDcl = new BIRVariableDcl(null, symbolTable.anyType,
-                    new Name("$_ret_jobject_val_$"), VarScope.FUNCTION, VarKind.LOCAL, "");
-            int returnJObjectVarRefIndex = indexMap.getIndex(retJObjectVarDcl);
-            mv.visitVarInsn(ASTORE, returnJObjectVarRefIndex);
-            mv.visitTypeInsn(NEW, HANDLE_VALUE);
-            mv.visitInsn(DUP);
-            mv.visitVarInsn(ALOAD, returnJObjectVarRefIndex);
-            mv.visitMethodInsn(INVOKESPECIAL, HANDLE_VALUE, "<init>", "(Ljava/lang/Object;)V", false);
-            mv.visitLabel(afterHandle);
-        } else if (sourceType.jTag == JTypeTags.JARRAY) {
-            // do nothing
-        } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'any'", sourceType));
+                mv.visitVarInsn(ALOAD, returnJObjectVarRefIndex);
+                mv.visitMethodInsn(INVOKESPECIAL, HANDLE_VALUE, "<init>", "(Ljava/lang/Object;)V", false);
+                mv.visitLabel(afterHandle);
+                break;
+            case JTypeTags.JARRAY:
+                // do nothing
+                break;
+            default:
+                throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'any'",
+                        sourceType));
         }
     }
 
     private static boolean isNillable(BType targetType) {
 
-        if (targetType.tag == TypeTags.NIL ||
-                targetType.tag == TypeTags.NEVER ||
-                targetType.tag == TypeTags.JSON ||
-                targetType.tag == TypeTags.ANY ||
-                targetType.tag == TypeTags.ANYDATA) {
-            return true;
-        } else if (targetType.tag == TypeTags.UNION || targetType.tag == TypeTags.INTERSECTION) {
-            return targetType.isNullable();
-        } else if (targetType.tag == TypeTags.FINITE) {
-            return targetType.isNullable();
+        switch (targetType.tag) {
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.JSON:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+                return true;
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+                return targetType.isNullable();
+            case TypeTags.FINITE:
+                return targetType.isNullable();
         }
 
         return false;
@@ -610,78 +733,83 @@ public class JvmCastGen {
 
     static void generateCheckCast(MethodVisitor mv, BType sourceType, BType targetType, BIRVarToJVMIndexMap indexMap) {
 
-        if (targetType.tag == TypeTags.INT) {
-            generateCheckCastToInt(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.SIGNED32_INT) {
-            generateCheckCastToSigned32(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.SIGNED16_INT) {
-            generateCheckCastToSigned16(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.SIGNED8_INT) {
-            generateCheckCastToSigned8(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.UNSIGNED32_INT) {
-            generateCheckCastToUnsigned32(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.UNSIGNED16_INT) {
-            generateCheckCastToUnsigned16(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.UNSIGNED8_INT) {
-            generateCheckCastToUnsigned8(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.FLOAT) {
-            generateCheckCastToFloat(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.STRING) {
-            generateCheckCastToString(mv, sourceType, indexMap);
-            return;
-        } else if (targetType.tag == TypeTags.CHAR_STRING) {
-            generateCheckCastToChar(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.DECIMAL) {
-            generateCheckCastToDecimal(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.BOOLEAN) {
-            generateCheckCastToBoolean(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.BYTE) {
-            generateCheckCastToByte(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.NIL || targetType.tag == TypeTags.NEVER) {
-            checkCast(mv, targetType);
-            return;
-        } else if (targetType.tag == TypeTags.UNION) {
-            generateCheckCastToUnionType(mv, sourceType, (BUnionType) targetType);
-            return;
-        } else if (targetType.tag == TypeTags.INTERSECTION) {
-            generateCheckCast(mv, sourceType, ((BIntersectionType) targetType).effectiveType, indexMap);
-            return;
-        } else if (targetType.tag == TypeTags.ANYDATA) {
-            generateCheckCastToAnyData(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.ANY) {
-            generateCastToAny(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.JSON) {
-            generateCheckCastToJSON(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.READONLY) {
-            generateCheckCastToReadonlyType(mv, sourceType, targetType);
-            return;
-        } else if (TypeTags.isXMLTypeTag(sourceType.tag) && targetType.tag == TypeTags.MAP) {
+        if (TypeTags.isXMLTypeTag(sourceType.tag) && targetType.tag == TypeTags.MAP) {
             generateXMLToAttributesMap(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.FINITE) {
-            generateCheckCastToFiniteType(mv, sourceType, (BFiniteType) targetType);
             return;
         } else if (sourceType.tag == TypeTags.RECORD && (targetType.tag == TypeTags.MAP
                 && ((BMapType) targetType).constraint.tag == TypeTags.ANY)) {
             // do nothing
         } else {
-            // do the ballerina checkcast
-            checkCast(mv, targetType);
+            switch (targetType.tag) {
+                case TypeTags.INT:
+                    generateCheckCastToInt(mv, sourceType);
+                    return;
+                case TypeTags.SIGNED32_INT:
+                    generateCheckCastToSigned32(mv, sourceType);
+                    return;
+                case TypeTags.SIGNED16_INT:
+                    generateCheckCastToSigned16(mv, sourceType);
+                    return;
+                case TypeTags.SIGNED8_INT:
+                    generateCheckCastToSigned8(mv, sourceType);
+                    return;
+                case TypeTags.UNSIGNED32_INT:
+                    generateCheckCastToUnsigned32(mv, sourceType);
+                    return;
+                case TypeTags.UNSIGNED16_INT:
+                    generateCheckCastToUnsigned16(mv, sourceType);
+                    return;
+                case TypeTags.UNSIGNED8_INT:
+                    generateCheckCastToUnsigned8(mv, sourceType);
+                    return;
+                case TypeTags.FLOAT:
+                    generateCheckCastToFloat(mv, sourceType);
+                    return;
+                case TypeTags.STRING:
+                    generateCheckCastToString(mv, sourceType, indexMap);
+                    return;
+                case TypeTags.CHAR_STRING:
+                    generateCheckCastToChar(mv, sourceType);
+                    return;
+                case TypeTags.DECIMAL:
+                    generateCheckCastToDecimal(mv, sourceType);
+                    return;
+                case TypeTags.BOOLEAN:
+                    generateCheckCastToBoolean(mv, sourceType);
+                    return;
+                case TypeTags.BYTE:
+                    generateCheckCastToByte(mv, sourceType);
+                    return;
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    checkCast(mv, targetType);
+                    return;
+                case TypeTags.UNION:
+                    generateCheckCastToUnionType(mv, sourceType, (BUnionType) targetType);
+                    return;
+                case TypeTags.INTERSECTION:
+                    generateCheckCast(mv, sourceType, ((BIntersectionType) targetType).effectiveType, indexMap);
+                    return;
+                case TypeTags.ANYDATA:
+                    generateCheckCastToAnyData(mv, sourceType);
+                    return;
+                case TypeTags.ANY:
+                    generateCastToAny(mv, sourceType);
+                    return;
+                case TypeTags.JSON:
+                    generateCheckCastToJSON(mv, sourceType);
+                    return;
+                case TypeTags.READONLY:
+                    generateCheckCastToReadonlyType(mv, sourceType, targetType);
+                    return;
+                case TypeTags.FINITE:
+                    generateCheckCastToFiniteType(mv, sourceType, (BFiniteType) targetType);
+                    return;
+                default:
+                    // do the ballerina checkcast
+                    checkCast(mv, targetType);
+                    break;
+            }
         }
 
         // cast to the specific java class
@@ -695,21 +823,28 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             // do nothing
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToInt", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'", sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToInt", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
+                            sourceType));
+            }
         }
     }
 
@@ -717,22 +852,29 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned32", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned32", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned32", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int:Signed32'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned32", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned32", String.format("(L%s;)J", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                            "to 'int:Signed32'", sourceType));
+            }
         }
     }
 
@@ -740,22 +882,29 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned16", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned16", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned16", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int:Signed16'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned16", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned16", String.format("(L%s;)J", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                            "to 'int:Signed16'", sourceType));
+            }
         }
     }
 
@@ -763,23 +912,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned8", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned8", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned8", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned8", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int:Signed8'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToSigned8", "(J)J", false);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToSigned8", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToSigned8", String.format("(L%s;)J", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s'" +
+                            " to 'int:Signed8'", sourceType));
+            }
         }
     }
 
@@ -787,22 +943,29 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToUnsigned32", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned32", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned32", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int:Unsigned32'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned32", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned32", String.format("(L%s;)J", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to " +
+                            "'int:Unsigned32'", sourceType));
+            }
         }
     }
 
@@ -810,22 +973,29 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToUnsigned16", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned16", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned16", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int:Unsigned16'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned16", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned16", String.format("(L%s;)J", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                                    "to 'int:Unsigned16'", sourceType));
+            }
         }
     }
 
@@ -833,66 +1003,89 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToUnsigned8", "(J)J", false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned8", "(D)J", false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned8", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int:Unsigned8'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToUnsigned8", "(D)J", false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToUnsigned8", String.format("(L%s;)J", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' " +
+                                    "to 'int:Unsigned8'", sourceType));
+            }
         }
     }
 
     private static void generateCheckCastToFloat(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.FLOAT) {
-            // do nothing
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitInsn(L2D);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2D);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.DECIMAL ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.FLOAT:
+                    // do nothing
+                    break;
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2D);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.DECIMAL:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCheckCastToDecimal(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.DECIMAL) {
-            // do nothing
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
-                    String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(J)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(I)L%s;", DECIMAL_VALUE), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.DECIMAL:
+                    // do nothing
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
+                            String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE),
+                            false);
+                    break;
+                case TypeTags.BYTE:
+                    mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(I)L%s;", DECIMAL_VALUE),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
+                            sourceType));
+            }
         }
     }
 
@@ -901,26 +1094,35 @@ public class JvmCastGen {
         if (TypeTags.isStringTypeTag(sourceType.tag)) {
             // do nothing
             return;
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.JSON ||
-                sourceType.tag == TypeTags.FINITE) {
-            checkCast(mv, symbolTable.stringType);
-            mv.visitTypeInsn(CHECKCAST, B_STRING_VALUE);
-            return;
         } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "toString", String.format("(J)L%s;", STRING_VALUE), false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "toString", String.format("(D)L%s;", STRING_VALUE), false);
-        } else if (sourceType.tag == TypeTags.BOOLEAN) {
-            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "toString", String.format("(Z)L%s;", STRING_VALUE), false);
-        } else if (sourceType.tag == TypeTags.DECIMAL) {
-            mv.visitMethodInsn(INVOKESTATIC, STRING_VALUE, "valueOf", String.format("(L%s;)L%s;", OBJECT, STRING_VALUE),
-                    false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'string'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    checkCast(mv, symbolTable.stringType);
+                    mv.visitTypeInsn(CHECKCAST, B_STRING_VALUE);
+                    return;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "toString", String.format("(D)L%s;", STRING_VALUE),
+                            false);
+                    break;
+                case TypeTags.BOOLEAN:
+                    mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "toString", String.format("(Z)L%s;", STRING_VALUE),
+                            false);
+                    break;
+                case TypeTags.DECIMAL:
+                    mv.visitMethodInsn(INVOKESTATIC, STRING_VALUE, "valueOf", String.format("(L%s;)L%s;", OBJECT,
+                            STRING_VALUE),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'string'",
+                            sourceType));
+            }
         }
 
         generateNonBMPStringValue(mv, indexMap);
@@ -981,20 +1183,30 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "intToByte", "(J)I", false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToByte", "(D)I", false);
-        } else if (sourceType.tag == TypeTags.DECIMAL) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT), false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            // do nothing
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.FINITE ||
-                sourceType.tag == TypeTags.JSON) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'byte'", sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToByte", "(D)I", false);
+                    break;
+                case TypeTags.DECIMAL:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
+                            false);
+                    break;
+                case TypeTags.BYTE:
+                    // do nothing
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.FINITE:
+                case TypeTags.JSON:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToByte", String.format("(L%s;)I", OBJECT),
+                            false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'byte'",
+                            sourceType));
+            }
         }
     }
 
@@ -1038,32 +1250,48 @@ public class JvmCastGen {
     static String getTargetClass(BType targetType) {
 
         String targetTypeClass;
-        if (targetType.tag == TypeTags.ARRAY || targetType.tag == TypeTags.TUPLE) {
-            targetTypeClass = ARRAY_VALUE;
-        } else if (targetType.tag == TypeTags.MAP) {
-            targetTypeClass = MAP_VALUE;
-        } else if (targetType.tag == TypeTags.TABLE) {
-            targetTypeClass = TABLE_VALUE_IMPL;
-        } else if (targetType.tag == TypeTags.RECORD) {
-            targetTypeClass = MAP_VALUE;
-        } else if (targetType.tag == TypeTags.STREAM) {
-            targetTypeClass = STREAM_VALUE;
-        } else if (targetType.tag == TypeTags.OBJECT) {
-            targetTypeClass = OBJECT_VALUE;
-        } else if (targetType.tag == TypeTags.ERROR) {
-            targetTypeClass = ERROR_VALUE;
-        } else if (TypeTags.isXMLTypeTag(targetType.tag)) {
+
+        if (TypeTags.isXMLTypeTag(targetType.tag)) {
             targetTypeClass = XML_VALUE;
-        } else if (targetType.tag == TypeTags.TYPEDESC) {
-            targetTypeClass = TYPEDESC_VALUE;
-        } else if (targetType.tag == TypeTags.INVOKABLE) {
-            targetTypeClass = FUNCTION_POINTER;
-        } else if (targetType.tag == TypeTags.FUTURE) {
-            targetTypeClass = FUTURE_VALUE;
-        } else if (targetType.tag == TypeTags.HANDLE) {
-            targetTypeClass = HANDLE_VALUE;
         } else {
-            return null;
+            switch (targetType.tag) {
+                case TypeTags.ARRAY:
+                case TypeTags.TUPLE:
+                    targetTypeClass = ARRAY_VALUE;
+                    break;
+                case TypeTags.MAP:
+                    targetTypeClass = MAP_VALUE;
+                    break;
+                case TypeTags.TABLE:
+                    targetTypeClass = TABLE_VALUE_IMPL;
+                    break;
+                case TypeTags.RECORD:
+                    targetTypeClass = MAP_VALUE;
+                    break;
+                case TypeTags.STREAM:
+                    targetTypeClass = STREAM_VALUE;
+                    break;
+                case TypeTags.OBJECT:
+                    targetTypeClass = OBJECT_VALUE;
+                    break;
+                case TypeTags.ERROR:
+                    targetTypeClass = ERROR_VALUE;
+                    break;
+                case TypeTags.TYPEDESC:
+                    targetTypeClass = TYPEDESC_VALUE;
+                    break;
+                case TypeTags.INVOKABLE:
+                    targetTypeClass = FUNCTION_POINTER;
+                    break;
+                case TypeTags.FUTURE:
+                    targetTypeClass = FUTURE_VALUE;
+                    break;
+                case TypeTags.HANDLE:
+                    targetTypeClass = HANDLE_VALUE;
+                    break;
+                default:
+                    return null;
+            }
         }
 
         return targetTypeClass;
@@ -1090,36 +1318,39 @@ public class JvmCastGen {
         if (TypeTags.isIntegerTypeTag(targetType.tag)) {
             generateCastToInt(mv, sourceType);
             return;
-        } else if (targetType.tag == TypeTags.FLOAT) {
-            generateCastToFloat(mv, sourceType);
-            return;
         } else if (TypeTags.isStringTypeTag(targetType.tag)) {
             generateCastToString(mv, sourceType);
             return;
-        } else if (targetType.tag == TypeTags.BOOLEAN) {
-            generateCastToBoolean(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.BYTE) {
-            generateCastToByte(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.DECIMAL) {
-            generateCastToDecimal(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.NIL || targetType.tag == TypeTags.NEVER) {
-            // do nothing
-            return;
-        } else if (targetType.tag == TypeTags.UNION ||
-                targetType.tag == TypeTags.ANYDATA ||
-                targetType.tag == TypeTags.ANY ||
-                targetType.tag == TypeTags.JSON ||
-                targetType.tag == TypeTags.FINITE) {
-            generateCastToAny(mv, sourceType);
-            return;
-        } else if (targetType.tag == TypeTags.INTERSECTION) {
-            generateCast(mv, sourceType, ((BIntersectionType) targetType).effectiveType);
-            return;
+        } else {
+            switch (targetType.tag) {
+                case TypeTags.FLOAT:
+                    generateCastToFloat(mv, sourceType);
+                    return;
+                case TypeTags.BOOLEAN:
+                    generateCastToBoolean(mv, sourceType);
+                    return;
+                case TypeTags.BYTE:
+                    generateCastToByte(mv, sourceType);
+                    return;
+                case TypeTags.DECIMAL:
+                    generateCastToDecimal(mv, sourceType);
+                    return;
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    // do nothing
+                    return;
+                case TypeTags.UNION:
+                case TypeTags.ANYDATA:
+                case TypeTags.ANY:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                    generateCastToAny(mv, sourceType);
+                    return;
+                case TypeTags.INTERSECTION:
+                    generateCast(mv, sourceType, ((BIntersectionType) targetType).effectiveType);
+                    return;
+            }
         }
-
         // cast to the specific java class
         String targetTypeClass = getTargetClass(targetType);
         if (targetTypeClass != null) {
@@ -1131,17 +1362,24 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             // do nothing
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitInsn(I2L);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(D2L);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.JSON) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'", sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(I2L);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(D2L);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.JSON:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToInt", String.format("(L%s;)J", OBJECT), false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'int'",
+                            sourceType));
+            }
         }
     }
 
@@ -1168,38 +1406,53 @@ public class JvmCastGen {
             // do nothing
         } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "toString", String.format("(J)L%s;", STRING_VALUE), false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "toString", String.format("(D)L%s;", STRING_VALUE), false);
-        } else if (sourceType.tag == TypeTags.BOOLEAN) {
-            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "toString", String.format("(Z)L%s;", STRING_VALUE), false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.JSON) {
-            mv.visitTypeInsn(CHECKCAST, B_STRING_VALUE);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'string'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "toString", String.format("(D)L%s;", STRING_VALUE),
+                            false);
+                    break;
+                case TypeTags.BOOLEAN:
+                    mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "toString", String.format("(Z)L%s;", STRING_VALUE),
+                            false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.JSON:
+                    mv.visitTypeInsn(CHECKCAST, B_STRING_VALUE);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'string'",
+                            sourceType));
+            }
         }
     }
 
     private static void generateCastToDecimal(MethodVisitor mv, BType sourceType) {
 
-        if (sourceType.tag == TypeTags.DECIMAL) {
-            // do nothing
-        } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
+        if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(J)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE), false);
-        } else if (sourceType.tag == TypeTags.ANY ||
-                sourceType.tag == TypeTags.ANYDATA ||
-                sourceType.tag == TypeTags.UNION ||
-                sourceType.tag == TypeTags.JSON) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
-                    String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
         } else {
-            throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
-                    sourceType));
+            switch (sourceType.tag) {
+                case TypeTags.DECIMAL:
+                    // do nothing
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, DECIMAL_VALUE, "valueOf", String.format("(D)L%s;", DECIMAL_VALUE),
+                            false);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.JSON:
+                    mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
+                            String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
+                    break;
+                default:
+                    throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'decimal'",
+                            sourceType));
+            }
         }
     }
 
@@ -1239,12 +1492,20 @@ public class JvmCastGen {
 
         if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
             mv.visitMethodInsn(INVOKESTATIC, LONG_VALUE, "valueOf", String.format("(J)L%s;", LONG_VALUE), false);
-        } else if (sourceType.tag == TypeTags.BYTE) {
-            mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
-        } else if (sourceType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE), false);
-        } else if (sourceType.tag == TypeTags.BOOLEAN) {
-            mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "valueOf", String.format("(Z)L%s;", BOOLEAN_VALUE), false);
+        } else {
+            switch (sourceType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKESTATIC, DOUBLE_VALUE, "valueOf", String.format("(D)L%s;", DOUBLE_VALUE),
+                            false);
+                    break;
+                case TypeTags.BOOLEAN:
+                    mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, "valueOf", String.format("(Z)L%s;", BOOLEAN_VALUE),
+                            false);
+                    break;
+            }
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
@@ -107,7 +107,7 @@ public class JvmErrorGen {
                         THROWABLE, ERROR_VALUE), false);
                 jvmInstructionGen.generateVarStore(this.mv, retVarDcl, this.currentPackageName, retIndex);
                 BIRTerminator.Return term = catchIns.term;
-                termGen.genReturnTerm(term, retIndex, func, -1);
+                termGen.genReturnTerm(term, retIndex, func);
                 this.mv.visitJumpInsn(GOTO, jumpLabel);
             }
             if (!exeptionExist) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -352,6 +352,7 @@ public class JvmInstructionGen {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             long intValue = constVal instanceof Long ? (long) constVal : Long.parseLong(String.valueOf(constVal));
             mv.visitLdcInsn(intValue);
+            return;
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             String val = String.valueOf(constVal);
             int[] highSurrogates = listHighSurrogates(val);
@@ -360,37 +361,38 @@ public class JvmInstructionGen {
             } else {
                 createBmpString(mv, val);
             }
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    int byteValue = ((Number) constVal).intValue();
-                    mv.visitLdcInsn(byteValue);
-                    break;
-                case TypeTags.FLOAT:
-                    double doubleValue = constVal instanceof Double ? (double) constVal :
-                            Double.parseDouble(String.valueOf(constVal));
-                    mv.visitLdcInsn(doubleValue);
-                    break;
-                case TypeTags.BOOLEAN:
-                    boolean booleanVal = constVal instanceof Boolean ? (boolean) constVal :
-                            Boolean.parseBoolean(String.valueOf(constVal));
-                    mv.visitLdcInsn(booleanVal);
-                    break;
-                case TypeTags.DECIMAL:
-                    mv.visitTypeInsn(NEW, DECIMAL_VALUE);
-                    mv.visitInsn(DUP);
-                    mv.visitLdcInsn(String.valueOf(constVal));
-                    mv.visitMethodInsn(INVOKESPECIAL, DECIMAL_VALUE, "<init>", String.format("(L%s;)V",
-                            STRING_VALUE), false);
-                    break;
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                    mv.visitInsn(ACONST_NULL);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type : " +
-                            String.format("%s", bType));
-            }
+            return;
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                int byteValue = ((Number) constVal).intValue();
+                mv.visitLdcInsn(byteValue);
+                break;
+            case TypeTags.FLOAT:
+                double doubleValue = constVal instanceof Double ? (double) constVal :
+                        Double.parseDouble(String.valueOf(constVal));
+                mv.visitLdcInsn(doubleValue);
+                break;
+            case TypeTags.BOOLEAN:
+                boolean booleanVal = constVal instanceof Boolean ? (boolean) constVal :
+                        Boolean.parseBoolean(String.valueOf(constVal));
+                mv.visitLdcInsn(booleanVal);
+                break;
+            case TypeTags.DECIMAL:
+                mv.visitTypeInsn(NEW, DECIMAL_VALUE);
+                mv.visitInsn(DUP);
+                mv.visitLdcInsn(String.valueOf(constVal));
+                mv.visitMethodInsn(INVOKESPECIAL, DECIMAL_VALUE, "<init>", String.format("(L%s;)V",
+                        STRING_VALUE), false);
+                break;
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+                mv.visitInsn(ACONST_NULL);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type : " +
+                        String.format("%s", bType));
         }
     }
 
@@ -499,53 +501,55 @@ public class JvmInstructionGen {
 
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitVarInsn(LLOAD, valueIndex);
+            return;
         }  else if (TypeTags.isXMLTypeTag(bType.tag) ||
                 TypeTags.isStringTypeTag(bType.tag)) {
             mv.visitVarInsn(ALOAD, valueIndex);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitVarInsn(ILOAD, valueIndex);
-                    mv.visitInsn(I2B);
-                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitVarInsn(DLOAD, valueIndex);
-                    break;
-                case TypeTags.BOOLEAN:
-                    mv.visitVarInsn(ILOAD, valueIndex);
-                    break;
-                case TypeTags.ARRAY:
-                case TypeTags.MAP:
-                case TypeTags.STREAM:
-                case TypeTags.TABLE:
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.TUPLE:
-                case TypeTags.RECORD:
-                case TypeTags.ERROR:
-                case TypeTags.JSON:
-                case TypeTags.FUTURE:
-                case TypeTags.OBJECT:
-                case TypeTags.DECIMAL:
-                case TypeTags.INVOKABLE:
-                case TypeTags.FINITE:
-                case TypeTags.HANDLE:
-                case TypeTags.TYPEDESC:
-                case TypeTags.READONLY:
-                    mv.visitVarInsn(ALOAD, valueIndex);
-                    break;
-                case JTypeTags.JTYPE:
-                    generateJVarLoad(mv, (JType) bType, currentPackageName, valueIndex);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", bType));
-            }
+            return;
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                mv.visitInsn(I2B);
+                mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitVarInsn(DLOAD, valueIndex);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                break;
+            case TypeTags.ARRAY:
+            case TypeTags.MAP:
+            case TypeTags.STREAM:
+            case TypeTags.TABLE:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.TUPLE:
+            case TypeTags.RECORD:
+            case TypeTags.ERROR:
+            case TypeTags.JSON:
+            case TypeTags.FUTURE:
+            case TypeTags.OBJECT:
+            case TypeTags.DECIMAL:
+            case TypeTags.INVOKABLE:
+            case TypeTags.FINITE:
+            case TypeTags.HANDLE:
+            case TypeTags.TYPEDESC:
+            case TypeTags.READONLY:
+                mv.visitVarInsn(ALOAD, valueIndex);
+                break;
+            case JTypeTags.JTYPE:
+                generateJVarLoad(mv, (JType) bType, currentPackageName, valueIndex);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 
@@ -572,51 +576,53 @@ public class JvmInstructionGen {
 
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitVarInsn(LSTORE, valueIndex);
+            return;
         } else if (TypeTags.isStringTypeTag(bType.tag) ||
                 TypeTags.isXMLTypeTag(bType.tag)) {
             mv.visitVarInsn(ASTORE, valueIndex);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitVarInsn(ISTORE, valueIndex);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitVarInsn(DSTORE, valueIndex);
-                    break;
-                case TypeTags.BOOLEAN:
-                    mv.visitVarInsn(ISTORE, valueIndex);
-                    break;
-                case TypeTags.ARRAY:
-                case TypeTags.MAP:
-                case TypeTags.STREAM:
-                case TypeTags.TABLE:
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.TUPLE:
-                case TypeTags.DECIMAL:
-                case TypeTags.RECORD:
-                case TypeTags.ERROR:
-                case TypeTags.JSON:
-                case TypeTags.FUTURE:
-                case TypeTags.OBJECT:
-                case TypeTags.INVOKABLE:
-                case TypeTags.FINITE:
-                case TypeTags.HANDLE:
-                case TypeTags.TYPEDESC:
-                case TypeTags.READONLY:
-                    mv.visitVarInsn(ASTORE, valueIndex);
-                    break;
-                case JTypeTags.JTYPE:
-                    generateJVarStore(mv, (JType) bType, currentPackageName, valueIndex);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", bType));
-            }
+            return;
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitVarInsn(DSTORE, valueIndex);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case TypeTags.ARRAY:
+            case TypeTags.MAP:
+            case TypeTags.STREAM:
+            case TypeTags.TABLE:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.TUPLE:
+            case TypeTags.DECIMAL:
+            case TypeTags.RECORD:
+            case TypeTags.ERROR:
+            case TypeTags.JSON:
+            case TypeTags.FUTURE:
+            case TypeTags.OBJECT:
+            case TypeTags.INVOKABLE:
+            case TypeTags.FINITE:
+            case TypeTags.HANDLE:
+            case TypeTags.TYPEDESC:
+            case TypeTags.READONLY:
+                mv.visitVarInsn(ASTORE, valueIndex);
+                break;
+            case JTypeTags.JTYPE:
+                generateJVarStore(mv, (JType) bType, currentPackageName, valueIndex);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -223,76 +223,110 @@ public class JvmInstructionGen {
         if (jType == null) {
             return;
         }
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJByte", String.format("(L%s;)B", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJChar", String.format("(L%s;)C", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJShort", String.format("(L%s;)S", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJInt", String.format("(L%s;)I", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJLong", String.format("(L%s;)J", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJFloat", String.format("(L%s;)F", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJDouble", String.format("(L%s;)D", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJBoolean", String.format("(L%s;)Z", OBJECT), false);
-        } else if (jType.jTag == JTypeTags.JREF) {
-            mv.visitTypeInsn(CHECKCAST, ((JType.JRefType) jType).typeValue);
+
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJByte", String.format("(L%s;)B", OBJECT), false);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJChar", String.format("(L%s;)C", OBJECT), false);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJShort", String.format("(L%s;)S", OBJECT), false);
+                break;
+            case JTypeTags.JINT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJInt", String.format("(L%s;)I", OBJECT), false);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJLong", String.format("(L%s;)J", OBJECT), false);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJFloat", String.format("(L%s;)F", OBJECT), false);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJDouble", String.format("(L%s;)D", OBJECT), false);
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToJBoolean", String.format("(L%s;)Z", OBJECT),
+                        false);
+                break;
+            case JTypeTags.JREF:
+                mv.visitTypeInsn(CHECKCAST, ((JType.JRefType) jType).typeValue);
+                break;
         }
     }
 
     private static void generateJVarLoad(MethodVisitor mv, JType jType, String currentPackageName, int valueIndex) {
 
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitVarInsn(LLOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitVarInsn(FLOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitVarInsn(DLOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-        } else if (jType.jTag == JTypeTags.JARRAY ||
-                jType.jTag == JTypeTags.JREF) {
-            mv.visitVarInsn(ALOAD, valueIndex);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", jType));
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                break;
+            case JTypeTags.JINT:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitVarInsn(LLOAD, valueIndex);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitVarInsn(FLOAD, valueIndex);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitVarInsn(DLOAD, valueIndex);
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitVarInsn(ILOAD, valueIndex);
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                mv.visitVarInsn(ALOAD, valueIndex);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", jType));
         }
     }
 
     private static void generateJVarStore(MethodVisitor mv, JType jType, String currentPackageName, int valueIndex) {
 
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitVarInsn(LSTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitVarInsn(FSTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitVarInsn(DSTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (jType.jTag == JTypeTags.JARRAY ||
-                jType.jTag == JTypeTags.JREF) {
-            mv.visitVarInsn(ASTORE, valueIndex);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", jType));
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case JTypeTags.JINT:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitVarInsn(LSTORE, valueIndex);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitVarInsn(FSTORE, valueIndex);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitVarInsn(DSTORE, valueIndex);
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitVarInsn(ISTORE, valueIndex);
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                mv.visitVarInsn(ASTORE, valueIndex);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", jType));
         }
     }
 
@@ -318,17 +352,6 @@ public class JvmInstructionGen {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             long intValue = constVal instanceof Long ? (long) constVal : Long.parseLong(String.valueOf(constVal));
             mv.visitLdcInsn(intValue);
-        } else if (bType.tag == TypeTags.BYTE) {
-            int byteValue = ((Number) constVal).intValue();
-            mv.visitLdcInsn(byteValue);
-        } else if (bType.tag == TypeTags.FLOAT) {
-            double doubleValue = constVal instanceof Double ? (double) constVal :
-                    Double.parseDouble(String.valueOf(constVal));
-            mv.visitLdcInsn(doubleValue);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            boolean booleanVal = constVal instanceof Boolean ? (boolean) constVal :
-                    Boolean.parseBoolean(String.valueOf(constVal));
-            mv.visitLdcInsn(booleanVal);
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             String val = String.valueOf(constVal);
             int[] highSurrogates = listHighSurrogates(val);
@@ -337,16 +360,37 @@ public class JvmInstructionGen {
             } else {
                 createBmpString(mv, val);
             }
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            mv.visitTypeInsn(NEW, DECIMAL_VALUE);
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn(String.valueOf(constVal));
-            mv.visitMethodInsn(INVOKESPECIAL, DECIMAL_VALUE, "<init>", String.format("(L%s;)V", STRING_VALUE), false);
-        } else if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
-            mv.visitInsn(ACONST_NULL);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type : " +
-                                                     String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    int byteValue = ((Number) constVal).intValue();
+                    mv.visitLdcInsn(byteValue);
+                    break;
+                case TypeTags.FLOAT:
+                    double doubleValue = constVal instanceof Double ? (double) constVal :
+                            Double.parseDouble(String.valueOf(constVal));
+                    mv.visitLdcInsn(doubleValue);
+                    break;
+                case TypeTags.BOOLEAN:
+                    boolean booleanVal = constVal instanceof Boolean ? (boolean) constVal :
+                            Boolean.parseBoolean(String.valueOf(constVal));
+                    mv.visitLdcInsn(booleanVal);
+                    break;
+                case TypeTags.DECIMAL:
+                    mv.visitTypeInsn(NEW, DECIMAL_VALUE);
+                    mv.visitInsn(DUP);
+                    mv.visitLdcInsn(String.valueOf(constVal));
+                    mv.visitMethodInsn(INVOKESPECIAL, DECIMAL_VALUE, "<init>", String.format("(L%s;)V",
+                            STRING_VALUE), false);
+                    break;
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    mv.visitInsn(ACONST_NULL);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type : " +
+                            String.format("%s", bType));
+            }
         }
     }
 
@@ -426,69 +470,82 @@ public class JvmInstructionGen {
 
         BType bType = varDcl.type;
 
-        if (varDcl.kind == VarKind.GLOBAL) {
-            BIRNode.BIRGlobalVariableDcl globalVar = (BIRNode.BIRGlobalVariableDcl) varDcl;
-            PackageID modId = globalVar.pkgId;
-            String moduleName = getPackageName(modId.orgName, modId.name, modId.version);
+        switch (varDcl.kind) {
+            case GLOBAL: {
+                BIRNode.BIRGlobalVariableDcl globalVar = (BIRNode.BIRGlobalVariableDcl) varDcl;
+                PackageID modId = globalVar.pkgId;
+                String moduleName = getPackageName(modId.orgName, modId.name, modId.version);
 
-            String varName = varDcl.name.value;
-            String className = jvmPackageGen.lookupGlobalVarClassName(moduleName, varName);
+                String varName = varDcl.name.value;
+                String className = jvmPackageGen.lookupGlobalVarClassName(moduleName, varName);
 
-            String typeSig = getTypeDesc(bType);
-            mv.visitFieldInsn(GETSTATIC, className, varName, typeSig);
-            return;
-        } else if (varDcl.kind == VarKind.SELF) {
-            mv.visitVarInsn(ALOAD, 0);
-            return;
-        } else if (varDcl.kind == VarKind.CONSTANT) {
-            String varName = varDcl.name.value;
-            PackageID moduleId = ((BIRNode.BIRGlobalVariableDcl) varDcl).pkgId;
-            String pkgName = getPackageName(moduleId.orgName, moduleId.name, moduleId.version);
-            String className = jvmPackageGen.lookupGlobalVarClassName(pkgName, varName);
-            String typeSig = getTypeDesc(bType);
-            mv.visitFieldInsn(GETSTATIC, className, varName, typeSig);
-            return;
+                String typeSig = getTypeDesc(bType);
+                mv.visitFieldInsn(GETSTATIC, className, varName, typeSig);
+                return;
+            }
+            case SELF:
+                mv.visitVarInsn(ALOAD, 0);
+                return;
+            case CONSTANT: {
+                String varName = varDcl.name.value;
+                PackageID moduleId = ((BIRNode.BIRGlobalVariableDcl) varDcl).pkgId;
+                String pkgName = getPackageName(moduleId.orgName, moduleId.name, moduleId.version);
+                String className = jvmPackageGen.lookupGlobalVarClassName(pkgName, varName);
+                String typeSig = getTypeDesc(bType);
+                mv.visitFieldInsn(GETSTATIC, className, varName, typeSig);
+                return;
+            }
         }
 
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitVarInsn(LLOAD, valueIndex);
-        } else if (bType.tag == TypeTags.BYTE) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-            mv.visitInsn(I2B);
-            mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
-        } else if (bType.tag == TypeTags.FLOAT) {
-            mv.visitVarInsn(DLOAD, valueIndex);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            mv.visitVarInsn(ILOAD, valueIndex);
-        } else if (bType.tag == TypeTags.ARRAY ||
-                TypeTags.isStringTypeTag(bType.tag) ||
-                bType.tag == TypeTags.MAP ||
-                bType.tag == TypeTags.STREAM ||
-                bType.tag == TypeTags.TABLE ||
-                bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.NIL ||
-                bType.tag == TypeTags.NEVER ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.TUPLE ||
-                bType.tag == TypeTags.RECORD ||
-                bType.tag == TypeTags.ERROR ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FUTURE ||
-                bType.tag == TypeTags.OBJECT ||
-                bType.tag == TypeTags.DECIMAL ||
-                TypeTags.isXMLTypeTag(bType.tag) ||
-                bType.tag == TypeTags.INVOKABLE ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.HANDLE ||
-                bType.tag == TypeTags.TYPEDESC ||
-                bType.tag == TypeTags.READONLY) {
+        }  else if (TypeTags.isXMLTypeTag(bType.tag) ||
+                TypeTags.isStringTypeTag(bType.tag)) {
             mv.visitVarInsn(ALOAD, valueIndex);
-        } else if (bType.tag == JTypeTags.JTYPE) {
-            generateJVarLoad(mv, (JType) bType, currentPackageName, valueIndex);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitVarInsn(ILOAD, valueIndex);
+                    mv.visitInsn(I2B);
+                    mv.visitMethodInsn(INVOKESTATIC, "java/lang/Byte", "toUnsignedInt", "(B)I", false);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitVarInsn(DLOAD, valueIndex);
+                    break;
+                case TypeTags.BOOLEAN:
+                    mv.visitVarInsn(ILOAD, valueIndex);
+                    break;
+                case TypeTags.ARRAY:
+                case TypeTags.MAP:
+                case TypeTags.STREAM:
+                case TypeTags.TABLE:
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.TUPLE:
+                case TypeTags.RECORD:
+                case TypeTags.ERROR:
+                case TypeTags.JSON:
+                case TypeTags.FUTURE:
+                case TypeTags.OBJECT:
+                case TypeTags.DECIMAL:
+                case TypeTags.INVOKABLE:
+                case TypeTags.FINITE:
+                case TypeTags.HANDLE:
+                case TypeTags.TYPEDESC:
+                case TypeTags.READONLY:
+                    mv.visitVarInsn(ALOAD, valueIndex);
+                    break;
+                case JTypeTags.JTYPE:
+                    generateJVarLoad(mv, (JType) bType, currentPackageName, valueIndex);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", bType));
+            }
         }
     }
 
@@ -515,42 +572,51 @@ public class JvmInstructionGen {
 
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitVarInsn(LSTORE, valueIndex);
-        } else if (bType.tag == TypeTags.BYTE) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (bType.tag == TypeTags.FLOAT) {
-            mv.visitVarInsn(DSTORE, valueIndex);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            mv.visitVarInsn(ISTORE, valueIndex);
-        } else if (bType.tag == TypeTags.ARRAY ||
-                TypeTags.isStringTypeTag(bType.tag) ||
-                bType.tag == TypeTags.MAP ||
-                bType.tag == TypeTags.STREAM ||
-                bType.tag == TypeTags.TABLE ||
-                bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.NIL ||
-                bType.tag == TypeTags.NEVER ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.TUPLE ||
-                bType.tag == TypeTags.DECIMAL ||
-                bType.tag == TypeTags.RECORD ||
-                bType.tag == TypeTags.ERROR ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FUTURE ||
-                bType.tag == TypeTags.OBJECT ||
-                bType.tag == TypeTags.SERVICE ||
-                TypeTags.isXMLTypeTag(bType.tag) ||
-                bType.tag == TypeTags.INVOKABLE ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.HANDLE ||
-                bType.tag == TypeTags.TYPEDESC ||
-                bType.tag == TypeTags.READONLY) {
+        } else if (TypeTags.isStringTypeTag(bType.tag) ||
+                TypeTags.isXMLTypeTag(bType.tag)) {
             mv.visitVarInsn(ASTORE, valueIndex);
-        } else if (bType.tag == JTypeTags.JTYPE) {
-            generateJVarStore(mv, (JType) bType, currentPackageName, valueIndex);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitVarInsn(ISTORE, valueIndex);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitVarInsn(DSTORE, valueIndex);
+                    break;
+                case TypeTags.BOOLEAN:
+                    mv.visitVarInsn(ISTORE, valueIndex);
+                    break;
+                case TypeTags.ARRAY:
+                case TypeTags.MAP:
+                case TypeTags.STREAM:
+                case TypeTags.TABLE:
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.TUPLE:
+                case TypeTags.DECIMAL:
+                case TypeTags.RECORD:
+                case TypeTags.ERROR:
+                case TypeTags.JSON:
+                case TypeTags.FUTURE:
+                case TypeTags.OBJECT:
+                case TypeTags.INVOKABLE:
+                case TypeTags.FINITE:
+                case TypeTags.HANDLE:
+                case TypeTags.TYPEDESC:
+                case TypeTags.READONLY:
+                    mv.visitVarInsn(ASTORE, valueIndex);
+                    break;
+                case JTypeTags.JTYPE:
+                    generateJVarStore(mv, (JType) bType, currentPackageName, valueIndex);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", bType));
+            }
         }
     }
 
@@ -745,16 +811,17 @@ public class JvmInstructionGen {
 
     private String getDecimalCompareFuncName(int opcode) {
 
-        if (opcode == IFGT) {
-            return "checkDecimalGreaterThan";
-        } else if (opcode == IFGE) {
-            return "checkDecimalGreaterThanOrEqual";
-        } else if (opcode == IFLT) {
-            return "checkDecimalLessThan";
-        } else if (opcode == IFLE) {
-            return "checkDecimalLessThanOrEqual";
-        } else {
-            throw new BLangCompilerException(String.format("Opcode: '%s' is not a comparison opcode.", opcode));
+        switch (opcode) {
+            case IFGT:
+                return "checkDecimalGreaterThan";
+            case IFGE:
+                return "checkDecimalGreaterThanOrEqual";
+            case IFLT:
+                return "checkDecimalLessThan";
+            case IFLE:
+                return "checkDecimalLessThanOrEqual";
+            default:
+                throw new BLangCompilerException(String.format("Opcode: '%s' is not a comparison opcode.", opcode));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1839,7 +1839,7 @@ public class JvmInstructionGen {
         this.loadVar(xmlAttrStoreIns.rhsOp.variableDcl);
 
         // invoke setAttribute() method
-            String signature = String.format("(L%s;L%s;)V", BXML_QNAME, JvmConstants.B_STRING_VALUE);
+        String signature = String.format("(L%s;L%s;)V", BXML_QNAME, JvmConstants.B_STRING_VALUE);
         this.mv.visitMethodInsn(INVOKEVIRTUAL, XML_VALUE, "setAttribute", signature, false);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -264,89 +264,105 @@ public class JvmMethodGen {
             if (TypeTags.isIntegerTypeTag(bType.tag)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
                 mv.visitVarInsn(LSTORE, index);
-            } else if (bType.tag == TypeTags.BYTE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-                mv.visitVarInsn(ISTORE, index);
-            } else if (bType.tag == TypeTags.FLOAT) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
-                mv.visitVarInsn(DSTORE, index);
             } else if (TypeTags.isStringTypeTag(bType.tag)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                  String.format("L%s;", JvmConstants.B_STRING_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.DECIMAL) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", DECIMAL_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.BOOLEAN) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
-                mv.visitVarInsn(ISTORE, index);
-            } else if (bType.tag == TypeTags.MAP || bType.tag == TypeTags.RECORD) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", MAP_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.STREAM) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", STREAM_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.TABLE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", TABLE_VALUE_IMPL));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.ARRAY ||
-                    bType.tag == TypeTags.TUPLE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", ARRAY_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.OBJECT) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", OBJECT_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.ERROR) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", ERROR_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.FUTURE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", FUTURE_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.TABLE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", TABLE_VALUE_IMPL));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.INVOKABLE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", FUNCTION_POINTER));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.TYPEDESC) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", TYPEDESC_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.NIL ||
-                    bType.tag == TypeTags.NEVER ||
-                    bType.tag == TypeTags.ANY ||
-                    bType.tag == TypeTags.ANYDATA ||
-                    bType.tag == TypeTags.UNION ||
-                    bType.tag == TypeTags.INTERSECTION ||
-                    bType.tag == TypeTags.JSON ||
-                    bType.tag == TypeTags.FINITE ||
-                    bType.tag == TypeTags.READONLY) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", OBJECT));
+                        String.format("L%s;", JvmConstants.B_STRING_VALUE));
                 mv.visitVarInsn(ASTORE, index);
             } else if (TypeTags.isXMLTypeTag(bType.tag)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
                         String.format("L%s;", XML_VALUE));
                 mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == TypeTags.HANDLE) {
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", HANDLE_VALUE));
-                mv.visitVarInsn(ASTORE, index);
-            } else if (bType.tag == JTypeTags.JTYPE) {
-                generateFrameClassJFieldLoad(localVar, mv, index, frameName);
             } else {
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", bType));
+                switch (bType.tag) {
+                    case TypeTags.BYTE:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                        mv.visitVarInsn(ISTORE, index);
+                        break;
+                    case TypeTags.FLOAT:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
+                        mv.visitVarInsn(DSTORE, index);
+                        break;
+                    case TypeTags.DECIMAL:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", DECIMAL_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.BOOLEAN:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
+                        mv.visitVarInsn(ISTORE, index);
+                        break;
+                    case TypeTags.MAP:
+                    case TypeTags.RECORD:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", MAP_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.STREAM:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", STREAM_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.TABLE:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", TABLE_VALUE_IMPL));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.ARRAY:
+                    case TypeTags.TUPLE:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", ARRAY_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.OBJECT:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", OBJECT_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.ERROR:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", ERROR_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.FUTURE:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", FUTURE_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.INVOKABLE:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", FUNCTION_POINTER));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.TYPEDESC:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", TYPEDESC_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.NIL:
+                    case TypeTags.NEVER:
+                    case TypeTags.ANY:
+                    case TypeTags.ANYDATA:
+                    case TypeTags.UNION:
+                    case TypeTags.INTERSECTION:
+                    case TypeTags.JSON:
+                    case TypeTags.FINITE:
+                    case TypeTags.READONLY:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", OBJECT));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case TypeTags.HANDLE:
+                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", HANDLE_VALUE));
+                        mv.visitVarInsn(ASTORE, index);
+                        break;
+                    case JTypeTags.JTYPE:
+                        generateFrameClassJFieldLoad(localVar, mv, index, frameName);
+                        break;
+                    default:
+                        throw new BLangCompilerException("JVM generation is not supported for type " +
+                                String.format("%s", bType));
+                }
             }
             k = k + 1;
         }
@@ -358,36 +374,47 @@ public class JvmMethodGen {
 
         JType jType = (JType) localVar.type;
 
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
-            mv.visitVarInsn(LSTORE, index);
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "F");
-            mv.visitVarInsn(FSTORE, index);
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
-            mv.visitVarInsn(DSTORE, index);
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JARRAY ||
-                jType.jTag == JTypeTags.JREF) {
-            mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), getJTypeSignature(jType));
-            mv.visitVarInsn(ASTORE, index);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", jType));
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JINT:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
+                mv.visitVarInsn(LSTORE, index);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "F");
+                mv.visitVarInsn(FSTORE, index);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
+                mv.visitVarInsn(DSTORE, index);
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), getJTypeSignature(jType));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", jType));
         }
     }
 
@@ -404,87 +431,106 @@ public class JvmMethodGen {
             if (TypeTags.isIntegerTypeTag(bType.tag)) {
                 mv.visitVarInsn(LLOAD, index);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
-            } else if (bType.tag == TypeTags.BYTE) {
-                mv.visitVarInsn(ILOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-            } else if (bType.tag == TypeTags.FLOAT) {
-                mv.visitVarInsn(DLOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
             } else if (TypeTags.isStringTypeTag(bType.tag)) {
                 mv.visitVarInsn(ALOAD, index);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                  String.format("L%s;", JvmConstants.B_STRING_VALUE));
-            } else if (bType.tag == TypeTags.DECIMAL) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", DECIMAL_VALUE));
-            } else if (bType.tag == TypeTags.BOOLEAN) {
-                mv.visitVarInsn(ILOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
-            } else if (bType.tag == TypeTags.MAP ||
-                    bType.tag == TypeTags.RECORD) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", MAP_VALUE));
-            } else if (bType.tag == TypeTags.STREAM) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", STREAM_VALUE));
-            } else if (bType.tag == TypeTags.TABLE) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", TABLE_VALUE_IMPL));
-            } else if (bType.tag == TypeTags.ARRAY ||
-                    bType.tag == TypeTags.TUPLE) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", ARRAY_VALUE));
-            } else if (bType.tag == TypeTags.ERROR) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", ERROR_VALUE));
-            } else if (bType.tag == TypeTags.FUTURE) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", FUTURE_VALUE));
-            } else if (bType.tag == TypeTags.TYPEDESC) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitTypeInsn(CHECKCAST, TYPEDESC_VALUE);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", TYPEDESC_VALUE));
-            } else if (bType.tag == TypeTags.OBJECT) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", OBJECT_VALUE));
-            } else if (bType.tag == TypeTags.INVOKABLE) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", FUNCTION_POINTER));
-            } else if (bType.tag == TypeTags.NIL ||
-                    bType.tag == TypeTags.NEVER ||
-                    bType.tag == TypeTags.ANY ||
-                    bType.tag == TypeTags.ANYDATA ||
-                    bType.tag == TypeTags.UNION ||
-                    bType.tag == TypeTags.INTERSECTION ||
-                    bType.tag == TypeTags.JSON ||
-                    bType.tag == TypeTags.FINITE ||
-                    bType.tag == TypeTags.READONLY) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", OBJECT));
+                        String.format("L%s;", JvmConstants.B_STRING_VALUE));
             } else if (TypeTags.isXMLTypeTag(bType.tag)) {
                 mv.visitVarInsn(ALOAD, index);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
                         String.format("L%s;", XML_VALUE));
-            } else if (bType.tag == TypeTags.HANDLE) {
-                mv.visitVarInsn(ALOAD, index);
-                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", HANDLE_VALUE));
-            } else if (bType.tag == JTypeTags.JTYPE) {
-                generateFrameClassJFieldUpdate(localVar, mv, index, frameName);
             } else {
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", bType));
+                switch (bType.tag) {
+                    case TypeTags.BYTE:
+                        mv.visitVarInsn(ILOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                        break;
+                    case TypeTags.FLOAT:
+                        mv.visitVarInsn(DLOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
+                        break;
+                    case TypeTags.DECIMAL:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", DECIMAL_VALUE));
+                        break;
+                    case TypeTags.BOOLEAN:
+                        mv.visitVarInsn(ILOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
+                        break;
+                    case TypeTags.MAP:
+                    case TypeTags.RECORD:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", MAP_VALUE));
+                        break;
+                    case TypeTags.STREAM:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", STREAM_VALUE));
+                        break;
+                    case TypeTags.TABLE:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", TABLE_VALUE_IMPL));
+                        break;
+                    case TypeTags.ARRAY:
+                    case TypeTags.TUPLE:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", ARRAY_VALUE));
+                        break;
+                    case TypeTags.ERROR:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", ERROR_VALUE));
+                        break;
+                    case TypeTags.FUTURE:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", FUTURE_VALUE));
+                        break;
+                    case TypeTags.TYPEDESC:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitTypeInsn(CHECKCAST, TYPEDESC_VALUE);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", TYPEDESC_VALUE));
+                        break;
+                    case TypeTags.OBJECT:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", OBJECT_VALUE));
+                        break;
+                    case TypeTags.INVOKABLE:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", FUNCTION_POINTER));
+                        break;
+                    case TypeTags.NIL:
+                    case TypeTags.NEVER:
+                    case TypeTags.ANY:
+                    case TypeTags.ANYDATA:
+                    case TypeTags.UNION:
+                    case TypeTags.INTERSECTION:
+                    case TypeTags.JSON:
+                    case TypeTags.FINITE:
+                    case TypeTags.READONLY:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", OBJECT));
+                        break;
+                    case TypeTags.HANDLE:
+                        mv.visitVarInsn(ALOAD, index);
+                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                String.format("L%s;", HANDLE_VALUE));
+                        break;
+                    case JTypeTags.JTYPE:
+                        generateFrameClassJFieldUpdate(localVar, mv, index, frameName);
+                        break;
+                    default:
+                        throw new BLangCompilerException("JVM generation is not supported for type " +
+                                String.format("%s", bType));
+                }
             }
             k = k + 1;
         }
@@ -494,38 +540,50 @@ public class JvmMethodGen {
                                                        int index, String frameName) {
 
         JType jType = (JType) localVar.type;
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitVarInsn(ILOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "B");
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitVarInsn(ILOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "C");
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitVarInsn(ILOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "S");
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitVarInsn(ILOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitVarInsn(LLOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitVarInsn(FLOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "F");
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitVarInsn(DLOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitVarInsn(ILOAD, index);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
-        } else if (jType.jTag == JTypeTags.JARRAY || jType.jTag == JTypeTags.JREF) {
-            String classSig = getJTypeSignature(jType);
-            String className = getSignatureForJType(jType);
-            mv.visitVarInsn(ALOAD, index);
-            mv.visitTypeInsn(CHECKCAST, className);
-            mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), classSig);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", jType));
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "B");
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "C");
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "S");
+                break;
+            case JTypeTags.JINT:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                break;
+            case JTypeTags.JLONG:
+                mv.visitVarInsn(LLOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitVarInsn(FLOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "F");
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitVarInsn(DLOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                String classSig = getJTypeSignature(jType);
+                String className = getSignatureForJType(jType);
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitTypeInsn(CHECKCAST, className);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), classSig);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", jType));
         }
     }
 
@@ -534,54 +592,75 @@ public class JvmMethodGen {
         String jvmType = "";
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             jvmType = "J";
-        } else if (bType.tag == TypeTags.BYTE) {
-            jvmType = "I";
-        } else if (bType.tag == TypeTags.FLOAT) {
-            jvmType = "D";
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            jvmType = "Z";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             jvmType = String.format("L%s;", STRING_VALUE);
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            jvmType = String.format("L%s;", DECIMAL_VALUE);
-        } else if (bType.tag == TypeTags.MAP || bType.tag == TypeTags.RECORD) {
-            jvmType = String.format("L%s;", MAP_VALUE);
-        } else if (bType.tag == TypeTags.STREAM) {
-            jvmType = String.format("L%s;", STREAM_VALUE);
-        } else if (bType.tag == TypeTags.TABLE) {
-            jvmType = String.format("L%s;", TABLE_VALUE_IMPL);
-        } else if (bType.tag == TypeTags.ARRAY ||
-                bType.tag == TypeTags.TUPLE) {
-            jvmType = String.format("L%s;", ARRAY_VALUE);
-        } else if (bType.tag == TypeTags.OBJECT) {
-            jvmType = String.format("L%s;", OBJECT_VALUE);
-        } else if (bType.tag == TypeTags.ERROR) {
-            jvmType = String.format("L%s;", ERROR_VALUE);
-        } else if (bType.tag == TypeTags.FUTURE) {
-            jvmType = String.format("L%s;", FUTURE_VALUE);
-        } else if (bType.tag == TypeTags.INVOKABLE) {
-            jvmType = String.format("L%s;", FUNCTION_POINTER);
-        } else if (bType.tag == TypeTags.HANDLE) {
-            jvmType = String.format("L%s;", HANDLE_VALUE);
-        } else if (bType.tag == TypeTags.TYPEDESC) {
-            jvmType = String.format("L%s;", TYPEDESC_VALUE);
-        } else if (bType.tag == TypeTags.NIL
-                || bType.tag == TypeTags.NEVER
-                || bType.tag == TypeTags.ANY
-                || bType.tag == TypeTags.ANYDATA
-                || bType.tag == TypeTags.UNION
-                || bType.tag == TypeTags.INTERSECTION
-                || bType.tag == TypeTags.JSON
-                || bType.tag == TypeTags.FINITE
-                || bType.tag == TypeTags.READONLY) {
-            jvmType = String.format("L%s;", OBJECT);
-        } else if (bType.tag == JTypeTags.JTYPE) {
-            jvmType = getJTypeSignature((JType) bType);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             jvmType = String.format("L%s;", XML_VALUE);
         } else {
-            throw new BLangCompilerException("JVM code generation is not supported for type " +
-                    String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    jvmType = "I";
+                    break;
+                case TypeTags.FLOAT:
+                    jvmType = "D";
+                    break;
+                case TypeTags.BOOLEAN:
+                    jvmType = "Z";
+                    break;
+                case TypeTags.DECIMAL:
+                    jvmType = String.format("L%s;", DECIMAL_VALUE);
+                    break;
+                case TypeTags.MAP:
+                case TypeTags.RECORD:
+                    jvmType = String.format("L%s;", MAP_VALUE);
+                    break;
+                case TypeTags.STREAM:
+                    jvmType = String.format("L%s;", STREAM_VALUE);
+                    break;
+                case TypeTags.TABLE:
+                    jvmType = String.format("L%s;", TABLE_VALUE_IMPL);
+                    break;
+                case TypeTags.ARRAY:
+                case TypeTags.TUPLE:
+                    jvmType = String.format("L%s;", ARRAY_VALUE);
+                    break;
+                case TypeTags.OBJECT:
+                    jvmType = String.format("L%s;", OBJECT_VALUE);
+                    break;
+                case TypeTags.ERROR:
+                    jvmType = String.format("L%s;", ERROR_VALUE);
+                    break;
+                case TypeTags.FUTURE:
+                    jvmType = String.format("L%s;", FUTURE_VALUE);
+                    break;
+                case TypeTags.INVOKABLE:
+                    jvmType = String.format("L%s;", FUNCTION_POINTER);
+                    break;
+                case TypeTags.HANDLE:
+                    jvmType = String.format("L%s;", HANDLE_VALUE);
+                    break;
+                case TypeTags.TYPEDESC:
+                    jvmType = String.format("L%s;", TYPEDESC_VALUE);
+                    break;
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                case TypeTags.READONLY:
+                    jvmType = String.format("L%s;", OBJECT);
+                    break;
+                case JTypeTags.JTYPE:
+                    jvmType = getJTypeSignature((JType) bType);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM code generation is not supported for type " +
+                            String.format("%s", bType));
+            }
+
         }
         return jvmType;
     }
@@ -864,83 +943,105 @@ public class JvmMethodGen {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitInsn(LCONST_0);
             mv.visitVarInsn(LSTORE, index);
-        } else if (bType.tag == TypeTags.BYTE) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (bType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(DCONST_0);
-            mv.visitVarInsn(DSTORE, index);
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             mv.visitInsn(ACONST_NULL);
             mv.visitVarInsn(ASTORE, index);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (bType.tag == TypeTags.MAP ||
-                bType.tag == TypeTags.ARRAY ||
-                bType.tag == TypeTags.STREAM ||
-                bType.tag == TypeTags.TABLE ||
-                bType.tag == TypeTags.ERROR ||
-                bType.tag == TypeTags.NIL ||
-                bType.tag == TypeTags.NEVER ||
-                bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.OBJECT ||
-                bType.tag == TypeTags.CHAR_STRING ||
-                bType.tag == TypeTags.DECIMAL ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.RECORD ||
-                bType.tag == TypeTags.TUPLE ||
-                bType.tag == TypeTags.FUTURE ||
-                bType.tag == TypeTags.JSON ||
-                TypeTags.isXMLTypeTag(bType.tag) ||
-                bType.tag == TypeTags.INVOKABLE ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.HANDLE ||
-                bType.tag == TypeTags.TYPEDESC ||
-                bType.tag == TypeTags.READONLY) {
+        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             mv.visitInsn(ACONST_NULL);
             mv.visitVarInsn(ASTORE, index);
-        } else if (bType.tag == JTypeTags.JTYPE) {
-            genJDefaultValue(mv, (JType) bType, index);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    mv.visitInsn(ICONST_0);
+                    mv.visitVarInsn(ISTORE, index);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitInsn(DCONST_0);
+                    mv.visitVarInsn(DSTORE, index);
+                    break;
+                case TypeTags.BOOLEAN:
+                    mv.visitInsn(ICONST_0);
+                    mv.visitVarInsn(ISTORE, index);
+                    break;
+                case TypeTags.MAP:
+                case TypeTags.ARRAY:
+                case TypeTags.STREAM:
+                case TypeTags.TABLE:
+                case TypeTags.ERROR:
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.OBJECT:
+                case TypeTags.CHAR_STRING:
+                case TypeTags.DECIMAL:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.RECORD:
+                case TypeTags.TUPLE:
+                case TypeTags.FUTURE:
+                case TypeTags.JSON:
+                case TypeTags.INVOKABLE:
+                case TypeTags.FINITE:
+                case TypeTags.HANDLE:
+                case TypeTags.TYPEDESC:
+                case TypeTags.READONLY:
+                    mv.visitInsn(ACONST_NULL);
+                    mv.visitVarInsn(ASTORE, index);
+                    break;
+                case JTypeTags.JTYPE:
+                    genJDefaultValue(mv, (JType) bType, index);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", bType));
+            }
         }
     }
 
     private static void genJDefaultValue(MethodVisitor mv, JType jType, int index) {
 
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitInsn(LCONST_0);
-            mv.visitVarInsn(LSTORE, index);
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitInsn(FCONST_0);
-            mv.visitVarInsn(FSTORE, index);
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitInsn(DCONST_0);
-            mv.visitVarInsn(DSTORE, index);
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitInsn(ICONST_0);
-            mv.visitVarInsn(ISTORE, index);
-        } else if (jType.jTag == JTypeTags.JARRAY ||
-                jType.jTag == JTypeTags.JREF) {
-            mv.visitInsn(ACONST_NULL);
-            mv.visitVarInsn(ASTORE, index);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", jType));
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JINT:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitInsn(LCONST_0);
+                mv.visitVarInsn(LSTORE, index);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitInsn(FCONST_0);
+                mv.visitVarInsn(FSTORE, index);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitInsn(DCONST_0);
+                mv.visitVarInsn(DSTORE, index);
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                mv.visitInsn(ACONST_NULL);
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", jType));
         }
     }
 
@@ -983,27 +1084,38 @@ public class JvmMethodGen {
 
     private static void loadDefaultJValue(MethodVisitor mv, JType jType) {
 
-        if (jType.jTag == JTypeTags.JBYTE) {
-            mv.visitInsn(ICONST_0);
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            mv.visitInsn(ICONST_0);
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            mv.visitInsn(ICONST_0);
-        } else if (jType.jTag == JTypeTags.JINT) {
-            mv.visitInsn(ICONST_0);
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            mv.visitInsn(LCONST_0);
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            mv.visitInsn(FCONST_0);
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitInsn(DCONST_0);
-        } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitInsn(ICONST_0);
-        } else if (jType.jTag == JTypeTags.JARRAY ||
-                jType.jTag == JTypeTags.JREF) {
-            mv.visitInsn(ACONST_NULL);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", jType));
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                mv.visitInsn(ICONST_0);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitInsn(ICONST_0);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitInsn(ICONST_0);
+                break;
+            case JTypeTags.JINT:
+                mv.visitInsn(ICONST_0);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitInsn(LCONST_0);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitInsn(FCONST_0);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitInsn(DCONST_0);
+                break;
+            case JTypeTags.JBOOLEAN:
+                mv.visitInsn(ICONST_0);
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                mv.visitInsn(ACONST_NULL);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", jType));
         }
     }
 
@@ -1052,50 +1164,57 @@ public class JvmMethodGen {
 
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             return "J";
-        } else if (bType.tag == TypeTags.BYTE) {
-            return "I";
-        } else if (bType.tag == TypeTags.FLOAT) {
-            return "D";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             return String.format("L%s;", B_STRING_VALUE);
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            return String.format("L%s;", DECIMAL_VALUE);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            return "Z";
-        } else if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
-            return String.format("L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.ARRAY || bType.tag == TypeTags.TUPLE) {
-            return String.format("L%s;", ARRAY_VALUE);
-        } else if (bType.tag == TypeTags.ERROR) {
-            return String.format("L%s;", ERROR_VALUE);
-        } else if (bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.READONLY) {
-            return String.format("L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.MAP || bType.tag == TypeTags.RECORD) {
-            return String.format("L%s;", MAP_VALUE);
-        } else if (bType.tag == TypeTags.FUTURE) {
-            return String.format("L%s;", FUTURE_VALUE);
-        } else if (bType.tag == TypeTags.STREAM) {
-            return String.format("L%s;", STREAM_VALUE);
-        } else if (bType.tag == TypeTags.TABLE) {
-            return String.format("L%s;", TABLE_VALUE_IMPL);
-        } else if (bType.tag == TypeTags.INVOKABLE) {
-            return String.format("L%s;", FUNCTION_POINTER);
-        } else if (bType.tag == TypeTags.TYPEDESC) {
-            return String.format("L%s;", TYPEDESC_VALUE);
-        } else if (bType.tag == TypeTags.OBJECT) {
-            return String.format("L%s;", OBJECT_VALUE);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             return String.format("L%s;", XML_VALUE);
-        } else if (bType.tag == TypeTags.HANDLE) {
-            return String.format("L%s;", HANDLE_VALUE);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    return "I";
+                case TypeTags.FLOAT:
+                    return "D";
+                case TypeTags.DECIMAL:
+                    return String.format("L%s;", DECIMAL_VALUE);
+                case TypeTags.BOOLEAN:
+                    return "Z";
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    return String.format("L%s;", OBJECT);
+                case TypeTags.ARRAY:
+                case TypeTags.TUPLE:
+                    return String.format("L%s;", ARRAY_VALUE);
+                case TypeTags.ERROR:
+                    return String.format("L%s;", ERROR_VALUE);
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                case TypeTags.ANY:
+                case TypeTags.READONLY:
+                    return String.format("L%s;", OBJECT);
+                case TypeTags.MAP:
+                case TypeTags.RECORD:
+                    return String.format("L%s;", MAP_VALUE);
+                case TypeTags.FUTURE:
+                    return String.format("L%s;", FUTURE_VALUE);
+                case TypeTags.STREAM:
+                    return String.format("L%s;", STREAM_VALUE);
+                case TypeTags.TABLE:
+                    return String.format("L%s;", TABLE_VALUE_IMPL);
+                case TypeTags.INVOKABLE:
+                    return String.format("L%s;", FUNCTION_POINTER);
+                case TypeTags.TYPEDESC:
+                    return String.format("L%s;", TYPEDESC_VALUE);
+                case TypeTags.OBJECT:
+                    return String.format("L%s;", OBJECT_VALUE);
+                case TypeTags.HANDLE:
+                    return String.format("L%s;", HANDLE_VALUE);
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", bType));
+            }
         }
     }
 
@@ -1109,51 +1228,54 @@ public class JvmMethodGen {
             return String.format(")L%s;", OBJECT);
         } else if (TypeTags.isIntegerTypeTag(bType.tag)) {
             return ")J";
-        } else if (bType.tag == TypeTags.BYTE) {
-            return ")I";
-        } else if (bType.tag == TypeTags.FLOAT) {
-            return ")D";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             return String.format(")L%s;", B_STRING_VALUE);
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            return String.format(")L%s;", DECIMAL_VALUE);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            return ")Z";
-        } else if (bType.tag == TypeTags.ARRAY ||
-                bType.tag == TypeTags.TUPLE) {
-            return String.format(")L%s;", ARRAY_VALUE);
-        } else if (bType.tag == TypeTags.MAP ||
-                bType.tag == TypeTags.RECORD) {
-            return String.format(")L%s;", MAP_VALUE);
-        } else if (bType.tag == TypeTags.ERROR) {
-            return String.format(")L%s;", ERROR_VALUE);
-        } else if (bType.tag == TypeTags.STREAM) {
-            return String.format(")L%s;", STREAM_VALUE);
-        } else if (bType.tag == TypeTags.TABLE) {
-            return String.format(")L%s;", TABLE_VALUE_IMPL);
-        } else if (bType.tag == TypeTags.FUTURE) {
-            return String.format(")L%s;", FUTURE_VALUE);
-        } else if (bType.tag == TypeTags.TYPEDESC) {
-            return String.format(")L%s;", TYPEDESC_VALUE);
-        } else if (bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.READONLY) {
-            return String.format(")L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.OBJECT) {
-            return String.format(")L%s;", OBJECT_VALUE);
-        } else if (bType.tag == TypeTags.INVOKABLE) {
-            return String.format(")L%s;", FUNCTION_POINTER);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             return String.format(")L%s;", XML_VALUE);
-        } else if (bType.tag == TypeTags.HANDLE) {
-            return String.format(")L%s;", HANDLE_VALUE);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
-                    String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    return ")I";
+                case TypeTags.FLOAT:
+                    return ")D";
+                case TypeTags.DECIMAL:
+                    return String.format(")L%s;", DECIMAL_VALUE);
+                case TypeTags.BOOLEAN:
+                    return ")Z";
+                case TypeTags.ARRAY:
+                case TypeTags.TUPLE:
+                    return String.format(")L%s;", ARRAY_VALUE);
+                case TypeTags.MAP:
+                case TypeTags.RECORD:
+                    return String.format(")L%s;", MAP_VALUE);
+                case TypeTags.ERROR:
+                    return String.format(")L%s;", ERROR_VALUE);
+                case TypeTags.STREAM:
+                    return String.format(")L%s;", STREAM_VALUE);
+                case TypeTags.TABLE:
+                    return String.format(")L%s;", TABLE_VALUE_IMPL);
+                case TypeTags.FUTURE:
+                    return String.format(")L%s;", FUTURE_VALUE);
+                case TypeTags.TYPEDESC:
+                    return String.format(")L%s;", TYPEDESC_VALUE);
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                case TypeTags.READONLY:
+                    return String.format(")L%s;", OBJECT);
+                case TypeTags.OBJECT:
+                    return String.format(")L%s;", OBJECT_VALUE);
+                case TypeTags.INVOKABLE:
+                    return String.format(")L%s;", FUNCTION_POINTER);
+                case TypeTags.HANDLE:
+                    return String.format(")L%s;", HANDLE_VALUE);
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", bType));
+            }
         }
     }
 
@@ -1226,55 +1348,78 @@ public class JvmMethodGen {
         String typeSig;
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             typeSig = "J";
-        } else if (bType.tag == TypeTags.BYTE) {
-            typeSig = "I";
-        } else if (bType.tag == TypeTags.FLOAT) {
-            typeSig = "D";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             typeSig = String.format("L%s;", B_STRING_VALUE);
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            typeSig = String.format("L%s;", DECIMAL_VALUE);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            typeSig = "Z";
-        } else if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
-            typeSig = String.format("L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.MAP) {
-            typeSig = String.format("L%s;", MAP_VALUE);
-        } else if (bType.tag == TypeTags.STREAM) {
-            typeSig = String.format("L%s;", STREAM_VALUE);
-        } else if (bType.tag == TypeTags.TABLE) {
-            typeSig = String.format("L%s;", TABLE_VALUE_IMPL);
-        } else if (bType.tag == TypeTags.RECORD) {
-            typeSig = String.format("L%s;", MAP_VALUE);
-        } else if (bType.tag == TypeTags.ARRAY ||
-                bType.tag == TypeTags.TUPLE) {
-            typeSig = String.format("L%s;", ARRAY_VALUE);
-        } else if (bType.tag == TypeTags.ERROR) {
-            typeSig = String.format("L%s;", ERROR_VALUE);
-        } else if (bType.tag == TypeTags.FUTURE) {
-            typeSig = String.format("L%s;", FUTURE_VALUE);
-        } else if (bType.tag == TypeTags.OBJECT) {
-            typeSig = String.format("L%s;", OBJECT_VALUE);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             typeSig = String.format("L%s;", XML_VALUE);
-        } else if (bType.tag == TypeTags.TYPEDESC) {
-            typeSig = String.format("L%s;", TYPEDESC_VALUE);
-        } else if (bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.READONLY) {
-            typeSig = String.format("L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.INVOKABLE) {
-            typeSig = String.format("L%s;", FUNCTION_POINTER);
-        } else if (bType.tag == TypeTags.HANDLE) {
-            typeSig = String.format("L%s;", HANDLE_VALUE);
-        } else if (bType.tag == JTypeTags.JTYPE) {
-            typeSig = getJTypeSignature((JType) bType);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    typeSig = "I";
+                    break;
+                case TypeTags.FLOAT:
+                    typeSig = "D";
+                    break;
+                case TypeTags.DECIMAL:
+                    typeSig = String.format("L%s;", DECIMAL_VALUE);
+                    break;
+                case TypeTags.BOOLEAN:
+                    typeSig = "Z";
+                    break;
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    typeSig = String.format("L%s;", OBJECT);
+                    break;
+                case TypeTags.MAP:
+                    typeSig = String.format("L%s;", MAP_VALUE);
+                    break;
+                case TypeTags.STREAM:
+                    typeSig = String.format("L%s;", STREAM_VALUE);
+                    break;
+                case TypeTags.TABLE:
+                    typeSig = String.format("L%s;", TABLE_VALUE_IMPL);
+                    break;
+                case TypeTags.RECORD:
+                    typeSig = String.format("L%s;", MAP_VALUE);
+                    break;
+                case TypeTags.ARRAY:
+                case TypeTags.TUPLE:
+                    typeSig = String.format("L%s;", ARRAY_VALUE);
+                    break;
+                case TypeTags.ERROR:
+                    typeSig = String.format("L%s;", ERROR_VALUE);
+                    break;
+                case TypeTags.FUTURE:
+                    typeSig = String.format("L%s;", FUTURE_VALUE);
+                    break;
+                case TypeTags.OBJECT:
+                    typeSig = String.format("L%s;", OBJECT_VALUE);
+                    break;
+                case TypeTags.TYPEDESC:
+                    typeSig = String.format("L%s;", TYPEDESC_VALUE);
+                    break;
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                case TypeTags.READONLY:
+                    typeSig = String.format("L%s;", OBJECT);
+                    break;
+                case TypeTags.INVOKABLE:
+                    typeSig = String.format("L%s;", FUNCTION_POINTER);
+                    break;
+                case TypeTags.HANDLE:
+                    typeSig = String.format("L%s;", HANDLE_VALUE);
+                    break;
+                case JTypeTags.JTYPE:
+                    typeSig = getJTypeSignature((JType) bType);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", bType));
+            }
         }
 
         FieldVisitor fv;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -45,7 +45,6 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunctionParameter;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRPackage;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.BinaryOp;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
@@ -216,9 +215,6 @@ import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.XMLAcce
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Branch;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Call;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Return;
-import static org.wso2.ballerinalang.compiler.bir.model.InstructionKind.ASYNC_CALL;
-import static org.wso2.ballerinalang.compiler.bir.model.InstructionKind.CALL;
-import static org.wso2.ballerinalang.compiler.bir.model.InstructionKind.FP_LOAD;
 
 /**
  * BIR function to JVM byte code generation class.
@@ -589,79 +585,79 @@ public class JvmMethodGen {
 
     private static String getJVMTypeSign(BType bType) {
 
-        String jvmType;
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            jvmType = "J";
+            return "J";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
-            jvmType = String.format("L%s;", STRING_VALUE);
+            return String.format("L%s;", STRING_VALUE);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
-            jvmType = String.format("L%s;", XML_VALUE);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    jvmType = "I";
-                    break;
-                case TypeTags.FLOAT:
-                    jvmType = "D";
-                    break;
-                case TypeTags.BOOLEAN:
-                    jvmType = "Z";
-                    break;
-                case TypeTags.DECIMAL:
-                    jvmType = String.format("L%s;", DECIMAL_VALUE);
-                    break;
-                case TypeTags.MAP:
-                case TypeTags.RECORD:
-                    jvmType = String.format("L%s;", MAP_VALUE);
-                    break;
-                case TypeTags.STREAM:
-                    jvmType = String.format("L%s;", STREAM_VALUE);
-                    break;
-                case TypeTags.TABLE:
-                    jvmType = String.format("L%s;", TABLE_VALUE_IMPL);
-                    break;
-                case TypeTags.ARRAY:
-                case TypeTags.TUPLE:
-                    jvmType = String.format("L%s;", ARRAY_VALUE);
-                    break;
-                case TypeTags.OBJECT:
-                    jvmType = String.format("L%s;", OBJECT_VALUE);
-                    break;
-                case TypeTags.ERROR:
-                    jvmType = String.format("L%s;", ERROR_VALUE);
-                    break;
-                case TypeTags.FUTURE:
-                    jvmType = String.format("L%s;", FUTURE_VALUE);
-                    break;
-                case TypeTags.INVOKABLE:
-                    jvmType = String.format("L%s;", FUNCTION_POINTER);
-                    break;
-                case TypeTags.HANDLE:
-                    jvmType = String.format("L%s;", HANDLE_VALUE);
-                    break;
-                case TypeTags.TYPEDESC:
-                    jvmType = String.format("L%s;", TYPEDESC_VALUE);
-                    break;
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                case TypeTags.READONLY:
-                    jvmType = String.format("L%s;", OBJECT);
-                    break;
-                case JTypeTags.JTYPE:
-                    jvmType = getJTypeSignature((JType) bType);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM code generation is not supported for type " +
-                            String.format("%s", bType));
-            }
-
+            return String.format("L%s;", XML_VALUE);
         }
+
+        String jvmType;
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                jvmType = "I";
+                break;
+            case TypeTags.FLOAT:
+                jvmType = "D";
+                break;
+            case TypeTags.BOOLEAN:
+                jvmType = "Z";
+                break;
+            case TypeTags.DECIMAL:
+                jvmType = String.format("L%s;", DECIMAL_VALUE);
+                break;
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                jvmType = String.format("L%s;", MAP_VALUE);
+                break;
+            case TypeTags.STREAM:
+                jvmType = String.format("L%s;", STREAM_VALUE);
+                break;
+            case TypeTags.TABLE:
+                jvmType = String.format("L%s;", TABLE_VALUE_IMPL);
+                break;
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                jvmType = String.format("L%s;", ARRAY_VALUE);
+                break;
+            case TypeTags.OBJECT:
+                jvmType = String.format("L%s;", OBJECT_VALUE);
+                break;
+            case TypeTags.ERROR:
+                jvmType = String.format("L%s;", ERROR_VALUE);
+                break;
+            case TypeTags.FUTURE:
+                jvmType = String.format("L%s;", FUTURE_VALUE);
+                break;
+            case TypeTags.INVOKABLE:
+                jvmType = String.format("L%s;", FUNCTION_POINTER);
+                break;
+            case TypeTags.HANDLE:
+                jvmType = String.format("L%s;", HANDLE_VALUE);
+                break;
+            case TypeTags.TYPEDESC:
+                jvmType = String.format("L%s;", TYPEDESC_VALUE);
+                break;
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.READONLY:
+                jvmType = String.format("L%s;", OBJECT);
+                break;
+            case JTypeTags.JTYPE:
+                jvmType = getJTypeSignature((JType) bType);
+                break;
+            default:
+                throw new BLangCompilerException("JVM code generation is not supported for type " +
+                        String.format("%s", bType));
+        }
+
         return jvmType;
     }
 
@@ -943,59 +939,62 @@ public class JvmMethodGen {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitInsn(LCONST_0);
             mv.visitVarInsn(LSTORE, index);
+            return;
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             mv.visitInsn(ACONST_NULL);
             mv.visitVarInsn(ASTORE, index);
+            return;
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             mv.visitInsn(ACONST_NULL);
             mv.visitVarInsn(ASTORE, index);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    mv.visitInsn(ICONST_0);
-                    mv.visitVarInsn(ISTORE, index);
-                    break;
-                case TypeTags.FLOAT:
-                    mv.visitInsn(DCONST_0);
-                    mv.visitVarInsn(DSTORE, index);
-                    break;
-                case TypeTags.BOOLEAN:
-                    mv.visitInsn(ICONST_0);
-                    mv.visitVarInsn(ISTORE, index);
-                    break;
-                case TypeTags.MAP:
-                case TypeTags.ARRAY:
-                case TypeTags.STREAM:
-                case TypeTags.TABLE:
-                case TypeTags.ERROR:
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.OBJECT:
-                case TypeTags.CHAR_STRING:
-                case TypeTags.DECIMAL:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.RECORD:
-                case TypeTags.TUPLE:
-                case TypeTags.FUTURE:
-                case TypeTags.JSON:
-                case TypeTags.INVOKABLE:
-                case TypeTags.FINITE:
-                case TypeTags.HANDLE:
-                case TypeTags.TYPEDESC:
-                case TypeTags.READONLY:
-                    mv.visitInsn(ACONST_NULL);
-                    mv.visitVarInsn(ASTORE, index);
-                    break;
-                case JTypeTags.JTYPE:
-                    genJDefaultValue(mv, (JType) bType, index);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", bType));
-            }
+            return;
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitInsn(DCONST_0);
+                mv.visitVarInsn(DSTORE, index);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitInsn(ICONST_0);
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case TypeTags.MAP:
+            case TypeTags.ARRAY:
+            case TypeTags.STREAM:
+            case TypeTags.TABLE:
+            case TypeTags.ERROR:
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.OBJECT:
+            case TypeTags.CHAR_STRING:
+            case TypeTags.DECIMAL:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.RECORD:
+            case TypeTags.TUPLE:
+            case TypeTags.FUTURE:
+            case TypeTags.JSON:
+            case TypeTags.INVOKABLE:
+            case TypeTags.FINITE:
+            case TypeTags.HANDLE:
+            case TypeTags.TYPEDESC:
+            case TypeTags.READONLY:
+                mv.visitInsn(ACONST_NULL);
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case JTypeTags.JTYPE:
+                genJDefaultValue(mv, (JType) bType, index);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 
@@ -1049,36 +1048,46 @@ public class JvmMethodGen {
 
         if (TypeTags.isIntegerTypeTag(bType.tag) || bType.tag == TypeTags.BYTE) {
             mv.visitInsn(LCONST_0);
-        } else if (bType.tag == TypeTags.FLOAT) {
-            mv.visitInsn(DCONST_0);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            mv.visitInsn(ICONST_0);
-        } else if (TypeTags.isStringTypeTag(bType.tag) ||
-                bType.tag == TypeTags.MAP ||
-                bType.tag == TypeTags.ARRAY ||
-                bType.tag == TypeTags.ERROR ||
-                bType.tag == TypeTags.NIL ||
-                bType.tag == TypeTags.NEVER ||
-                bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.OBJECT ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.RECORD ||
-                bType.tag == TypeTags.TUPLE ||
-                bType.tag == TypeTags.FUTURE ||
-                bType.tag == TypeTags.JSON ||
-                TypeTags.isXMLTypeTag(bType.tag) ||
-                bType.tag == TypeTags.INVOKABLE ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.HANDLE ||
-                bType.tag == TypeTags.TYPEDESC ||
-                bType.tag == TypeTags.READONLY) {
+            return;
+        } else if (TypeTags.isStringTypeTag(bType.tag) || TypeTags.isXMLTypeTag(bType.tag)) {
             mv.visitInsn(ACONST_NULL);
-        } else if (bType.tag == JTypeTags.JTYPE) {
-            loadDefaultJValue(mv, (JType) bType);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+            return;
+        }
+
+        switch (bType.tag) {
+            case TypeTags.FLOAT:
+                mv.visitInsn(DCONST_0);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitInsn(ICONST_0);
+                break;
+            case TypeTags.MAP:
+            case TypeTags.ARRAY:
+            case TypeTags.ERROR:
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.OBJECT:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.RECORD:
+            case TypeTags.TUPLE:
+            case TypeTags.FUTURE:
+            case TypeTags.JSON:
+            case TypeTags.INVOKABLE:
+            case TypeTags.FINITE:
+            case TypeTags.HANDLE:
+            case TypeTags.TYPEDESC:
+            case TypeTags.READONLY:
+                mv.visitInsn(ACONST_NULL);
+                break;
+            case JTypeTags.JTYPE:
+                loadDefaultJValue(mv, (JType) bType);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 
@@ -1168,53 +1177,53 @@ public class JvmMethodGen {
             return String.format("L%s;", B_STRING_VALUE);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             return String.format("L%s;", XML_VALUE);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    return "I";
-                case TypeTags.FLOAT:
-                    return "D";
-                case TypeTags.DECIMAL:
-                    return String.format("L%s;", DECIMAL_VALUE);
-                case TypeTags.BOOLEAN:
-                    return "Z";
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                    return String.format("L%s;", OBJECT);
-                case TypeTags.ARRAY:
-                case TypeTags.TUPLE:
-                    return String.format("L%s;", ARRAY_VALUE);
-                case TypeTags.ERROR:
-                    return String.format("L%s;", ERROR_VALUE);
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                case TypeTags.ANY:
-                case TypeTags.READONLY:
-                    return String.format("L%s;", OBJECT);
-                case TypeTags.MAP:
-                case TypeTags.RECORD:
-                    return String.format("L%s;", MAP_VALUE);
-                case TypeTags.FUTURE:
-                    return String.format("L%s;", FUTURE_VALUE);
-                case TypeTags.STREAM:
-                    return String.format("L%s;", STREAM_VALUE);
-                case TypeTags.TABLE:
-                    return String.format("L%s;", TABLE_VALUE_IMPL);
-                case TypeTags.INVOKABLE:
-                    return String.format("L%s;", FUNCTION_POINTER);
-                case TypeTags.TYPEDESC:
-                    return String.format("L%s;", TYPEDESC_VALUE);
-                case TypeTags.OBJECT:
-                    return String.format("L%s;", OBJECT_VALUE);
-                case TypeTags.HANDLE:
-                    return String.format("L%s;", HANDLE_VALUE);
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", bType));
-            }
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                return "I";
+            case TypeTags.FLOAT:
+                return "D";
+            case TypeTags.DECIMAL:
+                return String.format("L%s;", DECIMAL_VALUE);
+            case TypeTags.BOOLEAN:
+                return "Z";
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+                return String.format("L%s;", OBJECT);
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                return String.format("L%s;", ARRAY_VALUE);
+            case TypeTags.ERROR:
+                return String.format("L%s;", ERROR_VALUE);
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.ANY:
+            case TypeTags.READONLY:
+                return String.format("L%s;", OBJECT);
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                return String.format("L%s;", MAP_VALUE);
+            case TypeTags.FUTURE:
+                return String.format("L%s;", FUTURE_VALUE);
+            case TypeTags.STREAM:
+                return String.format("L%s;", STREAM_VALUE);
+            case TypeTags.TABLE:
+                return String.format("L%s;", TABLE_VALUE_IMPL);
+            case TypeTags.INVOKABLE:
+                return String.format("L%s;", FUNCTION_POINTER);
+            case TypeTags.TYPEDESC:
+                return String.format("L%s;", TYPEDESC_VALUE);
+            case TypeTags.OBJECT:
+                return String.format("L%s;", OBJECT_VALUE);
+            case TypeTags.HANDLE:
+                return String.format("L%s;", HANDLE_VALUE);
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 
@@ -1232,50 +1241,50 @@ public class JvmMethodGen {
             return String.format(")L%s;", B_STRING_VALUE);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             return String.format(")L%s;", XML_VALUE);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    return ")I";
-                case TypeTags.FLOAT:
-                    return ")D";
-                case TypeTags.DECIMAL:
-                    return String.format(")L%s;", DECIMAL_VALUE);
-                case TypeTags.BOOLEAN:
-                    return ")Z";
-                case TypeTags.ARRAY:
-                case TypeTags.TUPLE:
-                    return String.format(")L%s;", ARRAY_VALUE);
-                case TypeTags.MAP:
-                case TypeTags.RECORD:
-                    return String.format(")L%s;", MAP_VALUE);
-                case TypeTags.ERROR:
-                    return String.format(")L%s;", ERROR_VALUE);
-                case TypeTags.STREAM:
-                    return String.format(")L%s;", STREAM_VALUE);
-                case TypeTags.TABLE:
-                    return String.format(")L%s;", TABLE_VALUE_IMPL);
-                case TypeTags.FUTURE:
-                    return String.format(")L%s;", FUTURE_VALUE);
-                case TypeTags.TYPEDESC:
-                    return String.format(")L%s;", TYPEDESC_VALUE);
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                case TypeTags.READONLY:
-                    return String.format(")L%s;", OBJECT);
-                case TypeTags.OBJECT:
-                    return String.format(")L%s;", OBJECT_VALUE);
-                case TypeTags.INVOKABLE:
-                    return String.format(")L%s;", FUNCTION_POINTER);
-                case TypeTags.HANDLE:
-                    return String.format(")L%s;", HANDLE_VALUE);
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", bType));
-            }
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                return ")I";
+            case TypeTags.FLOAT:
+                return ")D";
+            case TypeTags.DECIMAL:
+                return String.format(")L%s;", DECIMAL_VALUE);
+            case TypeTags.BOOLEAN:
+                return ")Z";
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                return String.format(")L%s;", ARRAY_VALUE);
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                return String.format(")L%s;", MAP_VALUE);
+            case TypeTags.ERROR:
+                return String.format(")L%s;", ERROR_VALUE);
+            case TypeTags.STREAM:
+                return String.format(")L%s;", STREAM_VALUE);
+            case TypeTags.TABLE:
+                return String.format(")L%s;", TABLE_VALUE_IMPL);
+            case TypeTags.FUTURE:
+                return String.format(")L%s;", FUTURE_VALUE);
+            case TypeTags.TYPEDESC:
+                return String.format(")L%s;", TYPEDESC_VALUE);
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.READONLY:
+                return String.format(")L%s;", OBJECT);
+            case TypeTags.OBJECT:
+                return String.format(")L%s;", OBJECT_VALUE);
+            case TypeTags.INVOKABLE:
+                return String.format(")L%s;", FUNCTION_POINTER);
+            case TypeTags.HANDLE:
+                return String.format(")L%s;", HANDLE_VALUE);
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 
@@ -2270,24 +2279,28 @@ public class JvmMethodGen {
 
         PackageID packageID;
 
-        if (kind == CALL) {
-            BIRTerminator.Call call = (BIRTerminator.Call) callIns;
-            if (call.isVirtual) {
-                return false;
-            }
-            methodName = call.name.value;
-            packageID = call.calleePkg;
-        } else if (kind == ASYNC_CALL) {
-            BIRTerminator.AsyncCall asyncCall = (BIRTerminator.AsyncCall) callIns;
-            methodName = asyncCall.name.value;
-            packageID = asyncCall.calleePkg;
-        } else if (kind == FP_LOAD) {
-            BIRNonTerminator.FPLoad fpLoad = (BIRNonTerminator.FPLoad) callIns;
-            methodName = fpLoad.funcName.value;
-            packageID = fpLoad.pkgId;
-        } else {
-            throw new BLangCompilerException("JVM static function call generation is not supported for instruction " +
-                    String.format("%s", callIns));
+        switch (kind) {
+            case CALL:
+                Call call = (Call) callIns;
+                if (call.isVirtual) {
+                    return false;
+                }
+                methodName = call.name.value;
+                packageID = call.calleePkg;
+                break;
+            case ASYNC_CALL:
+                AsyncCall asyncCall = (AsyncCall) callIns;
+                methodName = asyncCall.name.value;
+                packageID = asyncCall.calleePkg;
+                break;
+            case FP_LOAD:
+                FPLoad fpLoad = (FPLoad) callIns;
+                methodName = fpLoad.funcName.value;
+                packageID = fpLoad.pkgId;
+                break;
+            default:
+                throw new BLangCompilerException("JVM static function call generation is not supported for " +
+                        "instruction " + String.format("%s", callIns));
         }
 
         String key = getPackageName(packageID.orgName.value, packageID.name.value,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -112,7 +112,7 @@ class JvmObservabilityGen {
 
     private Map<Object, BIROperand> compileTimeConstants;
 
-    public JvmObservabilityGen(JvmPackageGen pkgGen) {
+    JvmObservabilityGen(JvmPackageGen pkgGen) {
         compileTimeConstants = new HashMap<>();
         packageCache = pkgGen.packageCache;
         symbolTable = pkgGen.symbolTable;
@@ -126,7 +126,7 @@ class JvmObservabilityGen {
      *
      * @param pkg The package to instrument
      */
-    public void rewriteObservableFunctions(BIRPackage pkg) {
+    void rewriteObservableFunctions(BIRPackage pkg) {
         for (int i = 0; i < pkg.functions.size(); i++) {
             BIRFunction func = pkg.functions.get(i);
             rewriteAsyncInvocations(func, null, pkg);
@@ -176,7 +176,7 @@ class JvmObservabilityGen {
      * @param attachedTypeDef The type definition to which the function was attached to or null
      * @param pkg The package containing the function
      */
-    public void rewriteAsyncInvocations(BIRFunction func, BIRTypeDefinition attachedTypeDef, BIRPackage pkg) {
+    private void rewriteAsyncInvocations(BIRFunction func, BIRTypeDefinition attachedTypeDef, BIRPackage pkg) {
         PackageID currentPkgId = new PackageID(pkg.org, pkg.name, pkg.version);
         BSymbol functionOwner;
         List<BIRFunction> scopeFunctionsList;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -53,7 +53,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
@@ -128,7 +127,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethod
  */
 public class JvmPackageGen {
 
-    private static final CompilerContext.Key<JvmPackageGen> JVM_PACKAGE_GEN_KEY = new CompilerContext.Key<>();
     private static ResolvedTypeBuilder typeBuilder;
 
     public final SymbolTable symbolTable;
@@ -523,16 +521,15 @@ public class JvmPackageGen {
 
                 jvmMethodGen.generateMainMethod(mainFunc, cw, module, moduleClass, serviceEPAvailable);
                 if (mainFunc != null) {
-                    jvmMethodGen.generateLambdaForMain(mainFunc, cw, module, mainClass, moduleClass);
+                    jvmMethodGen.generateLambdaForMain(mainFunc, cw, mainClass);
                 }
-                jvmMethodGen.generateLambdaForPackageInits(cw, module, mainClass, moduleClass, moduleImports);
+                jvmMethodGen.generateLambdaForPackageInits(cw, module, moduleClass, moduleImports);
 
                 generateLockForVariable(cw);
                 generateStaticInitializer(cw, moduleClass, serviceEPAvailable);
                 generateCreateTypesMethod(cw, module.typeDefs, moduleInitClass, symbolTable);
                 jvmMethodGen.generateModuleInitializer(cw, module, moduleInitClass);
-                jvmMethodGen.generateExecutionStopMethod(cw, moduleInitClass, module, moduleImports,
-                        moduleInitClass);
+                jvmMethodGen.generateExecutionStopMethod(cw, moduleInitClass, module, moduleImports);
             } else {
                 cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, moduleClass, null, OBJECT, null);
                 generateDefaultConstructor(cw, OBJECT);
@@ -541,7 +538,7 @@ public class JvmPackageGen {
             // generate methods
             for (BIRFunction func : javaClass.functions) {
                 String workerName = getFunction(func).workerName == null ? null : func.workerName.value;
-                jvmMethodGen.generateMethod(getFunction(func), cw, module, null, false, workerName, lambdaMetadata);
+                jvmMethodGen.generateMethod(getFunction(func), cw, module, null, lambdaMetadata);
             }
             // generate lambdas created during generating methods
             for (Map.Entry<String, BIRInstruction> lambda : lambdaMetadata.getLambdas().entrySet()) {
@@ -787,6 +784,7 @@ public class JvmPackageGen {
             return objectNewIns.def.type;
         } else {
             PackageID id = objectNewIns.externalPackageId;
+            assert id != null;
             BPackageSymbol symbol = packageCache.getSymbol(id.orgName + "/" + id.name);
             if (symbol != null) {
                 BObjectTypeSymbol objectTypeSymbol =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -233,13 +233,13 @@ public class JvmTerminatorGen {
                 this.genLockTerm((BIRTerminator.Lock) terminator, funcName, localVarOffset);
                 return;
             case UNLOCK:
-                this.genUnlockTerm((BIRTerminator.Unlock) terminator, funcName, attachedType);
+                this.genUnlockTerm((BIRTerminator.Unlock) terminator, funcName);
                 return;
             case GOTO:
                 this.genGoToTerm((BIRTerminator.GOTO) terminator, funcName);
                 return;
             case CALL:
-                this.genCallTerm((BIRTerminator.Call) terminator, funcName, localVarOffset);
+                this.genCallTerm((BIRTerminator.Call) terminator, localVarOffset);
                 return;
             case ASYNC_CALL:
                 this.genAsyncCallTerm((BIRTerminator.AsyncCall) terminator, localVarOffset, lambdaMetadata);
@@ -248,39 +248,38 @@ public class JvmTerminatorGen {
                 this.genBranchTerm((BIRTerminator.Branch) terminator, funcName);
                 return;
             case RETURN:
-                this.genReturnTerm((BIRTerminator.Return) terminator, returnVarRefIndex, func,
-                        localVarOffset);
+                this.genReturnTerm((BIRTerminator.Return) terminator, returnVarRefIndex, func);
                 return;
             case PANIC:
                 this.errorGen.genPanic((BIRTerminator.Panic) terminator);
                 return;
             case WAIT:
-                this.generateWaitIns((BIRTerminator.Wait) terminator, funcName, localVarOffset);
+                this.generateWaitIns((BIRTerminator.Wait) terminator, localVarOffset);
                 return;
             case WAIT_ALL:
-                this.genWaitAllIns((BIRTerminator.WaitAll) terminator, funcName, localVarOffset);
+                this.genWaitAllIns((BIRTerminator.WaitAll) terminator, localVarOffset);
                 return;
             case FP_CALL:
-                this.genFPCallIns((BIRTerminator.FPCall) terminator, funcName, localVarOffset);
+                this.genFPCallIns((BIRTerminator.FPCall) terminator, localVarOffset);
                 return;
             case WK_SEND:
-                this.genWorkerSendIns((BIRTerminator.WorkerSend) terminator, funcName, localVarOffset);
+                this.genWorkerSendIns((BIRTerminator.WorkerSend) terminator, localVarOffset);
                 return;
             case WK_RECEIVE:
-                this.genWorkerReceiveIns((BIRTerminator.WorkerReceive) terminator, funcName, localVarOffset);
+                this.genWorkerReceiveIns((BIRTerminator.WorkerReceive) terminator, localVarOffset);
                 return;
             case FLUSH:
-                this.genFlushIns((BIRTerminator.Flush) terminator, funcName, localVarOffset);
+                this.genFlushIns((BIRTerminator.Flush) terminator, localVarOffset);
                 return;
             case PLATFORM:
                 if (terminator instanceof JavaMethodCall) {
-                    this.genJCallTerm((JavaMethodCall) terminator, funcName, attachedType, localVarOffset);
+                    this.genJCallTerm((JavaMethodCall) terminator, attachedType, localVarOffset);
                     return;
                 } else if (terminator instanceof JIMethodCall) {
-                    this.genJICallTerm((JIMethodCall) terminator, funcName, attachedType, localVarOffset);
+                    this.genJICallTerm((JIMethodCall) terminator, localVarOffset);
                     return;
                 } else if (terminator instanceof JIConstructorCall) {
-                    this.genJIConstructorTerm((JIConstructorCall) terminator, funcName, attachedType,
+                    this.genJIConstructorTerm((JIConstructorCall) terminator,
                             localVarOffset);
                     return;
                 }
@@ -313,7 +312,7 @@ public class JvmTerminatorGen {
         this.mv.visitJumpInsn(GOTO, gotoLabel);
     }
 
-    private void genUnlockTerm(BIRTerminator.Unlock unlockIns, String funcName, BType attachedType) {
+    private void genUnlockTerm(BIRTerminator.Unlock unlockIns, String funcName) {
 
         Label gotoLabel = this.labelGen.getLabel(funcName + unlockIns.unlockBB.id.value);
 
@@ -380,7 +379,7 @@ public class JvmTerminatorGen {
         this.mv.visitJumpInsn(GOTO, falseBBLabel);
     }
 
-    private void genCallTerm(BIRTerminator.Call callIns, String funcName, int localVarOffset) {
+    private void genCallTerm(BIRTerminator.Call callIns, int localVarOffset) {
 
         PackageID calleePkgId = callIns.calleePkg;
 
@@ -394,7 +393,7 @@ public class JvmTerminatorGen {
         this.storeReturnFromCallIns(callIns.lhsOp != null ? callIns.lhsOp.variableDcl : null);
     }
 
-    private void genJCallTerm(JavaMethodCall callIns, String funcName, BType attachedType, int localVarOffset) {
+    private void genJCallTerm(JavaMethodCall callIns, BType attachedType, int localVarOffset) {
         // Load function parameters of the target Java method to the stack..
         Label blockedOnExternLabel = new Label();
         Label notBlockedOnExternLabel = new Label();
@@ -452,7 +451,7 @@ public class JvmTerminatorGen {
         this.mv.visitLabel(notBlockedOnExternLabel);
     }
 
-    private void genJICallTerm(JIMethodCall callIns, String funcName, BType attachedType, int localVarOffset) {
+    private void genJICallTerm(JIMethodCall callIns, int localVarOffset) {
         // Load function parameters of the target Java method to the stack..
         Label blockedOnExternLabel = new Label();
         Label notBlockedOnExternLabel = new Label();
@@ -533,8 +532,7 @@ public class JvmTerminatorGen {
         this.mv.visitLabel(notBlockedOnExternLabel);
     }
 
-    private void genJIConstructorTerm(JIConstructorCall callIns, String funcName, BType attachedType,
-                                      int localVarOffset) {
+    private void genJIConstructorTerm(JIConstructorCall callIns, int localVarOffset) {
         // Load function parameters of the target Java method to the stack..
         Label blockedOnExternLabel = new Label();
         Label notBlockedOnExternLabel = new Label();
@@ -857,7 +855,7 @@ public class JvmTerminatorGen {
         this.submitToScheduler(callIns.lhsOp, localVarOffset, concurrent);
     }
 
-    private void generateWaitIns(BIRTerminator.Wait waitInst, String funcName, int localVarOffset) {
+    private void generateWaitIns(BIRTerminator.Wait waitInst, int localVarOffset) {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         this.mv.visitTypeInsn(NEW, ARRAY_LIST);
@@ -898,7 +896,7 @@ public class JvmTerminatorGen {
         this.mv.visitLabel(afterIf);
     }
 
-    private void genWaitAllIns(BIRTerminator.WaitAll waitAll, String funcName, int localVarOffset) {
+    private void genWaitAllIns(BIRTerminator.WaitAll waitAll, int localVarOffset) {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         this.mv.visitTypeInsn(NEW, "java/util/HashMap");
@@ -923,7 +921,7 @@ public class JvmTerminatorGen {
                 MAP, MAP_VALUE), false);
     }
 
-    private void genFPCallIns(BIRTerminator.FPCall fpCall, String funcName, int localVarOffset) {
+    private void genFPCallIns(BIRTerminator.FPCall fpCall, int localVarOffset) {
 
         if (fpCall.isAsync) {
             // Check if already locked before submitting to scheduler.
@@ -1019,7 +1017,7 @@ public class JvmTerminatorGen {
         this.mv.visitInsn(AASTORE);
     }
 
-    private void genWorkerSendIns(BIRTerminator.WorkerSend ins, String funcName, int localVarOffset) {
+    private void genWorkerSendIns(BIRTerminator.WorkerSend ins, int localVarOffset) {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         if (!ins.isSameStrand) {
@@ -1046,7 +1044,7 @@ public class JvmTerminatorGen {
         }
     }
 
-    private void genWorkerReceiveIns(BIRTerminator.WorkerReceive ins, String funcName, int localVarOffset) {
+    private void genWorkerReceiveIns(BIRTerminator.WorkerReceive ins, int localVarOffset) {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         if (!ins.isSameStrand) {
@@ -1079,7 +1077,7 @@ public class JvmTerminatorGen {
         this.mv.visitLabel(jumpAfterReceive);
     }
 
-    private void genFlushIns(BIRTerminator.Flush ins, String funcName, int localVarOffset) {
+    private void genFlushIns(BIRTerminator.Flush ins, int localVarOffset) {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         loadChannelDetails(this.mv, Arrays.asList(ins.channels));
@@ -1132,8 +1130,7 @@ public class JvmTerminatorGen {
         jvmInstructionGen.generateVarStore(this.mv, varDcl, this.currentPackageName, this.getJVMIndexOfVarRef(varDcl));
     }
 
-    public void genReturnTerm(BIRTerminator.Return returnIns, int returnVarRefIndex, BIRNode.BIRFunction func,
-                              int localVarOffset /* = -1 */) {
+    public void genReturnTerm(BIRTerminator.Return returnIns, int returnVarRefIndex, BIRNode.BIRFunction func) {
 
         BType bType = typeBuilder.build(func.type.retType);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -1137,67 +1137,70 @@ public class JvmTerminatorGen {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             this.mv.visitVarInsn(LLOAD, returnVarRefIndex);
             this.mv.visitInsn(LRETURN);
+            return;
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);
+            return;
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-                    this.mv.visitInsn(ARETURN);
-                    break;
-                case TypeTags.BYTE:
-                    this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
-                    this.mv.visitInsn(IRETURN);
-                    break;
-                case TypeTags.FLOAT:
-                    this.mv.visitVarInsn(DLOAD, returnVarRefIndex);
-                    this.mv.visitInsn(DRETURN);
-                    break;
-                case TypeTags.BOOLEAN:
-                    this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
-                    this.mv.visitInsn(IRETURN);
-                    break;
-                case TypeTags.MAP:
-                case TypeTags.ARRAY:
-                case TypeTags.ANY:
-                case TypeTags.INTERSECTION:
-                case TypeTags.STREAM:
-                case TypeTags.TABLE:
-                case TypeTags.ANYDATA:
-                case TypeTags.OBJECT:
-                case TypeTags.DECIMAL:
-                case TypeTags.RECORD:
-                case TypeTags.TUPLE:
-                case TypeTags.JSON:
-                case TypeTags.FUTURE:
-                case TypeTags.INVOKABLE:
-                case TypeTags.HANDLE:
-                case TypeTags.FINITE:
-                case TypeTags.TYPEDESC:
-                case TypeTags.READONLY:
-                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-                    this.mv.visitInsn(ARETURN);
-                    break;
-                case TypeTags.UNION:
-                    this.handleErrorRetInUnion(returnVarRefIndex, Arrays.asList(func.workerChannels),
-                            (BUnionType) bType);
-                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-                    this.mv.visitInsn(ARETURN);
-                    break;
-                case TypeTags.ERROR:
-                    this.notifyChannels(Arrays.asList(func.workerChannels), returnVarRefIndex);
-                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-                    this.mv.visitInsn(ARETURN);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", func.type.retType));
-            }
+            return;
+        }
+
+        switch (bType.tag) {
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+                this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                this.mv.visitInsn(ARETURN);
+                break;
+            case TypeTags.BYTE:
+                this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
+                this.mv.visitInsn(IRETURN);
+                break;
+            case TypeTags.FLOAT:
+                this.mv.visitVarInsn(DLOAD, returnVarRefIndex);
+                this.mv.visitInsn(DRETURN);
+                break;
+            case TypeTags.BOOLEAN:
+                this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
+                this.mv.visitInsn(IRETURN);
+                break;
+            case TypeTags.MAP:
+            case TypeTags.ARRAY:
+            case TypeTags.ANY:
+            case TypeTags.INTERSECTION:
+            case TypeTags.STREAM:
+            case TypeTags.TABLE:
+            case TypeTags.ANYDATA:
+            case TypeTags.OBJECT:
+            case TypeTags.DECIMAL:
+            case TypeTags.RECORD:
+            case TypeTags.TUPLE:
+            case TypeTags.JSON:
+            case TypeTags.FUTURE:
+            case TypeTags.INVOKABLE:
+            case TypeTags.HANDLE:
+            case TypeTags.FINITE:
+            case TypeTags.TYPEDESC:
+            case TypeTags.READONLY:
+                this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                this.mv.visitInsn(ARETURN);
+                break;
+            case TypeTags.UNION:
+                this.handleErrorRetInUnion(returnVarRefIndex, Arrays.asList(func.workerChannels),
+                        (BUnionType) bType);
+                this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                this.mv.visitInsn(ARETURN);
+                break;
+            case TypeTags.ERROR:
+                this.notifyChannels(Arrays.asList(func.workerChannels), returnVarRefIndex);
+                this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                this.mv.visitInsn(ARETURN);
+                break;
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", func.type.retType));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -1136,56 +1136,71 @@ public class JvmTerminatorGen {
                               int localVarOffset /* = -1 */) {
 
         BType bType = typeBuilder.build(func.type.retType);
-        if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
-            this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-            this.mv.visitInsn(ARETURN);
-        } else if (TypeTags.isIntegerTypeTag(bType.tag)) {
+
+        if (TypeTags.isIntegerTypeTag(bType.tag)) {
             this.mv.visitVarInsn(LLOAD, returnVarRefIndex);
             this.mv.visitInsn(LRETURN);
-        } else if (bType.tag == TypeTags.BYTE) {
-            this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
-            this.mv.visitInsn(IRETURN);
-        } else if (bType.tag == TypeTags.FLOAT) {
-            this.mv.visitVarInsn(DLOAD, returnVarRefIndex);
-            this.mv.visitInsn(DRETURN);
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
-            this.mv.visitInsn(IRETURN);
-        } else if (bType.tag == TypeTags.MAP ||
-                bType.tag == TypeTags.ARRAY ||
-                bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.STREAM ||
-                bType.tag == TypeTags.TABLE ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.OBJECT ||
-                bType.tag == TypeTags.DECIMAL ||
-                bType.tag == TypeTags.RECORD ||
-                bType.tag == TypeTags.TUPLE ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FUTURE ||
-                TypeTags.isXMLTypeTag(bType.tag) ||
-                bType.tag == TypeTags.INVOKABLE ||
-                bType.tag == TypeTags.HANDLE ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.TYPEDESC ||
-                bType.tag == TypeTags.READONLY) {
-            this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-            this.mv.visitInsn(ARETURN);
-        } else if (bType.tag == TypeTags.UNION) {
-            this.handleErrorRetInUnion(returnVarRefIndex, Arrays.asList(func.workerChannels), (BUnionType) bType);
-            this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-            this.mv.visitInsn(ARETURN);
-        } else if (bType.tag == TypeTags.ERROR) {
-            this.notifyChannels(Arrays.asList(func.workerChannels), returnVarRefIndex);
+        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
-                    String.format("%s", func.type.retType));
+            switch (bType.tag) {
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                    this.mv.visitInsn(ARETURN);
+                    break;
+                case TypeTags.BYTE:
+                    this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
+                    this.mv.visitInsn(IRETURN);
+                    break;
+                case TypeTags.FLOAT:
+                    this.mv.visitVarInsn(DLOAD, returnVarRefIndex);
+                    this.mv.visitInsn(DRETURN);
+                    break;
+                case TypeTags.BOOLEAN:
+                    this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
+                    this.mv.visitInsn(IRETURN);
+                    break;
+                case TypeTags.MAP:
+                case TypeTags.ARRAY:
+                case TypeTags.ANY:
+                case TypeTags.INTERSECTION:
+                case TypeTags.STREAM:
+                case TypeTags.TABLE:
+                case TypeTags.ANYDATA:
+                case TypeTags.OBJECT:
+                case TypeTags.DECIMAL:
+                case TypeTags.RECORD:
+                case TypeTags.TUPLE:
+                case TypeTags.JSON:
+                case TypeTags.FUTURE:
+                case TypeTags.INVOKABLE:
+                case TypeTags.HANDLE:
+                case TypeTags.FINITE:
+                case TypeTags.TYPEDESC:
+                case TypeTags.READONLY:
+                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                    this.mv.visitInsn(ARETURN);
+                    break;
+                case TypeTags.UNION:
+                    this.handleErrorRetInUnion(returnVarRefIndex, Arrays.asList(func.workerChannels),
+                            (BUnionType) bType);
+                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                    this.mv.visitInsn(ARETURN);
+                    break;
+                case TypeTags.ERROR:
+                    this.notifyChannels(Arrays.asList(func.workerChannels), returnVarRefIndex);
+                    this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
+                    this.mv.visitInsn(ARETURN);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for type " +
+                            String.format("%s", func.type.retType));
+            }
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -1151,21 +1151,6 @@ public class JvmTerminatorGen {
         switch (bType.tag) {
             case TypeTags.NIL:
             case TypeTags.NEVER:
-                this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-                this.mv.visitInsn(ARETURN);
-                break;
-            case TypeTags.BYTE:
-                this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
-                this.mv.visitInsn(IRETURN);
-                break;
-            case TypeTags.FLOAT:
-                this.mv.visitVarInsn(DLOAD, returnVarRefIndex);
-                this.mv.visitInsn(DRETURN);
-                break;
-            case TypeTags.BOOLEAN:
-                this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
-                this.mv.visitInsn(IRETURN);
-                break;
             case TypeTags.MAP:
             case TypeTags.ARRAY:
             case TypeTags.ANY:
@@ -1186,6 +1171,15 @@ public class JvmTerminatorGen {
             case TypeTags.READONLY:
                 this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
                 this.mv.visitInsn(ARETURN);
+                break;
+            case TypeTags.BYTE:
+            case TypeTags.BOOLEAN:
+                this.mv.visitVarInsn(ILOAD, returnVarRefIndex);
+                this.mv.visitInsn(IRETURN);
+                break;
+            case TypeTags.FLOAT:
+                this.mv.visitVarInsn(DLOAD, returnVarRefIndex);
+                this.mv.visitInsn(DRETURN);
                 break;
             case TypeTags.UNION:
                 this.handleErrorRetInUnion(returnVarRefIndex, Arrays.asList(func.workerChannels),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -160,7 +160,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getObject
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getRecordField;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getType;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getTypeDef;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getModuleLevelClassName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.NAME_HASH_COMPARATOR;
@@ -1018,21 +1017,9 @@ class JvmTypeGen {
                 String.format("(L%s;L%s;)V", STRING_VALUE, PACKAGE_TYPE), false);
     }
 
-    private static String typeRefToClassName(PackageID typeRef, String className) {
-
-        return getModuleLevelClassName(typeRef.orgName.value, typeRef.name.value, typeRef.version.value, className);
-    }
-
     // -------------------------------------------------------
     //              Type loading methods
     // -------------------------------------------------------
-
-    static void loadExternalType(MethodVisitor mv, PackageID pkgId, String name) {
-
-        String fieldName = getTypeFieldName(name);
-        String externlTypeOwner = typeRefToClassName(pkgId, MODULE_INIT_CLASS_NAME);
-        mv.visitFieldInsn(GETSTATIC, externlTypeOwner, fieldName, String.format("L%s;", BTYPE));
-    }
 
     static void loadLocalType(MethodVisitor mv, BIRTypeDefinition typeDefinition) {
 
@@ -1668,8 +1655,6 @@ class JvmTypeGen {
                         false);
             } else if (valueType.tag == TypeTags.BYTE) {
                 mv.visitMethodInsn(INVOKESTATIC, INT_VALUE, "valueOf", String.format("(I)L%s;", INT_VALUE), false);
-            } else if (valueType.tag == TypeTags.DECIMAL) {
-                // this is handled within the 'loadConstantValue()' method
             }
 
             // Add the value to the set

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -1049,113 +1049,143 @@ class JvmTypeGen {
         String typeFieldName = "";
         if (bType == null || bType.tag == TypeTags.NIL) {
             typeFieldName = "typeNull";
-        } else if (bType.tag == TypeTags.NEVER) {
-            typeFieldName = "typeNever";
-        } else if (bType.tag == TypeTags.INT) {
-            typeFieldName = "typeInt";
-        } else if (bType.tag == TypeTags.SIGNED32_INT) {
-            typeFieldName = "typeIntSigned32";
-        } else if (bType.tag == TypeTags.SIGNED16_INT) {
-            typeFieldName = "typeIntSigned16";
-        } else if (bType.tag == TypeTags.SIGNED8_INT) {
-            typeFieldName = "typeIntSigned8";
-        } else if (bType.tag == TypeTags.UNSIGNED32_INT) {
-            typeFieldName = "typeIntUnsigned32";
-        } else if (bType.tag == TypeTags.UNSIGNED16_INT) {
-            typeFieldName = "typeIntUnsigned16";
-        } else if (bType.tag == TypeTags.UNSIGNED8_INT) {
-            typeFieldName = "typeIntUnsigned8";
-        } else if (bType.tag == TypeTags.FLOAT) {
-            typeFieldName = "typeFloat";
-        } else if (bType.tag == TypeTags.STRING) {
-            typeFieldName = "typeString";
-        } else if (bType.tag == TypeTags.CHAR_STRING) {
-            typeFieldName = "typeStringChar";
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            typeFieldName = "typeDecimal";
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            typeFieldName = "typeBoolean";
-        } else if (bType.tag == TypeTags.BYTE) {
-            typeFieldName = "typeByte";
-        } else if (bType.tag == TypeTags.ANY) {
-            typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyAny" : "typeAny";
-        } else if (bType.tag == TypeTags.ANYDATA) {
-            typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyAnydata" : "typeAnydata";
-        } else if (bType.tag == TypeTags.JSON) {
-            typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyJSON" : "typeJSON";
-        } else if (bType.tag == TypeTags.XML) {
-            loadXmlType(mv, (BXMLType) bType);
-            return;
-        } else if (bType.tag == TypeTags.XML_ELEMENT) {
-            typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyElement" : "typeElement";
-        } else if (bType.tag == TypeTags.XML_PI) {
-            typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyProcessingInstruction" :
-                    "typeProcessingInstruction";
-        } else if (bType.tag == TypeTags.XML_COMMENT) {
-            typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyComment" : "typeComment";
-        } else if (bType.tag == TypeTags.XML_TEXT) {
-            typeFieldName = "typeText";
-        } else if (bType.tag == TypeTags.TYPEDESC) {
-            loadTypedescType(mv, (BTypedescType) bType);
-            return;
-        } else if (bType.tag == TypeTags.OBJECT) {
-            if (bType instanceof BServiceType) {
-                if (!Objects.equals(getTypeFieldName(toNameString(bType)), "$type$service")) {
+        } else {
+            switch (bType.tag) {
+                case TypeTags.NEVER:
+                    typeFieldName = "typeNever";
+                    break;
+                case TypeTags.INT:
+                    typeFieldName = "typeInt";
+                    break;
+                case TypeTags.SIGNED32_INT:
+                    typeFieldName = "typeIntSigned32";
+                    break;
+                case TypeTags.SIGNED16_INT:
+                    typeFieldName = "typeIntSigned16";
+                    break;
+                case TypeTags.SIGNED8_INT:
+                    typeFieldName = "typeIntSigned8";
+                    break;
+                case TypeTags.UNSIGNED32_INT:
+                    typeFieldName = "typeIntUnsigned32";
+                    break;
+                case TypeTags.UNSIGNED16_INT:
+                    typeFieldName = "typeIntUnsigned16";
+                    break;
+                case TypeTags.UNSIGNED8_INT:
+                    typeFieldName = "typeIntUnsigned8";
+                    break;
+                case TypeTags.FLOAT:
+                    typeFieldName = "typeFloat";
+                    break;
+                case TypeTags.STRING:
+                    typeFieldName = "typeString";
+                    break;
+                case TypeTags.CHAR_STRING:
+                    typeFieldName = "typeStringChar";
+                    break;
+                case TypeTags.DECIMAL:
+                    typeFieldName = "typeDecimal";
+                    break;
+                case TypeTags.BOOLEAN:
+                    typeFieldName = "typeBoolean";
+                    break;
+                case TypeTags.BYTE:
+                    typeFieldName = "typeByte";
+                    break;
+                case TypeTags.ANY:
+                    typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyAny" : "typeAny";
+                    break;
+                case TypeTags.ANYDATA:
+                    typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyAnydata" :
+                            "typeAnydata";
+                    break;
+                case TypeTags.JSON:
+                    typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyJSON" : "typeJSON";
+                    break;
+                case TypeTags.XML:
+                    loadXmlType(mv, (BXMLType) bType);
+                    return;
+                case TypeTags.XML_ELEMENT:
+                    typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyElement" :
+                            "typeElement";
+                    break;
+                case TypeTags.XML_PI:
+                    typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ?
+                            "typeReadonlyProcessingInstruction" : "typeProcessingInstruction";
+                    break;
+                case TypeTags.XML_COMMENT:
+                    typeFieldName = Symbols.isFlagOn(bType.flags, Flags.READONLY) ? "typeReadonlyComment" :
+                            "typeComment";
+                    break;
+                case TypeTags.XML_TEXT:
+                    typeFieldName = "typeText";
+                    break;
+                case TypeTags.TYPEDESC:
+                    loadTypedescType(mv, (BTypedescType) bType);
+                    return;
+                case TypeTags.OBJECT:
+                    if (bType instanceof BServiceType) {
+                        if (!Objects.equals(getTypeFieldName(toNameString(bType)), "$type$service")) {
+                            loadUserDefinedType(mv, bType);
+                            return;
+                        } else {
+                            typeFieldName = "typeAnyService";
+                        }
+                    } else if (bType instanceof BObjectType) {
+                        loadUserDefinedType(mv, bType);
+                        return;
+                    }
+                    break;
+                case TypeTags.HANDLE:
+                    typeFieldName = "typeHandle";
+                    break;
+                case TypeTags.ARRAY:
+                    loadArrayType(mv, (BArrayType) bType);
+                    return;
+                case TypeTags.MAP:
+                    loadMapType(mv, (BMapType) bType);
+                    return;
+                case TypeTags.STREAM:
+                    loadStreamType(mv, (BStreamType) bType);
+                    return;
+                case TypeTags.TABLE:
+                    loadTableType(mv, (BTableType) bType);
+                    return;
+                case TypeTags.ERROR:
+                    loadErrorType(mv, (BErrorType) bType);
+                    return;
+                case TypeTags.UNION:
+                    loadUnionType(mv, (BUnionType) bType);
+                    return;
+                case TypeTags.INTERSECTION:
+                    loadIntersectionType(mv, (BIntersectionType) bType);
+                    return;
+                case TypeTags.RECORD:
                     loadUserDefinedType(mv, bType);
                     return;
-                } else {
-                    typeFieldName = "typeAnyService";
-                }
-            } else if (bType instanceof BObjectType) {
-                loadUserDefinedType(mv, bType);
-                return;
+                case TypeTags.INVOKABLE:
+                    loadInvokableType(mv, (BInvokableType) bType);
+                    return;
+                case TypeTags.NONE:
+                    mv.visitInsn(ACONST_NULL);
+                    return;
+                case TypeTags.TUPLE:
+                    loadTupleType(mv, (BTupleType) bType);
+                    return;
+                case TypeTags.FINITE:
+                    loadFiniteType(mv, (BFiniteType) bType);
+                    return;
+                case TypeTags.FUTURE:
+                    loadFutureType(mv, (BFutureType) bType);
+                    return;
+                case TypeTags.READONLY:
+                    typeFieldName = "typeReadonly";
+                    break;
+                default:
+                    // TODO Fix properly - rajith
+                    return;
             }
-        } else if (bType.tag == TypeTags.HANDLE) {
-            typeFieldName = "typeHandle";
-        } else if (bType.tag == TypeTags.ARRAY) {
-            loadArrayType(mv, (BArrayType) bType);
-            return;
-        } else if (bType.tag == TypeTags.MAP) {
-            loadMapType(mv, (BMapType) bType);
-            return;
-        } else if (bType.tag == TypeTags.STREAM) {
-            loadStreamType(mv, (BStreamType) bType);
-            return;
-        } else if (bType.tag == TypeTags.TABLE) {
-            loadTableType(mv, (BTableType) bType);
-            return;
-        } else if (bType.tag == TypeTags.ERROR) {
-            loadErrorType(mv, (BErrorType) bType);
-            return;
-        } else if (bType.tag == TypeTags.UNION) {
-            loadUnionType(mv, (BUnionType) bType);
-            return;
-        } else if (bType.tag == TypeTags.INTERSECTION) {
-            loadIntersectionType(mv, (BIntersectionType) bType);
-            return;
-        } else if (bType.tag == TypeTags.RECORD) {
-            loadUserDefinedType(mv, bType);
-            return;
-        } else if (bType.tag == TypeTags.INVOKABLE) {
-            loadInvokableType(mv, (BInvokableType) bType);
-            return;
-        } else if (bType.tag == TypeTags.NONE) {
-            mv.visitInsn(ACONST_NULL);
-            return;
-        } else if (bType.tag == TypeTags.TUPLE) {
-            loadTupleType(mv, (BTupleType) bType);
-            return;
-        } else if (bType.tag == TypeTags.FINITE) {
-            loadFiniteType(mv, (BFiniteType) bType);
-            return;
-        } else if (bType.tag == TypeTags.FUTURE) {
-            loadFutureType(mv, (BFutureType) bType);
-            return;
-        } else if (bType.tag == TypeTags.READONLY) {
-            typeFieldName = "typeReadonly";
-        } else {
-            // TODO Fix properly - rajith
-            return;
         }
 
         mv.visitFieldInsn(GETSTATIC, BTYPES, typeFieldName, String.format("L%s;", BTYPE));
@@ -1552,50 +1582,57 @@ class JvmTypeGen {
 
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             return "J";
-        } else if (bType.tag == TypeTags.BYTE) {
-            return "I";
-        } else if (bType.tag == TypeTags.FLOAT) {
-            return "D";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
             return String.format("L%s;", B_STRING_VALUE);
-        } else if (bType.tag == TypeTags.BOOLEAN) {
-            return "Z";
-        } else if (bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
-            return String.format("L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.ARRAY || bType.tag == TypeTags.TUPLE) {
-            return String.format("L%s;", ARRAY_VALUE);
-        } else if (bType.tag == TypeTags.ERROR) {
-            return String.format("L%s;", ERROR_VALUE);
-        } else if (bType.tag == TypeTags.FUTURE) {
-            return String.format("L%s;", FUTURE_VALUE);
-        } else if (bType.tag == TypeTags.MAP || bType.tag == TypeTags.RECORD) {
-            return String.format("L%s;", MAP_VALUE);
-        } else if (bType.tag == TypeTags.TYPEDESC) {
-            return String.format("L%s;", TYPEDESC_VALUE);
-        } else if (bType.tag == TypeTags.STREAM) {
-            return String.format("L%s;", STREAM_VALUE);
-        } else if (bType.tag == TypeTags.TABLE) {
-            return String.format("L%s;", TABLE_VALUE_IMPL);
-        } else if (bType.tag == TypeTags.DECIMAL) {
-            return String.format("L%s;", DECIMAL_VALUE);
-        } else if (bType.tag == TypeTags.OBJECT) {
-            return String.format("L%s;", OBJECT_VALUE);
         } else if (TypeTags.isXMLTypeTag(bType.tag)) {
             return String.format("L%s;", XML_VALUE);
-        } else if (bType.tag == TypeTags.HANDLE) {
-            return String.format("L%s;", HANDLE_VALUE);
-        } else if (bType.tag == TypeTags.ANY ||
-                bType.tag == TypeTags.ANYDATA ||
-                bType.tag == TypeTags.UNION ||
-                bType.tag == TypeTags.INTERSECTION ||
-                bType.tag == TypeTags.JSON ||
-                bType.tag == TypeTags.FINITE ||
-                bType.tag == TypeTags.READONLY) {
-            return String.format("L%s;", OBJECT);
-        } else if (bType.tag == TypeTags.INVOKABLE) {
-            return String.format("L%s;", FUNCTION_POINTER);
-        } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " + String.format("%s", bType));
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                return "I";
+            case TypeTags.FLOAT:
+                return "D";
+            case TypeTags.BOOLEAN:
+                return "Z";
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+                return String.format("L%s;", OBJECT);
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                return String.format("L%s;", ARRAY_VALUE);
+            case TypeTags.ERROR:
+                return String.format("L%s;", ERROR_VALUE);
+            case TypeTags.FUTURE:
+                return String.format("L%s;", FUTURE_VALUE);
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                return String.format("L%s;", MAP_VALUE);
+            case TypeTags.TYPEDESC:
+                return String.format("L%s;", TYPEDESC_VALUE);
+            case TypeTags.STREAM:
+                return String.format("L%s;", STREAM_VALUE);
+            case TypeTags.TABLE:
+                return String.format("L%s;", TABLE_VALUE_IMPL);
+            case TypeTags.DECIMAL:
+                return String.format("L%s;", DECIMAL_VALUE);
+            case TypeTags.OBJECT:
+                return String.format("L%s;", OBJECT_VALUE);
+            case TypeTags.HANDLE:
+                return String.format("L%s;", HANDLE_VALUE);
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.READONLY:
+                return String.format("L%s;", OBJECT);
+            case TypeTags.INVOKABLE:
+                return String.format("L%s;", FUNCTION_POINTER);
+            default:
+                throw new BLangCompilerException("JVM generation is not supported for type " +
+                        String.format("%s", bType));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -233,12 +233,12 @@ class JvmTypeGen {
             fieldName = getTypeFieldName(typeDef.name.value);
             BType bType = typeDef.type;
             if (bType.tag == TypeTags.RECORD) {
-                createRecordType(mv, (BRecordType) bType, typeDef);
+                createRecordType(mv, (BRecordType) bType);
             } else if (bType.tag == TypeTags.OBJECT) {
                 if (bType instanceof BServiceType) {
-                    createServiceType(mv, (BServiceType) bType, typeDef.type);
+                    createServiceType(mv, (BServiceType) bType);
                 } else {
-                    createObjectType(mv, (BObjectType) bType, typeDef);
+                    createObjectType(mv, (BObjectType) bType);
                 }
             } else if (bType.tag == TypeTags.ERROR) {
                 createErrorType(mv, (BErrorType) bType, bType.tsymbol.name.value);
@@ -347,7 +347,7 @@ class JvmTypeGen {
         // Create TypeIdSet
         mv.visitTypeInsn(NEW, TYPE_ID_SET);
         mv.visitInsn(DUP);
-        mv.visitMethodInsn(INVOKESPECIAL, TYPE_ID_SET, "<init>", String.format("()V"), false);
+        mv.visitMethodInsn(INVOKESPECIAL, TYPE_ID_SET, "<init>", "()V", false);
 
         for (BTypeIdSet.BTypeId typeId : typeIdSet.primary) {
             addTypeId(mv, typeId, true);
@@ -595,9 +595,8 @@ class JvmTypeGen {
      *
      * @param mv         method visitor
      * @param recordType record type
-     * @param typeDef    record type definition
      */
-    private static void createRecordType(MethodVisitor mv, BRecordType recordType, BIRTypeDefinition typeDef) {
+    private static void createRecordType(MethodVisitor mv, BRecordType recordType) {
         // Create the record type
         mv.visitTypeInsn(NEW, RECORD_TYPE);
         mv.visitInsn(DUP);
@@ -722,9 +721,8 @@ class JvmTypeGen {
      *
      * @param mv         method visitor
      * @param objectType object type
-     * @param typeDef    object type definition.
      */
-    private static void createObjectType(MethodVisitor mv, BObjectType objectType, BIRTypeDefinition typeDef) {
+    private static void createObjectType(MethodVisitor mv, BObjectType objectType) {
         // Create the object type
         mv.visitTypeInsn(NEW, OBJECT_TYPE);
         mv.visitInsn(DUP);
@@ -759,9 +757,8 @@ class JvmTypeGen {
      *
      * @param mv         method visitor
      * @param objectType object type
-     * @param typeDef    type definition of the service
      */
-    private static void createServiceType(MethodVisitor mv, BObjectType objectType, BType typeDef) {
+    private static void createServiceType(MethodVisitor mv, BObjectType objectType) {
         // Create the object type
         mv.visitTypeInsn(NEW, SERVICE_TYPE);
         mv.visitInsn(DUP);
@@ -793,7 +790,7 @@ class JvmTypeGen {
     static void duplicateServiceTypeWithAnnots(MethodVisitor mv, BObjectType objectType, String pkgClassName,
                                                int strandIndex) {
 
-        createServiceType(mv, objectType, objectType);
+        createServiceType(mv, objectType);
         mv.visitInsn(DUP);
 
         mv.visitFieldInsn(GETSTATIC, pkgClassName, ANNOTATION_MAP_NAME, String.format("L%s;", MAP_VALUE));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -340,7 +340,7 @@ class JvmValueGen {
             if (func == null) {
                 continue;
             }
-            jvmMethodGen.generateMethod(func, cw, module, currentObjectType, isService, typeName, lambdaGenMetadata);
+            jvmMethodGen.generateMethod(func, cw, module, currentObjectType, lambdaGenMetadata);
         }
     }
 
@@ -376,7 +376,7 @@ class JvmValueGen {
     }
 
     private void createCallMethod(ClassWriter cw, List<BIRNode.BIRFunction> functions, String objClassName,
-                                  String objTypeName, boolean isService) {
+                                  boolean isService) {
 
         List<BIRNode.BIRFunction> funcs = getFunctions(functions);
 
@@ -405,7 +405,7 @@ class JvmValueGen {
             List<BType> paramTypes = func.type.paramTypes;
             BType retType = func.type.retType;
 
-            String methodSig = "";
+            String methodSig;
 
             // use index access, since retType can be nil.
             methodSig = getMethodDesc(paramTypes, retType, null, false);
@@ -558,7 +558,7 @@ class JvmValueGen {
         }
         cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, className, null, TYPEDESC_VALUE_IMPL, new String[]{TYPEDESC_VALUE});
 
-        this.createTypeDescConstructor(cw, className);
+        this.createTypeDescConstructor(cw);
         this.createInstantiateMethod(cw, recordType, typeDef);
 
         cw.visitEnd();
@@ -707,11 +707,11 @@ class JvmValueGen {
             if (func == null) {
                 continue;
             }
-            jvmMethodGen.generateMethod(func, cw, this.module, null, false, "", lambdaGenMetadata);
+            jvmMethodGen.generateMethod(func, cw, this.module, null, lambdaGenMetadata);
         }
     }
 
-    private void createTypeDescConstructor(ClassWriter cw, String className) {
+    private void createTypeDescConstructor(ClassWriter cw) {
 
         String descriptor = String.format("(L%s;[L%s;)V", BTYPE, MAP_VALUE);
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", descriptor, null, null);
@@ -1082,7 +1082,7 @@ class JvmValueGen {
         mv.visitEnd();
     }
 
-    void createRecordGetValuesMethod(ClassWriter cw, Map<String, BField> fields, String className) {
+    private void createRecordGetValuesMethod(ClassWriter cw, Map<String, BField> fields, String className) {
 
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "values", String.format("()L%s;", COLLECTION),
                                           String.format("()L%s<TV;>;", COLLECTION), null);
@@ -1128,7 +1128,7 @@ class JvmValueGen {
         mv.visitEnd();
     }
 
-    void createGetSizeMethod(ClassWriter cw, Map<String, BField> fields, String className) {
+    private void createGetSizeMethod(ClassWriter cw, Map<String, BField> fields, String className) {
 
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "size", "()I", null, null);
         mv.visitCode();
@@ -1264,7 +1264,7 @@ class JvmValueGen {
         }
     }
 
-    void createRecordGetKeysMethod(ClassWriter cw, Map<String, BField> fields, String className) {
+    private void createRecordGetKeysMethod(ClassWriter cw, Map<String, BField> fields, String className) {
 
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "getKeys", String.format("()[L%s;", OBJECT), "()[TK;", null);
         mv.visitCode();
@@ -1377,7 +1377,7 @@ class JvmValueGen {
         }
 
         this.createObjectInit(cw, fields, className);
-        this.createCallMethod(cw, attachedFuncs, className, toNameString(objectType), isService);
+        this.createCallMethod(cw, attachedFuncs, className, isService);
         this.createObjectGetMethod(cw, fields, className);
         this.createObjectSetMethod(cw, fields, className);
         this.createObjectSetOnInitializationMethod(cw, fields, className);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -450,25 +450,25 @@ class JvmValueGen {
 
     private void createObjectGetMethod(ClassWriter cw, Map<String, BField> fields, String className) {
 
-            String signature = String.format("(L%s;)L%s;", B_STRING_VALUE, OBJECT);
+        String signature = String.format("(L%s;)L%s;", B_STRING_VALUE, OBJECT);
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "get", signature, null, null);
         mv.visitCode();
 
-            int fieldNameRegIndex = 1;
-            mv.visitVarInsn(ALOAD, fieldNameRegIndex);
-            mv.visitMethodInsn(INVOKEINTERFACE, B_STRING_VALUE, "getValue",
-                               String.format("()L%s;", STRING_VALUE), true);
-            fieldNameRegIndex = 2;
-            mv.visitVarInsn(ASTORE, fieldNameRegIndex);
-            Label defaultCaseLabel = new Label();
+        int fieldNameRegIndex = 1;
+        mv.visitVarInsn(ALOAD, fieldNameRegIndex);
+        mv.visitMethodInsn(INVOKEINTERFACE, B_STRING_VALUE, "getValue",
+                String.format("()L%s;", STRING_VALUE), true);
+        fieldNameRegIndex = 2;
+        mv.visitVarInsn(ASTORE, fieldNameRegIndex);
+        Label defaultCaseLabel = new Label();
 
         // sort the fields before generating switch case
         List<BField> sortedFields = new ArrayList<>(fields.values());
         sortedFields.sort(NAME_HASH_COMPARATOR);
 
-            List<Label> labels = createLabelsForSwitch(mv, fieldNameRegIndex, sortedFields, defaultCaseLabel);
-            List<Label> targetLabels = createLabelsForEqualCheck(mv, fieldNameRegIndex, sortedFields, labels,
-                                                                 defaultCaseLabel);
+        List<Label> labels = createLabelsForSwitch(mv, fieldNameRegIndex, sortedFields, defaultCaseLabel);
+        List<Label> targetLabels = createLabelsForEqualCheck(mv, fieldNameRegIndex, sortedFields, labels,
+                defaultCaseLabel);
 
         int i = 0;
         for (BField optionalField : sortedFields) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -332,9 +332,8 @@ class JvmValueGen {
         }
     }
 
-    private void createObjectMethods(ClassWriter cw, List<BIRNode.BIRFunction> attachedFuncs, boolean isService,
-                                     String typeName, BObjectType currentObjectType,
-                                     LambdaMetadata lambdaGenMetadata) {
+    private void createObjectMethods(ClassWriter cw, List<BIRNode.BIRFunction> attachedFuncs,
+                                     BObjectType currentObjectType, LambdaMetadata lambdaGenMetadata) {
 
         for (BIRNode.BIRFunction func : attachedFuncs) {
             if (func == null) {
@@ -1373,7 +1372,7 @@ class JvmValueGen {
 
         List<BIRNode.BIRFunction> attachedFuncs = typeDef.attachedFuncs;
         if (attachedFuncs != null) {
-            this.createObjectMethods(cw, attachedFuncs, isService, typeDef.name.value, objectType, lambdaGenMetadata);
+            this.createObjectMethods(cw, attachedFuncs, objectType, lambdaGenMetadata);
         }
 
         this.createObjectInit(cw, fields, className);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/ExternalMethodGen.java
@@ -75,7 +75,7 @@ public class ExternalMethodGen {
             genJFieldForInteropField((JFieldFunctionWrapper) extFuncWrapper, cw, birModule, jvmPackageGen,
                     jvmMethodGen, lambdaGenMetadata);
         } else {
-            jvmMethodGen.genJMethodForBFunc(birFunc, cw, birModule, false, "", attachedType, lambdaGenMetadata);
+            jvmMethodGen.genJMethodForBFunc(birFunc, cw, birModule, attachedType, lambdaGenMetadata);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -496,27 +496,27 @@ public class InteropMethodGen {
         } else if (jType.jTag == JTypeTags.JARRAY) {
             JType eType = ((JType.JArrayType) jType).elementType;
             return "[" + getJTypeSignature(eType);
-        } else {
-            switch (jType.jTag) {
-                case JTypeTags.JBYTE:
-                    return "B";
-                case JTypeTags.JCHAR:
-                    return "C";
-                case JTypeTags.JSHORT:
-                    return "S";
-                case JTypeTags.JINT:
-                    return "I";
-                case JTypeTags.JLONG:
-                    return "J";
-                case JTypeTags.JFLOAT:
-                    return "F";
-                case JTypeTags.JDOUBLE:
-                    return "D";
-                case JTypeTags.JBOOLEAN:
-                    return "Z";
-                default:
-                    throw new BLangCompilerException(String.format("invalid element type: %s", jType));
-            }
+        }
+
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+                return "B";
+            case JTypeTags.JCHAR:
+                return "C";
+            case JTypeTags.JSHORT:
+                return "S";
+            case JTypeTags.JINT:
+                return "I";
+            case JTypeTags.JLONG:
+                return "J";
+            case JTypeTags.JFLOAT:
+                return "F";
+            case JTypeTags.JDOUBLE:
+                return "D";
+            case JTypeTags.JBOOLEAN:
+                return "Z";
+            default:
+                throw new BLangCompilerException(String.format("invalid element type: %s", jType));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -286,7 +286,7 @@ public class InteropMethodGen {
         Label retLabel = labelGen.getLabel("return_lable");
         mv.visitLabel(retLabel);
         mv.visitLineNumber(birFunc.pos.sLine, retLabel);
-        termGen.genReturnTerm(new BIRTerminator.Return(birFunc.pos), returnVarRefIndex, birFunc, -1);
+        termGen.genReturnTerm(new BIRTerminator.Return(birFunc.pos), returnVarRefIndex, birFunc);
         mv.visitMaxs(200, 400);
         mv.visitEnd();
     }
@@ -642,7 +642,7 @@ public class InteropMethodGen {
         }
 
         // unwrap from handleValue
-        generateBToJCheckCast(mv, bElementType, (JType) jElementType);
+        generateBToJCheckCast(mv, bElementType, jElementType);
 
         // valueArray[index] = varArg[index]
         genArrayStore(mv, jElementType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -497,24 +497,25 @@ public class InteropMethodGen {
             JType eType = ((JType.JArrayType) jType).elementType;
             return "[" + getJTypeSignature(eType);
         } else {
-            if (jType.jTag == JTypeTags.JBYTE) {
-                return "B";
-            } else if (jType.jTag == JTypeTags.JCHAR) {
-                return "C";
-            } else if (jType.jTag == JTypeTags.JSHORT) {
-                return "S";
-            } else if (jType.jTag == JTypeTags.JINT) {
-                return "I";
-            } else if (jType.jTag == JTypeTags.JLONG) {
-                return "J";
-            } else if (jType.jTag == JTypeTags.JFLOAT) {
-                return "F";
-            } else if (jType.jTag == JTypeTags.JDOUBLE) {
-                return "D";
-            } else if (jType.jTag == JTypeTags.JBOOLEAN) {
-                return "Z";
-            } else {
-                throw new BLangCompilerException(String.format("invalid element type: %s", jType));
+            switch (jType.jTag) {
+                case JTypeTags.JBYTE:
+                    return "B";
+                case JTypeTags.JCHAR:
+                    return "C";
+                case JTypeTags.JSHORT:
+                    return "S";
+                case JTypeTags.JINT:
+                    return "I";
+                case JTypeTags.JLONG:
+                    return "J";
+                case JTypeTags.JFLOAT:
+                    return "F";
+                case JTypeTags.JDOUBLE:
+                    return "D";
+                case JTypeTags.JBOOLEAN:
+                    return "Z";
+                default:
+                    throw new BLangCompilerException(String.format("invalid element type: %s", jType));
             }
         }
     }
@@ -531,26 +532,27 @@ public class InteropMethodGen {
                 sig += "[";
             }
 
-            if (eType.jTag == JTypeTags.JREF) {
-                return sig + "L" + getSignatureForJType(eType) + ";";
-            } else if (eType.jTag == JTypeTags.JBYTE) {
-                return sig + "B";
-            } else if (eType.jTag == JTypeTags.JCHAR) {
-                return sig + "C";
-            } else if (eType.jTag == JTypeTags.JSHORT) {
-                return sig + "S";
-            } else if (eType.jTag == JTypeTags.JINT) {
-                return sig + "I";
-            } else if (eType.jTag == JTypeTags.JLONG) {
-                return sig + "J";
-            } else if (eType.jTag == JTypeTags.JFLOAT) {
-                return sig + "F";
-            } else if (eType.jTag == JTypeTags.JDOUBLE) {
-                return sig + "D";
-            } else if (eType.jTag == JTypeTags.JBOOLEAN) {
-                return sig + "Z";
-            } else {
-                throw new BLangCompilerException(String.format("invalid element type: %s", eType));
+            switch (eType.jTag) {
+                case JTypeTags.JREF:
+                    return sig + "L" + getSignatureForJType(eType) + ";";
+                case JTypeTags.JBYTE:
+                    return sig + "B";
+                case JTypeTags.JCHAR:
+                    return sig + "C";
+                case JTypeTags.JSHORT:
+                    return sig + "S";
+                case JTypeTags.JINT:
+                    return sig + "I";
+                case JTypeTags.JLONG:
+                    return sig + "J";
+                case JTypeTags.JFLOAT:
+                    return sig + "F";
+                case JTypeTags.JDOUBLE:
+                    return sig + "D";
+                case JTypeTags.JBOOLEAN:
+                    return sig + "Z";
+                default:
+                    throw new BLangCompilerException(String.format("invalid element type: %s", eType));
             }
         } else {
             throw new BLangCompilerException(String.format("invalid element type: %s", jType));
@@ -616,17 +618,27 @@ public class InteropMethodGen {
         } else if (TypeTags.isStringTypeTag(bElementType.tag)) {
             mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getBString",
                                String.format("(J)L%s;", JvmConstants.B_STRING_VALUE), true);
-        } else if (bElementType.tag == TypeTags.BOOLEAN) {
-            mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getBoolean", "(J)Z", true);
-        } else if (bElementType.tag == TypeTags.BYTE) {
-            mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getByte", "(J)B", true);
-        } else if (bElementType.tag == TypeTags.FLOAT) {
-            mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getFloat", "(J)D", true);
-        } else if (bElementType.tag == TypeTags.HANDLE) {
-            mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getRefValue", String.format("(J)L%s;", OBJECT), true);
-            mv.visitTypeInsn(CHECKCAST, HANDLE_VALUE);
         } else {
-            mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getRefValue", String.format("(J)L%s;", OBJECT), true);
+            switch (bElementType.tag) {
+                case TypeTags.BOOLEAN:
+                    mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getBoolean", "(J)Z", true);
+                    break;
+                case TypeTags.BYTE:
+                    mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getByte", "(J)B", true);
+                    break;
+                case TypeTags.FLOAT:
+                    mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getFloat", "(J)D", true);
+                    break;
+                case TypeTags.HANDLE:
+                    mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getRefValue", String.format("(J)L%s;", OBJECT),
+                            true);
+                    mv.visitTypeInsn(CHECKCAST, HANDLE_VALUE);
+                    break;
+                default:
+                    mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getRefValue", String.format("(J)L%s;", OBJECT),
+                            true);
+                    break;
+            }
         }
 
         // unwrap from handleValue
@@ -646,22 +658,32 @@ public class InteropMethodGen {
     private static void genArrayStore(MethodVisitor mv, JType jType) {
 
         int code;
-        if (jType.jTag == JTypeTags.JINT) {
-            code = IASTORE;
-        } else if (jType.jTag == JTypeTags.JLONG) {
-            code = LASTORE;
-        } else if (jType.jTag == JTypeTags.JDOUBLE) {
-            code = DASTORE;
-        } else if (jType.jTag == JTypeTags.JBYTE || jType.jTag == JTypeTags.JBOOLEAN) {
-            code = BASTORE;
-        } else if (jType.jTag == JTypeTags.JSHORT) {
-            code = SASTORE;
-        } else if (jType.jTag == JTypeTags.JCHAR) {
-            code = CASTORE;
-        } else if (jType.jTag == JTypeTags.JFLOAT) {
-            code = FASTORE;
-        } else {
-            code = AASTORE;
+        switch (jType.jTag) {
+            case JTypeTags.JINT:
+                code = IASTORE;
+                break;
+            case JTypeTags.JLONG:
+                code = LASTORE;
+                break;
+            case JTypeTags.JDOUBLE:
+                code = DASTORE;
+                break;
+            case JTypeTags.JBYTE:
+            case JTypeTags.JBOOLEAN:
+                code = BASTORE;
+                break;
+            case JTypeTags.JSHORT:
+                code = SASTORE;
+                break;
+            case JTypeTags.JCHAR:
+                code = CASTORE;
+                break;
+            case JTypeTags.JFLOAT:
+                code = FASTORE;
+                break;
+            default:
+                code = AASTORE;
+                break;
         }
 
         mv.visitInsn(code);
@@ -669,24 +691,35 @@ public class InteropMethodGen {
 
     private static void genArrayNew(MethodVisitor mv, JType elementType) {
 
-        if (elementType.jTag == JTypeTags.JINT) {
-            mv.visitIntInsn(NEWARRAY, T_INT);
-        } else if (elementType.jTag == JTypeTags.JLONG) {
-            mv.visitIntInsn(NEWARRAY, T_LONG);
-        } else if (elementType.jTag == JTypeTags.JDOUBLE) {
-            mv.visitIntInsn(NEWARRAY, T_DOUBLE);
-        } else if (elementType.jTag == JTypeTags.JBYTE || elementType.jTag == JTypeTags.JBOOLEAN) {
-            mv.visitIntInsn(NEWARRAY, T_BOOLEAN);
-        } else if (elementType.jTag == JTypeTags.JSHORT) {
-            mv.visitIntInsn(NEWARRAY, T_SHORT);
-        } else if (elementType.jTag == JTypeTags.JCHAR) {
-            mv.visitIntInsn(NEWARRAY, T_CHAR);
-        } else if (elementType.jTag == JTypeTags.JFLOAT) {
-            mv.visitIntInsn(NEWARRAY, T_FLOAT);
-        } else if (elementType.jTag == JTypeTags.JREF || elementType.jTag == JTypeTags.JARRAY) {
-            mv.visitTypeInsn(ANEWARRAY, getSignatureForJType(elementType));
-        } else {
-            throw new BLangCompilerException(String.format("invalid type for var-arg: %s", elementType));
+        switch (elementType.jTag) {
+            case JTypeTags.JINT:
+                mv.visitIntInsn(NEWARRAY, T_INT);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitIntInsn(NEWARRAY, T_LONG);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitIntInsn(NEWARRAY, T_DOUBLE);
+                break;
+            case JTypeTags.JBYTE:
+            case JTypeTags.JBOOLEAN:
+                mv.visitIntInsn(NEWARRAY, T_BOOLEAN);
+                break;
+            case JTypeTags.JSHORT:
+                mv.visitIntInsn(NEWARRAY, T_SHORT);
+                break;
+            case JTypeTags.JCHAR:
+                mv.visitIntInsn(NEWARRAY, T_CHAR);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitIntInsn(NEWARRAY, T_FLOAT);
+                break;
+            case JTypeTags.JREF:
+            case JTypeTags.JARRAY:
+                mv.visitTypeInsn(ANEWARRAY, getSignatureForJType(elementType));
+                break;
+            default:
+                throw new BLangCompilerException(String.format("invalid type for var-arg: %s", elementType));
         }
     }
 


### PR DESCRIPTION
## Purpose
This PR refactor jvm codegen package with following changes.

- Use switch statements wherever appropriate
- Remove redundant method arguments and variables

Related to #24405