### PR TITLE
Add central access token as a env variable using github actions

### DIFF
--- a/.github/workflows/CI_push_build.yml
+++ b/.github/workflows/CI_push_build.yml
@@ -47,6 +47,8 @@ jobs:
           find ~/.gradle/caches/ -name "*.lock" -type f -delete
 
       - name: Run integration test
+        env:
+          CENTRAL_ACCESS_TOKEN: ${{secrets.CENTRAL_ACCESS_TOKEN}}
         run: |
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -75,6 +75,8 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run integration test
+        env:
+          CENTRAL_ACCESS_TOKEN: ${{secrets.CENTRAL_ACCESS_TOKEN}}
         run: |
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -70,6 +70,8 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Run integration test
+        env:
+          CENTRAL_ACCESS_TOKEN: ${{secrets.CENTRAL_ACCESS_TOKEN}}
         run: |
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/ModulePushTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/ModulePushTestCase.java
@@ -93,7 +93,7 @@ public class ModulePushTestCase extends BaseTest {
      *
      * @return env directory variable array
      */
-    private Map<String, String> addEnvVariables(Map<String, String> envVariables) {
+    private Map<String, String> addEnvVariables(Map<String, String> envVariables) throws IOException {
         envVariables.put(BALLERINA_STAGE_CENTRAL, "true");
         envVariables.put("BALLERINA_CENTRAL_ACCESS_TOKEN", PackerinaTestUtils.getToken());
         return envVariables;

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/MultipleVersionsModuleTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/MultipleVersionsModuleTestCase.java
@@ -162,7 +162,7 @@ public class MultipleVersionsModuleTestCase extends BaseTest {
      *
      * @return env directory variable array
      */
-    private Map<String, String> addEnvVariables(Map<String, String> envVariables) {
+    private Map<String, String> addEnvVariables(Map<String, String> envVariables) throws IOException {
         envVariables.put(BALLERINA_STAGE_CENTRAL, "true");
         envVariables.put("BALLERINA_CENTRAL_ACCESS_TOKEN", PackerinaTestUtils.getToken());
         return envVariables;

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/PackagingNegativeTestCase.java
@@ -327,7 +327,7 @@ public class PackagingNegativeTestCase extends BaseTest {
      *
      * @return env directory variable array
      */
-    private Map<String, String> addEnvVariables(Map<String, String> envVariables) {
+    private Map<String, String> addEnvVariables(Map<String, String> envVariables) throws IOException {
         envVariables.put(ProjectDirConstants.HOME_REPO_ENV_KEY, tempHomeDirectory.toString());
         envVariables.put(BALLERINA_STAGE_CENTRAL, "true");
         envVariables.put("BALLERINA_CENTRAL_ACCESS_TOKEN", PackerinaTestUtils.getToken());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/PackerinaTestUtils.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/packaging/PackerinaTestUtils.java
@@ -97,9 +97,13 @@ public class PackerinaTestUtils {
      *
      * @return token required to push the module.
      */
-    public static String getToken() {
+    public static String getToken() throws IOException {
+        String centralAccessToken = System.getenv("CENTRAL_ACCESS_TOKEN");
+        if (centralAccessToken == null || "".equals(centralAccessToken.trim())) {
+            throw new IOException("CENTRAL_ACCESS_TOKEN env variable is not set");
+        }
         // staging and dev both has the same access token
-        return new String(Base64.getDecoder().decode("YWYwMjkyODgtNjhkZC0zOTVmLTk5MzQtYTgyYWRjM2NlYzZi"));
+        return new String(Base64.getDecoder().decode(centralAccessToken));
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Add central access token as an env variable using GitHub actions to hide the access token in the repo.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
