### PR TITLE
 Remove antlr dependency from find-cursor-token for hover, rename, signature ops

### DIFF
--- a/language-server/modules/langserver-core/spotbugs-exclude.xml
+++ b/language-server/modules/langserver-core/spotbugs-exclude.xml
@@ -92,7 +92,7 @@
         <Class name="org.ballerinalang.langserver.symbols.SymbolFindingVisitor" />
     </Match>
     <Match>
-        <Class name="org.ballerinalang.langserver.hover.util.HoverUtil" />
+        <Class name="org.ballerinalang.langserver.hover.HoverUtil" />
         <OR>
             <Bug pattern="BC_UNCONFIRMED_CAST" />
         </OR>

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -47,6 +47,7 @@ import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
 import org.ballerinalang.langserver.exception.UserErrorException;
 import org.ballerinalang.langserver.extensions.ballerina.semantichighlighter.HighlightingFailedException;
 import org.ballerinalang.langserver.extensions.ballerina.semantichighlighter.SemanticHighlightProvider;
+import org.ballerinalang.langserver.hover.HoverUtil;
 import org.ballerinalang.langserver.implementation.GotoImplementationCustomErrorStrategy;
 import org.ballerinalang.langserver.signature.SignatureHelpUtil;
 import org.ballerinalang.langserver.signature.SignatureTreeVisitor;
@@ -54,6 +55,7 @@ import org.ballerinalang.langserver.symbols.SymbolFindingVisitor;
 import org.ballerinalang.langserver.util.Debouncer;
 import org.ballerinalang.langserver.util.definition.DefinitionUtil;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLens;
@@ -74,7 +76,6 @@ import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
-import org.eclipse.lsp4j.MarkedString;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceParams;
@@ -215,14 +216,13 @@ class BallerinaTextDocumentService implements TextDocumentService {
             Hover hover;
             try {
                 hover = ReferencesUtil.getHover(context);
+            } catch (TokenOrSymbolNotFoundException e) {
+                hover = HoverUtil.getDefaultHoverObject();
             } catch (Throwable e) {
                 // Note: Not catching UserErrorException separately to avoid flooding error msgs popups
                 String msg = "Operation 'text/hover' failed!";
                 logError(msg, e, position.getTextDocument(), position.getPosition());
-                hover = new Hover();
-                List<Either<String, MarkedString>> contents = new ArrayList<>();
-                contents.add(Either.forLeft(""));
-                hover.setContents(contents);
+                hover = HoverUtil.getDefaultHoverObject();
             }
             return hover;
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -15,7 +15,7 @@
  */
 package org.ballerinalang.langserver.codeaction;
 
-import org.ballerinalang.langserver.common.constants.NodeContextKeys;
+import io.ballerinalang.compiler.syntax.tree.Token;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.LSContext;
 import org.ballerinalang.langserver.commons.codeaction.CodeActionKeys;
@@ -29,9 +29,10 @@ import org.ballerinalang.langserver.compiler.LSModuleCompiler;
 import org.ballerinalang.langserver.compiler.common.LSCustomErrorStrategy;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
 import org.ballerinalang.langserver.exception.UserErrorException;
-import org.ballerinalang.langserver.util.references.ReferencesKeys;
+import org.ballerinalang.langserver.util.TokensUtil;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.TopLevelNode;
 import org.ballerinalang.util.diagnostic.Diagnostic;
@@ -216,19 +217,21 @@ public class CodeActionUtil {
      */
     public static SymbolReferencesModel.Reference getSymbolAtCursor(LSContext context, LSDocumentIdentifier document,
                                                                     Position position)
-            throws WorkspaceDocumentException, CompilationFailedException {
+            throws WorkspaceDocumentException, CompilationFailedException,
+                   TokenOrSymbolNotFoundException {
         TextDocumentIdentifier textDocIdentifier = new TextDocumentIdentifier(document.getURIString());
         TextDocumentPositionParams pos = new TextDocumentPositionParams(textDocIdentifier, position);
         context.put(DocumentServiceKeys.POSITION_KEY, pos);
         context.put(DocumentServiceKeys.FILE_URI_KEY, document.getURIString());
         context.put(DocumentServiceKeys.COMPILE_FULL_PROJECT, true);
-        List<BLangPackage> modules = ReferencesUtil.findCursorTokenAndCompileModules(context, false);
-        Optional<SymbolReferencesModel.Reference> symbolAtCursor = findSymbol(modules, context);
+
+        List<BLangPackage> modules = ReferencesUtil.compileModules(context);
         context.put(DocumentServiceKeys.BLANG_PACKAGES_CONTEXT_KEY, modules);
-        return symbolAtCursor.orElse(null);
+        return findSymbolAtCursor(modules, context);
     }
 
-    private static Optional<SymbolReferencesModel.Reference> findSymbol(List<BLangPackage> modules, LSContext context) {
+    private static SymbolReferencesModel.Reference findSymbolAtCursor(List<BLangPackage> modules, LSContext context)
+            throws WorkspaceDocumentException, TokenOrSymbolNotFoundException {
         String currentPkgName = context.get(DocumentServiceKeys.CURRENT_PKG_NAME_KEY);
         /*
         In windows platform, relative file path key components are separated with "\" while antlr always uses "/"
@@ -249,16 +252,16 @@ public class CodeActionUtil {
                 .filter(cUnit -> cUnit.name.equals(currentCUnitName))
                 .findAny();
 
-        CursorSymbolFindingVisitor refVisitor = new CursorSymbolFindingVisitor(context, currentPkgName, true);
-        refVisitor.visit(currentCUnit.get());
-
-        // Prune the found symbol references
-        SymbolReferencesModel symbolReferencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        if (!symbolReferencesModel.getReferenceAtCursor().isPresent()) {
-            String nodeName = context.get(NodeContextKeys.NODE_NAME_KEY);
-            throw new IllegalStateException("Symbol at cursor '" + nodeName + "' not supported or could not find!");
+        if (!currentCUnit.isPresent()) {
+            throw new UserErrorException("Not supported due to compilation failures!");
         }
 
+        // With the syntax-tree, find the cursor token
+        Token tokenAtCursor = TokensUtil.findtokenAtCursor(context);
+
+        CursorSymbolFindingVisitor refVisitor = new CursorSymbolFindingVisitor(tokenAtCursor, context,
+                                                                               currentPkgName, true);
+        SymbolReferencesModel symbolReferencesModel = refVisitor.accept(currentCUnit.get());
         return symbolReferencesModel.getReferenceAtCursor();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractCodeActionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractCodeActionProvider.java
@@ -172,6 +172,7 @@ public abstract class AbstractCodeActionProvider implements LSCodeActionProvider
 //            Lambda Functions: function() returns int { return 1; };
 //            Type Casts: <int>1.1;
 //            Streaming From Clauses: from var person in personList;
+        position = new Position(position.getLine(), position.getCharacter() + 1);
         String content = diagnosedContent.trim();
         int pointer = content.length();
         int count = 0;
@@ -270,7 +271,7 @@ public abstract class AbstractCodeActionProvider implements LSCodeActionProvider
         // Thus we offset into last
         int bal = diagnosedContent.length() - count;
         if (bal > 0) {
-            position = new Position(position.getLine(), position.getCharacter() + bal + 1);
+            position.setCharacter(position.getCharacter() + bal + 1);
         }
         return position;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateFunctionCodeAction.java
@@ -29,6 +29,7 @@ import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.PackageID;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -143,7 +144,7 @@ public class CreateFunctionCodeAction extends AbstractCodeActionProvider {
                     return action;
                 }
             }
-        } catch (CompilationFailedException | WorkspaceDocumentException e) {
+        } catch (CompilationFailedException | WorkspaceDocumentException | TokenOrSymbolNotFoundException e) {
             // ignore
         }
         return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateTestCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateTestCodeAction.java
@@ -31,6 +31,7 @@ import org.ballerinalang.langserver.compiler.exception.CompilationFailedExceptio
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.Flag;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Command;
@@ -90,7 +91,7 @@ public class CreateTestCodeAction extends AbstractCodeActionProvider {
             }
             return actions;
 
-        } catch (CompilationFailedException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | CompilationFailedException | TokenOrSymbolNotFoundException e) {
             // ignore
         }
         return null;
@@ -108,7 +109,7 @@ public class CreateTestCodeAction extends AbstractCodeActionProvider {
 
     private static boolean isTopLevelNode(String uri, WorkspaceDocumentManager docManager, LSContext context,
                                           Position pos)
-            throws CompilationFailedException, WorkspaceDocumentException {
+            throws CompilationFailedException, WorkspaceDocumentException, TokenOrSymbolNotFoundException {
         LSDocumentIdentifier lsDocument = docManager.getLSDocument(CommonUtil.getPathFromURI(uri).get());
         context.put(ReferencesKeys.OFFSET_CURSOR_N_TRY_NEXT_BEST, true);
         SymbolReferencesModel.Reference refAtCursor = ReferencesUtil.getReferenceAtCursor(context, lsDocument, pos);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateVariableCodeAction.java
@@ -33,6 +33,7 @@ import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel.Reference;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.TopLevelNode;
 import org.ballerinalang.model.tree.expressions.ExpressionNode;
@@ -189,7 +190,8 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
                     actions.add(createQuickFixCodeAction(commandTitle, getIgnoreCodeActionEdits(position), uri));
                 }
             }
-        } catch (CompilationFailedException | WorkspaceDocumentException | IOException e) {
+        } catch (WorkspaceDocumentException | CompilationFailedException | TokenOrSymbolNotFoundException |
+                IOException e) {
             // ignore
         }
         return actions;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
@@ -36,6 +36,7 @@ import org.ballerinalang.langserver.compiler.exception.CompilationFailedExceptio
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.TopLevelNode;
 import org.eclipse.lsp4j.Position;
@@ -125,7 +126,7 @@ public class CreateFunctionExecutor implements LSCommandExecutor {
             if (bLangNode instanceof BLangInvocation) {
                 functionNode = (BLangInvocation) bLangNode;
             }
-        } catch (CompilationFailedException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | CompilationFailedException | TokenOrSymbolNotFoundException e) {
             throw new LSCommandExecutorException("Error while compiling the source!");
         }
         if (functionNode == null) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateTestExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateTestExecutor.java
@@ -40,6 +40,7 @@ import org.ballerinalang.langserver.compiler.exception.CompilationFailedExceptio
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
 import org.eclipse.lsp4j.CreateFile;
 import org.eclipse.lsp4j.Location;
@@ -245,7 +246,8 @@ public class CreateTestExecutor implements LSCommandExecutor {
                 }
             }
             return editParams;
-        } catch (TestGeneratorException | CompilationFailedException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | CompilationFailedException | TokenOrSymbolNotFoundException
+                | TestGeneratorException e) {
             String message = "Test generation failed!: " + e.getMessage();
             if (client != null) {
                 client.showMessage(new MessageParams(MessageType.Error, message));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/OpenApiCodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/OpenApiCodeActionUtil.java
@@ -20,7 +20,9 @@ import org.ballerinalang.langserver.commons.workspace.LSDocumentIdentifier;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
+import org.ballerinalang.langserver.util.TokensUtil;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.tree.TopLevelNode;
 import org.ballerinalang.model.tree.expressions.RecordLiteralNode;
 import org.eclipse.lsp4j.Position;
@@ -55,13 +57,14 @@ public class OpenApiCodeActionUtil {
      */
     public static List<BLangPackage> getBLangPkg(LSContext context, LSDocumentIdentifier document,
                                                  Position position)
-            throws WorkspaceDocumentException, CompilationFailedException {
+            throws WorkspaceDocumentException, CompilationFailedException, TokenOrSymbolNotFoundException {
         TextDocumentIdentifier textDocIdentifier = new TextDocumentIdentifier(document.getURIString());
         TextDocumentPositionParams pos = new TextDocumentPositionParams(textDocIdentifier, position);
         context.put(DocumentServiceKeys.POSITION_KEY, pos);
         context.put(DocumentServiceKeys.FILE_URI_KEY, document.getURIString());
         context.put(DocumentServiceKeys.COMPILE_FULL_PROJECT, true);
-        return ReferencesUtil.findCursorTokenAndCompileModules(context, false);
+        TokensUtil.findtokenAtCursor(context);
+        return ReferencesUtil.compileModules(context);
     }
 
     public static BLangFunction getBLangFunction(List<BLangPackage> packages, Position position) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/ballerinatoopenapi/CreateBallerinaServiceResourceExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/ballerinatoopenapi/CreateBallerinaServiceResourceExecutor.java
@@ -54,6 +54,7 @@ import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
 import org.ballerinalang.langserver.compiler.ExtendedLSCompiler;
 import org.ballerinalang.langserver.compiler.common.modal.BallerinaFile;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.SimpleVariableNode;
 import org.ballerinalang.model.tree.TopLevelNode;
@@ -266,7 +267,8 @@ public class CreateBallerinaServiceResourceExecutor implements LSCommandExecutor
                 writeFile(Paths.get(contractURI), openApiResourceNew);
 
             }
-        } catch (CompilationFailedException | IOException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | CompilationFailedException | IOException |
+                TokenOrSymbolNotFoundException e) {
             throw new LSCommandExecutorException("Error while compiling the source!");
         }
         return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/ballerinatoopenapi/CreateBallerinaServiceResourceMethodExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/ballerinatoopenapi/CreateBallerinaServiceResourceMethodExecutor.java
@@ -54,6 +54,7 @@ import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
 import org.ballerinalang.langserver.compiler.ExtendedLSCompiler;
 import org.ballerinalang.langserver.compiler.common.modal.BallerinaFile;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.SimpleVariableNode;
 import org.ballerinalang.model.tree.TopLevelNode;
@@ -514,7 +515,8 @@ public class CreateBallerinaServiceResourceMethodExecutor implements LSCommandEx
                 writeFile(Paths.get(contractURI), openApiResourceNew);
 
             }
-        } catch (CompilationFailedException | IOException | WorkspaceDocumentException e) {
+        } catch (CompilationFailedException | IOException | WorkspaceDocumentException |
+                TokenOrSymbolNotFoundException e) {
             throw new LSCommandExecutorException("Error while compiling the source!");
         }
         return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/openapitoballerina/AddMissingParameterInBallerinaExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/openapitoballerina/AddMissingParameterInBallerinaExecutor.java
@@ -43,6 +43,7 @@ import org.ballerinalang.langserver.compiler.exception.CompilationFailedExceptio
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.model.tree.expressions.RecordLiteralNode;
 import org.ballerinalang.openapi.exception.BallerinaOpenApiException;
 import org.ballerinalang.openapi.typemodel.BallerinaOpenApiOperation;
@@ -284,7 +285,8 @@ public class AddMissingParameterInBallerinaExecutor implements LSCommandExecutor
             }
         } catch (CompilationFailedException e) {
             throw new LSCommandExecutorException("Error while compiling the source!");
-        } catch (BallerinaOpenApiException | IOException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | BallerinaOpenApiException | IOException |
+                TokenOrSymbolNotFoundException e) {
             throw new LSCommandExecutorException("Couldn't find the function node!");
         }
         return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/openapitoballerina/CreateOpenApiServiceResourceExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/openapitoballerina/CreateOpenApiServiceResourceExecutor.java
@@ -43,6 +43,7 @@ import org.ballerinalang.langserver.compiler.exception.CompilationFailedExceptio
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.openapi.exception.BallerinaOpenApiException;
 import org.ballerinalang.openapi.typemodel.BallerinaOpenApiPath;
 import org.ballerinalang.openapi.utils.GeneratorConstants;
@@ -228,7 +229,8 @@ public class CreateOpenApiServiceResourceExecutor implements LSCommandExecutor {
             }
         } catch (CompilationFailedException e) {
             throw new LSCommandExecutorException("Error while compiling the source!");
-        } catch (BallerinaOpenApiException | IOException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | BallerinaOpenApiException | TokenOrSymbolNotFoundException |
+                IOException e) {
             throw new LSCommandExecutorException("Couldn't find the function node!");
         }
         return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/openapitoballerina/CreateOpenApiServiceResourceMethodExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/openapi/openapitoballerina/CreateOpenApiServiceResourceMethodExecutor.java
@@ -43,6 +43,7 @@ import org.ballerinalang.langserver.compiler.exception.CompilationFailedExceptio
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
 import org.ballerinalang.langserver.util.references.ReferencesUtil;
 import org.ballerinalang.langserver.util.references.SymbolReferencesModel;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.ballerinalang.openapi.exception.BallerinaOpenApiException;
 import org.ballerinalang.openapi.typemodel.BallerinaOpenApiPath;
 import org.ballerinalang.openapi.utils.GeneratorConstants;
@@ -233,7 +234,8 @@ public class CreateOpenApiServiceResourceMethodExecutor implements LSCommandExec
             }
         } catch (CompilationFailedException e) {
             throw new LSCommandExecutorException("Error while compiling the source!");
-        } catch (BallerinaOpenApiException | IOException | WorkspaceDocumentException e) {
+        } catch (WorkspaceDocumentException | IOException | TokenOrSymbolNotFoundException |
+                BallerinaOpenApiException e) {
             throw new LSCommandExecutorException("Couldn't find the function node!");
         }
         return null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/NodeContextKeys.java
@@ -30,8 +30,6 @@ public class NodeContextKeys {
             = new LSContext.Key<>();
     public static final LSContext.Key<Stack<BLangNode>> NODE_STACK_KEY
             = new LSContext.Key<>();
-    public static final LSContext.Key<String> NODE_NAME_KEY
-            = new LSContext.Key<>();
     public static final LSContext.Key<Integer> INVOCATION_TOKEN_TYPE_KEY
             = new LSContext.Key<>();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.ballerinalang.langserver.hover.util;
+package org.ballerinalang.langserver.hover;
 
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TokensUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/TokensUtil.java
@@ -15,17 +15,28 @@
  */
 package org.ballerinalang.langserver.util;
 
+import io.ballerinalang.compiler.syntax.tree.ModuleMemberDeclarationNode;
+import io.ballerinalang.compiler.syntax.tree.ModulePartNode;
+import io.ballerinalang.compiler.syntax.tree.NonTerminalNode;
+import io.ballerinalang.compiler.syntax.tree.StatementNode;
+import io.ballerinalang.compiler.syntax.tree.SyntaxTree;
+import io.ballerinalang.compiler.text.LinePosition;
+import io.ballerinalang.compiler.text.TextDocument;
 import org.antlr.v4.runtime.Token;
 import org.ballerinalang.langserver.common.CommonKeys;
 import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.LSContext;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
 import org.ballerinalang.langserver.util.references.ReferencesKeys;
+import org.ballerinalang.langserver.util.references.TokenOrSymbolNotFoundException;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.wso2.ballerinalang.compiler.parser.antlr4.BallerinaParser;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 
@@ -40,12 +51,69 @@ public class TokensUtil {
     }
 
     /**
+     * Find the token at cursor.
+     *
+     * @throws WorkspaceDocumentException while retrieving the syntax tree from the document manager
+     * @return
+     */
+    public static io.ballerinalang.compiler.syntax.tree.Token findtokenAtCursor(LSContext context)
+            throws WorkspaceDocumentException, TokenOrSymbolNotFoundException {
+        WorkspaceDocumentManager docManager = context.get(DocumentServiceKeys.DOC_MANAGER_KEY);
+        Optional<Path> filePath = CommonUtil.getPathFromURI(context.get(DocumentServiceKeys.FILE_URI_KEY));
+        if (!filePath.isPresent()) {
+            throw new WorkspaceDocumentException("File " + filePath.toString() + " does not exists.");
+        }
+        SyntaxTree syntaxTree = docManager.getTree(filePath.get());
+        TextDocument textDocument = syntaxTree.textDocument();
+
+        Position position = context.get(DocumentServiceKeys.POSITION_KEY).getPosition();
+        int txtPos = textDocument.textPositionFrom(LinePosition.from(position.getLine(), position.getCharacter() - 1));
+        io.ballerinalang.compiler.syntax.tree.Token tokenAtCursor = ((ModulePartNode) syntaxTree.rootNode()).findToken(
+                txtPos);
+
+        if (tokenAtCursor == null) {
+            throw new TokenOrSymbolNotFoundException("Couldn't find a valid identifier token at cursor!");
+        }
+
+        int tokenType;
+        //TODO: Remove this, added for the backward compatibility of code
+        NonTerminalNode nodeAtCursor = getNodeAtCursor(tokenAtCursor);
+        switch (nodeAtCursor.kind()) {
+            case COLON_TOKEN:
+                tokenType = BallerinaParser.COLON;
+                break;
+            case RIGHT_ARROW_TOKEN:
+                tokenType = BallerinaParser.RARROW;
+                break;
+            case DOT_TOKEN:
+                tokenType = BallerinaParser.DOT;
+                break;
+            default:
+                tokenType = -1;
+                break;
+        }
+        context.put(NodeContextKeys.INVOCATION_TOKEN_TYPE_KEY, tokenType);
+        return tokenAtCursor;
+    }
+
+    private static NonTerminalNode getNodeAtCursor(io.ballerinalang.compiler.syntax.tree.Token tokenAtCursor) {
+        NonTerminalNode parent = tokenAtCursor.parent();
+
+        while (!(parent instanceof ModuleMemberDeclarationNode) && !(parent instanceof StatementNode)) {
+            parent = parent.parent();
+        }
+
+        return parent;
+    }
+
+    /**
      * Search and sets the token at cursor into LSContext.
      *
      * @param content content
      * @param context   {@link LSContext}
      * @param pos {@link Position}
      */
+    @Deprecated
     public static void searchTokenAtCursor(String content, LSContext context, Position pos) {
         // TODO: 1/23/19 Check what happens when the content is not a valid compilation unit and when there are errors
         List<Token> tokenList = CommonUtil.getTokenList(content);
@@ -53,7 +121,6 @@ public class TokensUtil {
         Optional<Token> tokenAtCursor = searchTokenAtCursor(context, tokenList, pos.getLine(), pos.getCharacter(), true,
                                                             (nextBest == null) ? false : nextBest);
         tokenAtCursor.ifPresent(token -> {
-            context.put(NodeContextKeys.NODE_NAME_KEY, token.getText());
             int tokenIndex = token.getTokenIndex() - 1;
             int tokenType = -1;
             if (tokenIndex > 0) {
@@ -72,6 +139,7 @@ public class TokensUtil {
      * @param cCol      cursor column
      * @return {@link Optional}
      */
+    @Deprecated
     public static Optional<Token> searchTokenAtCursor(LSContext context, List<Token> tokenList, int cLine, int cCol,
                                                       boolean identifiersOnly, boolean offsetAndTryNextBest) {
         return searchTokenAtCursor(context, tokenList, 0, tokenList.size(), cLine, cCol, identifiersOnly,

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
@@ -15,8 +15,8 @@
  */
 package org.ballerinalang.langserver.util.references;
 
+import io.ballerinalang.compiler.syntax.tree.Token;
 import org.ballerinalang.langserver.common.CommonKeys;
-import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.LSContext;
 import org.ballerinalang.langserver.commons.workspace.LSDocumentIdentifier;
@@ -27,8 +27,9 @@ import org.ballerinalang.langserver.compiler.LSModuleCompiler;
 import org.ballerinalang.langserver.compiler.common.LSCustomErrorStrategy;
 import org.ballerinalang.langserver.compiler.exception.CompilationFailedException;
 import org.ballerinalang.langserver.exception.UserErrorException;
-import org.ballerinalang.langserver.hover.util.HoverUtil;
+import org.ballerinalang.langserver.hover.HoverUtil;
 import org.ballerinalang.langserver.util.TokensUtil;
+import org.ballerinalang.langserver.util.references.SymbolReferencesModel.Reference;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -70,20 +71,19 @@ public class ReferencesUtil {
      * @throws WorkspaceDocumentException when couldn't find file for uri
      * @throws CompilationFailedException when compilation failed
      */
-    public static SymbolReferencesModel.Reference getReferenceAtCursor(LSContext context, LSDocumentIdentifier document,
-                                                                       Position position)
-            throws WorkspaceDocumentException, CompilationFailedException {
+    public static Reference getReferenceAtCursor(LSContext context, LSDocumentIdentifier document,
+                                                 Position position)
+            throws WorkspaceDocumentException, CompilationFailedException, TokenOrSymbolNotFoundException {
         TextDocumentIdentifier textDocIdentifier = new TextDocumentIdentifier(document.getURIString());
         TextDocumentPositionParams pos = new TextDocumentPositionParams(textDocIdentifier, position);
         context.put(DocumentServiceKeys.POSITION_KEY, pos);
         context.put(DocumentServiceKeys.FILE_URI_KEY, document.getURIString());
         context.put(DocumentServiceKeys.COMPILE_FULL_PROJECT, true);
-        List<BLangPackage> modules = ReferencesUtil.findCursorTokenAndCompileModules(context, false);
-        findReferences(modules, context);
+        Token tokenAtCursor = TokensUtil.findtokenAtCursor(context);
+        List<BLangPackage> modules = ReferencesUtil.compileModules(context);
+        SymbolReferencesModel referencesModel = findReferencesForCurrentCUnit(tokenAtCursor, modules, context);
         context.put(DocumentServiceKeys.BLANG_PACKAGES_CONTEXT_KEY, modules);
-        SymbolReferencesModel referencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        Optional<SymbolReferencesModel.Reference> symbolAtCursor = referencesModel.getReferenceAtCursor();
-        return symbolAtCursor.orElse(null);
+        return referencesModel.getReferenceAtCursor();
     }
 
     /**
@@ -96,31 +96,33 @@ public class ReferencesUtil {
      * @throws CompilationFailedException when compilation failed
      */
     public static WorkspaceEdit getRenameWorkspaceEdits(LSContext context, String newName)
-            throws WorkspaceDocumentException, CompilationFailedException {
-        List<BLangPackage> modules = findCursorTokenAndCompileModules(context, false);
-        SymbolReferencesModel referencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        String nodeName = context.get(NodeContextKeys.NODE_NAME_KEY);
+            throws WorkspaceDocumentException, CompilationFailedException, TokenOrSymbolNotFoundException {
+        Token tokenAtCursor = TokensUtil.findtokenAtCursor(context);
+        List<BLangPackage> modules = compileModules(context);
+        String nodeName = tokenAtCursor.text();
         if (CommonKeys.NEW_KEYWORD_KEY.equals(nodeName)) {
-            throw new IllegalStateException("Symbol at cursor '" + nodeName + "' not supported or could not find!");
+            throw new TokenOrSymbolNotFoundException(
+                    "Symbol at cursor '" + nodeName + "' not supported or could not find!");
         }
-        findReferences(modules, context);
-        fillAllReferences(modules, context);
-        return getWorkspaceEdit(referencesModel, context, newName);
+        SymbolReferencesModel referencesModel = findReferencesForCurrentCUnit(tokenAtCursor, modules, context);
+        SymbolReferencesModel allReferences = fillAllReferences(referencesModel, tokenAtCursor, modules, context);
+        return getWorkspaceEdit(allReferences, context, newName);
     }
 
     public static List<Location> getReferences(LSContext context, boolean includeDeclaration)
-            throws WorkspaceDocumentException, CompilationFailedException {
-        List<BLangPackage> modules = findCursorTokenAndCompileModules(context, false);
-        SymbolReferencesModel referencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        findReferences(modules, context);
-        fillAllReferences(modules, context);
-        List<SymbolReferencesModel.Reference> references = new ArrayList<>();
+            throws WorkspaceDocumentException, CompilationFailedException, TokenOrSymbolNotFoundException,
+                   TokenOrSymbolNotFoundException {
+        Token tokenAtCursor = TokensUtil.findtokenAtCursor(context);
+        List<BLangPackage> modules = compileModules(context);
+        SymbolReferencesModel referencesModel = findReferencesForCurrentCUnit(tokenAtCursor, modules, context);
+        SymbolReferencesModel allReferencesModel = fillAllReferences(referencesModel, tokenAtCursor, modules, context);
+        List<Reference> references = new ArrayList<>();
         if (includeDeclaration) {
-            references.addAll(referencesModel.getDefinitions());
+            references.addAll(allReferencesModel.getDefinitions());
         }
-        references.addAll(referencesModel.getReferences());
-        if (!referencesModel.getDefinitions().contains(referencesModel.getReferenceAtCursor().get())) {
-            references.add(referencesModel.getReferenceAtCursor().get());
+        references.addAll(allReferencesModel.getReferences());
+        if (!allReferencesModel.getDefinitions().contains(allReferencesModel.getReferenceAtCursor())) {
+            references.add(allReferencesModel.getReferenceAtCursor());
         }
 
         return getLocations(references, context.get(DocumentServiceKeys.SOURCE_ROOT_KEY));
@@ -134,27 +136,23 @@ public class ReferencesUtil {
      * @throws WorkspaceDocumentException when couldn't find file for uri
      * @throws CompilationFailedException when compilation failed
      */
-    public static Hover getHover(LSContext context) throws WorkspaceDocumentException, CompilationFailedException {
-        List<BLangPackage> modules = findCursorTokenAndCompileModules(context, true);
-        if (context.get(NodeContextKeys.NODE_NAME_KEY) == null) {
-            return HoverUtil.getDefaultHoverObject();
-        }
-        SymbolReferencesModel referencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        findReferences(modules, context);
-        Optional<SymbolReferencesModel.Reference> symbolAtCursor = referencesModel.getReferenceAtCursor();
+    public static Hover getHover(LSContext context)
+            throws WorkspaceDocumentException, CompilationFailedException, TokenOrSymbolNotFoundException {
+        Token tokenAtCursor = TokensUtil.findtokenAtCursor(context);
+        List<BLangPackage> modules = compileModules(context);
+        Reference symbolAtCursor = findReferencesForCurrentCUnit(tokenAtCursor, modules, context)
+                .getReferenceAtCursor();
 
         // Ignore the optional check since it has been handled during prepareReference and throws exception
-        BSymbol bSymbol = symbolAtCursor.get().getSymbol();
+        BSymbol bSymbol = symbolAtCursor.getSymbol();
         return bSymbol != null
                 ? HoverUtil.getHoverFromDocAttachment(HoverUtil.getMarkdownDocForSymbol(bSymbol), bSymbol, context)
                 : HoverUtil.getDefaultHoverObject();
     }
 
-    public static List<BLangPackage> findCursorTokenAndCompileModules(LSContext context, boolean isQuiteMode)
-            throws WorkspaceDocumentException, CompilationFailedException {
+    public static List<BLangPackage> compileModules(LSContext context) throws CompilationFailedException {
         String fileUri = context.get(DocumentServiceKeys.FILE_URI_KEY);
         WorkspaceDocumentManager docManager = context.get(DocumentServiceKeys.DOC_MANAGER_KEY);
-        Position position = context.get(DocumentServiceKeys.POSITION_KEY).getPosition();
         Boolean compileProject = context.get(DocumentServiceKeys.COMPILE_FULL_PROJECT);
         Optional<Path> defFilePath = CommonUtil.getPathFromURI(fileUri);
         if (!defFilePath.isPresent()) {
@@ -164,29 +162,19 @@ public class ReferencesUtil {
         Optional<Lock> lock = docManager.lockFile(compilationPath);
         Class<LSCustomErrorStrategy> errStrategy = LSCustomErrorStrategy.class;
         try {
-            context.put(DocumentServiceKeys.FILE_URI_KEY, fileUri);
-            context.put(ReferencesKeys.REFERENCES_KEY, new SymbolReferencesModel());
-
-            // With the sub-rule parser, find the token
-            String documentContent = docManager.getFileContent(compilationPath);
-            TokensUtil.searchTokenAtCursor(documentContent, context, position);
-
-            if (context.get(NodeContextKeys.NODE_NAME_KEY) == null && !isQuiteMode) {
-                throw new IllegalStateException("Couldn't find a valid identifier token at cursor!");
-            }
-
             return LSModuleCompiler.getBLangPackages(context, docManager, errStrategy, compileProject, false, false,
-                    true);
+                                                     true);
         } finally {
             lock.ifPresent(Lock::unlock);
         }
     }
 
-    private static void fillAllReferences(List<BLangPackage> modules, LSContext context) {
-        SymbolReferencesModel referencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        Optional<SymbolReferencesModel.Reference> symbolAtCursor = referencesModel.getReferenceAtCursor();
+    private static SymbolReferencesModel fillAllReferences(SymbolReferencesModel referencesModel, Token tokenAtCursor,
+                                                           List<BLangPackage> modules, LSContext context) {
+        Reference symbolAtCursor = referencesModel.getReferenceAtCursor();
+
         // Ignore the optional check since it has been handled during prepareReference and throws exception
-        String symbolOwnerPkg = symbolAtCursor.get().getSymbol().pkgID.toString();
+        String symbolOwnerPkg = symbolAtCursor.getSymbol().pkgID.toString();
 
         modules.forEach(bLangPackage -> {
             List<String> imports = bLangPackage.getImports().stream()
@@ -199,13 +187,20 @@ public class ReferencesUtil {
             for (BLangCompilationUnit compilationUnit : bLangPackage.getCompilationUnits()) {
                 // Possible Reference tokens found within the cUnit
                 String symbolPkgName = bLangPackage.symbol.getName().value;
-                SymbolReferenceFindingVisitor refVisitor = new SymbolReferenceFindingVisitor(context, symbolPkgName);
-                refVisitor.visit(compilationUnit);
+                SymbolReferenceFindingVisitor refVisitor = new SymbolReferenceFindingVisitor(context,
+                                                                                             tokenAtCursor,
+                                                                                             symbolPkgName);
+                SymbolReferencesModel symbolReferencesModel = refVisitor.accept(compilationUnit);
+                referencesModel.getDefinitions().addAll(symbolReferencesModel.getDefinitions());
+                referencesModel.getReferences().addAll(symbolReferencesModel.getReferences());
             }
         });
+        return referencesModel;
     }
 
-    public static void findReferences(List<BLangPackage> modules, LSContext context) {
+    public static SymbolReferencesModel findReferencesForCurrentCUnit(Token tokenAtCursor,
+                                                                      List<BLangPackage> modules, LSContext context)
+            throws TokenOrSymbolNotFoundException {
         String currentPkgName = context.get(DocumentServiceKeys.CURRENT_PKG_NAME_KEY);
         /*
         In windows platform, relative file path key components are separated with "\" while antlr always uses "/"
@@ -226,17 +221,22 @@ public class ReferencesUtil {
                 .filter(cUnit -> cUnit.name.equals(currentCUnitName))
                 .findAny();
 
-        SymbolReferenceFindingVisitor refVisitor = new SymbolReferenceFindingVisitor(context, currentPkgName, true);
-        refVisitor.visit(currentCUnit.get());
-
-        // Prune the found symbol references
-        SymbolReferencesModel symbolReferencesModel = context.get(ReferencesKeys.REFERENCES_KEY);
-        if (!symbolReferencesModel.getReferenceAtCursor().isPresent()) {
-            String nodeName = context.get(NodeContextKeys.NODE_NAME_KEY);
-            throw new IllegalStateException("Symbol at cursor '" + nodeName + "' not supported or could not find!");
+        if (!currentCUnit.isPresent()) {
+            throw new UserErrorException("Not supported due to compilation failures!");
         }
 
-        SymbolReferencesModel.Reference symbolAtCursor = symbolReferencesModel.getReferenceAtCursor().get();
+        SymbolReferenceFindingVisitor refVisitor = new SymbolReferenceFindingVisitor(context, tokenAtCursor,
+                                                                                     currentPkgName, true);
+        SymbolReferencesModel symbolReferencesModel = refVisitor.accept(currentCUnit.get());
+
+        // Prune the found symbol references
+        if (symbolReferencesModel.getReferenceAtCursor() == null) {
+            String nodeName = tokenAtCursor.text();
+            throw new TokenOrSymbolNotFoundException(
+                    "Symbol at cursor '" + nodeName + "' not supported or could not find!");
+        }
+
+        Reference symbolAtCursor = symbolReferencesModel.getReferenceAtCursor();
         BSymbol cursorSymbol = symbolAtCursor.getSymbol();
         symbolReferencesModel.getDefinitions()
                 .removeIf(reference -> reference.getSymbol() != cursorSymbol
@@ -244,9 +244,10 @@ public class ReferencesUtil {
         symbolReferencesModel.getReferences()
                 .removeIf(reference -> reference.getSymbol() != cursorSymbol
                         && (reference.getSymbol().type.tsymbol != cursorSymbol));
+        return symbolReferencesModel;
     }
 
-    public static List<Location> getLocations(List<SymbolReferencesModel.Reference> references, String sourceRoot) {
+    public static List<Location> getLocations(List<Reference> references, String sourceRoot) {
         return references.stream()
                 .map(reference -> {
                     DiagnosticPos position = reference.getPosition();
@@ -263,8 +264,8 @@ public class ReferencesUtil {
     private static WorkspaceEdit getWorkspaceEdit(SymbolReferencesModel referencesModel, LSContext context,
                                                   String newName) {
         WorkspaceEdit workspaceEdit = new WorkspaceEdit();
-        SymbolReferencesModel.Reference symbolAtCursor = referencesModel.getReferenceAtCursor().get();
-        List<SymbolReferencesModel.Reference> references = new ArrayList<>();
+        Reference symbolAtCursor = referencesModel.getReferenceAtCursor();
+        List<Reference> references = new ArrayList<>();
         references.add(symbolAtCursor);
         if (!referencesModel.getDefinitions().contains(symbolAtCursor)) {
             references.addAll(referencesModel.getDefinitions());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferenceFindingVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferenceFindingVisitor.java
@@ -15,8 +15,8 @@
  */
 package org.ballerinalang.langserver.util.references;
 
+import io.ballerinalang.compiler.syntax.tree.Token;
 import org.ballerinalang.langserver.common.LSNodeVisitor;
-import org.ballerinalang.langserver.common.constants.NodeContextKeys;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.LSContext;
 import org.ballerinalang.langserver.compiler.DocumentServiceKeys;
@@ -160,14 +160,18 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
     private List<BLangTypeDefinition> anonTypeDefinitions = new ArrayList<>();
     private HashMap<BSymbol, DiagnosticPos> workerVarDefMap = new HashMap<>();
 
-    public SymbolReferenceFindingVisitor(LSContext lsContext, String pkgName, boolean currentCUnitMode) {
+    public SymbolReferenceFindingVisitor(LSContext lsContext, Token tokenAtCursor, String pkgName,
+                                         boolean currentCUnitMode) {
         this.lsContext = lsContext;
 
         Boolean bDoNotSkipNullSymbols = lsContext.get(ReferencesKeys.DO_NOT_SKIP_NULL_SYMBOLS);
         this.doNotSkipNullSymbols = (bDoNotSkipNullSymbols == null) ? false : bDoNotSkipNullSymbols;
 
-        this.symbolReferences = lsContext.get(ReferencesKeys.REFERENCES_KEY);
-        this.tokenName = lsContext.get(NodeContextKeys.NODE_NAME_KEY);
+        //TODO: Check can exisits previous reference
+        this.symbolReferences = new SymbolReferencesModel();
+        lsContext.put(ReferencesKeys.REFERENCES_KEY, this.symbolReferences);
+
+        this.tokenName = tokenAtCursor.text();
         TextDocumentPositionParams position = lsContext.get(DocumentServiceKeys.POSITION_KEY);
         if (position == null) {
             throw new IllegalStateException("Position information not available in the Operation Context");
@@ -178,8 +182,16 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
         this.pkgName = pkgName;
     }
 
-    public SymbolReferenceFindingVisitor(LSContext lsContext, String pkgName) {
-        this(lsContext, pkgName, false);
+    public SymbolReferenceFindingVisitor(LSContext lsContext, Token tokenAtCursor, String pkgName) {
+        this(lsContext, tokenAtCursor, pkgName, false);
+    }
+
+    public SymbolReferencesModel accept(BLangCompilationUnit compilationUnit) {
+        if (compilationUnit == null) {
+            return null;
+        }
+        visit(compilationUnit);
+        return this.symbolReferences;
     }
 
     @Override
@@ -994,13 +1006,13 @@ public class SymbolReferenceFindingVisitor extends LSNodeVisitor {
     }
 
     protected void addSymbol(BLangNode bLangNode, BSymbol bSymbol, boolean isDefinition, DiagnosticPos position) {
-        Optional<SymbolReferencesModel.Reference> symbolAtCursor = this.symbolReferences.getReferenceAtCursor();
+        SymbolReferencesModel.Reference symbolAtCursor = this.symbolReferences.getReferenceAtCursor();
         // Here, tsymbol check has been added in order to support the finite types
         // TODO: Handle finite type. After the fix check if it falsely capture symbols in other files with same name
         if (bSymbol == null && !this.doNotSkipNullSymbols) {
             return;
         }
-        if ((!this.currentCUnitMode && symbolAtCursor.isPresent() && (symbolAtCursor.get().getSymbol() != bSymbol))) {
+        if ((!this.currentCUnitMode && (symbolAtCursor.getSymbol() != bSymbol))) {
             return;
         }
         DiagnosticPos zeroBasedPos = CommonUtil.toZeroBasedPosition(position);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferencesModel.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/SymbolReferencesModel.java
@@ -22,7 +22,6 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -51,8 +50,8 @@ public class SymbolReferencesModel {
         this.definitions.add(definition);
     }
 
-    public Optional<Reference> getReferenceAtCursor() {
-        return Optional.ofNullable(referenceAtCursor);
+    public Reference getReferenceAtCursor() {
+        return referenceAtCursor;
     }
 
     public void setReferenceAtCursor(Reference symbol) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/TokenOrSymbolNotFoundException.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/TokenOrSymbolNotFoundException.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.util.references;
+
+/**
+ * Exception when token or symbol is not found.
+ *
+ * @since 2.0.0
+ */
+public class TokenOrSymbolNotFoundException extends Exception {
+    public TokenOrSymbolNotFoundException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## Purpose
>  Remove antlr dependency from find-cursor-token for hover, rename, signature operations,

Fixes #24540

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
