### PR TITLE
Remove `name` claim from `username` & Append JWT mandatory parameters as custom claims [1.2.x]

### DIFF
--- a/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -87,11 +87,5 @@ function setPrincipal(JwtPayload jwtPayload) {
                 auth:setPrincipal(scopes = stringutils:split(scopeString, " "));
             }
         }
-        if (claims.hasKey("name")) {
-            json name = claims["name"];
-            if (name is string) {
-                auth:setPrincipal(username = name);
-            }
-        }
     }
 }

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -232,19 +232,19 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
         match (key) {
             ISS => {
                 jwtPayload.iss = jwtPayloadJson[key].toJsonString();
-                customClaims[ISS] = jwtPayload.iss;
+                customClaims[ISS] = jwtPayload?.iss;
             }
             SUB => {
                 jwtPayload.sub = jwtPayloadJson[key].toJsonString();
-                customClaims[SUB] = jwtPayload.sub;
+                customClaims[SUB] = jwtPayload?.sub;
             }
             AUD => {
                 jwtPayload.aud = check convertToStringArray(jwtPayloadJson[key]);
-                customClaims[AUD] = jwtPayload.aud;
+                customClaims[AUD] = jwtPayload?.aud;
             }
             JTI => {
                 jwtPayload.jti = jwtPayloadJson[key].toJsonString();
-                customClaims[JTI] = jwtPayload.jti;
+                customClaims[JTI] = jwtPayload?.jti;
             }
             EXP => {
                 string exp = jwtPayloadJson[key].toJsonString();

--- a/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/jwt_validator.bal
@@ -232,18 +232,23 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
         match (key) {
             ISS => {
                 jwtPayload.iss = jwtPayloadJson[key].toJsonString();
+                customClaims[ISS] = jwtPayload.iss;
             }
             SUB => {
                 jwtPayload.sub = jwtPayloadJson[key].toJsonString();
+                customClaims[SUB] = jwtPayload.sub;
             }
             AUD => {
                 jwtPayload.aud = check convertToStringArray(jwtPayloadJson[key]);
+                customClaims[AUD] = jwtPayload.aud;
             }
             JTI => {
                 jwtPayload.jti = jwtPayloadJson[key].toJsonString();
+                customClaims[JTI] = jwtPayload.jti;
             }
             EXP => {
                 string exp = jwtPayloadJson[key].toJsonString();
+                customClaims[EXP] = exp;
                 int|error value = langint:fromString(exp);
                 if (value is int) {
                     jwtPayload.exp = value;
@@ -253,6 +258,7 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
             }
             NBF => {
                 string nbf = jwtPayloadJson[key].toJsonString();
+                customClaims[NBF] = nbf;
                 int|error value = langint:fromString(nbf);
                 if (value is int) {
                     jwtPayload.nbf = value;
@@ -262,6 +268,7 @@ function parsePayload(map<json> jwtPayloadJson) returns JwtPayload|Error {
             }
             IAT => {
                 string iat = jwtPayloadJson[key].toJsonString();
+                customClaims[IAT] = iat;
                 int|error value = langint:fromString(iat);
                 if (value is int) {
                     jwtPayload.iat = value;


### PR DESCRIPTION
## Purpose
- Appends JWT mandatory parameters as custom claims. Then those parameters can be retrieved from `runtime:InvocationContext` once inbound authentication got succeeded.
- Removes the `name` claim adding as the `username` of `runtime:Principal` record once authenticated.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
