### PR TITLE
Add support for resolving the dependently typed function signature using the contextually expected type(s)

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/TreeBuilder.java
@@ -58,6 +58,7 @@ import org.ballerinalang.model.tree.expressions.ErrorVariableReferenceNode;
 import org.ballerinalang.model.tree.expressions.FieldBasedAccessNode;
 import org.ballerinalang.model.tree.expressions.GroupExpressionNode;
 import org.ballerinalang.model.tree.expressions.IndexBasedAccessNode;
+import org.ballerinalang.model.tree.expressions.InferTypedescExpressionNode;
 import org.ballerinalang.model.tree.expressions.IntRangeExpression;
 import org.ballerinalang.model.tree.expressions.InvocationNode;
 import org.ballerinalang.model.tree.expressions.IsLikeExpressionNode;
@@ -192,6 +193,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsLikeExpr;
@@ -910,6 +912,10 @@ public class TreeBuilder {
 
     public static IsLikeExpressionNode createIsLikeExpressionNode() {
         return new BLangIsLikeExpr();
+    }
+
+    public static InferTypedescExpressionNode createInferTypedescExpressionNode() {
+        return new BLangInferTypedescExpr();
     }
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/NodeKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/NodeKind.java
@@ -125,6 +125,7 @@ public enum NodeKind {
     LET_EXPR,
     TABLE_CONSTRUCTOR_EXPR,
     TRANSACTIONAL_EXPRESSION,
+    INFER_TYPEDESC_EXPR,
 
     /* Statements */
     ABORT,

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/InferTypedescExpressionNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/InferTypedescExpressionNode.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.model.tree.expressions;
+
+/**
+ * @since 2.0.0-preview2
+ */
+public interface InferTypedescExpressionNode extends ExpressionNode {
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -382,7 +382,7 @@ public class ASTBuilderUtil {
         return unaryExpr;
     }
 
-    static BLangTypedescExpr createTypeofExpr(DiagnosticPos pos, BType type, BType resolvedType) {
+    static BLangTypedescExpr createTypedescExpr(DiagnosticPos pos, BType type, BType resolvedType) {
         final BLangTypedescExpr typeofExpr = (BLangTypedescExpr) TreeBuilder.createTypeAccessNode();
         typeofExpr.pos = pos;
         typeofExpr.type = type;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -63,6 +63,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsLikeExpr;
@@ -924,6 +925,11 @@ public class ConstantPropagation extends BLangNodeVisitor {
     }
 
     @Override
+    public void visit(BLangInferTypedescExpr inferTypedescExpr) {
+        result = inferTypedescExpr;
+    }
+
+    @Override
     public void visit(BLangSimpleVarRef varRefExpr) {
 
         if (varRefExpr.symbol == null) {
@@ -942,7 +948,7 @@ public class ConstantPropagation extends BLangNodeVisitor {
             // from a simple literal
             if (constSymbol.literalType.tag <= TypeTags.BOOLEAN || constSymbol.literalType.tag == TypeTags.NIL) {
                 BLangConstRef constRef = ASTBuilderUtil.createBLangConstRef(varRefExpr.pos, constSymbol.literalType,
-                        constSymbol.value.value);
+                                                                            constSymbol.value.value);
                 constRef.variableName = varRefExpr.variableName;
                 constRef.symbol = constSymbol;
                 constRef.pkgAlias = varRefExpr.pkgAlias;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -122,6 +122,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BL
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BLangTableAccessExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BLangTupleAccessExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BLangXMLAccessExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation.BFunctionPointerInvocation;
@@ -1000,6 +1001,12 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         result = funcNode;
+    }
+
+    @Override
+    public void visit(BLangInferTypedescExpr inferTypedescExpr) {
+        BType constraintType = ((BTypedescType) inferTypedescExpr.type).constraint;
+        result = ASTBuilderUtil.createTypedescExpr(inferTypedescExpr.pos, inferTypedescExpr.type, constraintType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -80,6 +80,7 @@ import io.ballerinalang.compiler.syntax.tree.ImportPrefixNode;
 import io.ballerinalang.compiler.syntax.tree.ImportSubVersionNode;
 import io.ballerinalang.compiler.syntax.tree.ImportVersionNode;
 import io.ballerinalang.compiler.syntax.tree.IndexedExpressionNode;
+import io.ballerinalang.compiler.syntax.tree.InferDefaultValueNode;
 import io.ballerinalang.compiler.syntax.tree.InterpolationNode;
 import io.ballerinalang.compiler.syntax.tree.IntersectionTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.JoinClauseNode;
@@ -273,6 +274,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation.BLangActionInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
@@ -3256,6 +3258,14 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
         intersectionType.pos = getPosition(intersectionTypeDescriptorNode);
         return intersectionType;
+    }
+
+    @Override
+    public BLangNode transform(InferDefaultValueNode inferDefaultValueNode) {
+        BLangInferTypedescExpr inferTypedescExpr =
+                (BLangInferTypedescExpr) TreeBuilder.createInferTypedescExpressionNode();
+        inferTypedescExpr.pos = getPosition(inferDefaultValueNode);
+        return inferTypedescExpr;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -79,6 +79,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIgnoreExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsAssignableExpr;
@@ -1079,6 +1080,12 @@ public class NodeCloner extends BLangNodeVisitor {
         source.cloneRef = clone;
         clone.typeNode = clone(source.typeNode);
         clone.resolvedType = source.resolvedType;
+    }
+
+    @Override
+    public void visit(BLangInferTypedescExpr source) {
+        BLangInferTypedescExpr clone = new BLangInferTypedescExpr();
+        source.cloneRef = clone;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -100,6 +100,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
@@ -2783,6 +2784,11 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                         symTable.semanticError;
         }
         return false;
+    }
+
+    @Override
+    public void visit(BLangInferTypedescExpr inferTypedescExpr) {
+        /* Ignore */
     }
 
     // private methods

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -83,6 +83,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation.BLangActionInvocation;
@@ -1477,6 +1478,10 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangAnnotAccessExpr annotAccessExpr) {
+    }
+
+    @Override
+    public void visit(BLangInferTypedescExpr inferTypedescExpr) {
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1872,6 +1872,10 @@ public class SymbolEnter extends BLangNodeVisitor {
             if (varNode.expr != null) {
                 symbol.flags |= Flags.OPTIONAL;
                 symbol.defaultableParam = true;
+
+                if (varNode.expr.getKind() == NodeKind.INFER_TYPEDESC_EXPR) {
+                    symbol.flags |= Flags.INFER;
+                }
             }
             paramSymbols.add(symbol);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1270,7 +1270,7 @@ public class SymbolResolver extends BLangNodeVisitor {
     private BType getTypedescParamValueType(List<BLangSimpleVariable> params, BSymbol varSym) {
         for (BLangSimpleVariable param : params) {
             if (param.name.value.equals(varSym.name.value)) {
-                if (param.expr == null) {
+                if (param.expr == null || param.expr.getKind() == NodeKind.INFER_TYPEDESC_EXPR) {
                     return ((BTypedescType) varSym.type).constraint;
                 }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TaintAnalyzer.java
@@ -74,6 +74,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
@@ -1650,6 +1651,11 @@ public class TaintAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangConstant constant) {
+        /* ignore */
+    }
+
+    @Override
+    public void visit(BLangInferTypedescExpr inferTypedescExpr) {
         /* ignore */
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangNodeVisitor.java
@@ -50,6 +50,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BL
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BLangTableAccessExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BLangTupleAccessExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess.BLangXMLAccessExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInferTypedescExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIntRangeExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation.BFunctionPointerInvocation;
@@ -654,6 +655,10 @@ public abstract class BLangNodeVisitor {
     }
 
     public void visit(BLangCommitExpr commitExpr) {
+        throw new AssertionError();
+    }
+
+    public void visit(BLangInferTypedescExpr inferTypedescExpr) {
         throw new AssertionError();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInferTypedescExpr.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangInferTypedescExpr.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.ballerinalang.compiler.tree.expressions;
+
+import org.ballerinalang.model.tree.NodeKind;
+import org.ballerinalang.model.tree.expressions.InferTypedescExpressionNode;
+import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
+
+/**
+ * Represents the expression `<>`. This is only allowed to be used for default values of typedesc params in an external
+ * function signature.
+ *
+ * @since 2.0.0-preview2
+ */
+public class BLangInferTypedescExpr extends BLangExpression implements InferTypedescExpressionNode {
+
+    @Override
+    public void accept(BLangNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public NodeKind getKind() {
+        return NodeKind.INFER_TYPEDESC_EXPR;
+    }
+
+    @Override
+    public String toString() {
+        return ("<>");
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
@@ -1,0 +1,484 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.util;
+
+import org.ballerinalang.model.TreeBuilder;
+import org.ballerinalang.model.tree.NodeKind;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BBuiltInRefType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BParameterizedType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypeVisitor;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangInvocation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangTypedescExpr;
+import org.wso2.ballerinalang.compiler.util.diagnotic.BLangDiagnosticLogHelper;
+import org.wso2.ballerinalang.util.Flags;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Util class for building concrete BType types from parameterized types.
+ *
+ * @since 2.0.0
+ */
+public class Unifier implements BTypeVisitor<BType, BType> {
+
+    private static final CompilerContext.Key<Unifier> UNIFIER_KEY = new CompilerContext.Key<>();
+
+    private Map<String, BType> paramValueTypes;
+    private Set<BType> visitedTypes;
+    private boolean isInvocation;
+    private BLangInvocation invocation;
+    private BLangDiagnosticLogHelper dlogHelper;
+    private final SymbolTable symTable;
+    private final Types types;
+
+    private Unifier(CompilerContext context) {
+        context.put(UNIFIER_KEY, this);
+
+        this.symTable = SymbolTable.getInstance(context);
+        this.types = Types.getInstance(context);
+        this.dlogHelper = BLangDiagnosticLogHelper.getInstance(context);
+    }
+
+    public static Unifier getInstance(CompilerContext context) {
+        Unifier unifier = context.get(UNIFIER_KEY);
+        if (unifier == null) {
+            unifier = new Unifier(context);
+        }
+
+        return unifier;
+    }
+
+    public BType build(BType originalType, BType expType, BLangInvocation invocation) {
+        this.isInvocation = invocation != null;
+        this.visitedTypes = new HashSet<>();
+        if (this.isInvocation) {
+            this.invocation = invocation;
+            createParamMap(invocation);
+        }
+        BType newType = originalType.accept(this, expType);
+        reset();
+        return newType;
+    }
+
+    @Override
+    public BType visit(BType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BBuiltInRefType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BAnyType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BAnydataType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BMapType originalType, BType expType) {
+        BType expConstraint = isDifferentTypeKind(originalType, expType) ? expType : ((BMapType) expType).constraint;
+        BType newConstraint = originalType.constraint.accept(this, expConstraint);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BMapType newMType = new BMapType(originalType.tag, newConstraint, null);
+        setFlags(newMType, originalType.flags);
+        return newMType;
+    }
+
+    @Override
+    public BType visit(BXMLType originalType, BType expType) {
+        BType expConstraint = isDifferentTypeKind(originalType, expType) ? expType : ((BXMLType) expType).constraint;
+        BType newConstraint = originalType.constraint.accept(this, expConstraint);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BXMLType newXMLType = new BXMLType(newConstraint, null);
+        setFlags(newXMLType, originalType.flags);
+        return newXMLType;
+    }
+
+    @Override
+    public BType visit(BJSONType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BArrayType originalType, BType expType) {
+        BType expElemType = isDifferentTypeKind(originalType, expType) ? expType : ((BArrayType) expType).eType;
+        BType newElemType = originalType.eType.accept(this, expElemType);
+
+        if (newElemType == originalType.eType) {
+            return originalType;
+        }
+
+        BArrayType newArrayType = new BArrayType(newElemType, null, originalType.size, originalType.state);
+        setFlags(newArrayType, originalType.flags);
+        return newArrayType;
+    }
+
+    @Override
+    public BType visit(BObjectType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BRecordType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BTupleType originalType, BType expType) {
+        boolean hasNewType = false;
+        List<BType> members = new ArrayList<>();
+        for (BType member : originalType.tupleTypes) {
+            BType newMem = member.accept(this, null);
+            members.add(newMem);
+
+            if (newMem != member) {
+                hasNewType = true;
+            }
+        }
+
+        BType rest = originalType.restType;
+        if (rest != null) {
+            rest = rest.accept(this, null);
+
+            if (rest != originalType.restType) {
+                hasNewType = true;
+            }
+        }
+
+        if (!hasNewType) {
+            return originalType;
+        }
+
+        BTupleType type = new BTupleType(null, members);
+        type.restType = rest;
+        setFlags(type, originalType.flags);
+        return type;
+    }
+
+    @Override
+    public BType visit(BStreamType originalType, BType expType) {
+        boolean isDifferentType = isDifferentTypeKind(originalType, expType);
+        BType expConstraint = isDifferentType ? expType : ((BStreamType) expType).constraint;
+        BType newConstraint = originalType.constraint.accept(this, expConstraint);
+
+        BType newError = null;
+        if (originalType.error != null) {
+            BType expError = isDifferentType ? expType : ((BStreamType) expType).error;
+            newError = originalType.error.accept(this, expError);
+        }
+
+        if (newConstraint == originalType.constraint && newError == originalType.error) {
+            return originalType;
+        }
+
+        BStreamType type = new BStreamType(originalType.tag, newConstraint, newError, null);
+        setFlags(type, originalType.flags);
+        return type;
+    }
+
+    @Override
+    public BType visit(BTableType originalType, BType expType) {
+        boolean isDifferentType = isDifferentTypeKind(originalType, expType);
+        BType expConstraint = isDifferentType ? expType : ((BTableType) expType).constraint;
+        BType newConstraint = originalType.constraint.accept(this, expConstraint);
+
+        BType newKeyTypeConstraint = null;
+        if (originalType.keyTypeConstraint != null) {
+            BType expKeyConstraint = isDifferentType ? expType : ((BTableType) expType).keyTypeConstraint;
+            originalType.keyTypeConstraint.accept(this, expKeyConstraint);
+        }
+
+        if (newConstraint == originalType.constraint && newKeyTypeConstraint == originalType.keyTypeConstraint) {
+            return originalType;
+        }
+
+        BTableType newTableType = new BTableType(TypeTags.TABLE, newConstraint, null);
+        newTableType.keyTypeConstraint = newKeyTypeConstraint;
+        newTableType.fieldNameList = originalType.fieldNameList;
+        newTableType.constraintPos = originalType.constraintPos;
+        newTableType.keyPos = originalType.keyPos;
+        setFlags(newTableType, originalType.flags);
+        return newTableType;
+    }
+
+    @Override
+    public BType visit(BInvokableType originalType, BType expType) {
+        boolean hasNewType = false;
+        List<BType> paramTypes = new ArrayList<>();
+
+        for (BType type : originalType.paramTypes) {
+            BType newT = type.accept(this, null);
+            paramTypes.add(newT);
+
+            if (newT != type) {
+                hasNewType = true;
+            }
+        }
+
+        BType rest = originalType.restType;
+        if (rest != null) {
+            rest = rest.accept(this, null);
+
+            if (rest != originalType.restType) {
+                hasNewType = true;
+            }
+        }
+
+        BType retType = originalType.retType.accept(this, null);
+
+        if (!hasNewType && retType != originalType.retType) {
+            return originalType;
+        }
+
+        BType type = new BInvokableType(paramTypes, rest, retType, null);
+        setFlags(type, originalType.flags);
+        return type;
+    }
+
+    @Override
+    public BType visit(BUnionType originalType, BType expType) {
+        boolean hasNewType = false;
+        LinkedHashSet<BType> newMemberTypes = new LinkedHashSet<>();
+
+        for (BType member : originalType.getMemberTypes()) {
+            BType newMember = member.accept(this, null);
+            newMemberTypes.add(newMember);
+
+            if (newMember != member) {
+                hasNewType = true;
+            }
+        }
+
+        if (!hasNewType) {
+            return originalType;
+        }
+
+        BUnionType type = BUnionType.create(null, newMemberTypes);
+        setFlags(type, originalType.flags);
+        return type;
+    }
+
+    @Override
+    public BType visit(BIntersectionType originalType, BType expType) {
+        BType expEffectiveType = isDifferentTypeKind(originalType, expType) ?
+                expType : ((BIntersectionType) expType).effectiveType;
+        BType newEffectiveType = originalType.effectiveType.accept(this, expEffectiveType);
+
+        if (newEffectiveType == originalType.effectiveType) {
+            return originalType;
+        }
+
+        BIntersectionType type = new BIntersectionType(null, (LinkedHashSet<BType>) originalType.getConstituentTypes(),
+                                                       newEffectiveType);
+        setFlags(type, originalType.flags);
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BErrorType originalType, BType expType) {
+        BType expDetailType = isDifferentTypeKind(originalType, expType) ? expType : ((BErrorType) expType).detailType;
+        BType newDetail = originalType.detailType.accept(this, expDetailType);
+
+        if (newDetail == originalType.detailType) {
+            return originalType;
+        }
+
+        BErrorType type = new BErrorType(null, newDetail);
+        setFlags(type, originalType.flags);
+        return type;
+    }
+
+    @Override
+    public BType visit(BFutureType originalType, BType expType) {
+        BType expConstraint = isDifferentTypeKind(originalType, expType) ? expType : ((BFutureType) expType).constraint;
+        BType newConstraint = originalType.constraint.accept(this, expConstraint);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BFutureType newFutureType = new BFutureType(originalType.tag, newConstraint, null,
+                                                    originalType.workerDerivative);
+        setFlags(newFutureType, originalType.flags);
+        return newFutureType;
+    }
+
+    @Override
+    public BType visit(BFiniteType originalType, BType expType) {
+        // Not applicable for finite types since the descriptor has to be defined before using in the return type.
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BServiceType originalType, BType expType) {
+        return originalType;
+    }
+
+    @Override
+    public BType visit(BTypedescType originalType, BType expType) {
+        BType expConstraint = isDifferentTypeKind(originalType, expType) ?
+                expType : ((BTypedescType) expType).constraint;
+        BType newConstraint = originalType.constraint.accept(this, expConstraint);
+
+        if (newConstraint == originalType.constraint) {
+            return originalType;
+        }
+
+        BTypedescType newTypedescType = new BTypedescType(newConstraint, null);
+        setFlags(newTypedescType, originalType.flags);
+        return newTypedescType;
+    }
+
+    @Override
+    public BType visit(BParameterizedType originalType, BType expType) {
+        String paramVarName = originalType.paramSymbol.name.value;
+
+        if (Symbols.isFlagOn(originalType.paramSymbol.flags, Flags.INFER)) {
+            BType paramSymbolType = ((BTypedescType) originalType.paramSymbol.type).constraint;
+            if (types.isAssignable(expType, paramSymbolType)) {
+                BLangTypedescExpr typedescExpr = (BLangTypedescExpr) TreeBuilder.createTypeAccessNode();
+                typedescExpr.pos = this.invocation.pos;
+                typedescExpr.resolvedType = expType;
+                typedescExpr.type = new BTypedescType(expType, null);
+
+                int indx = pos(originalType.paramSymbol);
+                if (indx >= invocation.requiredArgs.size()) {
+                    this.invocation.argExprs.add(indx, typedescExpr);
+                    this.invocation.requiredArgs.add(indx, typedescExpr);
+                }
+                return expType;
+            }
+            // TODO: Instead of this, see if a more specific error message can be given here.
+            // e.g., incompatible inferred type: expected '(string|float)', inferred 'int'
+            return paramSymbolType;
+        }
+
+        // This would return null if the calling function gets analyzed before the callee function. This only
+        // happens when the invocation uses the default value of the param.
+        BType type = paramValueTypes.get(paramVarName);
+
+        if (type == null) {
+            return originalType.paramValueType;
+        }
+
+        if (type.tag == TypeTags.SEMANTIC_ERROR) {
+            return type;
+        }
+
+        type = ((BTypedescType) type).constraint;
+        return type;
+    }
+
+    private void createParamMap(BLangInvocation invocation) {
+        paramValueTypes = new LinkedHashMap<>();
+        BInvokableSymbol symbol = (BInvokableSymbol) invocation.symbol;
+        int nArgs = invocation.requiredArgs.size();
+        int nParams = symbol.params.size();
+        BVarSymbol param;
+
+        for (int i = 0; i < nParams; i++) {
+            param = symbol.params.get(i);
+
+            if (param.defaultableParam &&
+                    (i >= nArgs || invocation.requiredArgs.get(i).getKind() == NodeKind.IGNORE_EXPR)) {
+                paramValueTypes.put(param.name.value, symbol.paramDefaultValTypes.get(param.name.value));
+                continue;
+            }
+
+            paramValueTypes.put(param.name.value, invocation.requiredArgs.get(i).type);
+        }
+    }
+
+    private void setFlags(BType type, int originalFlags) {
+        type.flags = originalFlags & (~Flags.PARAMETERIZED);
+    }
+
+    private boolean isDifferentTypeKind(BType source, BType target) {
+        // TODO: Consider subtypes
+        if (source.tag != target.tag) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private int pos(BVarSymbol sym) {
+        BInvokableSymbol invokableSymbol = (BInvokableSymbol) invocation.symbol;
+        List<BVarSymbol> params = invokableSymbol.params;
+        for (int i = 0; i < params.size(); i++) {
+            BVarSymbol param = params.get(i);
+            if (param.equals(sym)) {
+                return i;
+            }
+        }
+
+        throw new IllegalStateException(
+                String.format("Param '%s' not found in function '%s'", sym.name, invokableSymbol.name));
+    }
+
+    private void reset() {
+        this.visitedTypes = null;
+        this.paramValueTypes = null;
+        this.isInvocation = false;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -55,6 +55,7 @@ public class Flags {
     public static final int TRANSACTIONAL = FORKED << 1;
     public static final int PARAMETERIZED = TRANSACTIONAL << 1;
     public static final int DISTINCT = PARAMETERIZED << 1;
+    public static final int INFER = DISTINCT << 1;
 
     public static int asMask(Set<Flag> flagSet) {
         int mask = 0;

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -4078,6 +4078,10 @@ public class BallerinaParser extends AbstractParser {
             case OPEN_BRACKET_TOKEN:
                 return parseListConstructorExpr();
             case LT_TOKEN:
+                STToken nextToken = getNextNextToken(kind);
+                if (nextToken.kind == SyntaxKind.GT_TOKEN) {
+                    return parseInferDefaultValueTypeExpr();
+                }
                 return parseTypeCastExpr(isRhsExpr, allowActions, isInConditionalExpr);
             case TABLE_KEYWORD:
             case STREAM_KEYWORD:
@@ -8664,6 +8668,12 @@ public class BallerinaParser extends AbstractParser {
         STNode expression =
                 parseExpression(OperatorPrecedence.EXPRESSION_ACTION, isRhsExpr, allowActions, isInConditionalExpr);
         return STNodeFactory.createTypeCastExpressionNode(ltToken, typeCastParam, gtToken, expression);
+    }
+
+    private STNode parseInferDefaultValueTypeExpr() {
+        STNode ltToken = parseLTToken();
+        STNode gtToken = parseGTToken();
+        return STNodeFactory.createInferDefaultValueNode(ltToken, gtToken);
     }
 
     private STNode parseTypeCastParam() {

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STInferDefaultValueNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STInferDefaultValueNode.java
@@ -1,0 +1,94 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.internal.parser.tree;
+
+import io.ballerinalang.compiler.syntax.tree.InferDefaultValueNode;
+import io.ballerinalang.compiler.syntax.tree.Node;
+import io.ballerinalang.compiler.syntax.tree.NonTerminalNode;
+import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * This is a generated internal syntax tree node.
+ *
+ * @since 2.0.0
+ */
+public class STInferDefaultValueNode extends STExpressionNode {
+    public final STNode ltToken;
+    public final STNode gtToken;
+
+    STInferDefaultValueNode(
+            STNode ltToken,
+            STNode gtToken) {
+        this(
+                ltToken,
+                gtToken,
+                Collections.emptyList());
+    }
+
+    STInferDefaultValueNode(
+            STNode ltToken,
+            STNode gtToken,
+            Collection<STNodeDiagnostic> diagnostics) {
+        super(SyntaxKind.REST_ARG, diagnostics);
+        this.ltToken = ltToken;
+        this.gtToken = gtToken;
+
+        addChildren(
+                ltToken,
+                gtToken);
+    }
+
+    public STNode modifyWith(Collection<STNodeDiagnostic> diagnostics) {
+        return new STInferDefaultValueNode(
+                this.ltToken,
+                this.gtToken,
+                diagnostics);
+    }
+
+    public STInferDefaultValueNode modify(
+            STNode ltToken,
+            STNode gtToken) {
+        if (checkForReferenceEquality(
+                ltToken,
+                gtToken)) {
+            return this;
+        }
+
+        return new STInferDefaultValueNode(
+                ltToken,
+                gtToken,
+                diagnostics);
+    }
+
+    public Node createFacade(int position, NonTerminalNode parent) {
+        return new InferDefaultValueNode(this, position, parent);
+    }
+
+    @Override
+    public void accept(STNodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(STNodeTransformer<T> transformer) {
+        return transformer.transform(this);
+    }
+}

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
@@ -648,6 +648,15 @@ public class STNodeFactory extends STAbstractNodeFactory {
                 expression);
     }
 
+    public static STNode createInferDefaultValueNode(
+            STNode ltToken,
+            STNode gtToken) {
+
+        return new STInferDefaultValueNode(
+                ltToken,
+                gtToken);
+    }
+
     public static STNode createObjectTypeDescriptorNode(
             STNode objectTypeQualifiers,
             STNode objectKeyword,

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeTransformer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeTransformer.java
@@ -221,6 +221,10 @@ public abstract class STNodeTransformer<T> {
         return transformSyntaxNode(restArgumentNode);
     }
 
+    public T transform(STInferDefaultValueNode inferDefaultValueNode) {
+        return transformSyntaxNode(inferDefaultValueNode);
+    }
+
     public T transform(STObjectTypeDescriptorNode objectTypeDescriptorNode) {
         return transformSyntaxNode(objectTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeVisitor.java
@@ -221,6 +221,10 @@ public abstract class STNodeVisitor {
         visitSyntaxNode(restArgumentNode);
     }
 
+    public void visit(STInferDefaultValueNode inferDefaultValueNode) {
+        visitSyntaxNode(inferDefaultValueNode);
+    }
+
     public void visit(STObjectTypeDescriptorNode objectTypeDescriptorNode) {
         visitSyntaxNode(objectTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STTreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STTreeModifier.java
@@ -684,6 +684,16 @@ public abstract class STTreeModifier extends STNodeTransformer<STNode> {
     }
 
     @Override
+    public STInferDefaultValueNode transform(
+            STInferDefaultValueNode inferDefaultValueNode) {
+        STNode ltToken = modifyNode(inferDefaultValueNode.ltToken);
+        STNode gtToken = modifyNode(inferDefaultValueNode.gtToken);
+        return inferDefaultValueNode.modify(
+                ltToken,
+                gtToken);
+    }
+
+    @Override
     public STObjectTypeDescriptorNode transform(
             STObjectTypeDescriptorNode objectTypeDescriptorNode) {
         STNode objectTypeQualifiers = modifyNode(objectTypeDescriptorNode.objectTypeQualifiers);

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/InferDefaultValueNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/InferDefaultValueNode.java
@@ -1,0 +1,114 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerinalang.compiler.syntax.tree;
+
+import io.ballerinalang.compiler.internal.parser.tree.STNode;
+
+import java.util.Objects;
+
+/**
+ * This is a generated syntax tree node.
+ *
+ * @since 2.0.0
+ */
+public class InferDefaultValueNode extends ExpressionNode {
+
+    public InferDefaultValueNode(STNode internalNode, int position, NonTerminalNode parent) {
+        super(internalNode, position, parent);
+    }
+
+    public Token ltToken() {
+        return childInBucket(0);
+    }
+
+    public Token gtToken() {
+        return childInBucket(1);
+    }
+
+    @Override
+    public void accept(NodeVisitor visitor) {
+        visitor.visit(this);
+    }
+
+    @Override
+    public <T> T apply(NodeTransformer<T> visitor) {
+        return visitor.transform(this);
+    }
+
+    @Override
+    protected String[] childNames() {
+        return new String[]{
+                "ltToken",
+                "gtToken"};
+    }
+
+    public InferDefaultValueNode modify(
+            Token ltToken,
+            Token gtToken) {
+        if (checkForReferenceEquality(
+                ltToken,
+                gtToken)) {
+            return this;
+        }
+
+        return NodeFactory.createInferDefaultValueNode(
+                ltToken,
+                gtToken);
+    }
+
+    public InferDefaultValueNodeModifier modify() {
+        return new InferDefaultValueNodeModifier(this);
+    }
+
+    /**
+     * This is a generated tree node modifier utility.
+     *
+     * @since 2.0.0
+     */
+    public static class InferDefaultValueNodeModifier {
+        private final InferDefaultValueNode oldNode;
+        private Token ltToken;
+        private Token gtToken;
+
+        public InferDefaultValueNodeModifier(InferDefaultValueNode oldNode) {
+            this.oldNode = oldNode;
+            this.ltToken = oldNode.ltToken();
+            this.gtToken = oldNode.gtToken();
+        }
+
+        public InferDefaultValueNodeModifier withLtToken(
+                Token ltToken) {
+            Objects.requireNonNull(ltToken, "ltToken must not be null");
+            this.ltToken = ltToken;
+            return this;
+        }
+
+        public InferDefaultValueNodeModifier withGtToken(
+                Token gtToken) {
+            Objects.requireNonNull(gtToken, "gtToken must not be null");
+            this.gtToken = gtToken;
+            return this;
+        }
+
+        public InferDefaultValueNode apply() {
+            return oldNode.modify(
+                    ltToken,
+                    gtToken);
+        }
+    }
+}

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
@@ -850,6 +850,18 @@ public abstract class NodeFactory extends AbstractNodeFactory {
         return stRestArgumentNode.createUnlinkedFacade();
     }
 
+    public static InferDefaultValueNode createInferDefaultValueNode(
+            Token ltToken,
+            Token gtToken) {
+        Objects.requireNonNull(ltToken, "ltToken must not be null");
+        Objects.requireNonNull(gtToken, "gtToken must not be null");
+
+        STNode stInferDefaultValueNode = STNodeFactory.createInferDefaultValueNode(
+                ltToken.internalNode(),
+                gtToken.internalNode());
+        return stInferDefaultValueNode.createUnlinkedFacade();
+    }
+
     public static ObjectTypeDescriptorNode createObjectTypeDescriptorNode(
             NodeList<Token> objectTypeQualifiers,
             Token objectKeyword,

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeTransformer.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeTransformer.java
@@ -232,6 +232,10 @@ public abstract class NodeTransformer<T> {
         return transformSyntaxNode(restArgumentNode);
     }
 
+    public T transform(InferDefaultValueNode inferDefaultValueNode) {
+        return transformSyntaxNode(inferDefaultValueNode);
+    }
+
     public T transform(ObjectTypeDescriptorNode objectTypeDescriptorNode) {
         return transformSyntaxNode(objectTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeVisitor.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeVisitor.java
@@ -231,6 +231,10 @@ public abstract class NodeVisitor {
         visitSyntaxNode(restArgumentNode);
     }
 
+    public void visit(InferDefaultValueNode inferDefaultValueNode) {
+        visitSyntaxNode(inferDefaultValueNode);
+    }
+
     public void visit(ObjectTypeDescriptorNode objectTypeDescriptorNode) {
         visitSyntaxNode(objectTypeDescriptorNode);
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
@@ -870,6 +870,18 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
     }
 
     @Override
+    public InferDefaultValueNode transform(
+            InferDefaultValueNode inferDefaultValueNode) {
+        Token ltToken =
+                modifyToken(inferDefaultValueNode.ltToken());
+        Token gtToken =
+                modifyToken(inferDefaultValueNode.gtToken());
+        return inferDefaultValueNode.modify(
+                ltToken,
+                gtToken);
+    }
+
+    @Override
     public ObjectTypeDescriptorNode transform(
             ObjectTypeDescriptorNode objectTypeDescriptorNode) {
         NodeList<Token> objectTypeQualifiers =

--- a/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
+++ b/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
@@ -1146,6 +1146,21 @@
             ]
         },
         {
+            "name": "InferDefaultValueNode",
+            "base": "ExpressionNode",
+            "kind": "REST_ARG",
+            "attributes": [
+                {
+                    "name": "ltToken",
+                    "type": "Token"
+                },
+                {
+                    "name": "gtToken",
+                    "type": "Token"
+                }
+            ]
+        },
+        {
             "name": "ObjectTypeDescriptorNode",
             "base": "TypeDescriptorNode",
             "kind": "OBJECT_TYPE_DESC",

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -65,7 +65,7 @@ public class VariableReturnType {
     private static final BString JANE_DOE = new BmpStringValue("Jane Doe");
     private static final BString SOFTWARE_ENGINEER = new BmpStringValue("Software Engineer");
 
-    public static Object echo(BTypedesc td, BValue value) {
+    public static Object echo(BValue value, BTypedesc td) {
         return value;
     }
 
@@ -73,15 +73,15 @@ public class VariableReturnType {
         return value;
     }
 
-    public static BStream getStream(BTypedesc td, BStream value) {
+    public static BStream getStream(BStream value, BTypedesc td) {
         return value;
     }
 
-    public static TableValue getTable(BTypedesc td, TableValue value) {
+    public static TableValue getTable(TableValue value, BTypedesc td) {
         return value;
     }
 
-    public static BFunctionPointer getFunction(BTypedesc param, BTypedesc ret, BFunctionPointer fp) {
+    public static BFunctionPointer getFunction(BFunctionPointer fp, BTypedesc param, BTypedesc ret) {
         return fp;
     }
 
@@ -89,7 +89,7 @@ public class VariableReturnType {
         return td;
     }
 
-    public static BFuture getFuture(BTypedesc td, BFuture value) {
+    public static BFuture getFuture(BFuture value, BTypedesc td) {
         return value;
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFuncSignatureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/InferredDependentlyTypeFuncSignatureTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.test.javainterop;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for dependently typed function signatures derived from contextual type.
+ *
+ * @since 2.0.0
+ */
+public class InferredDependentlyTypeFuncSignatureTest {
+
+    private CompileResult result;
+
+    @BeforeClass
+    public void setup() {
+        result = BCompileUtil.compile("test-src/javainterop/inferred_dependently_typed_func_signature.bal");
+    }
+
+    @Test(dataProvider = "FunctionNames")
+    public void testVariableTypeAsReturnType(String funcName) {
+        BRunUtil.invoke(result, funcName);
+    }
+
+    @DataProvider(name = "FunctionNames")
+    public Object[][] getFuncNames() {
+        return new Object[][]{
+                {"testRecordVarRef"},
+                {"testVarRefInMapConstraint"},
+                {"testVarRefUseInMultiplePlaces"},
+                {"testSimpleTypes"},
+                {"testArrayTypes"},
+                {"testStream"},
+                {"testTable"},
+                {"testFunctionPointers"},
+                {"testTypedesc"},
+                {"testFuture"},
+                {"testComplexTypes"},
+                {"testRuntimeCastError"},
+                {"testFunctionAssignment"}
+//                {"testCastingForInvalidValues"}
+        };
+    }
+}


### PR DESCRIPTION
## Purpose
> $subject

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
```ballerina
import ballerina/io;
import ballerina/java;

public function main() {
    map<int> m = query("foo");
    io:println(m);
}

function query(string q, typedesc<anydata> rowType = <>) returns map<rowType> = @java:Method {
    class: "xyz.pubudu.Hello",
    name: "query",
    paramTypes: ["org.ballerinalang.jvm.values.api.BString", "org.ballerinalang.jvm.values.api.BTypedesc"]
} external;
```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
