### PR TITLE
[1.1.x] Use the original caller request as the cached-response validation request

### DIFF
--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Respond.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/nativeimpl/connection/Respond.java
@@ -84,6 +84,8 @@ public class Respond extends ConnectionAction {
         // Based on https://tools.ietf.org/html/rfc7232#section-4.1
         if (CacheUtils.isValidCachedResponse(outboundResponseMsg, inboundRequestMsg)) {
             outboundResponseMsg.setHttpStatusCode(HttpResponseStatus.NOT_MODIFIED.code());
+            outboundResponseMsg.setProperty(HttpConstants.HTTP_REASON_PHRASE,
+                                            HttpResponseStatus.NOT_MODIFIED.reasonPhrase());
             outboundResponseMsg.removeHeader(HttpHeaderNames.CONTENT_LENGTH.toString());
             outboundResponseMsg.removeHeader(HttpHeaderNames.CONTENT_TYPE.toString());
             outboundResponseMsg.waitAndReleaseAllEntities();

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -40,7 +40,7 @@ public class HttpBaseTest extends BaseTest {
                 9102, 9103, 9104, 9105, 9106, 9107, 9108, 9109, 9110, 9111, 9112, 9113, 9114, 9115, 9116, 9117, 9118,
                 9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225, 9226, 9227, 9228, 9229, 9230, 9231, 9232, 9233,
                 9234, 9235, 9236, 9237, 9238, 9239, 9240, 9241, 9242, 9243, 9244, 9245, 9246, 9247, 9248, 9249, 9250,
-                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258};
+                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260};
         String balFile = Paths.get("src", "test", "resources", "http").toAbsolutePath().toString();
         String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
                                                                    "private.key").toAbsolutePath().toString());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPCachingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/HTTPCachingTestCase.java
@@ -17,14 +17,18 @@
  */
 package org.ballerinalang.test.service.http.sample;
 
+import io.netty.handler.codec.http.HttpHeaderNames;
 import org.ballerinalang.test.service.http.HttpBaseTest;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 /**
  * Test cases for HTTP caching.
@@ -109,5 +113,48 @@ public class HTTPCachingTestCase extends HttpBaseTest {
         assertEquals(response.getData(), payload);
         assertEquals(response.getHeaders().get(serviceHitCount), "2");
         assertEquals(response.getHeaders().get(proxyHitCount), "3");
+    }
+
+    @Test(description = "Test preservation of caller request headers in the validation request")
+    public void testCallerRequestHeaderPreservation() throws IOException, InterruptedException {
+        final String callerReqHeader = "x-caller-req-header";
+        Map<String, String> headers = new HashMap<>();
+        headers.put(callerReqHeader, "First Request");
+
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9259, "validation-request"),
+                                                        headers);
+        assertEquals(response.getData(), payload);
+        assertEquals(response.getHeaders().get(callerReqHeader), "First Request");
+        assertFalse(response.getHeaders().containsKey(HttpHeaderNames.IF_NONE_MATCH.toString()));
+        assertFalse(response.getHeaders().containsKey(HttpHeaderNames.IF_MODIFIED_SINCE.toString()));
+
+        // Since this request gets served straight from the cache, the value of 'x-caller-req-header' doesn't change.
+        headers.put(callerReqHeader, "Second Request");
+        response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9259, "validation-request"), headers);
+        assertEquals(response.getData(), payload);
+        assertEquals(response.getHeaders().get(callerReqHeader), "First Request");
+        assertFalse(response.getHeaders().containsKey(HttpHeaderNames.IF_NONE_MATCH.toString()));
+        assertFalse(response.getHeaders().containsKey(HttpHeaderNames.IF_MODIFIED_SINCE.toString()));
+
+        Thread.sleep(3000);
+
+        headers.put(callerReqHeader, "Third Request");
+        response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9259, "validation-request"), headers);
+        assertEquals(response.getData(), payload);
+        assertEquals(response.getHeaders().get(callerReqHeader), "Third Request");
+        assertFalse(response.getHeaders().containsKey(HttpHeaderNames.IF_NONE_MATCH.toString()));
+        assertFalse(response.getHeaders().containsKey(HttpHeaderNames.IF_MODIFIED_SINCE.toString()));
+    }
+
+    @Test(description = "Test preservation of caller request headers in the validation request")
+    public void testCallerRequestHeaderPreservation2() throws IOException, InterruptedException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(HttpHeaderNames.IF_NONE_MATCH.toString(), "c854ce2c");
+
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(9259, "validation-request"),
+                                                        headers);
+        assertEquals(response.getResponseCode(), 304);
+        assertEquals(response.getResponseMessage(), "Not Modified");
+        assertEquals(response.getData(), "");
     }
 }

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/47_cache_validation_request_header_preservation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/47_cache_validation_request_header_preservation.bal
@@ -1,0 +1,62 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+
+http:Client cachingEP4 = new("http://localhost:9260", { cache: { isShared: true } });
+
+@http:ServiceConfig {
+    basePath: "/validation-request"
+}
+service cachingProxy2 on new http:Listener(9259) {
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/"
+    }
+    resource function cacheableProxyResource(http:Caller caller, http:Request req) {
+        var response = cachingEP4->forward("/validation-req-be", req);
+        if (response is http:Response) {
+            checkpanic caller->respond(response);
+        } else {
+            http:Response res = new;
+            res.statusCode = 500;
+            res.setPayload(response.reason());
+            checkpanic caller->respond(res);
+        }
+    }
+}
+
+@http:ServiceConfig {
+    basePath: "/validation-req-be"
+}
+service cachingBackEnd2 on new http:Listener(9260) {
+
+    @http:ResourceConfig { path: "/" }
+    resource function mustRevalidate(http:Caller caller, http:Request req) {
+        json payload = {"message":"Hello, World!"};
+        http:Response res = new;
+        http:ResponseCacheControl resCC = new;
+        resCC.mustRevalidate = true;
+        resCC.maxAge = 3;
+        res.cacheControl = resCC;
+        res.setETag(payload);
+        res.setPayload(payload);
+        res.setHeader("x-caller-req-header", req.getHeader("x-caller-req-header"));
+
+        checkpanic caller->respond(<@untainted>res);
+    }
+}
+


### PR DESCRIPTION
## Purpose
> This PR modifies the validation request sending part of the cached-response validation logic. Previously, a brand new HTTP request was made to the backend as a validation request, with the necessary precondition headers. With this PR, this is changed to use the original caller request itself as the validation request, with the precondition headers added, if they aren't there.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
