### PR TITLE
Add `scp` claim data as scopes when `scope` claim is not present [1.2.x]

### DIFF
--- a/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
+++ b/stdlib/jwt/src/main/ballerina/src/jwt/inbound_jwt_auth_provider.bal
@@ -86,6 +86,14 @@ function setPrincipal(JwtPayload jwtPayload) {
             if (scopeString is string && scopeString != "") {
                 auth:setPrincipal(scopes = stringutils:split(scopeString, " "));
             }
+        } else if (claims.hasKey("scp")) {
+            json scopeString = claims["scp"];
+            if (scopeString is json[] && scopeString.length() > 0) {
+                string[]|error scopes = string[].constructFrom(scopeString);
+                if (scopes is string[]) {
+                    auth:setPrincipal(scopes = scopes);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds the `scp` claim data as scopes when the `scope` claim is not available.
https://tools.ietf.org/html/draft-ietf-oauth-token-exchange-12#section-4.2

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
