### PR TITLE
Improve mocking initialization to use dependently-typed function signature

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
@@ -8,5 +8,5 @@ target = "java8"
     [[platform.libraries]]
         artifactId = "mock"
         version = "0.0.0"
-        path = "./lib/testerina-core-2.0.0-Preview2-SNAPSHOT.jar"
+        path = "./lib/testerina-core-@project.version@.jar"
         groupId = "ballerina"

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/src/test/mock.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/src/test/mock.bal
@@ -42,20 +42,6 @@ public type FunctionCallError distinct error;
 # Represents mocking related errors
 public type Error InvalidObjectError|FunctionNotFoundError|FunctionSignatureMismatchError|InvalidMemberFieldError|FunctionCallError;
 
-
-# Creates and returns a mock object of provided type description.
-#
-# + T - type of object to create the mock
-# + mockObject - mock object to replace the original (optional)
-# + return - created mock object
-public function mock(typedesc<object {}> T, object{} mockObject = new) returns object{} {
-    object {}|Error mockExtResult = mockExt(T, mockObject);
-    if (mockExtResult is Error) {
-        panic mockExtResult;
-    }
-    return <object{}>mockExtResult;
-}
-
 # Prepares a provided default mock object for stubbing.
 #
 # + mockObject - created default mock object
@@ -297,14 +283,12 @@ public type FunctionStub object {
     }
 };
 
-
-# Inter-op to create the mock object
+# Creates and returns a mock object of provided type description.
 #
-# + T - type description
-# + obj - mock object
-# + return - type casted mock object or and error if creation failed
-function mockExt(typedesc<object {}> T, object {} obj) returns object{}|Error = @java:Method {
-    name: "mock",
+# + T - type of object to create the mock
+# + mockObject - mock object to replace the original (optional)
+# + return - created mock object or throw an error if validation failed
+public function mock(public typedesc<object{}> T, object{} mockObj = new) returns T = @java:Method {
     class: "org.ballerinalang.testerina.natives.test.Mock"
 } external;
 

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/test/Mock.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/natives/test/Mock.java
@@ -47,28 +47,28 @@ public class Mock {
      * @param objectValue mock object to impersonate the type
      * @return mock object of provided type
      */
-    public static Object mock(TypedescValue typedescValue, ObjectValue objectValue) {
+    public static ObjectValue mock(TypedescValue typedescValue, ObjectValue objectValue) {
         if (!objectValue.getType().getName().contains(MockConstants.DEFAULT_MOCK_OBJ_ANON)) {
             // handle user-defined mock object
             if (objectValue.getType().getAttachedFunctions().length == 0 &&
                     objectValue.getType().getFields().size() == 0) {
-                String detail = "Mock object type '" + objectValue.getType().getName()
+                String detail = "mock object type '" + objectValue.getType().getName()
                         + "' should have at least one member function or field declared.";
-                return BallerinaErrors.createDistinctError(
+                throw BallerinaErrors.createDistinctError(
                         MockConstants.INVALID_MOCK_OBJECT_ERROR, MockConstants.TEST_PACKAGE_ID, detail);
             } else {
                 for (AttachedFunction attachedFunction : objectValue.getType().getAttachedFunctions()) {
                     ErrorValue errorValue = validateFunctionSignatures(attachedFunction,
                             ((BObjectType) typedescValue.getDescribingType()).getAttachedFunctions());
                     if (errorValue != null) {
-                        return errorValue;
+                        throw  errorValue;
                     }
                 }
                 for (Map.Entry<String, BField> field : objectValue.getType().getFields().entrySet()) {
                     ErrorValue errorValue = validateField(field,
                             ((BObjectType) typedescValue.getDescribingType()).getFields());
                     if (errorValue != null) {
-                        return errorValue;
+                        throw  errorValue;
                     }
                 }
             }
@@ -89,8 +89,8 @@ public class Mock {
         ObjectValue mockObj = genericMock.getMockObj();
         String objectType = mockObj.getType().getName();
         if (!objectType.contains(MockConstants.DEFAULT_MOCK_OBJ_ANON)) {
-            String detail =
-                    "cases cannot be registered to user-defined object type '" + genericMock.getType().getName() + "'";
+            String detail = "cases cannot be registered to user-defined object type '"
+                            + genericMock.getType().getName() + "'";
             return BallerinaErrors.createDistinctError(
                     MockConstants.INVALID_MOCK_OBJECT_ERROR, MockConstants.TEST_PACKAGE_ID, detail);
         }

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/mocking-tests/src/object-mock/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/mocking-tests/src/object-mock/tests/main_test.bal
@@ -17,7 +17,7 @@ public type MockHttpClient client object {
 @test:Config {}
 function testUserDefinedMockObject() {
 
-  clientEndpoint = <http:Client>test:mock(http:Client, new MockHttpClient());
+  clientEndpoint = test:mock(http:Client, new MockHttpClient());
   http:Response res = doGet();
   test:assertEquals(res.statusCode, 500);
   test:assertEquals(getClientUrl(), "http://mockUrl");
@@ -26,7 +26,7 @@ function testUserDefinedMockObject() {
 @test:Config {}
 function testProvideAReturnValue() {
 
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   http:Response mockResponse = new;
   mockResponse.statusCode = 500;
 
@@ -39,7 +39,7 @@ function testProvideAReturnValue() {
 @test:Config {}
 function testProvideAReturnValueBasedOnInput() {
 
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).when("get").withArguments("/get?test=123", test:ANY).thenReturn(new http:Response());
   clientEndpoint = mockHttpClient;
   http:Response res = doGet();
@@ -49,7 +49,7 @@ function testProvideAReturnValueBasedOnInput() {
 @test:Config {}
 function testProvideErrorAsReturnValue() {
 
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient);
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient);
   smtpClient = mockSmtpClient;
 
   string[] emailIds = ["user1@test.com", "user2@test.com"];
@@ -62,7 +62,7 @@ function testProvideErrorAsReturnValue() {
 @test:Config {}
 function testDoNothing() {
 
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient);
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient);
   http:Response mockResponse = new;
   mockResponse.statusCode = 500;
 
@@ -77,7 +77,7 @@ function testDoNothing() {
 @test:Config {}
 function testMockMemberVarible() {
   string mockClientUrl = "http://foo";
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).getMember("url").thenReturn(mockClientUrl);
 
   clientEndpoint = mockHttpClient;
@@ -86,7 +86,7 @@ function testMockMemberVarible() {
 
 @test:Config {}
 function testProvideAReturnSequence() {
-    http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+    http:Client mockHttpClient = test:mock(http:Client);
     http:Response mockResponse = new;
     mockResponse.statusCode = 500;
 
@@ -136,7 +136,7 @@ public type MockHttpClientSigErr client object {
 // 1.1) when the user-defined mock object is empty
 @test:Config {}
 function testEmptyUserDefinedObj() {
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient, new MockSmtpClientEmpty());
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient, new MockSmtpClientEmpty());
   smtpClient = mockSmtpClient;
 }
 
@@ -144,14 +144,14 @@ function testEmptyUserDefinedObj() {
 // 1.2) when user-defined object is passed to test:prepare function
 @test:Config {}
 function testUserDefinedMockRegisterCases() {
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient, new MockSmtpClient()); 
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient, new MockSmtpClient()); 
   test:prepare(mockSmtpClient).when("send").doNothing();
 }
 
 // 1.3) when the functions in mock is not available in the original
 @test:Config {}
 function testUserDefinedMockInvalidFunction() {
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient, new MockSmtpClientFuncErr());
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient, new MockSmtpClientFuncErr());
   smtpClient = mockSmtpClient;
   error? sendNotificationResult = sendNotification(["user1@test.com"]);
 }
@@ -159,7 +159,7 @@ function testUserDefinedMockInvalidFunction() {
 // 1.4.1) when the function return types do not match
 @test:Config {}
 function testUserDefinedMockFunctionSignatureMismatch() {
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient, new MockSmtpClientSigErr());
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient, new MockSmtpClientSigErr());
   smtpClient = mockSmtpClient;
   error? sendNotificationResult = sendNotification(["user1@test.com"]);
 }
@@ -167,7 +167,7 @@ function testUserDefinedMockFunctionSignatureMismatch() {
 // 1.4.2) when the function parameters do not match
 @test:Config {}
 function testUserDefinedMockFunctionSignatureMismatch2() {
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient, new MockSmtpClientSigErr2());
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient, new MockSmtpClientSigErr2());
   smtpClient = mockSmtpClient;
   error? sendNotificationResult = sendNotification(["user1@test.com"]);
 }
@@ -175,7 +175,7 @@ function testUserDefinedMockFunctionSignatureMismatch2() {
 // 1.4.3
 @test:Config {}
 function testUserDefinedMockFunctionSignatureMismatch3() {
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client, new MockHttpClientSigErr());
+  http:Client mockHttpClient = test:mock(http:Client, new MockHttpClientSigErr());
 }
 
 # 2 - Validations for framework provided default mock object
@@ -183,35 +183,35 @@ function testUserDefinedMockFunctionSignatureMismatch3() {
 // 2.1  when the function called in mock is not available in the original
 @test:Config {}
 function testDefaultMockInvalidFunctionName() {
-  email:SmtpClient mockSmtpClient = <email:SmtpClient>test:mock(email:SmtpClient);
+  email:SmtpClient mockSmtpClient = test:mock(email:SmtpClient);
   test:prepare(mockSmtpClient).when("get").doNothing();
 }
 
 // 2.2) call doNothing() - the function has a return type specified
 @test:Config {}
 function testDefaultMockWrongAction() {
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).when("get").doNothing();
 }
 
 // 2.3) when the return value does not match the function return type
 @test:Config {}
 function testDefaultInvalidFunctionReturnValue() {
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).when("get").thenReturn("success");
 }
 
 // 2.4.1) when the number of arguments provided does not match the function signature
 @test:Config {}
 function testDefaultTooManyArgs() {
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).when("get").withArguments("test", "", "").thenReturn(new http:Response());
 }
 
 // 2.4.2) when the type of arguments provided does not match the function signature
 @test:Config {}
 function testDefaultIncompatibleArgs() {
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).when("get").withArguments(0).thenReturn(new http:Response());
 }
 
@@ -219,7 +219,7 @@ function testDefaultIncompatibleArgs() {
 @test:Config {}
 function testDefaultMockInvalidFieldName() {
   string mockClientUrl = "http://foo";
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).getMember("clientUrl").thenReturn(mockClientUrl);
 
   clientEndpoint = mockHttpClient;
@@ -229,6 +229,6 @@ function testDefaultMockInvalidFieldName() {
 // 2.6) when the member variable type does not match the return value
 @test:Config{}
 function testDefaultInvalidMemberReturnValue() {
-  http:Client mockHttpClient = <http:Client>test:mock(http:Client);
+  http:Client mockHttpClient = test:mock(http:Client);
   test:prepare(mockHttpClient).getMember("url").thenReturn(());
 }


### PR DESCRIPTION
## Purpose
> The current mocking API initialization syntax is as follows:
```ballerina
http:Client mockHttpClient = <http:Client>test:mock(http:Client);
```
> This pr improves the syntax to remove the casting by changing the API implementation to have a dependently-typed function signature. The improved syntax will be as follows
```balleina
http:Client mockHttpClient = test:mock(http:Client);
```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
