### PR TITLE
Allow redirection for non-safe methods[1.2.x]

### DIFF
--- a/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
@@ -286,6 +286,20 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "HTTP_ERROR_CODE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Constant for the http error code"
+                }
+            },
+            "sortText": "130",
+            "insertText": "HTTP_ERROR_CODE",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "MULTIPART_AS_PRIMARY_TYPE",
             "kind": "Variable",
             "detail": "string",
@@ -636,6 +650,426 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_RETRY_ATTEMPTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "IDLE_TIMEOUT_TRIGGERED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "IDLE_TIMEOUT_TRIGGERED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHN_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthenticationError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "AUTHN_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHZ_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthorizationError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "AUTHZ_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_INBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_COOKIE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InvalidCookieError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_COOKIE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for generic client error"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_LISTENER_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:GenericListenerError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_LISTENER_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UNSUPPORTED_ACTION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "UNSUPPORTED_ACTION",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "HTTP2_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Http2ClientError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "HTTP2_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "SSL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:SslError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "SSL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "COOKIE_HANDLING_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:CookieHandlingError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "COOKIE_HANDLING_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -656,7 +1090,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` \n"
+                    "value": "HTTP header key `authorization` "
                 }
             },
             "sortText": "130",
@@ -768,7 +1202,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` \n"
+                    "value": "HTTP header key `if-match` "
                 }
             },
             "sortText": "130",
@@ -810,7 +1244,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` \n"
+                    "value": "HTTP header key `if-range` "
                 }
             },
             "sortText": "130",
@@ -824,7 +1258,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` \n"
+                    "value": "HTTP header key `if-unmodified-since` "
                 }
             },
             "sortText": "130",
@@ -1714,6 +2148,104 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "CONNECTION_CLOSURE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for failures during connection closure"
+                }
+            },
+            "sortText": "130",
+            "insertText": "CONNECTION_CLOSURE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_HANDSHAKE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for WebSocket handshake failures"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_HANDSHAKE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PAYLOAD_TOO_BIG_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for exceeding maximum frame size"
+                }
+            },
+            "sortText": "130",
+            "insertText": "PAYLOAD_TOO_BIG_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROTOCOL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for other side breaking the protocol"
+                }
+            },
+            "sortText": "130",
+            "insertText": "PROTOCOL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CONNECTION_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for connection failures"
+                }
+            },
+            "sortText": "130",
+            "insertText": "CONNECTION_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_CONTINUATION_FRAME_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for invalid continuation frame"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for errors not captured by the specific errors"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -1751,7 +2283,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+                "left": "Configurations for a WebSocket service.\n"
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -1784,7 +2316,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a service.\n"
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -1795,7 +2327,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a resource.\n"
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -1880,7 +2412,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+                "left": "Configures cache control directives for an `http:Response`.\n"
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -1891,7 +2423,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -1912,7 +2444,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -1934,7 +2466,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
             "sortText": "190",
             "insertText": "Client",
@@ -1989,7 +2521,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -2000,7 +2532,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -2033,7 +2565,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+                "left": "Client configuration for cookies.\n"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -2152,7 +2684,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -2162,7 +2694,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -2255,6 +2787,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "Detail",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Holds the details of an HTTP error\n"
+            },
+            "sortText": "180",
+            "insertText": "Detail",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2296,17 +2839,6 @@
             },
             "sortText": "200",
             "insertText": "AllLoadBalanceEndpointsFailedError",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CircuitBreakerConfigError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to circuit breaker configuration error."
-            },
-            "sortText": "200",
-            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2721,7 +3253,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+                "left": "Represents an HTTP request.\n"
             },
             "sortText": "190",
             "insertText": "Request",
@@ -2754,7 +3286,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+                "left": "Represents an HTTP response.\n"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -2863,7 +3395,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -2896,7 +3428,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -2940,7 +3472,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -2973,7 +3505,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -2983,9 +3515,6 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
-            "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector."
-            },
             "sortText": "200",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3039,7 +3568,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -3050,7 +3579,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+                "left": "Provides settings related to HTTP/1.x protocol.\n"
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -3061,7 +3590,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+                "left": "Authentication configurations for the listener.\n"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -3072,7 +3601,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -3115,7 +3644,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -3126,7 +3655,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+                "left": "Retry configurations for WebSocket.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -3236,7 +3765,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3269,7 +3798,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -3280,7 +3809,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -3337,7 +3866,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3355,7 +3884,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3373,7 +3902,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3391,7 +3920,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3409,7 +3938,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3427,7 +3956,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
@@ -152,7 +152,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "Indicates that the client is only accepting responses whose freshness lifetime \u003e\u003d current age + min-fresh."
+                    "value": "Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
                 }
             },
             "sortText": "130",
@@ -283,20 +283,6 @@
             },
             "sortText": "130",
             "insertText": "RFC_7234",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP_ERROR_CODE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the http error code"
-                }
-            },
-            "sortText": "130",
-            "insertText": "HTTP_ERROR_CODE",
             "insertTextFormat": "Snippet"
         },
         {
@@ -650,426 +636,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_RETRY_ATTEMPTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "IDLE_TIMEOUT_TRIGGERED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "IDLE_TIMEOUT_TRIGGERED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHN_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthenticationError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "AUTHN_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHZ_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthorizationError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "AUTHZ_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_INBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_COOKIE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InvalidCookieError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_COOKIE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for generic client error"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_LISTENER_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:GenericListenerError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_LISTENER_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UNSUPPORTED_ACTION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "UNSUPPORTED_ACTION",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP2_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Http2ClientError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "HTTP2_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "SSL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:SslError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "SSL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "COOKIE_HANDLING_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:CookieHandlingError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "COOKIE_HANDLING_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -1090,7 +656,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` "
+                    "value": "HTTP header key `authorization` \n"
                 }
             },
             "sortText": "130",
@@ -1202,7 +768,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` "
+                    "value": "HTTP header key `if-match` \n"
                 }
             },
             "sortText": "130",
@@ -1244,7 +810,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` "
+                    "value": "HTTP header key `if-range` \n"
                 }
             },
             "sortText": "130",
@@ -1258,7 +824,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` "
+                    "value": "HTTP header key `if-unmodified-since` \n"
                 }
             },
             "sortText": "130",
@@ -1305,6 +871,20 @@
             },
             "sortText": "130",
             "insertText": "PRAGMA",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROXY_AUTHORIZATION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
+                }
+            },
+            "sortText": "130",
+            "insertText": "PROXY_AUTHORIZATION",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2134,104 +1714,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "CONNECTION_CLOSURE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for failures during connection closure"
-                }
-            },
-            "sortText": "130",
-            "insertText": "CONNECTION_CLOSURE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_HANDSHAKE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for WebSocket handshake failures"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_HANDSHAKE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PAYLOAD_TOO_BIG_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for exceeding maximum frame size"
-                }
-            },
-            "sortText": "130",
-            "insertText": "PAYLOAD_TOO_BIG_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PROTOCOL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for other side breaking the protocol"
-                }
-            },
-            "sortText": "130",
-            "insertText": "PROTOCOL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONNECTION_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for connection failures"
-                }
-            },
-            "sortText": "130",
-            "insertText": "CONNECTION_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_CONTINUATION_FRAME_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for invalid continuation frame"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for errors not captured by the specific errors"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -2269,7 +1751,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -2302,7 +1784,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -2313,7 +1795,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -2398,7 +1880,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -2409,7 +1891,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -2430,7 +1912,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -2452,7 +1934,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "190",
             "insertText": "Client",
@@ -2507,7 +1989,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -2518,7 +2000,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -2551,7 +2033,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -2606,7 +2088,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -2670,7 +2152,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -2680,7 +2162,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -2773,17 +2255,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "180",
-            "insertText": "Detail",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2825,6 +2296,17 @@
             },
             "sortText": "200",
             "insertText": "AllLoadBalanceEndpointsFailedError",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CircuitBreakerConfigError",
+            "kind": "Event",
+            "detail": "Error",
+            "documentation": {
+                "left": "Represents a client error that occurred due to circuit breaker configuration error."
+            },
+            "sortText": "200",
+            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -3239,7 +2721,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "190",
             "insertText": "Request",
@@ -3272,7 +2754,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -3381,7 +2863,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -3414,7 +2896,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -3458,7 +2940,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -3491,7 +2973,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -3501,6 +2983,9 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
+            "documentation": {
+                "left": "Represents an error occurred in an remote function of the Load Balance connector."
+            },
             "sortText": "200",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3554,7 +3039,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -3565,7 +3050,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -3576,7 +3061,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -3587,7 +3072,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -3630,7 +3115,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -3641,7 +3126,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -3751,7 +3236,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3784,7 +3269,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -3795,7 +3280,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -3852,7 +3337,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3870,7 +3355,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3888,7 +3373,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
                 }
             },
             "sortText": "120",
@@ -3900,13 +3385,13 @@
             }
         },
         {
-            "label": "parseHeader(string headerValue)(([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "label": "parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
             "kind": "Function",
             "detail": "Function",
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3924,7 +3409,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3942,7 +3427,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
@@ -43,7 +43,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -76,7 +76,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -87,7 +87,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -183,7 +183,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -194,7 +194,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -215,7 +215,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -237,7 +237,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "190",
             "insertText": "Client",
@@ -292,7 +292,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -303,7 +303,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -336,7 +336,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -399,7 +399,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -471,7 +471,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -481,7 +481,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -495,6 +495,16 @@
             },
             "sortText": "110",
             "insertText": "HttpOperation",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "safeHttpOperation",
+            "detail": "Union",
+            "documentation": {
+                "left": "Defines the safe HTTP operations which do not modify resources representation"
+            },
+            "sortText": "110",
+            "insertText": "safeHttpOperation",
             "insertTextFormat": "Snippet"
         },
         {
@@ -579,17 +589,6 @@
             },
             "sortText": "110",
             "insertText": "RedirectCode",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "180",
-            "insertText": "Detail",
             "insertTextFormat": "Snippet"
         },
         {
@@ -718,7 +717,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "190",
             "insertText": "Request",
@@ -751,7 +750,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -828,7 +827,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "FailoverClientConfiguration",
@@ -860,7 +859,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -893,7 +892,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -937,7 +936,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -970,7 +969,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -981,7 +980,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceClientConfiguration",
@@ -1025,7 +1024,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -1036,7 +1035,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -1047,7 +1046,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -1058,7 +1057,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -1109,7 +1108,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -1120,7 +1119,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -1164,7 +1163,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -1197,7 +1196,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -1208,7 +1207,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -1219,7 +1218,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
             "sortText": "180",
             "insertText": "ClientConfiguration",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
@@ -43,7 +43,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+                "left": "Configurations for a WebSocket service.\n"
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -76,7 +76,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a service.\n"
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -87,7 +87,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a resource.\n"
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -183,7 +183,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+                "left": "Configures cache control directives for an `http:Response`.\n"
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -194,7 +194,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -215,7 +215,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -237,7 +237,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
             "sortText": "190",
             "insertText": "Client",
@@ -292,7 +292,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -303,7 +303,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -336,7 +336,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+                "left": "Client configuration for cookies.\n"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -471,7 +471,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -481,7 +481,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -501,7 +501,7 @@
             "label": "safeHttpOperation",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the safe HTTP operations which do not modify resources representation"
+                "left": "Defines the safe HTTP operations which do not modify resource representation."
             },
             "sortText": "110",
             "insertText": "safeHttpOperation",
@@ -589,6 +589,17 @@
             },
             "sortText": "110",
             "insertText": "RedirectCode",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "Detail",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Holds the details of an HTTP error\n"
+            },
+            "sortText": "180",
+            "insertText": "Detail",
             "insertTextFormat": "Snippet"
         },
         {
@@ -717,7 +728,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+                "left": "Represents an HTTP request.\n"
             },
             "sortText": "190",
             "insertText": "Request",
@@ -750,7 +761,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+                "left": "Represents an HTTP response.\n"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -827,7 +838,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "FailoverClientConfiguration",
@@ -859,7 +870,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -892,7 +903,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -936,7 +947,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -969,7 +980,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -980,7 +991,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceClientConfiguration",
@@ -1024,7 +1035,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -1035,7 +1046,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+                "left": "Provides settings related to HTTP/1.x protocol.\n"
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -1046,7 +1057,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+                "left": "Authentication configurations for the listener.\n"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -1057,7 +1068,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -1108,7 +1119,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -1119,7 +1130,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+                "left": "Retry configurations for WebSocket.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -1163,7 +1174,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -1196,7 +1207,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -1207,7 +1218,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -1218,7 +1229,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
             "sortText": "180",
             "insertText": "ClientConfiguration",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
@@ -1,7 +1,7 @@
 {
     "position": {
-        "line":11,
-        "character":15
+        "line": 11,
+        "character": 15
     },
     "source": "function/source/matchStatementSuggestions4.bal",
     "items": [
@@ -152,7 +152,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "Indicates that the client is only accepting responses whose freshness lifetime \u003e\u003d current age + min-fresh."
+                    "value": "Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
                 }
             },
             "sortText": "130",
@@ -283,20 +283,6 @@
             },
             "sortText": "130",
             "insertText": "RFC_7234",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP_ERROR_CODE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the http error code"
-                }
-            },
-            "sortText": "130",
-            "insertText": "HTTP_ERROR_CODE",
             "insertTextFormat": "Snippet"
         },
         {
@@ -650,426 +636,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_RETRY_ATTEMPTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "IDLE_TIMEOUT_TRIGGERED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "IDLE_TIMEOUT_TRIGGERED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHN_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthenticationError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "AUTHN_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHZ_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthorizationError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "AUTHZ_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_INBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_COOKIE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InvalidCookieError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_COOKIE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for generic client error"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_LISTENER_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:GenericListenerError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_LISTENER_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UNSUPPORTED_ACTION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "UNSUPPORTED_ACTION",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP2_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Http2ClientError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "HTTP2_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "SSL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:SslError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "SSL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "COOKIE_HANDLING_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:CookieHandlingError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "COOKIE_HANDLING_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -1090,7 +656,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` "
+                    "value": "HTTP header key `authorization` \n"
                 }
             },
             "sortText": "130",
@@ -1202,7 +768,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` "
+                    "value": "HTTP header key `if-match` \n"
                 }
             },
             "sortText": "130",
@@ -1244,7 +810,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` "
+                    "value": "HTTP header key `if-range` \n"
                 }
             },
             "sortText": "130",
@@ -1258,7 +824,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` "
+                    "value": "HTTP header key `if-unmodified-since` \n"
                 }
             },
             "sortText": "130",
@@ -1305,6 +871,20 @@
             },
             "sortText": "130",
             "insertText": "PRAGMA",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROXY_AUTHORIZATION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
+                }
+            },
+            "sortText": "130",
+            "insertText": "PROXY_AUTHORIZATION",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2134,104 +1714,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "CONNECTION_CLOSURE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for failures during connection closure"
-                }
-            },
-            "sortText": "130",
-            "insertText": "CONNECTION_CLOSURE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_HANDSHAKE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for WebSocket handshake failures"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_HANDSHAKE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PAYLOAD_TOO_BIG_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for exceeding maximum frame size"
-                }
-            },
-            "sortText": "130",
-            "insertText": "PAYLOAD_TOO_BIG_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PROTOCOL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for other side breaking the protocol"
-                }
-            },
-            "sortText": "130",
-            "insertText": "PROTOCOL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONNECTION_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for connection failures"
-                }
-            },
-            "sortText": "130",
-            "insertText": "CONNECTION_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_CONTINUATION_FRAME_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for invalid continuation frame"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for errors not captured by the specific errors"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -2269,7 +1751,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -2302,7 +1784,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -2313,7 +1795,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -2398,7 +1880,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -2409,7 +1891,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -2430,7 +1912,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -2452,7 +1934,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "190",
             "insertText": "Client",
@@ -2507,7 +1989,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -2518,7 +2000,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -2551,7 +2033,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -2606,7 +2088,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -2670,7 +2152,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -2680,7 +2162,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -2773,17 +2255,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "180",
-            "insertText": "Detail",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2825,6 +2296,17 @@
             },
             "sortText": "200",
             "insertText": "AllLoadBalanceEndpointsFailedError",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CircuitBreakerConfigError",
+            "kind": "Event",
+            "detail": "Error",
+            "documentation": {
+                "left": "Represents a client error that occurred due to circuit breaker configuration error."
+            },
+            "sortText": "200",
+            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -3239,7 +2721,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "190",
             "insertText": "Request",
@@ -3272,7 +2754,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -3381,7 +2863,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -3414,7 +2896,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -3458,7 +2940,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -3491,7 +2973,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -3501,6 +2983,9 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
+            "documentation": {
+                "left": "Represents an error occurred in an remote function of the Load Balance connector."
+            },
             "sortText": "200",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3554,7 +3039,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -3565,7 +3050,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -3576,7 +3061,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -3587,7 +3072,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -3630,7 +3115,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -3641,7 +3126,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -3751,7 +3236,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3784,7 +3269,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -3795,7 +3280,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -3852,7 +3337,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3870,7 +3355,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3888,7 +3373,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
                 }
             },
             "sortText": "120",
@@ -3900,13 +3385,13 @@
             }
         },
         {
-            "label": "parseHeader(string headerValue)(([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "label": "parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
             "kind": "Function",
             "detail": "Function",
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3924,7 +3409,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3942,7 +3427,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
@@ -286,6 +286,20 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "HTTP_ERROR_CODE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Constant for the http error code"
+                }
+            },
+            "sortText": "130",
+            "insertText": "HTTP_ERROR_CODE",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "MULTIPART_AS_PRIMARY_TYPE",
             "kind": "Variable",
             "detail": "string",
@@ -636,6 +650,426 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_RETRY_ATTEMPTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "IDLE_TIMEOUT_TRIGGERED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "IDLE_TIMEOUT_TRIGGERED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHN_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthenticationError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "AUTHN_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHZ_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthorizationError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "AUTHZ_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_INBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_COOKIE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InvalidCookieError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_COOKIE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for generic client error"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_LISTENER_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:GenericListenerError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_LISTENER_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UNSUPPORTED_ACTION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "UNSUPPORTED_ACTION",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "HTTP2_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Http2ClientError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "HTTP2_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "SSL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:SslError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "SSL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "COOKIE_HANDLING_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:CookieHandlingError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "COOKIE_HANDLING_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -656,7 +1090,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` \n"
+                    "value": "HTTP header key `authorization` "
                 }
             },
             "sortText": "130",
@@ -768,7 +1202,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` \n"
+                    "value": "HTTP header key `if-match` "
                 }
             },
             "sortText": "130",
@@ -810,7 +1244,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` \n"
+                    "value": "HTTP header key `if-range` "
                 }
             },
             "sortText": "130",
@@ -824,7 +1258,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` \n"
+                    "value": "HTTP header key `if-unmodified-since` "
                 }
             },
             "sortText": "130",
@@ -1714,6 +2148,104 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "CONNECTION_CLOSURE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for failures during connection closure"
+                }
+            },
+            "sortText": "130",
+            "insertText": "CONNECTION_CLOSURE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_HANDSHAKE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for WebSocket handshake failures"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_HANDSHAKE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PAYLOAD_TOO_BIG_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for exceeding maximum frame size"
+                }
+            },
+            "sortText": "130",
+            "insertText": "PAYLOAD_TOO_BIG_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROTOCOL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for other side breaking the protocol"
+                }
+            },
+            "sortText": "130",
+            "insertText": "PROTOCOL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CONNECTION_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for connection failures"
+                }
+            },
+            "sortText": "130",
+            "insertText": "CONNECTION_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_CONTINUATION_FRAME_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for invalid continuation frame"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for errors not captured by the specific errors"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -1751,7 +2283,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+                "left": "Configurations for a WebSocket service.\n"
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -1784,7 +2316,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a service.\n"
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -1795,7 +2327,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a resource.\n"
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -1880,7 +2412,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+                "left": "Configures cache control directives for an `http:Response`.\n"
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -1891,7 +2423,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -1912,7 +2444,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -1934,7 +2466,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
             "sortText": "190",
             "insertText": "Client",
@@ -1989,7 +2521,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -2000,7 +2532,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -2033,7 +2565,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+                "left": "Client configuration for cookies.\n"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -2152,7 +2684,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -2162,7 +2694,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -2255,6 +2787,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "Detail",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Holds the details of an HTTP error\n"
+            },
+            "sortText": "180",
+            "insertText": "Detail",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2296,17 +2839,6 @@
             },
             "sortText": "200",
             "insertText": "AllLoadBalanceEndpointsFailedError",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CircuitBreakerConfigError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to circuit breaker configuration error."
-            },
-            "sortText": "200",
-            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2721,7 +3253,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+                "left": "Represents an HTTP request.\n"
             },
             "sortText": "190",
             "insertText": "Request",
@@ -2754,7 +3286,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+                "left": "Represents an HTTP response.\n"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -2863,7 +3395,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -2896,7 +3428,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -2940,7 +3472,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -2973,7 +3505,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -2983,9 +3515,6 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
-            "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector."
-            },
             "sortText": "200",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3039,7 +3568,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -3050,7 +3579,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+                "left": "Provides settings related to HTTP/1.x protocol.\n"
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -3061,7 +3590,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+                "left": "Authentication configurations for the listener.\n"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -3072,7 +3601,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -3115,7 +3644,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -3126,7 +3655,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+                "left": "Retry configurations for WebSocket.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -3236,7 +3765,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3269,7 +3798,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -3280,7 +3809,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -3337,7 +3866,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3355,7 +3884,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3373,7 +3902,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3391,7 +3920,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3409,7 +3938,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3427,7 +3956,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
@@ -1,1269 +1,1280 @@
 {
-    "position": {
-        "line": 6,
-        "character": 33
+    "position":{
+        "line":6,
+        "character":33
     },
-    "source": "function/source/workerDeclarationContext4.bal",
-    "items": [
+    "source":"function/source/workerDeclarationContext4.bal",
+    "items":[
         {
-            "label": "HttpServiceConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Contains the configurations for an HTTP service.\n"
+            "label":"HttpServiceConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Contains the configurations for an HTTP service.\n"
             },
-            "sortText": "180",
-            "insertText": "HttpServiceConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"HttpServiceConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CorsConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for CORS support.\n"
+            "label":"CorsConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for CORS support.\n"
             },
-            "sortText": "180",
-            "insertText": "CorsConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CorsConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Versioning",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for service versioning.\n"
+            "label":"Versioning",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for service versioning.\n"
             },
-            "sortText": "180",
-            "insertText": "Versioning",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"Versioning",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WSServiceConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+            "label":"WSServiceConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for a WebSocket service.\n"
             },
-            "sortText": "180",
-            "insertText": "WSServiceConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"WSServiceConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpResourceConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configuration for an HTTP resource.\n"
+            "label":"HttpResourceConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configuration for an HTTP resource.\n"
             },
-            "sortText": "180",
-            "insertText": "HttpResourceConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"HttpResourceConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketUpgradeConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Resource configuration to upgrade from HTTP to WebSocket.\n"
+            "label":"WebSocketUpgradeConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Resource configuration to upgrade from HTTP to WebSocket.\n"
             },
-            "sortText": "180",
-            "insertText": "WebSocketUpgradeConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"WebSocketUpgradeConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ServiceAuth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+            "label":"ServiceAuth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configures the authentication scheme for a service.\n"
             },
-            "sortText": "180",
-            "insertText": "ServiceAuth",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ServiceAuth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResourceAuth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+            "label":"ResourceAuth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configures the authentication scheme for a resource.\n"
             },
-            "sortText": "180",
-            "insertText": "ResourceAuth",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ResourceAuth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpParamOrderConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Path param order config keep the signature path param index against the variable names for runtime path param processing.\n"
+            "label":"HttpParamOrderConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Path param order config keep the signature path param index against the variable names for runtime path param processing.\n"
             },
-            "sortText": "180",
-            "insertText": "HttpParamOrderConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"HttpParamOrderConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthzHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of Authorization Handler for HTTP.\n"
+            "label":"AuthzHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of Authorization Handler for HTTP.\n"
             },
-            "sortText": "190",
-            "insertText": "AuthzHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"AuthzHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The representation of an inbound authentication handler for HTTP traffic."
+            "label":"InboundAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The representation of an inbound authentication handler for HTTP traffic."
             },
-            "sortText": "190",
-            "insertText": "InboundAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"InboundAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The representation of an outbound authentication handler for HTTP traffic."
+            "label":"OutboundAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The representation of an outbound authentication handler for HTTP traffic."
             },
-            "sortText": "190",
-            "insertText": "OutboundAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"OutboundAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CredentialBearer",
-            "detail": "Union",
-            "documentation": {
-                "left": "Specifies how to send the authentication credentials when exchanging tokens."
+            "label":"CredentialBearer",
+            "detail":"Union",
+            "documentation":{
+                "left":"Specifies how to send the authentication credentials when exchanging tokens."
             },
-            "sortText": "110",
-            "insertText": "CredentialBearer",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"CredentialBearer",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundAuthHandlers",
-            "detail": "Union",
-            "documentation": {
-                "left": "Represents inbound auth handler patterns."
+            "label":"InboundAuthHandlers",
+            "detail":"Union",
+            "documentation":{
+                "left":"Represents inbound auth handler patterns."
             },
-            "sortText": "110",
-            "insertText": "InboundAuthHandlers",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"InboundAuthHandlers",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Scopes",
-            "detail": "Union",
-            "documentation": {
-                "left": "Represents scopes patterns."
+            "label":"Scopes",
+            "detail":"Union",
+            "documentation":{
+                "left":"Represents scopes patterns."
             },
-            "sortText": "110",
-            "insertText": "Scopes",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"Scopes",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RequestCacheControl",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Configures the cache control directives for an `http:Request`.\n"
+            "label":"RequestCacheControl",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Configures the cache control directives for an `http:Request`.\n"
             },
-            "sortText": "190",
-            "insertText": "RequestCacheControl",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"RequestCacheControl",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResponseCacheControl",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+            "label":"ResponseCacheControl",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Configures cache control directives for an `http:Response`.\n"
             },
-            "sortText": "190",
-            "insertText": "ResponseCacheControl",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"ResponseCacheControl",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpCache",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+            "label":"HttpCache",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
-            "sortText": "190",
-            "insertText": "HttpCache",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"HttpCache",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CachingPolicy",
-            "detail": "Union",
-            "documentation": {
-                "left": "Used for configuring the caching behaviour. Setting the `policy` field in the `CacheConfig` record allows\nthe user to control the caching behaviour."
+            "label":"CachingPolicy",
+            "detail":"Union",
+            "documentation":{
+                "left":"Used for configuring the caching behaviour. Setting the `policy` field in the `CacheConfig` record allows\nthe user to control the caching behaviour."
             },
-            "sortText": "110",
-            "insertText": "CachingPolicy",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"CachingPolicy",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CacheConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+            "label":"CacheConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "CacheConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CacheConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpCachingClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "An HTTP caching client implementation which takes an `HttpActions` instance and wraps it with an HTTP caching layer.\n"
+            "label":"HttpCachingClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"An HTTP caching client implementation which takes an `HttpActions` instance and wraps it with an HTTP caching layer.\n"
             },
-            "sortText": "190",
-            "insertText": "HttpCachingClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"HttpCachingClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Client",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+            "label":"Client",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
-            "sortText": "190",
-            "insertText": "Client",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"Client",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "TargetService",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents a single service and its related configurations.\n"
+            "label":"TargetService",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents a single service and its related configurations.\n"
             },
-            "sortText": "180",
-            "insertText": "TargetService",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"TargetService",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientHttp1Settings",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+            "label":"ClientHttp1Settings",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides settings related to HTTP/1.x protocol.\n"
             },
-            "sortText": "180",
-            "insertText": "ClientHttp1Settings",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ClientHttp1Settings",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientHttp2Settings",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides settings related to HTTP/2 protocol.\n"
+            "label":"ClientHttp2Settings",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides settings related to HTTP/2 protocol.\n"
             },
-            "sortText": "180",
-            "insertText": "ClientHttp2Settings",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ClientHttp2Settings",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RetryConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides configurations for controlling the retrying behavior in failure scenarios.\n"
+            "label":"RetryConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides configurations for controlling the retrying behavior in failure scenarios.\n"
             },
-            "sortText": "180",
-            "insertText": "RetryConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"RetryConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientSecureSocket",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+            "label":"ClientSecureSocket",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "ClientSecureSocket",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ClientSecureSocket",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FollowRedirects",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
+            "label":"FollowRedirects",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
-            "sortText": "180",
-            "insertText": "FollowRedirects",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"FollowRedirects",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ProxyConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Proxy server configurations to be used with the HTTP client endpoint.\n"
+            "label":"ProxyConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Proxy server configurations to be used with the HTTP client endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "ProxyConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ProxyConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundAuthConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "The `OutboundAuthConfig` record can be used to configure the authentication mechanism used by the HTTP endpoint.\n"
+            "label":"OutboundAuthConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"The `OutboundAuthConfig` record can be used to configure the authentication mechanism used by the HTTP endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "OutboundAuthConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"OutboundAuthConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+            "label":"CookieConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Client configuration for cookies.\n"
             },
-            "sortText": "180",
-            "insertText": "CookieConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CookieConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Cookie",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a Cookie.\n"
+            "label":"Cookie",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a Cookie.\n"
             },
-            "sortText": "190",
-            "insertText": "Cookie",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"Cookie",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieStore",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents the cookie store.\n"
+            "label":"CookieStore",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents the cookie store.\n"
             },
-            "sortText": "190",
-            "insertText": "CookieStore",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"CookieStore",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "myCookie",
-            "kind": "Struct",
-            "detail": "Record",
-            "sortText": "180",
-            "insertText": "myCookie",
-            "insertTextFormat": "Snippet"
+            "label":"myCookie",
+            "kind":"Struct",
+            "detail":"Record",
+            "sortText":"180",
+            "insertText":"myCookie",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides the cookie functionality across HTTP client actions.\n"
+            "label":"CookieClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides the cookie functionality across HTTP client actions.\n"
             },
-            "sortText": "190",
-            "insertText": "CookieClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"CookieClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PersistentCookieHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The representation of a persistent cookie handler for managing persistent cookies."
+            "label":"PersistentCookieHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The representation of a persistent cookie handler for managing persistent cookies."
             },
-            "sortText": "190",
-            "insertText": "PersistentCookieHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"PersistentCookieHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpFuture",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+            "label":"HttpFuture",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
-            "sortText": "190",
-            "insertText": "HttpFuture",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"HttpFuture",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PushPromise",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents an HTTP/2 `PUSH_PROMISE` frame.\n"
+            "label":"PushPromise",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents an HTTP/2 `PUSH_PROMISE` frame.\n"
             },
-            "sortText": "190",
-            "insertText": "PushPromise",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"PushPromise",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides the HTTP actions for interacting with an HTTP server. Apart from the standard HTTP methods,\n`HttpClient.forward()` and `HttpClient.execute()` functions are provided. More complex and specific endpoint types\ncan be created by wrapping this generic HTTP actions implementation.\n"
+            "label":"HttpClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides the HTTP actions for interacting with an HTTP server. Apart from the standard HTTP methods,\n`HttpClient.forward()` and `HttpClient.execute()` functions are provided. More complex and specific endpoint types\ncan be created by wrapping this generic HTTP actions implementation.\n"
             },
-            "sortText": "190",
-            "insertText": "HttpClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"HttpClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpTimeoutError",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Defines a timeout error occurred during service invocation.\n"
+            "label":"HttpTimeoutError",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Defines a timeout error occurred during service invocation.\n"
             },
-            "sortText": "180",
-            "insertText": "HttpTimeoutError",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"HttpTimeoutError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PoolConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for managing HTTP client connection pool.\n"
+            "label":"PoolConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for managing HTTP client connection pool.\n"
             },
-            "sortText": "180",
-            "insertText": "PoolConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"PoolConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ConnectionManager",
-            "kind": "Interface",
-            "detail": "Object",
-            "sortText": "190",
-            "insertText": "ConnectionManager",
-            "insertTextFormat": "Snippet"
+            "label":"ConnectionManager",
+            "kind":"Interface",
+            "detail":"Object",
+            "sortText":"190",
+            "insertText":"ConnectionManager",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpVersion",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the supported HTTP protocols.\n\n`HTTP_1_0`: HTTP/1.0 protocol\n`HTTP_1_1`: HTTP/1.1 protocol\n`HTTP_2_0`: HTTP/2.0 protocol"
+            "label":"HttpVersion",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the supported HTTP protocols.\n\n`HTTP_1_0`: HTTP/1.0 protocol\n`HTTP_1_1`: HTTP/1.1 protocol\n`HTTP_2_0`: HTTP/2.0 protocol"
             },
-            "sortText": "110",
-            "insertText": "HttpVersion",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"HttpVersion",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Chunking",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+            "label":"Chunking",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
-            "sortText": "110",
-            "insertText": "Chunking",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"Chunking",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Compression",
-            "detail": "Union",
-            "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+            "label":"Compression",
+            "detail":"Union",
+            "documentation":{
+                "left":"Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
-            "sortText": "110",
-            "insertText": "Compression",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"Compression",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpOperation",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the HTTP operations related to circuit breaker, failover and load balancer.\n\n`FORWARD`: Forward the specified payload\n`GET`: Request a resource\n`POST`: Create a new resource\n`DELETE`: Deletes the specified resource\n`OPTIONS`: Request communication options available\n`PUT`: Replace the target resource\n`PATCH`: Apply partial modification to the resource\n`HEAD`: Identical to `GET` but no resource body should be returned\n`SUBMIT`: Submits a http request and returns an HttpFuture object\n`NONE`: No operation should be performed"
+            "label":"HttpOperation",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the HTTP operations related to circuit breaker, failover and load balancer.\n\n`FORWARD`: Forward the specified payload\n`GET`: Request a resource\n`POST`: Create a new resource\n`DELETE`: Deletes the specified resource\n`OPTIONS`: Request communication options available\n`PUT`: Replace the target resource\n`PATCH`: Apply partial modification to the resource\n`HEAD`: Identical to `GET` but no resource body should be returned\n`SUBMIT`: Submits a http request and returns an HttpFuture object\n`NONE`: No operation should be performed"
             },
-            "sortText": "110",
-            "insertText": "HttpOperation",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"HttpOperation",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "safeHttpOperation",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the safe HTTP operations which do not modify resources representation"
+            "label":"safeHttpOperation",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the safe HTTP operations which do not modify resource representation."
             },
-            "sortText": "110",
-            "insertText": "safeHttpOperation",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"safeHttpOperation",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Protocols",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for configuring SSL/TLS protocol and version to be used.\n"
+            "label":"Protocols",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for configuring SSL/TLS protocol and version to be used.\n"
             },
-            "sortText": "180",
-            "insertText": "Protocols",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"Protocols",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ValidateCert",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing configurations for certificate revocation status checks.\n"
+            "label":"ValidateCert",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing configurations for certificate revocation status checks.\n"
             },
-            "sortText": "180",
-            "insertText": "ValidateCert",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ValidateCert",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerOcspStapling",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing configurations for certificate revocation status checks.\n"
+            "label":"ListenerOcspStapling",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing configurations for certificate revocation status checks.\n"
             },
-            "sortText": "180",
-            "insertText": "ListenerOcspStapling",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ListenerOcspStapling",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CompressionConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing configurations for content compression.\n"
+            "label":"CompressionConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing configurations for content compression.\n"
             },
-            "sortText": "180",
-            "insertText": "CompressionConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CompressionConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTPError",
-            "kind": "Struct",
-            "detail": "Record",
-            "sortText": "180",
-            "insertText": "HTTPError",
-            "insertTextFormat": "Snippet"
+            "label":"HTTPError",
+            "kind":"Struct",
+            "detail":"Record",
+            "sortText":"180",
+            "insertText":"HTTPError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CommonClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Common client configurations for the next level clients.\n"
+            "label":"CommonClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Common client configurations for the next level clients.\n"
             },
-            "sortText": "180",
-            "insertText": "CommonClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CommonClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Caller",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The caller actions for responding to client requests.\n"
+            "label":"Caller",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The caller actions for responding to client requests.\n"
             },
-            "sortText": "190",
-            "insertText": "Caller",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"Caller",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RedirectCode",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the HTTP redirect codes as a type."
+            "label":"RedirectCode",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the HTTP redirect codes as a type."
             },
-            "sortText": "110",
-            "insertText": "RedirectCode",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"RedirectCode",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResiliencyError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the resiliency error types that returned from client"
+            "label":"Detail",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Holds the details of an HTTP error\n"
             },
-            "sortText": "200",
-            "insertText": "ResiliencyError",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"Detail",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientAuthError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the Auth error types that returned from client"
+            "label":"ResiliencyError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the resiliency error types that returned from client"
             },
-            "sortText": "200",
-            "insertText": "ClientAuthError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"ResiliencyError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundRequestError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the client error types that returned while sending outbound request"
+            "label":"ClientAuthError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the Auth error types that returned from client"
             },
-            "sortText": "200",
-            "insertText": "OutboundRequestError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"ClientAuthError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundResponseError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the client error types that returned while receiving inbound response"
+            "label":"OutboundRequestError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the client error types that returned while sending outbound request"
             },
-            "sortText": "200",
-            "insertText": "InboundResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"OutboundRequestError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundRequestError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the listener error types that returned while receiving inbound request"
+            "label":"InboundResponseError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the client error types that returned while receiving inbound response"
             },
-            "sortText": "200",
-            "insertText": "InboundRequestError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"InboundResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundResponseError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the listener error types that returned while sending outbound response"
+            "label":"InboundRequestError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the listener error types that returned while receiving inbound request"
             },
-            "sortText": "200",
-            "insertText": "OutboundResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"InboundRequestError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible client error types"
+            "label":"OutboundResponseError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the listener error types that returned while sending outbound response"
             },
-            "sortText": "200",
-            "insertText": "ClientError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"OutboundResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible listener error types"
+            "label":"ClientError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible client error types"
             },
-            "sortText": "200",
-            "insertText": "ListenerError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"ClientError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RequestFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Abstract Representation of a HTTP Request Filter.\nThis filter will be applied before the request is dispatched to the relevant resource.\nAny RequestFilter implementation should be structurally similar to or implement the RequestFilter object."
+            "label":"ListenerError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible listener error types"
             },
-            "sortText": "190",
-            "insertText": "RequestFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"ListenerError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResponseFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Abstract Representation of a HTTP Response Filter.\nThis filter will be applied in the response path.\nAny ResponseFilter implementation should be structurally similar to or implement the ResponseFilter object."
+            "label":"RequestFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Abstract Representation of a HTTP Request Filter.\nThis filter will be applied before the request is dispatched to the relevant resource.\nAny RequestFilter implementation should be structurally similar to or implement the RequestFilter object."
             },
-            "sortText": "190",
-            "insertText": "ResponseFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"RequestFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FilterContext",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of request filter Context.\n"
+            "label":"ResponseFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Abstract Representation of a HTTP Response Filter.\nThis filter will be applied in the response path.\nAny ResponseFilter implementation should be structurally similar to or implement the ResponseFilter object."
             },
-            "sortText": "190",
-            "insertText": "FilterContext",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"ResponseFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Request",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+            "label":"FilterContext",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of request filter Context.\n"
             },
-            "sortText": "190",
-            "insertText": "Request",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"FilterContext",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MutualSslHandshake",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing mutual SSL handshake results.\n"
+            "label":"Request",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents an HTTP request.\n"
             },
-            "sortText": "180",
-            "insertText": "MutualSslHandshake",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"Request",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MutualSslStatus",
-            "kind": "Enum",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible values for the mutual ssl status.\n\n`passed`: Mutual SSL handshake is successful.\n`failed`: Mutual SSL handshake has failed."
+            "label":"MutualSslHandshake",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing mutual SSL handshake results.\n"
             },
-            "sortText": "160",
-            "insertText": "MutualSslStatus",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"MutualSslHandshake",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Response",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+            "label":"MutualSslStatus",
+            "kind":"Enum",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible values for the mutual ssl status.\n\n`passed`: Mutual SSL handshake is successful.\n`failed`: Mutual SSL handshake has failed."
             },
-            "sortText": "190",
-            "insertText": "Response",
-            "insertTextFormat": "Snippet"
+            "sortText":"160",
+            "insertText":"MutualSslStatus",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpSecureClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides secure HTTP remote functions for interacting with HTTP endpoints. This will make use of the authentication\nschemes configured in the HTTP client endpoint to secure the HTTP requests.\n"
+            "label":"Response",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents an HTTP response.\n"
             },
-            "sortText": "190",
-            "insertText": "HttpSecureClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"Response",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MockListener",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Mock server endpoint which does not open a listening port."
+            "label":"HttpSecureClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides secure HTTP remote functions for interacting with HTTP endpoints. This will make use of the authentication\nschemes configured in the HTTP client endpoint to secure the HTTP requests.\n"
             },
-            "sortText": "190",
-            "insertText": "MockListener",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"HttpSecureClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RedirectClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides redirect functionality for HTTP client remote functions.\n"
+            "label":"MockListener",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Mock server endpoint which does not open a listening port."
             },
-            "sortText": "190",
-            "insertText": "RedirectClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"MockListener",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the failover behaviour of the endpoint.\n"
+            "label":"RedirectClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides redirect functionality for HTTP client remote functions.\n"
             },
-            "sortText": "180",
-            "insertText": "FailoverConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"RedirectClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverInferredConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents the inferred failover configurations passed into the failover client.\n"
+            "label":"FailoverConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the failover behaviour of the endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "FailoverInferredConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"FailoverConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "An HTTP client endpoint which provides failover support over multiple HTTP clients.\n"
+            "label":"FailoverInferredConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents the inferred failover configurations passed into the failover client.\n"
             },
-            "sortText": "190",
-            "insertText": "FailoverClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"FailoverInferredConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                             |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration        |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration        |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+            "label":"FailoverClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"An HTTP client endpoint which provides failover support over multiple HTTP clients.\n"
             },
-            "sortText": "180",
-            "insertText": "FailoverClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"FailoverClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitState",
-            "detail": "Union",
-            "documentation": {
-                "left": "A finite type for modeling the states of the Circuit Breaker. The Circuit Breaker starts in the `CLOSED` state.\nIf any failure thresholds are exceeded during execution, the circuit trips and goes to the `OPEN` state. After\nthe specified timeout period expires, the circuit goes to the `HALF_OPEN` state. If the trial request sent while\nin the `HALF_OPEN` state succeeds, the circuit goes back to the `CLOSED` state."
+            "label":"FailoverClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
-            "sortText": "110",
-            "insertText": "CircuitState",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"FailoverClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitHealth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Maintains the health of the Circuit Breaker.\n"
+            "label":"CircuitState",
+            "detail":"Union",
+            "documentation":{
+                "left":"A finite type for modeling the states of the Circuit Breaker. The Circuit Breaker starts in the `CLOSED` state.\nIf any failure thresholds are exceeded during execution, the circuit trips and goes to the `OPEN` state. After\nthe specified timeout period expires, the circuit goes to the `HALF_OPEN` state. If the trial request sent while\nin the `HALF_OPEN` state succeeds, the circuit goes back to the `CLOSED` state."
             },
-            "sortText": "180",
-            "insertText": "CircuitHealth",
-            "insertTextFormat": "Snippet"
+            "sortText":"110",
+            "insertText":"CircuitState",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+            "label":"CircuitHealth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Maintains the health of the Circuit Breaker.\n"
             },
-            "sortText": "180",
-            "insertText": "CircuitBreakerConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CircuitHealth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RollingWindow",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents a rolling window in the Circuit Breaker.\n"
+            "label":"CircuitBreakerConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
-            "sortText": "180",
-            "insertText": "RollingWindow",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CircuitBreakerConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Bucket",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents a discrete sub-part of the time window (Bucket).\n"
+            "label":"RollingWindow",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents a rolling window in the Circuit Breaker.\n"
             },
-            "sortText": "180",
-            "insertText": "Bucket",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"RollingWindow",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerInferredConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+            "label":"Bucket",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents a discrete sub-part of the time window (Bucket).\n"
             },
-            "sortText": "180",
-            "insertText": "CircuitBreakerInferredConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"Bucket",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "A Circuit Breaker implementation which can be used to gracefully handle network failures.\n"
+            "label":"CircuitBreakerInferredConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
-            "sortText": "190",
-            "insertText": "CircuitBreakerClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"CircuitBreakerInferredConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalancerRule",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "\nLoadBalancerRule provides a required interfaces to implement different algorithms.\n"
+            "label":"CircuitBreakerClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"A Circuit Breaker implementation which can be used to gracefully handle network failures.\n"
             },
-            "sortText": "190",
-            "insertText": "LoadBalancerRule",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"CircuitBreakerClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RetryInferredConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Derived set of configurations from the `RetryConfig`.\n"
+            "label":"LoadBalancerRule",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"\nLoadBalancerRule provides a required interfaces to implement different algorithms.\n"
             },
-            "sortText": "180",
-            "insertText": "RetryInferredConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"LoadBalancerRule",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RetryClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+            "label":"RetryInferredConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Derived set of configurations from the `RetryConfig`.\n"
             },
-            "sortText": "190",
-            "insertText": "RetryClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"RetryInferredConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalancerRoundRobinRule",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Implementation of round robin load balancing strategy.\n"
+            "label":"RetryClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
-            "sortText": "190",
-            "insertText": "LoadBalancerRoundRobinRule",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"RetryClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "LoadBalanceClient endpoint provides load balancing functionality over multiple HTTP clients.\n"
+            "label":"LoadBalancerRoundRobinRule",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Implementation of round robin load balancing strategy.\n"
             },
-            "sortText": "190",
-            "insertText": "LoadBalanceClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"LoadBalancerRoundRobinRule",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceActionErrorData",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+            "label":"LoadBalanceClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"LoadBalanceClient endpoint provides load balancing functionality over multiple HTTP clients.\n"
             },
-            "sortText": "180",
-            "insertText": "LoadBalanceActionErrorData",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"LoadBalanceClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                             |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration        |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration        |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+            "label":"LoadBalanceActionErrorData",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
-            "sortText": "180",
-            "insertText": "LoadBalanceClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"LoadBalanceActionErrorData",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Listener",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "This is used for creating HTTP server endpoints. An HTTP server endpoint is capable of responding to\nremote callers. The `Listener` is responsible for initializing the endpoint using the provided configurations."
+            "label":"LoadBalanceClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
-            "sortText": "190",
-            "insertText": "Listener",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"LoadBalanceClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Remote",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Presents a read-only view of the remote address.\n"
+            "label":"Listener",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"This is used for creating HTTP server endpoints. An HTTP server endpoint is capable of responding to\nremote callers. The `Listener` is responsible for initializing the endpoint using the provided configurations."
             },
-            "sortText": "180",
-            "insertText": "Remote",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"Listener",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Local",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Presents a read-only view of the local address.\n"
+            "label":"Remote",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Presents a read-only view of the remote address.\n"
             },
-            "sortText": "180",
-            "insertText": "Local",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"Remote",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+            "label":"Local",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Presents a read-only view of the local address.\n"
             },
-            "sortText": "180",
-            "insertText": "ListenerConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"Local",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerHttp1Settings",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+            "label":"ListenerConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for HTTP service endpoints.\n"
             },
-            "sortText": "180",
-            "insertText": "ListenerHttp1Settings",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ListenerConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerAuth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+            "label":"ListenerHttp1Settings",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides settings related to HTTP/1.x protocol.\n"
             },
-            "sortText": "180",
-            "insertText": "ListenerAuth",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ListenerHttp1Settings",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerSecureSocket",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+            "label":"ListenerAuth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Authentication configurations for the listener.\n"
             },
-            "sortText": "180",
-            "insertText": "ListenerSecureSocket",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ListenerAuth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "KeepAlive",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible values for the keep-alive configuration in service and client endpoints."
+            "label":"ListenerSecureSocket",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configures the SSL/TLS options to be used for HTTP service.\n"
             },
-            "sortText": "110",
-            "insertText": "KeepAlive",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ListenerSecureSocket",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AttributeFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "sortText": "190",
-            "insertText": "AttributeFilter",
-            "insertTextFormat": "Snippet"
+            "label":"KeepAlive",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible values for the keep-alive configuration in service and client endpoints."
+            },
+            "sortText":"110",
+            "insertText":"KeepAlive",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"AttributeFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "sortText":"190",
+            "insertText":"AttributeFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketCaller",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a WebSocket caller."
+            "label":"WebSocketCaller",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a WebSocket caller."
             },
-            "sortText": "190",
-            "insertText": "WebSocketCaller",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"WebSocketCaller",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a WebSocket client endpoint."
+            "label":"WebSocketClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a WebSocket client endpoint."
             },
-            "sortText": "190",
-            "insertText": "WebSocketClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"WebSocketClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+            "label":"WebSocketClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for the WebSocket client endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "WebSocketClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"WebSocketClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketRetryConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+            "label":"WebSocketRetryConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Retry configurations for WebSocket.\n"
             },
-            "sortText": "180",
-            "insertText": "WebSocketRetryConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"WebSocketRetryConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketConnector",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a WebSocket connection in Ballerina. This includes all connection-oriented operations."
+            "label":"WebSocketConnector",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a WebSocket connection in Ballerina. This includes all connection-oriented operations."
             },
-            "sortText": "190",
-            "insertText": "WebSocketConnector",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"WebSocketConnector",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "The union of all the WebSocket related errors"
+            "label":"WebSocketError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"The union of all the WebSocket related errors"
             },
-            "sortText": "200",
-            "insertText": "WebSocketError",
-            "insertTextFormat": "Snippet"
+            "sortText":"200",
+            "insertText":"WebSocketError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketFailoverClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "A WebSocket client endpoint, which provides failover support for multiple WebSocket targets."
+            "label":"WebSocketFailoverClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"A WebSocket client endpoint, which provides failover support for multiple WebSocket targets."
             },
-            "sortText": "190",
-            "insertText": "WebSocketFailoverClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"WebSocketFailoverClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketFailoverClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+            "label":"WebSocketFailoverClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for the WebSocket client endpoint.\n"
             },
-            "sortText": "180",
-            "insertText": "WebSocketFailoverClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"WebSocketFailoverClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthnFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of the Authentication filter.\n"
+            "label":"AuthnFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of the Authentication filter.\n"
             },
-            "sortText": "190",
-            "insertText": "AuthnFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"AuthnFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthzFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of the Authorization filter.\n"
+            "label":"AuthzFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of the Authorization filter.\n"
             },
-            "sortText": "190",
-            "insertText": "AuthzFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"AuthzFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "BasicAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+            "label":"BasicAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
-            "sortText": "190",
-            "insertText": "BasicAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"BasicAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "BearerAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+            "label":"BearerAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
-            "sortText": "190",
-            "insertText": "BearerAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"BearerAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                             |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration        |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration        |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+            "label":"ClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
-            "sortText": "180",
-            "insertText": "ClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"180",
+            "insertText":"ClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CsvPersistentCookieHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a default persistent cookie handler, which stores persistent cookies in a CSV file.\n"
+            "label":"CsvPersistentCookieHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a default persistent cookie handler, which stores persistent cookies in a CSV file.\n"
             },
-            "sortText": "190",
-            "insertText": "CsvPersistentCookieHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"190",
+            "insertText":"CsvPersistentCookieHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RequestMessage",
-            "kind": "Enum",
-            "detail": "Union",
-            "documentation": {
-                "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+            "label":"RequestMessage",
+            "kind":"Enum",
+            "detail":"Union",
+            "documentation":{
+                "left":"The types of messages that are accepted by HTTP `client` when sending out the outbound request."
             },
-            "sortText": "160",
-            "insertText": "RequestMessage",
-            "insertTextFormat": "Snippet"
+            "sortText":"160",
+            "insertText":"RequestMessage",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResponseMessage",
-            "kind": "Enum",
-            "detail": "Union",
-            "documentation": {
-                "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+            "label":"ResponseMessage",
+            "kind":"Enum",
+            "detail":"Union",
+            "documentation":{
+                "left":"The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
             },
-            "sortText": "160",
-            "insertText": "ResponseMessage",
-            "insertTextFormat": "Snippet"
+            "sortText":"160",
+            "insertText":"ResponseMessage",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpResponse",
-            "kind": "Interface",
-            "detail": "Union",
-            "sortText": "190",
-            "insertText": "HttpResponse",
-            "insertTextFormat": "Snippet"
+            "label":"HttpResponse",
+            "kind":"Interface",
+            "detail":"Union",
+            "sortText":"190",
+            "insertText":"HttpResponse",
+            "insertTextFormat":"Snippet"
         }
     ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
@@ -1,4 +1,4 @@
-    {
+{
     "position": {
         "line": 6,
         "character": 33
@@ -43,7 +43,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -76,7 +76,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -87,7 +87,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -183,7 +183,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -194,7 +194,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -215,7 +215,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -237,7 +237,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "190",
             "insertText": "Client",
@@ -292,7 +292,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -303,7 +303,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -336,7 +336,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -399,7 +399,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -471,7 +471,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -481,7 +481,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -495,6 +495,16 @@
             },
             "sortText": "110",
             "insertText": "HttpOperation",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "safeHttpOperation",
+            "detail": "Union",
+            "documentation": {
+                "left": "Defines the safe HTTP operations which do not modify resources representation"
+            },
+            "sortText": "110",
+            "insertText": "safeHttpOperation",
             "insertTextFormat": "Snippet"
         },
         {
@@ -579,17 +589,6 @@
             },
             "sortText": "110",
             "insertText": "RedirectCode",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "180",
-            "insertText": "Detail",
             "insertTextFormat": "Snippet"
         },
         {
@@ -718,7 +717,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "190",
             "insertText": "Request",
@@ -751,7 +750,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -828,7 +827,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                             |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration        |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration        |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "FailoverClientConfiguration",
@@ -860,7 +859,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -893,7 +892,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -937,7 +936,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -970,7 +969,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -981,7 +980,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                             |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration        |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration        |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceClientConfiguration",
@@ -1025,7 +1024,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -1036,7 +1035,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -1047,7 +1046,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -1058,7 +1057,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -1109,7 +1108,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -1120,7 +1119,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -1164,7 +1163,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -1197,7 +1196,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -1208,7 +1207,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -1219,7 +1218,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                             |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration        |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration        |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
             "sortText": "180",
             "insertText": "ClientConfiguration",

--- a/language-server/modules/langserver-core/src/test/resources/completion/object/objectTest13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/object/objectTest13.json
@@ -43,7 +43,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+                "left": "Configurations for a WebSocket service.\n"
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -76,7 +76,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a service.\n"
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -87,7 +87,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a resource.\n"
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -183,7 +183,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+                "left": "Configures cache control directives for an `http:Response`.\n"
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -194,7 +194,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -215,7 +215,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -237,7 +237,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
             "sortText": "190",
             "insertText": "Client",
@@ -292,7 +292,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -303,7 +303,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -336,7 +336,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+                "left": "Client configuration for cookies.\n"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -471,7 +471,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -481,7 +481,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -589,6 +589,17 @@
             },
             "sortText": "110",
             "insertText": "RedirectCode",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "Detail",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Holds the details of an HTTP error\n"
+            },
+            "sortText": "180",
+            "insertText": "Detail",
             "insertTextFormat": "Snippet"
         },
         {
@@ -717,7 +728,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+                "left": "Represents an HTTP request.\n"
             },
             "sortText": "190",
             "insertText": "Request",
@@ -750,7 +761,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+                "left": "Represents an HTTP response.\n"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -827,7 +838,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "FailoverClientConfiguration",
@@ -859,7 +870,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -892,7 +903,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -936,7 +947,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -969,7 +980,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -980,7 +991,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceClientConfiguration",
@@ -1024,7 +1035,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -1035,7 +1046,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+                "left": "Provides settings related to HTTP/1.x protocol.\n"
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -1046,7 +1057,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+                "left": "Authentication configurations for the listener.\n"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -1057,7 +1068,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -1108,7 +1119,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -1119,7 +1130,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+                "left": "Retry configurations for WebSocket.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -1163,7 +1174,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -1196,7 +1207,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -1207,7 +1218,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -1218,7 +1229,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
             "sortText": "180",
             "insertText": "ClientConfiguration",

--- a/language-server/modules/langserver-core/src/test/resources/completion/object/objectTest13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/object/objectTest13.json
@@ -43,7 +43,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -76,7 +76,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -87,7 +87,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -183,7 +183,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -194,7 +194,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -215,7 +215,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -237,7 +237,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "190",
             "insertText": "Client",
@@ -292,7 +292,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -303,7 +303,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -336,7 +336,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -399,7 +399,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -471,7 +471,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -481,7 +481,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -495,6 +495,16 @@
             },
             "sortText": "110",
             "insertText": "HttpOperation",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "safeHttpOperation",
+            "detail": "Union",
+            "documentation": {
+                "left": "Defines the safe HTTP operations which do not modify resource representation."
+            },
+            "sortText": "110",
+            "insertText": "safeHttpOperation",
             "insertTextFormat": "Snippet"
         },
         {
@@ -579,17 +589,6 @@
             },
             "sortText": "110",
             "insertText": "RedirectCode",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "180",
-            "insertText": "Detail",
             "insertTextFormat": "Snippet"
         },
         {
@@ -718,7 +717,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "190",
             "insertText": "Request",
@@ -751,7 +750,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -828,7 +827,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "FailoverClientConfiguration",
@@ -860,7 +859,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -893,7 +892,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -937,7 +936,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -970,7 +969,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -981,7 +980,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceClientConfiguration",
@@ -1025,7 +1024,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -1036,7 +1035,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -1047,7 +1046,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -1058,7 +1057,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -1109,7 +1108,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -1120,7 +1119,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -1164,7 +1163,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -1197,7 +1196,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -1208,7 +1207,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -1219,7 +1218,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                     |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration      |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
             "sortText": "180",
             "insertText": "ClientConfiguration",

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
@@ -286,6 +286,20 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "HTTP_ERROR_CODE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Constant for the http error code"
+                }
+            },
+            "sortText": "130",
+            "insertText": "HTTP_ERROR_CODE",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "MULTIPART_AS_PRIMARY_TYPE",
             "kind": "Variable",
             "detail": "string",
@@ -636,6 +650,426 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_RETRY_ATTEMPTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "IDLE_TIMEOUT_TRIGGERED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "IDLE_TIMEOUT_TRIGGERED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHN_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthenticationError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "AUTHN_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHZ_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthorizationError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "AUTHZ_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_INBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_COOKIE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InvalidCookieError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_COOKIE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for generic client error"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_LISTENER_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:GenericListenerError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_LISTENER_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UNSUPPORTED_ACTION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "UNSUPPORTED_ACTION",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "HTTP2_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Http2ClientError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "HTTP2_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "SSL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:SslError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "SSL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "COOKIE_HANDLING_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:CookieHandlingError`"
+                }
+            },
+            "sortText": "130",
+            "insertText": "COOKIE_HANDLING_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -656,7 +1090,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` \n"
+                    "value": "HTTP header key `authorization` "
                 }
             },
             "sortText": "130",
@@ -768,7 +1202,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` \n"
+                    "value": "HTTP header key `if-match` "
                 }
             },
             "sortText": "130",
@@ -810,7 +1244,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` \n"
+                    "value": "HTTP header key `if-range` "
                 }
             },
             "sortText": "130",
@@ -824,7 +1258,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` \n"
+                    "value": "HTTP header key `if-unmodified-since` "
                 }
             },
             "sortText": "130",
@@ -1714,6 +2148,104 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "CONNECTION_CLOSURE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for failures during connection closure"
+                }
+            },
+            "sortText": "130",
+            "insertText": "CONNECTION_CLOSURE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_HANDSHAKE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for WebSocket handshake failures"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_HANDSHAKE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PAYLOAD_TOO_BIG_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for exceeding maximum frame size"
+                }
+            },
+            "sortText": "130",
+            "insertText": "PAYLOAD_TOO_BIG_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROTOCOL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for other side breaking the protocol"
+                }
+            },
+            "sortText": "130",
+            "insertText": "PROTOCOL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CONNECTION_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for connection failures"
+                }
+            },
+            "sortText": "130",
+            "insertText": "CONNECTION_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_CONTINUATION_FRAME_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for invalid continuation frame"
+                }
+            },
+            "sortText": "130",
+            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for errors not captured by the specific errors"
+                }
+            },
+            "sortText": "130",
+            "insertText": "GENERIC_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -1751,7 +2283,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+                "left": "Configurations for a WebSocket service.\n"
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -1784,7 +2316,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a service.\n"
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -1795,7 +2327,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a resource.\n"
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -1880,7 +2412,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+                "left": "Configures cache control directives for an `http:Response`.\n"
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -1891,7 +2423,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -1912,7 +2444,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -1934,7 +2466,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
             "sortText": "190",
             "insertText": "Client",
@@ -1989,7 +2521,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -2000,7 +2532,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -2033,7 +2565,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+                "left": "Client configuration for cookies.\n"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -2152,7 +2684,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -2162,7 +2694,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -2255,6 +2787,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "Detail",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Holds the details of an HTTP error\n"
+            },
+            "sortText": "180",
+            "insertText": "Detail",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2296,17 +2839,6 @@
             },
             "sortText": "200",
             "insertText": "AllLoadBalanceEndpointsFailedError",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CircuitBreakerConfigError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to circuit breaker configuration error."
-            },
-            "sortText": "200",
-            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2721,7 +3253,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+                "left": "Represents an HTTP request.\n"
             },
             "sortText": "190",
             "insertText": "Request",
@@ -2754,7 +3286,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+                "left": "Represents an HTTP response.\n"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -2863,7 +3395,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -2896,7 +3428,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -2940,7 +3472,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -2973,7 +3505,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -2983,9 +3515,6 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
-            "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector."
-            },
             "sortText": "200",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3039,7 +3568,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -3050,7 +3579,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+                "left": "Provides settings related to HTTP/1.x protocol.\n"
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -3061,7 +3590,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+                "left": "Authentication configurations for the listener.\n"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -3072,7 +3601,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -3115,7 +3644,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -3126,7 +3655,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+                "left": "Retry configurations for WebSocket.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -3236,7 +3765,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3269,7 +3798,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -3280,7 +3809,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -3337,7 +3866,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3355,7 +3884,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3373,7 +3902,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3391,7 +3920,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3409,7 +3938,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3427,7 +3956,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
@@ -152,7 +152,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "Indicates that the client is only accepting responses whose freshness lifetime \u003e\u003d current age + min-fresh."
+                    "value": "Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
                 }
             },
             "sortText": "130",
@@ -283,20 +283,6 @@
             },
             "sortText": "130",
             "insertText": "RFC_7234",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP_ERROR_CODE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the http error code"
-                }
-            },
-            "sortText": "130",
-            "insertText": "HTTP_ERROR_CODE",
             "insertTextFormat": "Snippet"
         },
         {
@@ -650,426 +636,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_RETRY_ATTEMPTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "IDLE_TIMEOUT_TRIGGERED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "IDLE_TIMEOUT_TRIGGERED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHN_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthenticationError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "AUTHN_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHZ_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthorizationError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "AUTHZ_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_INBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_COOKIE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InvalidCookieError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_COOKIE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for generic client error"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_LISTENER_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:GenericListenerError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_LISTENER_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UNSUPPORTED_ACTION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "UNSUPPORTED_ACTION",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP2_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Http2ClientError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "HTTP2_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "SSL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:SslError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "SSL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "COOKIE_HANDLING_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:CookieHandlingError`"
-                }
-            },
-            "sortText": "130",
-            "insertText": "COOKIE_HANDLING_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -1090,7 +656,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` "
+                    "value": "HTTP header key `authorization` \n"
                 }
             },
             "sortText": "130",
@@ -1202,7 +768,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` "
+                    "value": "HTTP header key `if-match` \n"
                 }
             },
             "sortText": "130",
@@ -1244,7 +810,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` "
+                    "value": "HTTP header key `if-range` \n"
                 }
             },
             "sortText": "130",
@@ -1258,7 +824,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` "
+                    "value": "HTTP header key `if-unmodified-since` \n"
                 }
             },
             "sortText": "130",
@@ -1305,6 +871,20 @@
             },
             "sortText": "130",
             "insertText": "PRAGMA",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROXY_AUTHORIZATION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
+                }
+            },
+            "sortText": "130",
+            "insertText": "PROXY_AUTHORIZATION",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2134,104 +1714,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "CONNECTION_CLOSURE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for failures during connection closure"
-                }
-            },
-            "sortText": "130",
-            "insertText": "CONNECTION_CLOSURE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_HANDSHAKE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for WebSocket handshake failures"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_HANDSHAKE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PAYLOAD_TOO_BIG_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for exceeding maximum frame size"
-                }
-            },
-            "sortText": "130",
-            "insertText": "PAYLOAD_TOO_BIG_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PROTOCOL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for other side breaking the protocol"
-                }
-            },
-            "sortText": "130",
-            "insertText": "PROTOCOL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONNECTION_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for connection failures"
-                }
-            },
-            "sortText": "130",
-            "insertText": "CONNECTION_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_CONTINUATION_FRAME_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for invalid continuation frame"
-                }
-            },
-            "sortText": "130",
-            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for errors not captured by the specific errors"
-                }
-            },
-            "sortText": "130",
-            "insertText": "GENERIC_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -2269,7 +1751,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "180",
             "insertText": "WSServiceConfig",
@@ -2302,7 +1784,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ServiceAuth",
@@ -2313,7 +1795,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "180",
             "insertText": "ResourceAuth",
@@ -2398,7 +1880,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "190",
             "insertText": "ResponseCacheControl",
@@ -2409,7 +1891,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "190",
             "insertText": "HttpCache",
@@ -2430,7 +1912,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "180",
             "insertText": "CacheConfig",
@@ -2452,7 +1934,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "190",
             "insertText": "Client",
@@ -2507,7 +1989,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "180",
             "insertText": "ClientSecureSocket",
@@ -2518,7 +2000,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -2551,7 +2033,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "180",
             "insertText": "CookieConfig",
@@ -2606,7 +2088,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -2670,7 +2152,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "110",
             "insertText": "Chunking",
@@ -2680,7 +2162,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "110",
             "insertText": "Compression",
@@ -2773,17 +2255,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "180",
-            "insertText": "Detail",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2825,6 +2296,17 @@
             },
             "sortText": "200",
             "insertText": "AllLoadBalanceEndpointsFailedError",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CircuitBreakerConfigError",
+            "kind": "Event",
+            "detail": "Error",
+            "documentation": {
+                "left": "Represents a client error that occurred due to circuit breaker configuration error."
+            },
+            "sortText": "200",
+            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -3239,7 +2721,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "190",
             "insertText": "Request",
@@ -3272,7 +2754,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "190",
             "insertText": "Response",
@@ -3381,7 +2863,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerConfig",
@@ -3414,7 +2896,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "180",
             "insertText": "CircuitBreakerInferredConfig",
@@ -3458,7 +2940,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "190",
             "insertText": "RetryClient",
@@ -3491,7 +2973,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "180",
             "insertText": "LoadBalanceActionErrorData",
@@ -3501,6 +2983,9 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
+            "documentation": {
+                "left": "Represents an error occurred in an remote function of the Load Balance connector."
+            },
             "sortText": "200",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3554,7 +3039,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "180",
             "insertText": "ListenerConfiguration",
@@ -3565,7 +3050,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
@@ -3576,7 +3061,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "180",
             "insertText": "ListenerAuth",
@@ -3587,7 +3072,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "180",
             "insertText": "ListenerSecureSocket",
@@ -3630,7 +3115,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "180",
             "insertText": "WebSocketClientConfiguration",
@@ -3641,7 +3126,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "180",
             "insertText": "WebSocketRetryConfig",
@@ -3751,7 +3236,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "180",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3784,7 +3269,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BasicAuthHandler",
@@ -3795,7 +3280,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "190",
             "insertText": "BearerAuthHandler",
@@ -3852,7 +3337,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3870,7 +3355,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3888,7 +3373,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
                 }
             },
             "sortText": "120",
@@ -3900,13 +3385,13 @@
             }
         },
         {
-            "label": "parseHeader(string headerValue)(([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "label": "parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
             "kind": "Function",
             "detail": "Function",
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3924,7 +3409,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3942,7 +3427,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
@@ -152,7 +152,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "Indicates that the client is only accepting responses whose freshness lifetime \u003e\u003d current age + min-fresh."
+                    "value": "Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
                 }
             },
             "sortText": "120",
@@ -283,20 +283,6 @@
             },
             "sortText": "120",
             "insertText": "RFC_7234",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP_ERROR_CODE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the http error code"
-                }
-            },
-            "sortText": "120",
-            "insertText": "HTTP_ERROR_CODE",
             "insertTextFormat": "Snippet"
         },
         {
@@ -650,426 +636,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_RETRY_ATTEMPTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "IDLE_TIMEOUT_TRIGGERED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "IDLE_TIMEOUT_TRIGGERED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHN_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthenticationError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "AUTHN_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHZ_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthorizationError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "AUTHZ_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_INBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_COOKIE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InvalidCookieError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INVALID_COOKIE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for generic client error"
-                }
-            },
-            "sortText": "120",
-            "insertText": "GENERIC_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_LISTENER_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:GenericListenerError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "GENERIC_LISTENER_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UNSUPPORTED_ACTION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "UNSUPPORTED_ACTION",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP2_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Http2ClientError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "HTTP2_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "SSL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:SslError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "SSL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "COOKIE_HANDLING_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:CookieHandlingError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "COOKIE_HANDLING_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -1090,7 +656,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` "
+                    "value": "HTTP header key `authorization` \n"
                 }
             },
             "sortText": "120",
@@ -1202,7 +768,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` "
+                    "value": "HTTP header key `if-match` \n"
                 }
             },
             "sortText": "120",
@@ -1244,7 +810,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` "
+                    "value": "HTTP header key `if-range` \n"
                 }
             },
             "sortText": "120",
@@ -1258,7 +824,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` "
+                    "value": "HTTP header key `if-unmodified-since` \n"
                 }
             },
             "sortText": "120",
@@ -1305,6 +871,20 @@
             },
             "sortText": "120",
             "insertText": "PRAGMA",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROXY_AUTHORIZATION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
+                }
+            },
+            "sortText": "120",
+            "insertText": "PROXY_AUTHORIZATION",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2134,104 +1714,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "CONNECTION_CLOSURE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for failures during connection closure"
-                }
-            },
-            "sortText": "120",
-            "insertText": "CONNECTION_CLOSURE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_HANDSHAKE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for WebSocket handshake failures"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INVALID_HANDSHAKE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PAYLOAD_TOO_BIG_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for exceeding maximum frame size"
-                }
-            },
-            "sortText": "120",
-            "insertText": "PAYLOAD_TOO_BIG_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PROTOCOL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for other side breaking the protocol"
-                }
-            },
-            "sortText": "120",
-            "insertText": "PROTOCOL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONNECTION_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for connection failures"
-                }
-            },
-            "sortText": "120",
-            "insertText": "CONNECTION_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_CONTINUATION_FRAME_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for invalid continuation frame"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for errors not captured by the specific errors"
-                }
-            },
-            "sortText": "120",
-            "insertText": "GENERIC_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -2269,7 +1751,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "120",
             "insertText": "WSServiceConfig",
@@ -2302,7 +1784,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "120",
             "insertText": "ServiceAuth",
@@ -2313,7 +1795,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "120",
             "insertText": "ResourceAuth",
@@ -2398,7 +1880,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "120",
             "insertText": "ResponseCacheControl",
@@ -2409,7 +1891,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "120",
             "insertText": "HttpCache",
@@ -2430,7 +1912,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "120",
             "insertText": "CacheConfig",
@@ -2452,7 +1934,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "120",
             "insertText": "Client",
@@ -2507,7 +1989,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "120",
             "insertText": "ClientSecureSocket",
@@ -2518,7 +2000,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
             },
             "sortText": "120",
             "insertText": "FollowRedirects",
@@ -2551,7 +2033,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "120",
             "insertText": "CookieConfig",
@@ -2606,7 +2088,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "120",
             "insertText": "HttpFuture",
@@ -2670,7 +2152,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "120",
             "insertText": "Chunking",
@@ -2680,7 +2162,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "120",
             "insertText": "Compression",
@@ -2773,17 +2255,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "120",
-            "insertText": "Detail",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2825,6 +2296,17 @@
             },
             "sortText": "120",
             "insertText": "AllLoadBalanceEndpointsFailedError",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CircuitBreakerConfigError",
+            "kind": "Event",
+            "detail": "Error",
+            "documentation": {
+                "left": "Represents a client error that occurred due to circuit breaker configuration error."
+            },
+            "sortText": "120",
+            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -3239,7 +2721,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "120",
             "insertText": "Request",
@@ -3272,7 +2754,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "120",
             "insertText": "Response",
@@ -3381,7 +2863,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "120",
             "insertText": "CircuitBreakerConfig",
@@ -3414,7 +2896,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "120",
             "insertText": "CircuitBreakerInferredConfig",
@@ -3458,7 +2940,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "120",
             "insertText": "RetryClient",
@@ -3491,7 +2973,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "120",
             "insertText": "LoadBalanceActionErrorData",
@@ -3501,6 +2983,9 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
+            "documentation": {
+                "left": "Represents an error occurred in an remote function of the Load Balance connector."
+            },
             "sortText": "120",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3554,7 +3039,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "120",
             "insertText": "ListenerConfiguration",
@@ -3565,7 +3050,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "120",
             "insertText": "ListenerHttp1Settings",
@@ -3576,7 +3061,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "120",
             "insertText": "ListenerAuth",
@@ -3587,7 +3072,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "120",
             "insertText": "ListenerSecureSocket",
@@ -3630,7 +3115,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "120",
             "insertText": "WebSocketClientConfiguration",
@@ -3641,7 +3126,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "120",
             "insertText": "WebSocketRetryConfig",
@@ -3751,7 +3236,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "120",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3784,7 +3269,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "120",
             "insertText": "BasicAuthHandler",
@@ -3795,7 +3280,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "120",
             "insertText": "BearerAuthHandler",
@@ -3852,7 +3337,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3870,7 +3355,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3888,7 +3373,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
                 }
             },
             "sortText": "120",
@@ -3900,13 +3385,13 @@
             }
         },
         {
-            "label": "parseHeader(string headerValue)(([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "label": "parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
             "kind": "Function",
             "detail": "Function",
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3924,7 +3409,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3942,7 +3427,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
@@ -286,6 +286,20 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "HTTP_ERROR_CODE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Constant for the http error code"
+                }
+            },
+            "sortText": "120",
+            "insertText": "HTTP_ERROR_CODE",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "MULTIPART_AS_PRIMARY_TYPE",
             "kind": "Variable",
             "detail": "string",
@@ -636,6 +650,426 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ALL_RETRY_ATTEMPTS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "IDLE_TIMEOUT_TRIGGERED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "IDLE_TIMEOUT_TRIGGERED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHN_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthenticationError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "AUTHN_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "AUTHZ_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:AuthorizationError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "AUTHZ_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_INBOUND_REQUEST_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INIT_INBOUND_REQUEST_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_COOKIE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:InvalidCookieError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INVALID_COOKIE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for generic client error"
+                }
+            },
+            "sortText": "120",
+            "insertText": "GENERIC_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_LISTENER_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:GenericListenerError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "GENERIC_LISTENER_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "UNSUPPORTED_ACTION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "UNSUPPORTED_ACTION",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "HTTP2_CLIENT_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:Http2ClientError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "HTTP2_CLIENT_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "SSL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:SslError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "SSL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "COOKIE_HANDLING_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Represents the reason string for the `http:CookieHandlingError`"
+                }
+            },
+            "sortText": "120",
+            "insertText": "COOKIE_HANDLING_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -656,7 +1090,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` \n"
+                    "value": "HTTP header key `authorization` "
                 }
             },
             "sortText": "120",
@@ -768,7 +1202,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` \n"
+                    "value": "HTTP header key `if-match` "
                 }
             },
             "sortText": "120",
@@ -810,7 +1244,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` \n"
+                    "value": "HTTP header key `if-range` "
                 }
             },
             "sortText": "120",
@@ -824,7 +1258,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` \n"
+                    "value": "HTTP header key `if-unmodified-since` "
                 }
             },
             "sortText": "120",
@@ -1714,6 +2148,104 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "CONNECTION_CLOSURE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for failures during connection closure"
+                }
+            },
+            "sortText": "120",
+            "insertText": "CONNECTION_CLOSURE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_HANDSHAKE_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for WebSocket handshake failures"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INVALID_HANDSHAKE_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PAYLOAD_TOO_BIG_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for exceeding maximum frame size"
+                }
+            },
+            "sortText": "120",
+            "insertText": "PAYLOAD_TOO_BIG_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROTOCOL_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for other side breaking the protocol"
+                }
+            },
+            "sortText": "120",
+            "insertText": "PROTOCOL_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CONNECTION_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for connection failures"
+                }
+            },
+            "sortText": "120",
+            "insertText": "CONNECTION_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "INVALID_CONTINUATION_FRAME_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for invalid continuation frame"
+                }
+            },
+            "sortText": "120",
+            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "GENERIC_ERROR",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "Error reason for errors not captured by the specific errors"
+                }
+            },
+            "sortText": "120",
+            "insertText": "GENERIC_ERROR",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -1751,7 +2283,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+                "left": "Configurations for a WebSocket service.\n"
             },
             "sortText": "120",
             "insertText": "WSServiceConfig",
@@ -1784,7 +2316,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a service.\n"
             },
             "sortText": "120",
             "insertText": "ServiceAuth",
@@ -1795,7 +2327,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+                "left": "Configures the authentication scheme for a resource.\n"
             },
             "sortText": "120",
             "insertText": "ResourceAuth",
@@ -1880,7 +2412,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+                "left": "Configures cache control directives for an `http:Response`.\n"
             },
             "sortText": "120",
             "insertText": "ResponseCacheControl",
@@ -1891,7 +2423,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
             "sortText": "120",
             "insertText": "HttpCache",
@@ -1912,7 +2444,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
             "sortText": "120",
             "insertText": "CacheConfig",
@@ -1934,7 +2466,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
             "sortText": "120",
             "insertText": "Client",
@@ -1989,7 +2521,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
             "sortText": "120",
             "insertText": "ClientSecureSocket",
@@ -2000,7 +2532,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "120",
             "insertText": "FollowRedirects",
@@ -2033,7 +2565,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+                "left": "Client configuration for cookies.\n"
             },
             "sortText": "120",
             "insertText": "CookieConfig",
@@ -2152,7 +2684,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "120",
             "insertText": "Chunking",
@@ -2162,7 +2694,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "120",
             "insertText": "Compression",
@@ -2255,6 +2787,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "Detail",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Holds the details of an HTTP error\n"
+            },
+            "sortText": "120",
+            "insertText": "Detail",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2296,17 +2839,6 @@
             },
             "sortText": "120",
             "insertText": "AllLoadBalanceEndpointsFailedError",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CircuitBreakerConfigError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to circuit breaker configuration error."
-            },
-            "sortText": "120",
-            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2721,7 +3253,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+                "left": "Represents an HTTP request.\n"
             },
             "sortText": "120",
             "insertText": "Request",
@@ -2754,7 +3286,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+                "left": "Represents an HTTP response.\n"
             },
             "sortText": "120",
             "insertText": "Response",
@@ -2863,7 +3395,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
             "sortText": "120",
             "insertText": "CircuitBreakerConfig",
@@ -2896,7 +3428,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
             "sortText": "120",
             "insertText": "CircuitBreakerInferredConfig",
@@ -2940,7 +3472,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
             "sortText": "120",
             "insertText": "RetryClient",
@@ -2973,7 +3505,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
             },
             "sortText": "120",
             "insertText": "LoadBalanceActionErrorData",
@@ -2983,9 +3515,6 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
-            "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector."
-            },
             "sortText": "120",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3039,7 +3568,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n"
             },
             "sortText": "120",
             "insertText": "ListenerConfiguration",
@@ -3050,7 +3579,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+                "left": "Provides settings related to HTTP/1.x protocol.\n"
             },
             "sortText": "120",
             "insertText": "ListenerHttp1Settings",
@@ -3061,7 +3590,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+                "left": "Authentication configurations for the listener.\n"
             },
             "sortText": "120",
             "insertText": "ListenerAuth",
@@ -3072,7 +3601,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
             },
             "sortText": "120",
             "insertText": "ListenerSecureSocket",
@@ -3115,7 +3644,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "120",
             "insertText": "WebSocketClientConfiguration",
@@ -3126,7 +3655,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+                "left": "Retry configurations for WebSocket.\n"
             },
             "sortText": "120",
             "insertText": "WebSocketRetryConfig",
@@ -3236,7 +3765,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+                "left": "Configurations for the WebSocket client endpoint.\n"
             },
             "sortText": "120",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3269,7 +3798,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
             "sortText": "120",
             "insertText": "BasicAuthHandler",
@@ -3280,7 +3809,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
             "sortText": "120",
             "insertText": "BearerAuthHandler",
@@ -3337,7 +3866,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3355,7 +3884,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3373,7 +3902,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3391,7 +3920,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3409,7 +3938,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3427,7 +3956,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon2.json
@@ -303,7 +303,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
             "sortText": "180",
             "insertText": "FollowRedirects",
@@ -399,7 +399,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "190",
             "insertText": "HttpFuture",
@@ -495,6 +495,16 @@
             },
             "sortText": "110",
             "insertText": "HttpOperation",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "safeHttpOperation",
+            "detail": "Union",
+            "documentation": {
+                "left": "Defines the safe HTTP operations which do not modify resource representation."
+            },
+            "sortText": "110",
+            "insertText": "safeHttpOperation",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon3.json
@@ -152,7 +152,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "Indicates that the client is only accepting responses whose freshness lifetime \u003e\u003d current age + min-fresh."
+                    "value": "Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
                 }
             },
             "sortText": "120",
@@ -283,20 +283,6 @@
             },
             "sortText": "120",
             "insertText": "RFC_7234",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP_ERROR_CODE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the http error code"
-                }
-            },
-            "sortText": "120",
-            "insertText": "HTTP_ERROR_CODE",
             "insertTextFormat": "Snippet"
         },
         {
@@ -650,426 +636,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "FAILOVER_ALL_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:FailoverActionFailedError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "FAILOVER_ENDPOINT_ACTION_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UpstreamServiceUnavailableError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "UPSTREAM_SERVICE_UNAVAILABLE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ALL_RETRY_ATTEMPTS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AllRetryAttemptsFailed`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "ALL_RETRY_ATTEMPTS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "IDLE_TIMEOUT_TRIGGERED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:IdleTimeoutError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "IDLE_TIMEOUT_TRIGGERED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHN_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthenticationError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "AUTHN_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "AUTHZ_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:AuthorizationError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "AUTHZ_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundRequestError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_OUTBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundRequestBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingInboundResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_INBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundResponseBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_INBOUND_REQUEST_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitialingInboundRequestError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_INBOUND_REQUEST_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_REQUEST_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:ReadingInboundRequestBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "READING_INBOUND_REQUEST_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InitializingOutboundResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INIT_OUTBOUND_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:WritingOutboundResponseBodyError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Initiating100ContinueResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INITIATING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Writing100ContinueResponseError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "WRITING_100_CONTINUE_RESPONSE_FAILED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_COOKIE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:InvalidCookieError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INVALID_COOKIE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for generic client error"
-                }
-            },
-            "sortText": "120",
-            "insertText": "GENERIC_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_LISTENER_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:GenericListenerError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "GENERIC_LISTENER_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "UNSUPPORTED_ACTION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:UnsupportedActionError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "UNSUPPORTED_ACTION",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "HTTP2_CLIENT_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:Http2ClientError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "HTTP2_CLIENT_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:MaximumWaitTimeExceededError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "MAXIMUM_WAIT_TIME_EXCEEDED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "SSL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:SslError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "SSL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "COOKIE_HANDLING_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the reason string for the `http:CookieHandlingError`"
-                }
-            },
-            "sortText": "120",
-            "insertText": "COOKIE_HANDLING_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "AGE",
             "kind": "Variable",
             "detail": "string",
@@ -1090,7 +656,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `authorization` "
+                    "value": "HTTP header key `authorization` \n"
                 }
             },
             "sortText": "120",
@@ -1202,7 +768,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-match` "
+                    "value": "HTTP header key `if-match` \n"
                 }
             },
             "sortText": "120",
@@ -1244,7 +810,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-range` "
+                    "value": "HTTP header key `if-range` \n"
                 }
             },
             "sortText": "120",
@@ -1258,7 +824,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` "
+                    "value": "HTTP header key `if-unmodified-since` \n"
                 }
             },
             "sortText": "120",
@@ -1305,6 +871,20 @@
             },
             "sortText": "120",
             "insertText": "PRAGMA",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "PROXY_AUTHORIZATION",
+            "kind": "Variable",
+            "detail": "string",
+            "documentation": {
+                "right": {
+                    "kind": "markdown",
+                    "value": "HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
+                }
+            },
+            "sortText": "120",
+            "insertText": "PROXY_AUTHORIZATION",
             "insertTextFormat": "Snippet"
         },
         {
@@ -2134,104 +1714,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "CONNECTION_CLOSURE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for failures during connection closure"
-                }
-            },
-            "sortText": "120",
-            "insertText": "CONNECTION_CLOSURE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_HANDSHAKE_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for WebSocket handshake failures"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INVALID_HANDSHAKE_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PAYLOAD_TOO_BIG_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for exceeding maximum frame size"
-                }
-            },
-            "sortText": "120",
-            "insertText": "PAYLOAD_TOO_BIG_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "PROTOCOL_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for other side breaking the protocol"
-                }
-            },
-            "sortText": "120",
-            "insertText": "PROTOCOL_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONNECTION_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for connection failures"
-                }
-            },
-            "sortText": "120",
-            "insertText": "CONNECTION_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "INVALID_CONTINUATION_FRAME_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for invalid continuation frame"
-                }
-            },
-            "sortText": "120",
-            "insertText": "INVALID_CONTINUATION_FRAME_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GENERIC_ERROR",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Error reason for errors not captured by the specific errors"
-                }
-            },
-            "sortText": "120",
-            "insertText": "GENERIC_ERROR",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "HttpServiceConfig",
             "kind": "Struct",
             "detail": "Record",
@@ -2269,7 +1751,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for a WebSocket service.\n"
+                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
             },
             "sortText": "120",
             "insertText": "WSServiceConfig",
@@ -2302,7 +1784,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a service.\n"
+                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
             },
             "sortText": "120",
             "insertText": "ServiceAuth",
@@ -2313,7 +1795,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n"
+                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
             },
             "sortText": "120",
             "insertText": "ResourceAuth",
@@ -2398,7 +1880,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n"
+                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
             },
             "sortText": "120",
             "insertText": "ResponseCacheControl",
@@ -2409,7 +1891,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
+                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "120",
             "insertText": "HttpCache",
@@ -2430,7 +1912,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
+                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
             },
             "sortText": "120",
             "insertText": "CacheConfig",
@@ -2452,7 +1934,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
+                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
             },
             "sortText": "120",
             "insertText": "Client",
@@ -2507,7 +1989,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
+                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
             },
             "sortText": "120",
             "insertText": "ClientSecureSocket",
@@ -2518,7 +2000,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides configurations for controlling the endpoint\u0027s behaviour in response to HTTP redirect related responses.\n"
+                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
             },
             "sortText": "120",
             "insertText": "FollowRedirects",
@@ -2551,7 +2033,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Client configuration for cookies.\n"
+                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
             },
             "sortText": "120",
             "insertText": "CookieConfig",
@@ -2606,7 +2088,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents a \u0027future\u0027 that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
             "sortText": "120",
             "insertText": "HttpFuture",
@@ -2670,7 +2152,7 @@
             "label": "Chunking",
             "detail": "Union",
             "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
             "sortText": "120",
             "insertText": "Chunking",
@@ -2680,7 +2162,7 @@
             "label": "Compression",
             "detail": "Union",
             "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
             "sortText": "120",
             "insertText": "Compression",
@@ -2773,17 +2255,6 @@
             "insertTextFormat": "Snippet"
         },
         {
-            "label": "Detail",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Holds the details of an HTTP error\n"
-            },
-            "sortText": "120",
-            "insertText": "Detail",
-            "insertTextFormat": "Snippet"
-        },
-        {
             "label": "FailoverAllEndpointsFailedError",
             "kind": "Event",
             "detail": "Error",
@@ -2825,6 +2296,17 @@
             },
             "sortText": "120",
             "insertText": "AllLoadBalanceEndpointsFailedError",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "CircuitBreakerConfigError",
+            "kind": "Event",
+            "detail": "Error",
+            "documentation": {
+                "left": "Represents a client error that occurred due to circuit breaker configuration error."
+            },
+            "sortText": "120",
+            "insertText": "CircuitBreakerConfigError",
             "insertTextFormat": "Snippet"
         },
         {
@@ -3239,7 +2721,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP request.\n"
+                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
             },
             "sortText": "120",
             "insertText": "Request",
@@ -3272,7 +2754,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Represents an HTTP response.\n"
+                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
             },
             "sortText": "120",
             "insertText": "Response",
@@ -3381,7 +2863,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
+                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "120",
             "insertText": "CircuitBreakerConfig",
@@ -3414,7 +2896,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n"
+                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
             },
             "sortText": "120",
             "insertText": "CircuitBreakerInferredConfig",
@@ -3458,7 +2940,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
+                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
             },
             "sortText": "120",
             "insertText": "RetryClient",
@@ -3491,7 +2973,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector.\n"
+                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
             },
             "sortText": "120",
             "insertText": "LoadBalanceActionErrorData",
@@ -3501,6 +2983,9 @@
             "label": "LoadBalanceActionError",
             "kind": "Event",
             "detail": "Error",
+            "documentation": {
+                "left": "Represents an error occurred in an remote function of the Load Balance connector."
+            },
             "sortText": "120",
             "insertText": "LoadBalanceActionError",
             "insertTextFormat": "Snippet"
@@ -3554,7 +3039,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n"
+                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
             },
             "sortText": "120",
             "insertText": "ListenerConfiguration",
@@ -3565,7 +3050,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
             },
             "sortText": "120",
             "insertText": "ListenerHttp1Settings",
@@ -3576,7 +3061,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Authentication configurations for the listener.\n"
+                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
             },
             "sortText": "120",
             "insertText": "ListenerAuth",
@@ -3587,7 +3072,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n"
+                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
             },
             "sortText": "120",
             "insertText": "ListenerSecureSocket",
@@ -3630,7 +3115,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
             },
             "sortText": "120",
             "insertText": "WebSocketClientConfiguration",
@@ -3641,7 +3126,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Retry configurations for WebSocket.\n"
+                "left": "Retry configurations for WebSocket.\n\npersist"
             },
             "sortText": "120",
             "insertText": "WebSocketRetryConfig",
@@ -3751,7 +3236,7 @@
             "kind": "Struct",
             "detail": "Record",
             "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n"
+                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
             },
             "sortText": "120",
             "insertText": "WebSocketFailoverClientConfiguration",
@@ -3784,7 +3269,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
+                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
             },
             "sortText": "120",
             "insertText": "BasicAuthHandler",
@@ -3795,7 +3280,7 @@
             "kind": "Interface",
             "detail": "Object",
             "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
+                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
             },
             "sortText": "120",
             "insertText": "BearerAuthHandler",
@@ -3852,7 +3337,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3870,7 +3355,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3888,7 +3373,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
                 }
             },
             "sortText": "120",
@@ -3900,13 +3385,13 @@
             }
         },
         {
-            "label": "parseHeader(string headerValue)(([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "label": "parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
             "kind": "Function",
             "detail": "Function",
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map\u003cany\u003e]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3924,7 +3409,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
             "sortText": "120",
@@ -3942,7 +3427,7 @@
             "documentation": {
                 "right": {
                     "kind": "markdown",
-                    "value": "**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
             "sortText": "120",

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon3.json
@@ -1,3441 +1,3970 @@
 {
-    "position": {
-        "line": 19,
-        "character": 26
+    "position":{
+        "line":19,
+        "character":26
     },
-    "source": "toplevel/source/statementWithMissingSemiColon3.bal",
-    "items": [
+    "source":"toplevel/source/statementWithMissingSemiColon3.bal",
+    "items":[
         {
-            "label": "AUTH_HEADER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the Authorization header name."
+            "label":"AUTH_HEADER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the Authorization header name."
                 }
             },
-            "sortText": "120",
-            "insertText": "AUTH_HEADER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AUTH_HEADER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AUTH_HEADER_BEARER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the authentication credentials should be sent via the Authentication header."
+            "label":"AUTH_HEADER_BEARER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the authentication credentials should be sent via the Authentication header."
                 }
             },
-            "sortText": "120",
-            "insertText": "AUTH_HEADER_BEARER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AUTH_HEADER_BEARER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "POST_BODY_BEARER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the Authentication credentials should be sent via the body of the POST request."
+            "label":"POST_BODY_BEARER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the Authentication credentials should be sent via the body of the POST request."
                 }
             },
-            "sortText": "120",
-            "insertText": "POST_BODY_BEARER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"POST_BODY_BEARER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "NO_BEARER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the authentication credentials should not be sent."
+            "label":"NO_BEARER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the authentication credentials should not be sent."
                 }
             },
-            "sortText": "120",
-            "insertText": "NO_BEARER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"NO_BEARER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_CODE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates the status code."
+            "label":"STATUS_CODE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates the status code."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_CODE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_CODE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "NO_CACHE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Forces the cache to validate a cached response with the origin server before serving."
+            "label":"NO_CACHE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Forces the cache to validate a cached response with the origin server before serving."
                 }
             },
-            "sortText": "120",
-            "insertText": "NO_CACHE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"NO_CACHE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "NO_STORE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Instructs the cache to not store a response in non-volatile storage."
+            "label":"NO_STORE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Instructs the cache to not store a response in non-volatile storage."
                 }
             },
-            "sortText": "120",
-            "insertText": "NO_STORE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"NO_STORE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "NO_TRANSFORM",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Instructs intermediaries not to transform the payload."
+            "label":"NO_TRANSFORM",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Instructs intermediaries not to transform the payload."
                 }
             },
-            "sortText": "120",
-            "insertText": "NO_TRANSFORM",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"NO_TRANSFORM",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MAX_AGE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "When used in requests, `max-age` implies that clients are not willing to accept responses whose age is greater\nthan `max-age`. When used in responses, the response is to be considered stale after the specified\nnumber of seconds."
+            "label":"MAX_AGE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"When used in requests, `max-age` implies that clients are not willing to accept responses whose age is greater\nthan `max-age`. When used in responses, the response is to be considered stale after the specified\nnumber of seconds."
                 }
             },
-            "sortText": "120",
-            "insertText": "MAX_AGE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MAX_AGE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MAX_STALE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the client is willing to accept responses which have exceeded their freshness lifetime by no more\nthan the specified number of seconds."
+            "label":"MAX_STALE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the client is willing to accept responses which have exceeded their freshness lifetime by no more\nthan the specified number of seconds."
                 }
             },
-            "sortText": "120",
-            "insertText": "MAX_STALE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MAX_STALE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MIN_FRESH",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
+            "label":"MIN_FRESH",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the client is only accepting responses whose freshness lifetime >= current age + min-fresh."
                 }
             },
-            "sortText": "120",
-            "insertText": "MIN_FRESH",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MIN_FRESH",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ONLY_IF_CACHED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the client is only willing to accept a cached response. A cached response is served subject to\nother constraints posed by the request."
+            "label":"ONLY_IF_CACHED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the client is only willing to accept a cached response. A cached response is served subject to\nother constraints posed by the request."
                 }
             },
-            "sortText": "120",
-            "insertText": "ONLY_IF_CACHED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ONLY_IF_CACHED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MUST_REVALIDATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that once the response has become stale, it should not be reused for subsequent requests without\nvalidating with the origin server."
+            "label":"MUST_REVALIDATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that once the response has become stale, it should not be reused for subsequent requests without\nvalidating with the origin server."
                 }
             },
-            "sortText": "120",
-            "insertText": "MUST_REVALIDATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MUST_REVALIDATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PUBLIC",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that any cache may store the response."
+            "label":"PUBLIC",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that any cache may store the response."
                 }
             },
-            "sortText": "120",
-            "insertText": "PUBLIC",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PUBLIC",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PRIVATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Indicates that the response is intended for a single user and should not be stored by shared caches."
+            "label":"PRIVATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Indicates that the response is intended for a single user and should not be stored by shared caches."
                 }
             },
-            "sortText": "120",
-            "insertText": "PRIVATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PRIVATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PROXY_REVALIDATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Has the same semantics as `must-revalidate`, except that this does not apply to private caches."
+            "label":"PROXY_REVALIDATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Has the same semantics as `must-revalidate`, except that this does not apply to private caches."
                 }
             },
-            "sortText": "120",
-            "insertText": "PROXY_REVALIDATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PROXY_REVALIDATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "S_MAX_AGE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "In shared caches, `s-maxage` overrides the `max-age` or `expires` header field."
+            "label":"S_MAX_AGE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"In shared caches, `s-maxage` overrides the `max-age` or `expires` header field."
                 }
             },
-            "sortText": "120",
-            "insertText": "S_MAX_AGE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"S_MAX_AGE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MAX_STALE_ANY_AGE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Setting this as the `max-stale` directives indicates that the `max-stale` directive does not specify a limit."
+            "label":"MAX_STALE_ANY_AGE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Setting this as the `max-stale` directives indicates that the `max-stale` directive does not specify a limit."
                 }
             },
-            "sortText": "120",
-            "insertText": "MAX_STALE_ANY_AGE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MAX_STALE_ANY_AGE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CACHE_CONTROL_AND_VALIDATORS",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "This is a more restricted mode of RFC 7234. Setting this as the caching policy restricts caching to instances\nwhere the `cache-control` header and either the `etag` or `last-modified` header are present."
+            "label":"CACHE_CONTROL_AND_VALIDATORS",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"This is a more restricted mode of RFC 7234. Setting this as the caching policy restricts caching to instances\nwhere the `cache-control` header and either the `etag` or `last-modified` header are present."
                 }
             },
-            "sortText": "120",
-            "insertText": "CACHE_CONTROL_AND_VALIDATORS",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CACHE_CONTROL_AND_VALIDATORS",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RFC_7234",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Caching behaviour is as specified by the RFC 7234 specification."
+            "label":"RFC_7234",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Caching behaviour is as specified by the RFC 7234 specification."
                 }
             },
-            "sortText": "120",
-            "insertText": "RFC_7234",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RFC_7234",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MULTIPART_AS_PRIMARY_TYPE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents multipart primary type"
+            "label":"HTTP_ERROR_CODE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the http error code"
                 }
             },
-            "sortText": "120",
-            "insertText": "MULTIPART_AS_PRIMARY_TYPE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_ERROR_CODE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_FORWARD",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP FORWARD method"
+            "label":"MULTIPART_AS_PRIMARY_TYPE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents multipart primary type"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_FORWARD",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MULTIPART_AS_PRIMARY_TYPE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_GET",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP GET method"
+            "label":"HTTP_FORWARD",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP FORWARD method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_GET",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_FORWARD",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_POST",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP POST method"
+            "label":"HTTP_GET",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP GET method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_POST",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_GET",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_DELETE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP DELETE method"
+            "label":"HTTP_POST",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP POST method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_DELETE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_POST",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_OPTIONS",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP OPTIONS method"
+            "label":"HTTP_DELETE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP DELETE method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_OPTIONS",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_DELETE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_PUT",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP PUT method"
+            "label":"HTTP_OPTIONS",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP OPTIONS method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_PUT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_OPTIONS",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_PATCH",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP PATCH method"
+            "label":"HTTP_PUT",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP PUT method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_PATCH",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_PUT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_HEAD",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the HTTP HEAD method"
+            "label":"HTTP_PATCH",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP PATCH method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_HEAD",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_PATCH",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_SUBMIT",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "constant for the HTTP SUBMIT method"
+            "label":"HTTP_HEAD",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the HTTP HEAD method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_SUBMIT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_HEAD",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HTTP_NONE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the identify not an HTTP Operation"
+            "label":"HTTP_SUBMIT",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"constant for the HTTP SUBMIT method"
                 }
             },
-            "sortText": "120",
-            "insertText": "HTTP_NONE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_SUBMIT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CHUNKING_AUTO",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response.}"
+            "label":"HTTP_NONE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the identify not an HTTP Operation"
                 }
             },
-            "sortText": "120",
-            "insertText": "CHUNKING_AUTO",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP_NONE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CHUNKING_ALWAYS",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Always set chunking header in the response."
+            "label":"CHUNKING_AUTO",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response.}"
                 }
             },
-            "sortText": "120",
-            "insertText": "CHUNKING_ALWAYS",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CHUNKING_AUTO",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CHUNKING_NEVER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Never set the chunking header even if the payload is larger than 8KB in the outbound request/response."
+            "label":"CHUNKING_ALWAYS",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Always set chunking header in the response."
                 }
             },
-            "sortText": "120",
-            "insertText": "CHUNKING_NEVER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CHUNKING_ALWAYS",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "COMPRESSION_AUTO",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option."
+            "label":"CHUNKING_NEVER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Never set the chunking header even if the payload is larger than 8KB in the outbound request/response."
                 }
             },
-            "sortText": "120",
-            "insertText": "COMPRESSION_AUTO",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CHUNKING_NEVER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "COMPRESSION_ALWAYS",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Always set accept-encoding/content-encoding in outbound request/response."
+            "label":"COMPRESSION_AUTO",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option."
                 }
             },
-            "sortText": "120",
-            "insertText": "COMPRESSION_ALWAYS",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"COMPRESSION_AUTO",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "COMPRESSION_NEVER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Never set accept-encoding/content-encoding header in outbound request/response."
+            "label":"COMPRESSION_ALWAYS",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Always set accept-encoding/content-encoding in outbound request/response."
                 }
             },
-            "sortText": "120",
-            "insertText": "COMPRESSION_NEVER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"COMPRESSION_ALWAYS",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_MULTIPLE_CHOICES_300",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `300 - Multiple Choices`."
+            "label":"COMPRESSION_NEVER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Never set accept-encoding/content-encoding header in outbound request/response."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_MULTIPLE_CHOICES_300",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"COMPRESSION_NEVER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_MOVED_PERMANENTLY_301",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `301 - Moved Permanently`."
+            "label":"REDIRECT_MULTIPLE_CHOICES_300",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `300 - Multiple Choices`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_MOVED_PERMANENTLY_301",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_MULTIPLE_CHOICES_300",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_FOUND_302",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `302 - Found`."
+            "label":"REDIRECT_MOVED_PERMANENTLY_301",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `301 - Moved Permanently`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_FOUND_302",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_MOVED_PERMANENTLY_301",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_SEE_OTHER_303",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `303 - See Other`."
+            "label":"REDIRECT_FOUND_302",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `302 - Found`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_SEE_OTHER_303",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_FOUND_302",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_NOT_MODIFIED_304",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `304 - Not Modified`."
+            "label":"REDIRECT_SEE_OTHER_303",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `303 - See Other`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_NOT_MODIFIED_304",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_SEE_OTHER_303",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_USE_PROXY_305",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `305 - Use Proxy`."
+            "label":"REDIRECT_NOT_MODIFIED_304",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `304 - Not Modified`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_USE_PROXY_305",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_NOT_MODIFIED_304",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_TEMPORARY_REDIRECT_307",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `307 - Temporary Redirect`."
+            "label":"REDIRECT_USE_PROXY_305",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `305 - Use Proxy`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_TEMPORARY_REDIRECT_307",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_USE_PROXY_305",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REDIRECT_PERMANENT_REDIRECT_308",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the HTTP redirect status code `308 - Permanent Redirect`."
+            "label":"REDIRECT_TEMPORARY_REDIRECT_307",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `307 - Temporary Redirect`."
                 }
             },
-            "sortText": "120",
-            "insertText": "REDIRECT_PERMANENT_REDIRECT_308",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_TEMPORARY_REDIRECT_307",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AGE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `age`. Gives the current age of a cached HTTP response. "
+            "label":"REDIRECT_PERMANENT_REDIRECT_308",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the HTTP redirect status code `308 - Permanent Redirect`."
                 }
             },
-            "sortText": "120",
-            "insertText": "AGE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"REDIRECT_PERMANENT_REDIRECT_308",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AUTHORIZATION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `authorization` \n"
+            "label":"FAILOVER_ALL_ENDPOINTS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:FailoverAllEndpointsFailedError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "AUTHORIZATION",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FAILOVER_ALL_ENDPOINTS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CACHE_CONTROL",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `cache-control`. Specifies the cache control directives required for the function of HTTP caches."
+            "label":"FAILOVER_ENDPOINT_ACTION_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:FailoverActionFailedError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CACHE_CONTROL",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FAILOVER_ENDPOINT_ACTION_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CONTENT_LENGTH",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `content-length`. Specifies the size of the response body in bytes. "
+            "label":"UPSTREAM_SERVICE_UNAVAILABLE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:UpstreamServiceUnavailableError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CONTENT_LENGTH",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"UPSTREAM_SERVICE_UNAVAILABLE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CONTENT_TYPE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `content-type`. Specifies the type of the message payload. "
+            "label":"ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:AllLoadBalanceEndpointsFailedError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CONTENT_TYPE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ALL_LOAD_BALANCE_ENDPOINTS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "DATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `date`. The timestamp at the time the response was generated/received. "
+            "label":"ALL_RETRY_ATTEMPTS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:AllRetryAttemptsFailed`"
                 }
             },
-            "sortText": "120",
-            "insertText": "DATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ALL_RETRY_ATTEMPTS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ETAG",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `etag`. A finger print for a resource which is used by HTTP caches to identify whether a\nresource representation has changed."
+            "label":"IDLE_TIMEOUT_TRIGGERED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:IdleTimeoutError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "ETAG",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IDLE_TIMEOUT_TRIGGERED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "EXPECT",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `expect`. Specifies expectations to be fulfilled by the server. "
+            "label":"AUTHN_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:AuthenticationError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "EXPECT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AUTHN_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "EXPIRES",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `expires`. Specifies the time at which the response becomes stale. "
+            "label":"AUTHZ_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:AuthorizationError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "EXPIRES",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AUTHZ_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "IF_MATCH",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `if-match` \n"
+            "label":"INIT_OUTBOUND_REQUEST_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:InitializingOutboundRequestError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "IF_MATCH",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"INIT_OUTBOUND_REQUEST_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "IF_MODIFIED_SINCE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `if-modified-since`. Used when validating (with the origin server) whether a cached response\nis still valid. If the representation of the resource has modified since the timestamp in this field, a\n304 response is returned."
+            "label":"WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:WritingOutboundRequestHeadersError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "IF_MODIFIED_SINCE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WRITING_OUTBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "IF_NONE_MATCH",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `if-none-match`. Used when validating (with the origin server) whether a cached response is\nstill valid. If the ETag provided in this field matches the representation of the requested resource, a\n304 response is returned."
+            "label":"WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:WritingOutboundRequestBodyError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "IF_NONE_MATCH",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WRITING_OUTBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "IF_RANGE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `if-range` \n"
+            "label":"INIT_INBOUND_RESPONSE_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:InitializingInboundResponseError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "IF_RANGE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"INIT_INBOUND_RESPONSE_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "IF_UNMODIFIED_SINCE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `if-unmodified-since` \n"
+            "label":"READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:ReadingInboundResponseBodyError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "IF_UNMODIFIED_SINCE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"READING_INBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LAST_MODIFIED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `last-modified`. The time at which the resource was last modified. "
+            "label":"READING_INBOUND_RESPONSE_BODY_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:ReadingInboundResponseBodyError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "LAST_MODIFIED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"READING_INBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LOCATION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `location`. Indicates the URL to redirect a request to. "
+            "label":"INIT_INBOUND_REQUEST_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:InitialingInboundRequestError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "LOCATION",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"INIT_INBOUND_REQUEST_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PRAGMA",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `pragma`. Used in dealing with HTTP 1.0 caches which do not understand the `cache-control` header."
+            "label":"READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:ReadingInboundRequestHeadersError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "PRAGMA",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"READING_INBOUND_REQUEST_HEADERS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PROXY_AUTHORIZATION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
+            "label":"READING_INBOUND_REQUEST_BODY_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:ReadingInboundRequestBodyError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "PROXY_AUTHORIZATION",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"READING_INBOUND_REQUEST_BODY_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "SERVER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `server`. Specifies the details of the origin server."
+            "label":"INIT_OUTBOUND_RESPONSE_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:InitializingOutboundResponseError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "SERVER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"INIT_OUTBOUND_RESPONSE_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WARNING",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `warning`. Specifies warnings generated when serving stale responses from HTTP caches. "
+            "label":"WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:WritingOutboundResponseHeadersError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "WARNING",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WRITING_OUTBOUND_RESPONSE_HEADERS_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "TRANSFER_ENCODING",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `transfer-encoding`. Specifies what type of transformation has been applied to entity body. "
+            "label":"WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:WritingOutboundResponseBodyError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "TRANSFER_ENCODING",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WRITING_OUTBOUND_RESPONSE_BODY_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CONNECTION",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `connection`. Allows the sender to specify options that are desired for that particular connection."
+            "label":"INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:Initiating100ContinueResponseError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CONNECTION",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"INITIATING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "UPGRADE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "HTTP header key `upgrade`. Allows the client to specify what additional communication protocols it supports and\nwould like to use, if the server finds it appropriate to switch protocols."
+            "label":"WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:Writing100ContinueResponseError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "UPGRADE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WRITING_100_CONTINUE_RESPONSE_FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PASSED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Mutual SSL handshake is successful."
+            "label":"INVALID_COOKIE_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:InvalidCookieError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "PASSED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"INVALID_COOKIE_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FAILED",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Mutual SSL handshake has failed."
+            "label":"GENERIC_CLIENT_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for generic client error"
                 }
             },
-            "sortText": "120",
-            "insertText": "FAILED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"GENERIC_CLIENT_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "NONE",
-            "kind": "Variable",
-            "detail": "()",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Not a mutual ssl connection."
+            "label":"GENERIC_LISTENER_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:GenericListenerError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "NONE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"GENERIC_LISTENER_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CB_OPEN_STATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the open state of the circuit. When the Circuit Breaker is in `OPEN` state, requests will fail\nimmediately."
+            "label":"UNSUPPORTED_ACTION",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:UnsupportedActionError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CB_OPEN_STATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"UNSUPPORTED_ACTION",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CB_HALF_OPEN_STATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the half-open state of the circuit. When the Circuit Breaker is in `HALF_OPEN` state, a trial request\nwill be sent to the upstream service. If it fails, the circuit will trip again and move to the `OPEN` state. If not,\nit will move to the `CLOSED` state."
+            "label":"HTTP2_CLIENT_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:Http2ClientError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CB_HALF_OPEN_STATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HTTP2_CLIENT_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CB_CLOSED_STATE",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Represents the closed state of the circuit. When the Circuit Breaker is in `CLOSED` state, all requests will be\nallowed to go through to the upstream service. If the failures exceed the configured threhold values, the circuit\nwill trip and move to the `OPEN` state."
+            "label":"MAXIMUM_WAIT_TIME_EXCEEDED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:MaximumWaitTimeExceededError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "CB_CLOSED_STATE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MAXIMUM_WAIT_TIME_EXCEEDED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_CONTINUE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 100 Continue"
+            "label":"SSL_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:SslError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_CONTINUE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"SSL_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_SWITCHING_PROTOCOLS",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 101 Switching Protocols"
+            "label":"COOKIE_HANDLING_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the reason string for the `http:CookieHandlingError`"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_SWITCHING_PROTOCOLS",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"COOKIE_HANDLING_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_OK",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 200 OK"
+            "label":"AGE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `age`. Gives the current age of a cached HTTP response. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_OK",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AGE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_CREATED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 201 Created"
+            "label":"AUTHORIZATION",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `authorization` "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_CREATED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AUTHORIZATION",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_ACCEPTED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 202 Accepted"
+            "label":"CACHE_CONTROL",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `cache-control`. Specifies the cache control directives required for the function of HTTP caches."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_ACCEPTED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CACHE_CONTROL",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_NON_AUTHORITATIVE_INFORMATION",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 203 Non Authoritative Information"
+            "label":"CONTENT_LENGTH",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `content-length`. Specifies the size of the response body in bytes. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_NON_AUTHORITATIVE_INFORMATION",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CONTENT_LENGTH",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_NO_CONTENT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 204 No Content"
+            "label":"CONTENT_TYPE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `content-type`. Specifies the type of the message payload. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_NO_CONTENT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CONTENT_TYPE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_RESET_CONTENT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 205 Reset Content"
+            "label":"DATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `date`. The timestamp at the time the response was generated/received. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_RESET_CONTENT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"DATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_PARTIAL_CONTENT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 206 Partial Content"
+            "label":"ETAG",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `etag`. A finger print for a resource which is used by HTTP caches to identify whether a\nresource representation has changed."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_PARTIAL_CONTENT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ETAG",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_MULTIPLE_CHOICES",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 300 Multiple Choices"
+            "label":"EXPECT",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `expect`. Specifies expectations to be fulfilled by the server. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_MULTIPLE_CHOICES",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"EXPECT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_MOVED_PERMANENTLY",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 301 Moved Permanently"
+            "label":"EXPIRES",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `expires`. Specifies the time at which the response becomes stale. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_MOVED_PERMANENTLY",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"EXPIRES",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_FOUND",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 302 Found"
+            "label":"IF_MATCH",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `if-match` "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_FOUND",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IF_MATCH",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_SEE_OTHER",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 303 See Other"
+            "label":"IF_MODIFIED_SINCE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `if-modified-since`. Used when validating (with the origin server) whether a cached response\nis still valid. If the representation of the resource has modified since the timestamp in this field, a\n304 response is returned."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_SEE_OTHER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IF_MODIFIED_SINCE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_NOT_MODIFIED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 304 Not Modified"
+            "label":"IF_NONE_MATCH",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `if-none-match`. Used when validating (with the origin server) whether a cached response is\nstill valid. If the ETag provided in this field matches the representation of the requested resource, a\n304 response is returned."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_NOT_MODIFIED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IF_NONE_MATCH",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_USE_PROXY",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 305 Use Proxy"
+            "label":"IF_RANGE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `if-range` "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_USE_PROXY",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IF_RANGE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_TEMPORARY_REDIRECT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 307 Temporary Redirect"
+            "label":"IF_UNMODIFIED_SINCE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `if-unmodified-since` "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_TEMPORARY_REDIRECT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IF_UNMODIFIED_SINCE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_PERMANENT_REDIRECT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 308 Permanent Redirect"
+            "label":"LAST_MODIFIED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `last-modified`. The time at which the resource was last modified. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_PERMANENT_REDIRECT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"LAST_MODIFIED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_BAD_REQUEST",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 400 Bad Request"
+            "label":"LOCATION",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `location`. Indicates the URL to redirect a request to. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_BAD_REQUEST",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"LOCATION",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_UNAUTHORIZED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 401 Unauthorized"
+            "label":"PRAGMA",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `pragma`. Used in dealing with HTTP 1.0 caches which do not understand the `cache-control` header."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_UNAUTHORIZED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PRAGMA",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_PAYMENT_REQUIRED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 402 Payment Required"
+            "label":"PROXY_AUTHORIZATION",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_PAYMENT_REQUIRED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PROXY_AUTHORIZATION",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_FORBIDDEN",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 403 Forbidden"
+            "label":"SERVER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `server`. Specifies the details of the origin server."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_FORBIDDEN",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"SERVER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_NOT_FOUND",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 404 Not Found"
+            "label":"WARNING",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `warning`. Specifies warnings generated when serving stale responses from HTTP caches. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_NOT_FOUND",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WARNING",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_METHOD_NOT_ALLOWED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 405 Method Not Allowed"
+            "label":"TRANSFER_ENCODING",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `transfer-encoding`. Specifies what type of transformation has been applied to entity body. "
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_METHOD_NOT_ALLOWED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"TRANSFER_ENCODING",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_NOT_ACCEPTABLE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 406 Not Acceptable"
+            "label":"CONNECTION",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `connection`. Allows the sender to specify options that are desired for that particular connection."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_NOT_ACCEPTABLE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CONNECTION",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_PROXY_AUTHENTICATION_REQUIRED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 407 Proxy Authentication Required"
+            "label":"UPGRADE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"HTTP header key `upgrade`. Allows the client to specify what additional communication protocols it supports and\nwould like to use, if the server finds it appropriate to switch protocols."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_PROXY_AUTHENTICATION_REQUIRED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"UPGRADE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_REQUEST_TIMEOUT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 408 Request Timeout"
+            "label":"PASSED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Mutual SSL handshake is successful."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_REQUEST_TIMEOUT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PASSED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_CONFLICT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 409 Conflict"
+            "label":"FAILED",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Mutual SSL handshake has failed."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_CONFLICT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FAILED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_GONE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 410 Gone"
+            "label":"NONE",
+            "kind":"Variable",
+            "detail":"()",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Not a mutual ssl connection."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_GONE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"NONE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_LENGTH_REQUIRED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 411 Length Required"
+            "label":"CB_OPEN_STATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the open state of the circuit. When the Circuit Breaker is in `OPEN` state, requests will fail\nimmediately."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_LENGTH_REQUIRED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CB_OPEN_STATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_PRECONDITION_FAILED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 412 Precondition Failed"
+            "label":"CB_HALF_OPEN_STATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the half-open state of the circuit. When the Circuit Breaker is in `HALF_OPEN` state, a trial request\nwill be sent to the upstream service. If it fails, the circuit will trip again and move to the `OPEN` state. If not,\nit will move to the `CLOSED` state."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_PRECONDITION_FAILED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CB_HALF_OPEN_STATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_PAYLOAD_TOO_LARGE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 413 Payload Too Large"
+            "label":"CB_CLOSED_STATE",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Represents the closed state of the circuit. When the Circuit Breaker is in `CLOSED` state, all requests will be\nallowed to go through to the upstream service. If the failures exceed the configured threhold values, the circuit\nwill trip and move to the `OPEN` state."
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_PAYLOAD_TOO_LARGE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CB_CLOSED_STATE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_URI_TOO_LONG",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 414 URI Too Long"
+            "label":"STATUS_CONTINUE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 100 Continue"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_URI_TOO_LONG",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_CONTINUE",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_UNSUPPORTED_MEDIA_TYPE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 415 Unsupported Media Type"
+            "label":"STATUS_SWITCHING_PROTOCOLS",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 101 Switching Protocols"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_UNSUPPORTED_MEDIA_TYPE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_SWITCHING_PROTOCOLS",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_RANGE_NOT_SATISFIABLE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 416 Range Not Satisfiable"
+            "label":"STATUS_OK",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 200 OK"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_RANGE_NOT_SATISFIABLE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_OK",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_EXPECTATION_FAILED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 417 Expectation Failed"
+            "label":"STATUS_CREATED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 201 Created"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_EXPECTATION_FAILED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_CREATED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_UPGRADE_REQUIRED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 426 Upgrade Required"
+            "label":"STATUS_ACCEPTED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 202 Accepted"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_UPGRADE_REQUIRED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_ACCEPTED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_INTERNAL_SERVER_ERROR",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 500 Internal Server Error"
+            "label":"STATUS_NON_AUTHORITATIVE_INFORMATION",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 203 Non Authoritative Information"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_INTERNAL_SERVER_ERROR",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_NON_AUTHORITATIVE_INFORMATION",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_NOT_IMPLEMENTED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 501 Not Implemented"
+            "label":"STATUS_NO_CONTENT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 204 No Content"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_NOT_IMPLEMENTED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_NO_CONTENT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_BAD_GATEWAY",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 502 Bad Gateway"
+            "label":"STATUS_RESET_CONTENT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 205 Reset Content"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_BAD_GATEWAY",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_RESET_CONTENT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_SERVICE_UNAVAILABLE",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 503 Service Unavailable"
+            "label":"STATUS_PARTIAL_CONTENT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 206 Partial Content"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_SERVICE_UNAVAILABLE",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_PARTIAL_CONTENT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_GATEWAY_TIMEOUT",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 504 Gateway Timeout"
+            "label":"STATUS_MULTIPLE_CHOICES",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 300 Multiple Choices"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_GATEWAY_TIMEOUT",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_MULTIPLE_CHOICES",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "STATUS_HTTP_VERSION_NOT_SUPPORTED",
-            "kind": "Variable",
-            "detail": "int",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "The HTTP response status code: 505 HTTP Version Not Supported"
+            "label":"STATUS_MOVED_PERMANENTLY",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 301 Moved Permanently"
                 }
             },
-            "sortText": "120",
-            "insertText": "STATUS_HTTP_VERSION_NOT_SUPPORTED",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_MOVED_PERMANENTLY",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "KEEPALIVE_AUTO",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Decides to keep the connection alive or not based on the `connection` header of the client request }"
+            "label":"STATUS_FOUND",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 302 Found"
                 }
             },
-            "sortText": "120",
-            "insertText": "KEEPALIVE_AUTO",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_FOUND",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "KEEPALIVE_ALWAYS",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Keeps the connection alive irrespective of the `connection` header value }"
+            "label":"STATUS_SEE_OTHER",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 303 See Other"
                 }
             },
-            "sortText": "120",
-            "insertText": "KEEPALIVE_ALWAYS",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_SEE_OTHER",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "KEEPALIVE_NEVER",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Closes the connection irrespective of the `connection` header value }"
+            "label":"STATUS_NOT_MODIFIED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 304 Not Modified"
                 }
             },
-            "sortText": "120",
-            "insertText": "KEEPALIVE_NEVER",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_NOT_MODIFIED",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "SERVICE_NAME",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the service name reference."
+            "label":"STATUS_USE_PROXY",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 305 Use Proxy"
                 }
             },
-            "sortText": "120",
-            "insertText": "SERVICE_NAME",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_USE_PROXY",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RESOURCE_NAME",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the resource name reference."
+            "label":"STATUS_TEMPORARY_REDIRECT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 307 Temporary Redirect"
                 }
             },
-            "sortText": "120",
-            "insertText": "RESOURCE_NAME",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_TEMPORARY_REDIRECT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "REQUEST_METHOD",
-            "kind": "Variable",
-            "detail": "string",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "Constant for the request method reference."
+            "label":"STATUS_PERMANENT_REDIRECT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 308 Permanent Redirect"
                 }
             },
-            "sortText": "120",
-            "insertText": "REQUEST_METHOD",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"STATUS_PERMANENT_REDIRECT",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpServiceConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Contains the configurations for an HTTP service.\n"
+            "label":"STATUS_BAD_REQUEST",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 400 Bad Request"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_BAD_REQUEST",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_UNAUTHORIZED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 401 Unauthorized"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_UNAUTHORIZED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_PAYMENT_REQUIRED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 402 Payment Required"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_PAYMENT_REQUIRED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_FORBIDDEN",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 403 Forbidden"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_FORBIDDEN",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_NOT_FOUND",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 404 Not Found"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_NOT_FOUND",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_METHOD_NOT_ALLOWED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 405 Method Not Allowed"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_METHOD_NOT_ALLOWED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_NOT_ACCEPTABLE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 406 Not Acceptable"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_NOT_ACCEPTABLE",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_PROXY_AUTHENTICATION_REQUIRED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 407 Proxy Authentication Required"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_PROXY_AUTHENTICATION_REQUIRED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_REQUEST_TIMEOUT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 408 Request Timeout"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_REQUEST_TIMEOUT",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_CONFLICT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 409 Conflict"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_CONFLICT",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_GONE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 410 Gone"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_GONE",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_LENGTH_REQUIRED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 411 Length Required"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_LENGTH_REQUIRED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_PRECONDITION_FAILED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 412 Precondition Failed"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_PRECONDITION_FAILED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_PAYLOAD_TOO_LARGE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 413 Payload Too Large"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_PAYLOAD_TOO_LARGE",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_URI_TOO_LONG",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 414 URI Too Long"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_URI_TOO_LONG",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_UNSUPPORTED_MEDIA_TYPE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 415 Unsupported Media Type"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_UNSUPPORTED_MEDIA_TYPE",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_RANGE_NOT_SATISFIABLE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 416 Range Not Satisfiable"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_RANGE_NOT_SATISFIABLE",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_EXPECTATION_FAILED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 417 Expectation Failed"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_EXPECTATION_FAILED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_UPGRADE_REQUIRED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 426 Upgrade Required"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_UPGRADE_REQUIRED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_INTERNAL_SERVER_ERROR",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 500 Internal Server Error"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_INTERNAL_SERVER_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_NOT_IMPLEMENTED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 501 Not Implemented"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_NOT_IMPLEMENTED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_BAD_GATEWAY",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 502 Bad Gateway"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_BAD_GATEWAY",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_SERVICE_UNAVAILABLE",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 503 Service Unavailable"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_SERVICE_UNAVAILABLE",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_GATEWAY_TIMEOUT",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 504 Gateway Timeout"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_GATEWAY_TIMEOUT",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"STATUS_HTTP_VERSION_NOT_SUPPORTED",
+            "kind":"Variable",
+            "detail":"int",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"The HTTP response status code: 505 HTTP Version Not Supported"
+                }
+            },
+            "sortText":"120",
+            "insertText":"STATUS_HTTP_VERSION_NOT_SUPPORTED",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"KEEPALIVE_AUTO",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Decides to keep the connection alive or not based on the `connection` header of the client request }"
+                }
+            },
+            "sortText":"120",
+            "insertText":"KEEPALIVE_AUTO",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"KEEPALIVE_ALWAYS",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Keeps the connection alive irrespective of the `connection` header value }"
+                }
+            },
+            "sortText":"120",
+            "insertText":"KEEPALIVE_ALWAYS",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"KEEPALIVE_NEVER",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Closes the connection irrespective of the `connection` header value }"
+                }
+            },
+            "sortText":"120",
+            "insertText":"KEEPALIVE_NEVER",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"SERVICE_NAME",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the service name reference."
+                }
             },
-            "sortText": "120",
-            "insertText": "HttpServiceConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"SERVICE_NAME",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CorsConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for CORS support.\n"
+            "label":"RESOURCE_NAME",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the resource name reference."
+                }
+            },
+            "sortText":"120",
+            "insertText":"RESOURCE_NAME",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"REQUEST_METHOD",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Constant for the request method reference."
+                }
+            },
+            "sortText":"120",
+            "insertText":"REQUEST_METHOD",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"CONNECTION_CLOSURE_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for failures during connection closure"
+                }
+            },
+            "sortText":"120",
+            "insertText":"CONNECTION_CLOSURE_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"INVALID_HANDSHAKE_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for WebSocket handshake failures"
+                }
+            },
+            "sortText":"120",
+            "insertText":"INVALID_HANDSHAKE_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"PAYLOAD_TOO_BIG_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for exceeding maximum frame size"
+                }
+            },
+            "sortText":"120",
+            "insertText":"PAYLOAD_TOO_BIG_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"PROTOCOL_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for other side breaking the protocol"
+                }
+            },
+            "sortText":"120",
+            "insertText":"PROTOCOL_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"CONNECTION_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for connection failures"
+                }
+            },
+            "sortText":"120",
+            "insertText":"CONNECTION_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"INVALID_CONTINUATION_FRAME_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for invalid continuation frame"
+                }
+            },
+            "sortText":"120",
+            "insertText":"INVALID_CONTINUATION_FRAME_ERROR",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"GENERIC_ERROR",
+            "kind":"Variable",
+            "detail":"string",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"Error reason for errors not captured by the specific errors"
+                }
             },
-            "sortText": "120",
-            "insertText": "CorsConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"GENERIC_ERROR",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Versioning",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for service versioning.\n"
+            "label":"HttpServiceConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Contains the configurations for an HTTP service.\n"
             },
-            "sortText": "120",
-            "insertText": "Versioning",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpServiceConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WSServiceConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for a WebSocket service.\n\nin the server service will be triggered. Note that this overrides the `timeoutInMillis` config\nin the `http:Listener`.\nIf this is not set or is negative or zero, the default frame size will be used."
+            "label":"CorsConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for CORS support.\n"
             },
-            "sortText": "120",
-            "insertText": "WSServiceConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CorsConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpResourceConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configuration for an HTTP resource.\n"
+            "label":"Versioning",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for service versioning.\n"
             },
-            "sortText": "120",
-            "insertText": "HttpResourceConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Versioning",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketUpgradeConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Resource configuration to upgrade from HTTP to WebSocket.\n"
+            "label":"WSServiceConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for a WebSocket service.\n"
             },
-            "sortText": "120",
-            "insertText": "WebSocketUpgradeConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WSServiceConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ServiceAuth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configures the authentication scheme for a service.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays \nshould be successfully authorized."
+            "label":"HttpResourceConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configuration for an HTTP resource.\n"
             },
-            "sortText": "120",
-            "insertText": "ServiceAuth",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpResourceConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResourceAuth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configures the authentication scheme for a resource.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould be successfully authorized."
+            "label":"WebSocketUpgradeConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Resource configuration to upgrade from HTTP to WebSocket.\n"
             },
-            "sortText": "120",
-            "insertText": "ResourceAuth",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketUpgradeConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthzHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of Authorization Handler for HTTP.\n"
+            "label":"ServiceAuth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configures the authentication scheme for a service.\n"
             },
-            "sortText": "120",
-            "insertText": "AuthzHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ServiceAuth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The representation of an inbound authentication handler for HTTP traffic."
+            "label":"ResourceAuth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configures the authentication scheme for a resource.\n"
             },
-            "sortText": "120",
-            "insertText": "InboundAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ResourceAuth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The representation of an outbound authentication handler for HTTP traffic."
+            "label":"AuthzHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of Authorization Handler for HTTP.\n"
             },
-            "sortText": "120",
-            "insertText": "OutboundAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AuthzHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CredentialBearer",
-            "detail": "Union",
-            "documentation": {
-                "left": "Specifies how to send the authentication credentials when exchanging tokens."
+            "label":"InboundAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The representation of an inbound authentication handler for HTTP traffic."
             },
-            "sortText": "120",
-            "insertText": "CredentialBearer",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InboundAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundAuthHandlers",
-            "detail": "Union",
-            "documentation": {
-                "left": "Represents inbound auth handler patterns."
+            "label":"OutboundAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The representation of an outbound authentication handler for HTTP traffic."
             },
-            "sortText": "120",
-            "insertText": "InboundAuthHandlers",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"OutboundAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Scopes",
-            "detail": "Union",
-            "documentation": {
-                "left": "Represents scopes patterns."
+            "label":"CredentialBearer",
+            "detail":"Union",
+            "documentation":{
+                "left":"Specifies how to send the authentication credentials when exchanging tokens."
             },
-            "sortText": "120",
-            "insertText": "Scopes",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CredentialBearer",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RequestCacheControl",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Configures the cache control directives for an `http:Request`.\n"
+            "label":"InboundAuthHandlers",
+            "detail":"Union",
+            "documentation":{
+                "left":"Represents inbound auth handler patterns."
             },
-            "sortText": "120",
-            "insertText": "RequestCacheControl",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InboundAuthHandlers",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResponseCacheControl",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Configures cache control directives for an `http:Response`.\n\nmust be validated with the origin server.\nthe rest of the response."
+            "label":"Scopes",
+            "detail":"Union",
+            "documentation":{
+                "left":"Represents scopes patterns."
             },
-            "sortText": "120",
-            "insertText": "ResponseCacheControl",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Scopes",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpCache",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+            "label":"RequestCacheControl",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Configures the cache control directives for an `http:Request`.\n"
             },
-            "sortText": "120",
-            "insertText": "HttpCache",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RequestCacheControl",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CachingPolicy",
-            "detail": "Union",
-            "documentation": {
-                "left": "Used for configuring the caching behaviour. Setting the `policy` field in the `CacheConfig` record allows\nthe user to control the caching behaviour."
+            "label":"ResponseCacheControl",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Configures cache control directives for an `http:Response`.\n"
             },
-            "sortText": "120",
-            "insertText": "CachingPolicy",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ResponseCacheControl",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CacheConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the caching behaviour of the endpoint.\n\nbetween 0 (exclusive) and 1 (inclusive).\n`CACHE_CONTROL_AND_VALIDATORS`. The default behaviour is to allow caching only when the `cache-control`\n\nheader and either the `etag` or `last-modified` header are present."
+            "label":"HttpCache",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Implements a cache for storing HTTP responses. This cache complies with the caching policy set when configuring\nHTTP caching in the HTTP client endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "CacheConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpCache",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpCachingClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "An HTTP caching client implementation which takes an `HttpActions` instance and wraps it with an HTTP caching layer.\n"
+            "label":"CachingPolicy",
+            "detail":"Union",
+            "documentation":{
+                "left":"Used for configuring the caching behaviour. Setting the `policy` field in the `CacheConfig` record allows\nthe user to control the caching behaviour."
             },
-            "sortText": "120",
-            "insertText": "HttpCachingClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CachingPolicy",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Client",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs.\nHTTP service in resilient manner"
+            "label":"CacheConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the caching behaviour of the endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "Client",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CacheConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "TargetService",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents a single service and its related configurations.\n"
+            "label":"HttpCachingClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"An HTTP caching client implementation which takes an `HttpActions` instance and wraps it with an HTTP caching layer.\n"
             },
-            "sortText": "120",
-            "insertText": "TargetService",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpCachingClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientHttp1Settings",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n"
+            "label":"Client",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The HTTP client provides the capability for initiating contact with a remote HTTP service. The API it\nprovides includes functions for the standard HTTP methods, forwarding a received request and sending requests\nusing custom HTTP verbs."
             },
-            "sortText": "120",
-            "insertText": "ClientHttp1Settings",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Client",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientHttp2Settings",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides settings related to HTTP/2 protocol.\n"
+            "label":"TargetService",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents a single service and its related configurations.\n"
             },
-            "sortText": "120",
-            "insertText": "ClientHttp2Settings",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"TargetService",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RetryConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides configurations for controlling the retrying behavior in failure scenarios.\n"
+            "label":"ClientHttp1Settings",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides settings related to HTTP/1.x protocol.\n"
             },
-            "sortText": "120",
-            "insertText": "RetryConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ClientHttp1Settings",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientSecureSocket",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n\neg: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA"
+            "label":"ClientHttp2Settings",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides settings related to HTTP/2 protocol.\n"
             },
-            "sortText": "120",
-            "insertText": "ClientSecureSocket",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ClientHttp2Settings",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FollowRedirects",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n\nSet it to true if Auth headers are needed to be sent during the redirection"
+            "label":"RetryConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides configurations for controlling the retrying behavior in failure scenarios.\n"
             },
-            "sortText": "120",
-            "insertText": "FollowRedirects",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RetryConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ProxyConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Proxy server configurations to be used with the HTTP client endpoint.\n"
+            "label":"ClientSecureSocket",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides configurations for facilitating secure communication with a remote HTTP endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "ProxyConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ClientSecureSocket",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundAuthConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "The `OutboundAuthConfig` record can be used to configure the authentication mechanism used by the HTTP endpoint.\n"
+            "label":"FollowRedirects",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.\nThe response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308\nstatus codes use the original request HTTP method during redirection.\n"
             },
-            "sortText": "120",
-            "insertText": "OutboundAuthConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FollowRedirects",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Client configuration for cookies.\n\nwhich references the persistent cookie handler or specifying the CSV persistent cookie handler. If not specified any, only the session cookies are used"
+            "label":"ProxyConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Proxy server configurations to be used with the HTTP client endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "CookieConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ProxyConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Cookie",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a Cookie.\n"
+            "label":"OutboundAuthConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"The `OutboundAuthConfig` record can be used to configure the authentication mechanism used by the HTTP endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "Cookie",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"OutboundAuthConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieStore",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents the cookie store.\n"
+            "label":"CookieConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Client configuration for cookies.\n"
             },
-            "sortText": "120",
-            "insertText": "CookieStore",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CookieConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides the cookie functionality across HTTP client actions.\n"
+            "label":"Cookie",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a Cookie.\n"
             },
-            "sortText": "120",
-            "insertText": "CookieClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Cookie",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PersistentCookieHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The representation of a persistent cookie handler for managing persistent cookies."
+            "label":"CookieStore",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents the cookie store.\n"
             },
-            "sortText": "120",
-            "insertText": "PersistentCookieHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CookieStore",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpFuture",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
+            "label":"CookieClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides the cookie functionality across HTTP client actions.\n"
             },
-            "sortText": "120",
-            "insertText": "HttpFuture",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CookieClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PushPromise",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents an HTTP/2 `PUSH_PROMISE` frame.\n"
+            "label":"PersistentCookieHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The representation of a persistent cookie handler for managing persistent cookies."
             },
-            "sortText": "120",
-            "insertText": "PushPromise",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PersistentCookieHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides the HTTP actions for interacting with an HTTP server. Apart from the standard HTTP methods,\n`HttpClient.forward()` and `HttpClient.execute()` functions are provided. More complex and specific endpoint types\ncan be created by wrapping this generic HTTP actions implementation.\n"
+            "label":"HttpFuture",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a 'future' that returns as a result of an asynchronous HTTP request submission.\nThis can be used as a reference to fetch the results of the submission."
             },
-            "sortText": "120",
-            "insertText": "HttpClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpFuture",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpTimeoutError",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Defines a timeout error occurred during service invocation.\n"
+            "label":"PushPromise",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents an HTTP/2 `PUSH_PROMISE` frame.\n"
             },
-            "sortText": "120",
-            "insertText": "HttpTimeoutError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PushPromise",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "PoolConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for managing HTTP client connection pool.\n"
+            "label":"HttpClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides the HTTP actions for interacting with an HTTP server. Apart from the standard HTTP methods,\n`HttpClient.forward()` and `HttpClient.execute()` functions are provided. More complex and specific endpoint types\ncan be created by wrapping this generic HTTP actions implementation.\n"
             },
-            "sortText": "120",
-            "insertText": "PoolConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpVersion",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the supported HTTP protocols.\n\n`HTTP_1_0`: HTTP/1.0 protocol\n`HTTP_1_1`: HTTP/1.1 protocol\n`HTTP_2_0`: HTTP/2.0 protocol"
+            "label":"HttpTimeoutError",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Defines a timeout error occurred during service invocation.\n"
             },
-            "sortText": "120",
-            "insertText": "HttpVersion",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpTimeoutError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Chunking",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\notherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
+            "label":"PoolConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for managing HTTP client connection pool.\n"
             },
-            "sortText": "120",
-            "insertText": "Chunking",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"PoolConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Compression",
-            "detail": "Union",
-            "documentation": {
-                "left": "Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\noutbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
+            "label":"HttpVersion",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the supported HTTP protocols.\n\n`HTTP_1_0`: HTTP/1.0 protocol\n`HTTP_1_1`: HTTP/1.1 protocol\n`HTTP_2_0`: HTTP/2.0 protocol"
             },
-            "sortText": "120",
-            "insertText": "Compression",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpVersion",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpOperation",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the HTTP operations related to circuit breaker, failover and load balancer.\n\n`FORWARD`: Forward the specified payload\n`GET`: Request a resource\n`POST`: Create a new resource\n`DELETE`: Deletes the specified resource\n`OPTIONS`: Request communication options available\n`PUT`: Replace the target resource\n`PATCH`: Apply partial modification to the resource\n`HEAD`: Identical to `GET` but no resource body should be returned\n`SUBMIT`: Submits a http request and returns an HttpFuture object\n`NONE`: No operation should be performed"
+            "label":"Chunking",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible values for the chunking configuration in HTTP services and clients.\n\n`AUTO`: If the payload is less than 8KB, content-length header is set in the outbound request/response,\n        otherwise chunking header is set in the outbound request/response\n`ALWAYS`: Always set chunking header in the response\n`NEVER`: Never set the chunking header even if the payload is larger than 8KB in the outbound request/response"
             },
-            "sortText": "120",
-            "insertText": "HttpOperation",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Chunking",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Protocols",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for configuring SSL/TLS protocol and version to be used.\n"
+            "label":"Compression",
+            "detail":"Union",
+            "documentation":{
+                "left":"Options to compress using gzip or deflate.\n\n`AUTO`: When service behaves as a HTTP gateway inbound request/response accept-encoding option is set as the\n        outbound request/response accept-encoding/content-encoding option\n`ALWAYS`: Always set accept-encoding/content-encoding in outbound request/response\n`NEVER`: Never set accept-encoding/content-encoding header in outbound request/response"
             },
-            "sortText": "120",
-            "insertText": "Protocols",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Compression",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ValidateCert",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing configurations for certificate revocation status checks.\n"
+            "label":"HttpOperation",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the HTTP operations related to circuit breaker, failover and load balancer.\n\n`FORWARD`: Forward the specified payload\n`GET`: Request a resource\n`POST`: Create a new resource\n`DELETE`: Deletes the specified resource\n`OPTIONS`: Request communication options available\n`PUT`: Replace the target resource\n`PATCH`: Apply partial modification to the resource\n`HEAD`: Identical to `GET` but no resource body should be returned\n`SUBMIT`: Submits a http request and returns an HttpFuture object\n`NONE`: No operation should be performed"
             },
-            "sortText": "120",
-            "insertText": "ValidateCert",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpOperation",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerOcspStapling",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing configurations for certificate revocation status checks.\n"
+            "label":"Protocols",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for configuring SSL/TLS protocol and version to be used.\n"
             },
-            "sortText": "120",
-            "insertText": "ListenerOcspStapling",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Protocols",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CompressionConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing configurations for content compression.\n"
+            "label":"ValidateCert",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing configurations for certificate revocation status checks.\n"
             },
-            "sortText": "120",
-            "insertText": "CompressionConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ValidateCert",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CommonClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Common client configurations for the next level clients.\n"
+            "label":"ListenerOcspStapling",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing configurations for certificate revocation status checks.\n"
             },
-            "sortText": "120",
-            "insertText": "CommonClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ListenerOcspStapling",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Caller",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "The caller actions for responding to client requests.\n"
+            "label":"CompressionConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing configurations for content compression.\n"
             },
-            "sortText": "120",
-            "insertText": "Caller",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CompressionConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RedirectCode",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the HTTP redirect codes as a type."
+            "label":"CommonClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Common client configurations for the next level clients.\n"
             },
-            "sortText": "120",
-            "insertText": "RedirectCode",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CommonClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverAllEndpointsFailedError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to all the failover endpoint failure"
+            "label":"Caller",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"The caller actions for responding to client requests.\n"
             },
-            "sortText": "120",
-            "insertText": "FailoverAllEndpointsFailedError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Caller",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverActionFailedError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to failover action failure"
+            "label":"RedirectCode",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the HTTP redirect codes as a type."
             },
-            "sortText": "120",
-            "insertText": "FailoverActionFailedError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RedirectCode",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "UpstreamServiceUnavailableError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to upstream service unavailability"
+            "label":"Detail",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Holds the details of an HTTP error\n"
             },
-            "sortText": "120",
-            "insertText": "UpstreamServiceUnavailableError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Detail",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AllLoadBalanceEndpointsFailedError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to all the load balance endpoint failure"
+            "label":"FailoverAllEndpointsFailedError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to all the failover endpoint failure"
             },
-            "sortText": "120",
-            "insertText": "AllLoadBalanceEndpointsFailedError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FailoverAllEndpointsFailedError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerConfigError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to circuit breaker configuration error."
+            "label":"FailoverActionFailedError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to failover action failure"
             },
-            "sortText": "120",
-            "insertText": "CircuitBreakerConfigError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FailoverActionFailedError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AllRetryAttemptsFailed",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to all the the retry attempts failure"
+            "label":"UpstreamServiceUnavailableError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to upstream service unavailability"
             },
-            "sortText": "120",
-            "insertText": "AllRetryAttemptsFailed",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"UpstreamServiceUnavailableError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "IdleTimeoutError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents the error that triggered upon a request/response idle timeout"
+            "label":"AllLoadBalanceEndpointsFailedError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to all the load balance endpoint failure"
             },
-            "sortText": "120",
-            "insertText": "IdleTimeoutError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AllLoadBalanceEndpointsFailedError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthenticationError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred due to inbound request authentication failure"
+            "label":"AllRetryAttemptsFailed",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to all the the retry attempts failure"
             },
-            "sortText": "120",
-            "insertText": "AuthenticationError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AllRetryAttemptsFailed",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthorizationError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred due to inbound request authorization failure"
+            "label":"IdleTimeoutError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents the error that triggered upon a request/response idle timeout"
             },
-            "sortText": "120",
-            "insertText": "AuthorizationError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"IdleTimeoutError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InitializingOutboundRequestError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to outbound request initialization failure"
+            "label":"AuthenticationError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred due to inbound request authentication failure"
             },
-            "sortText": "120",
-            "insertText": "InitializingOutboundRequestError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AuthenticationError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WritingOutboundRequestHeadersError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred while writing outbound request headers"
+            "label":"AuthorizationError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred due to inbound request authorization failure"
             },
-            "sortText": "120",
-            "insertText": "WritingOutboundRequestHeadersError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AuthorizationError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WritingOutboundRequestBodyError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred while writing outbound request entity body"
+            "label":"InitializingOutboundRequestError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to outbound request initialization failure"
             },
-            "sortText": "120",
-            "insertText": "WritingOutboundRequestBodyError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InitializingOutboundRequestError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InitializingInboundResponseError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to inbound response initialization failure"
+            "label":"WritingOutboundRequestHeadersError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred while writing outbound request headers"
             },
-            "sortText": "120",
-            "insertText": "InitializingInboundResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WritingOutboundRequestHeadersError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ReadingInboundResponseHeadersError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred while reading inbound response headers"
+            "label":"WritingOutboundRequestBodyError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred while writing outbound request entity body"
             },
-            "sortText": "120",
-            "insertText": "ReadingInboundResponseHeadersError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WritingOutboundRequestBodyError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ReadingInboundResponseBodyError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred while reading inbound response entity body"
+            "label":"InitializingInboundResponseError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to inbound response initialization failure"
             },
-            "sortText": "120",
-            "insertText": "ReadingInboundResponseBodyError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InitializingInboundResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InitializingInboundRequestError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred due to inbound request initialization failure"
+            "label":"ReadingInboundResponseHeadersError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred while reading inbound response headers"
             },
-            "sortText": "120",
-            "insertText": "InitializingInboundRequestError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ReadingInboundResponseHeadersError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ReadingInboundRequestHeadersError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred while reading inbound request headers"
+            "label":"ReadingInboundResponseBodyError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred while reading inbound response entity body"
             },
-            "sortText": "120",
-            "insertText": "ReadingInboundRequestHeadersError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ReadingInboundResponseBodyError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ReadingInboundRequestBodyError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred while writing the inbound request entity body"
+            "label":"InitializingInboundRequestError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred due to inbound request initialization failure"
             },
-            "sortText": "120",
-            "insertText": "ReadingInboundRequestBodyError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InitializingInboundRequestError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InitializingOutboundResponseError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred due to outbound response initialization failure"
+            "label":"ReadingInboundRequestHeadersError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred while reading inbound request headers"
             },
-            "sortText": "120",
-            "insertText": "InitializingOutboundResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ReadingInboundRequestHeadersError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WritingOutboundResponseHeadersError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred while writing outbound response headers"
+            "label":"ReadingInboundRequestBodyError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred while writing the inbound request entity body"
             },
-            "sortText": "120",
-            "insertText": "WritingOutboundResponseHeadersError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ReadingInboundRequestBodyError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WritingOutboundResponseBodyError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a listener error that occurred while writing outbound response entity body"
+            "label":"InitializingOutboundResponseError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred due to outbound response initialization failure"
             },
-            "sortText": "120",
-            "insertText": "WritingOutboundResponseBodyError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InitializingOutboundResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Initiating100ContinueResponseError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents an error that occurred due to 100 continue response initialization failure"
+            "label":"WritingOutboundResponseHeadersError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred while writing outbound response headers"
             },
-            "sortText": "120",
-            "insertText": "Initiating100ContinueResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WritingOutboundResponseHeadersError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Writing100ContinueResponseError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents an error that occurred while writing 100 continue response"
+            "label":"WritingOutboundResponseBodyError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a listener error that occurred while writing outbound response entity body"
             },
-            "sortText": "120",
-            "insertText": "Writing100ContinueResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WritingOutboundResponseBodyError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InvalidCookieError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a cookie error that occurred when sending cookies in the response"
+            "label":"Initiating100ContinueResponseError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents an error that occurred due to 100 continue response initialization failure"
             },
-            "sortText": "120",
-            "insertText": "InvalidCookieError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Initiating100ContinueResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "GenericClientError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a generic client error"
+            "label":"Writing100ContinueResponseError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents an error that occurred while writing 100 continue response"
             },
-            "sortText": "120",
-            "insertText": "GenericClientError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Writing100ContinueResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "GenericListenerError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a generic listener error"
+            "label":"InvalidCookieError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a cookie error that occurred when sending cookies in the response"
             },
-            "sortText": "120",
-            "insertText": "GenericListenerError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InvalidCookieError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "UnsupportedActionError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to unsupported action invocation"
+            "label":"GenericClientError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a generic client error"
             },
-            "sortText": "120",
-            "insertText": "UnsupportedActionError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"GenericClientError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Http2ClientError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents an HTTP/2 client generic error"
+            "label":"GenericListenerError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a generic listener error"
             },
-            "sortText": "120",
-            "insertText": "Http2ClientError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"GenericListenerError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MaximumWaitTimeExceededError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred exceeding maximum wait time"
+            "label":"UnsupportedActionError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to unsupported action invocation"
             },
-            "sortText": "120",
-            "insertText": "MaximumWaitTimeExceededError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"UnsupportedActionError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "SslError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a client error that occurred due to SSL failure"
+            "label":"Http2ClientError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents an HTTP/2 client generic error"
             },
-            "sortText": "120",
-            "insertText": "SslError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Http2ClientError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CookieHandlingError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents a cookie error that occurred when using the cookies"
+            "label":"MaximumWaitTimeExceededError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred exceeding maximum wait time"
             },
-            "sortText": "120",
-            "insertText": "CookieHandlingError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MaximumWaitTimeExceededError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResiliencyError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the resiliency error types that returned from client"
+            "label":"SslError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a client error that occurred due to SSL failure"
             },
-            "sortText": "120",
-            "insertText": "ResiliencyError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"SslError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientAuthError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the Auth error types that returned from client"
+            "label":"CookieHandlingError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Represents a cookie error that occurred when using the cookies"
             },
-            "sortText": "120",
-            "insertText": "ClientAuthError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CookieHandlingError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundRequestError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the client error types that returned while sending outbound request"
+            "label":"ResiliencyError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the resiliency error types that returned from client"
             },
-            "sortText": "120",
-            "insertText": "OutboundRequestError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ResiliencyError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundResponseError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the client error types that returned while receiving inbound response"
+            "label":"ClientAuthError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the Auth error types that returned from client"
             },
-            "sortText": "120",
-            "insertText": "InboundResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ClientAuthError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "InboundRequestError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the listener error types that returned while receiving inbound request"
+            "label":"OutboundRequestError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the client error types that returned while sending outbound request"
             },
-            "sortText": "120",
-            "insertText": "InboundRequestError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"OutboundRequestError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "OutboundResponseError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the listener error types that returned while sending outbound response"
+            "label":"InboundResponseError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the client error types that returned while receiving inbound response"
             },
-            "sortText": "120",
-            "insertText": "OutboundResponseError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InboundResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible client error types"
+            "label":"InboundRequestError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the listener error types that returned while receiving inbound request"
             },
-            "sortText": "120",
-            "insertText": "ClientError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"InboundRequestError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible listener error types"
+            "label":"OutboundResponseError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the listener error types that returned while sending outbound response"
             },
-            "sortText": "120",
-            "insertText": "ListenerError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"OutboundResponseError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RequestFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Abstract Representation of a HTTP Request Filter.\nThis filter will be applied before the request is dispatched to the relevant resource.\nAny RequestFilter implementation should be structurally similar to or implement the RequestFilter object."
+            "label":"ClientError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible client error types"
             },
-            "sortText": "120",
-            "insertText": "RequestFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ClientError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResponseFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Abstract Representation of a HTTP Response Filter.\nThis filter will be applied in the response path.\nAny ResponseFilter implementation should be structurally similar to or implement the ResponseFilter object."
+            "label":"ListenerError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible listener error types"
             },
-            "sortText": "120",
-            "insertText": "ResponseFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ListenerError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FilterContext",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of request filter Context.\n"
+            "label":"RequestFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Abstract Representation of a HTTP Request Filter.\nThis filter will be applied before the request is dispatched to the relevant resource.\nAny RequestFilter implementation should be structurally similar to or implement the RequestFilter object."
             },
-            "sortText": "120",
-            "insertText": "FilterContext",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RequestFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Request",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents an HTTP request.\n\non utilizing HTTP caching."
+            "label":"ResponseFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Abstract Representation of a HTTP Response Filter.\nThis filter will be applied in the response path.\nAny ResponseFilter implementation should be structurally similar to or implement the ResponseFilter object."
             },
-            "sortText": "120",
-            "insertText": "Request",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ResponseFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MutualSslHandshake",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "A record for providing mutual SSL handshake results.\n"
+            "label":"FilterContext",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of request filter Context.\n"
             },
-            "sortText": "120",
-            "insertText": "MutualSslHandshake",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FilterContext",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MutualSslStatus",
-            "kind": "Enum",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible values for the mutual ssl status.\n\n`passed`: Mutual SSL handshake is successful.\n`failed`: Mutual SSL handshake has failed."
+            "label":"Request",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents an HTTP request.\n"
             },
-            "sortText": "120",
-            "insertText": "MutualSslStatus",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Request",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Response",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents an HTTP response.\n\nintending on utilizing HTTP caching. For incoming responses, this will already be populated\nif the response was sent with cache-control directives"
+            "label":"MutualSslHandshake",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"A record for providing mutual SSL handshake results.\n"
             },
-            "sortText": "120",
-            "insertText": "Response",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MutualSslHandshake",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "HttpSecureClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides secure HTTP remote functions for interacting with HTTP endpoints. This will make use of the authentication\nschemes configured in the HTTP client endpoint to secure the HTTP requests.\n"
+            "label":"MutualSslStatus",
+            "kind":"Enum",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible values for the mutual ssl status.\n\n`passed`: Mutual SSL handshake is successful.\n`failed`: Mutual SSL handshake has failed."
             },
-            "sortText": "120",
-            "insertText": "HttpSecureClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MutualSslStatus",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "MockListener",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Mock server endpoint which does not open a listening port."
+            "label":"Response",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents an HTTP response.\n"
             },
-            "sortText": "120",
-            "insertText": "MockListener",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Response",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RedirectClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides redirect functionality for HTTP client remote functions.\n"
+            "label":"HttpSecureClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides secure HTTP remote functions for interacting with HTTP endpoints. This will make use of the authentication\nschemes configured in the HTTP client endpoint to secure the HTTP requests.\n"
             },
-            "sortText": "120",
-            "insertText": "RedirectClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"HttpSecureClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the failover behaviour of the endpoint.\n"
+            "label":"MockListener",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Mock server endpoint which does not open a listening port."
             },
-            "sortText": "120",
-            "insertText": "FailoverConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"MockListener",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverInferredConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents the inferred failover configurations passed into the failover client.\n"
+            "label":"RedirectClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides redirect functionality for HTTP client remote functions.\n"
             },
-            "sortText": "120",
-            "insertText": "FailoverInferredConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RedirectClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "An HTTP client endpoint which provides failover support over multiple HTTP clients.\n"
+            "label":"FailoverConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the failover behaviour of the endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "FailoverClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FailoverConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "FailoverClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+            "label":"FailoverInferredConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents the inferred failover configurations passed into the failover client.\n"
             },
-            "sortText": "120",
-            "insertText": "FailoverClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FailoverInferredConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitState",
-            "detail": "Union",
-            "documentation": {
-                "left": "A finite type for modeling the states of the Circuit Breaker. The Circuit Breaker starts in the `CLOSED` state.\nIf any failure thresholds are exceeded during execution, the circuit trips and goes to the `OPEN` state. After\nthe specified timeout period expires, the circuit goes to the `HALF_OPEN` state. If the trial request sent while\nin the `HALF_OPEN` state succeeds, the circuit goes back to the `CLOSED` state."
+            "label":"FailoverClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"An HTTP client endpoint which provides failover support over multiple HTTP clients.\n"
             },
-            "sortText": "120",
-            "insertText": "CircuitState",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FailoverClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitHealth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Maintains the health of the Circuit Breaker.\n"
+            "label":"FailoverClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of HTTP related configurations and failover related configurations.\nFollowing fields are inherited from the other configuration records in addition to the failover client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
-            "sortText": "120",
-            "insertText": "CircuitHealth",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"FailoverClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+            "label":"CircuitState",
+            "detail":"Union",
+            "documentation":{
+                "left":"A finite type for modeling the states of the Circuit Breaker. The Circuit Breaker starts in the `CLOSED` state.\nIf any failure thresholds are exceeded during execution, the circuit trips and goes to the `OPEN` state. After\nthe specified timeout period expires, the circuit goes to the `HALF_OPEN` state. If the trial request sent while\nin the `HALF_OPEN` state succeeds, the circuit goes back to the `CLOSED` state."
             },
-            "sortText": "120",
-            "insertText": "CircuitBreakerConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CircuitState",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RollingWindow",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents a rolling window in the Circuit Breaker.\n"
+            "label":"CircuitHealth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Maintains the health of the Circuit Breaker.\n"
             },
-            "sortText": "120",
-            "insertText": "RollingWindow",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CircuitHealth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Bucket",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents a discrete sub-part of the time window (Bucket).\n"
+            "label":"CircuitBreakerConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the behaviour of the Circuit Breaker.\n"
             },
-            "sortText": "120",
-            "insertText": "Bucket",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CircuitBreakerConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerInferredConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Derived set of configurations from the `CircuitBreakerConfig`.\n\nThe threshold should be a value between 0 and 1\nthe upstream service"
+            "label":"RollingWindow",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents a rolling window in the Circuit Breaker.\n"
             },
-            "sortText": "120",
-            "insertText": "CircuitBreakerInferredConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RollingWindow",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CircuitBreakerClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "A Circuit Breaker implementation which can be used to gracefully handle network failures.\n"
+            "label":"Bucket",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents a discrete sub-part of the time window (Bucket).\n"
             },
-            "sortText": "120",
-            "insertText": "CircuitBreakerClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Bucket",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalancerRule",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "\nLoadBalancerRule provides a required interfaces to implement different algorithms.\n"
+            "label":"CircuitBreakerInferredConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Derived set of configurations from the `CircuitBreakerConfig`.\n"
             },
-            "sortText": "120",
-            "insertText": "LoadBalancerRule",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CircuitBreakerInferredConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RetryInferredConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Derived set of configurations from the `RetryConfig`.\n"
+            "label":"CircuitBreakerClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"A Circuit Breaker implementation which can be used to gracefully handle network failures.\n"
             },
-            "sortText": "120",
-            "insertText": "RetryInferredConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CircuitBreakerClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RetryClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n\nHTTP service in resilient manner."
+            "label":"LoadBalancerRule",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"\nLoadBalancerRule provides a required interfaces to implement different algorithms.\n"
             },
-            "sortText": "120",
-            "insertText": "RetryClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"LoadBalancerRule",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalancerRoundRobinRule",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Implementation of round robin load balancing strategy.\n"
+            "label":"RetryInferredConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Derived set of configurations from the `RetryConfig`.\n"
             },
-            "sortText": "120",
-            "insertText": "LoadBalancerRoundRobinRule",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RetryInferredConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "LoadBalanceClient endpoint provides load balancing functionality over multiple HTTP clients.\n"
+            "label":"RetryClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Provides the HTTP remote functions for interacting with an HTTP endpoint. This is created by wrapping the HTTP client\nto provide retrying over HTTP requests.\n"
             },
-            "sortText": "120",
-            "insertText": "LoadBalanceClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RetryClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceActionErrorData",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Represents the error attributes in addition to the message and the cause of the `LoadBalanceActionError`.\n"
+            "label":"LoadBalancerRoundRobinRule",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Implementation of round robin load balancing strategy.\n"
             },
-            "sortText": "120",
-            "insertText": "LoadBalanceActionErrorData",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"LoadBalancerRoundRobinRule",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceActionError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Represents an error occurred in an remote function of the Load Balance connector."
+            "label":"LoadBalanceClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"LoadBalanceClient endpoint provides load balancing functionality over multiple HTTP clients.\n"
             },
-            "sortText": "120",
-            "insertText": "LoadBalanceActionError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"LoadBalanceClient",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"LoadBalanceActionErrorData",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Represents an error occurred in an remote function of the Load Balance connector.\n"
+            },
+            "sortText":"120",
+            "insertText":"LoadBalanceActionErrorData",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"LoadBalanceActionError",
+            "kind":"Event",
+            "detail":"Error",
+            "sortText":"120",
+            "insertText":"LoadBalanceActionError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "LoadBalanceClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
+            "label":"LoadBalanceClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"The configurations related to the load balance client endpoint. Following fields are inherited from the other\nconfiguration records in addition to the load balance client specific configs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |\n"
             },
-            "sortText": "120",
-            "insertText": "LoadBalanceClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"LoadBalanceClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Listener",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "This is used for creating HTTP server endpoints. An HTTP server endpoint is capable of responding to\nremote callers. The `Listener` is responsible for initializing the endpoint using the provided configurations."
+            "label":"Listener",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"This is used for creating HTTP server endpoints. An HTTP server endpoint is capable of responding to\nremote callers. The `Listener` is responsible for initializing the endpoint using the provided configurations."
             },
-            "sortText": "120",
-            "insertText": "Listener",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Listener",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Remote",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Presents a read-only view of the remote address.\n"
+            "label":"Remote",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Presents a read-only view of the remote address.\n"
             },
-            "sortText": "120",
-            "insertText": "Remote",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Remote",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "Local",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Presents a read-only view of the local address.\n"
+            "label":"Local",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Presents a read-only view of the local address.\n"
             },
-            "sortText": "120",
-            "insertText": "Local",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"Local",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for HTTP service endpoints.\n\ncommunicate through HTTPS.\nresource, filters can applied\ndisable timeout"
+            "label":"ListenerConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for HTTP service endpoints.\n"
             },
-            "sortText": "120",
-            "insertText": "ListenerConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ListenerConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerHttp1Settings",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides settings related to HTTP/1.x protocol.\n\nwhich always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection\nconnection. By default 10 requests can be pipelined on a single cinnection and user can\nchange this limit appropriately.\n`414 - URI Too Long` response.\n`413 - Payload Too Large` response.\nis no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a\n`413 - Payload Too Large` response."
+            "label":"ListenerHttp1Settings",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides settings related to HTTP/1.x protocol.\n"
             },
-            "sortText": "120",
-            "insertText": "ListenerHttp1Settings",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ListenerHttp1Settings",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerAuth",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Authentication configurations for the listener.\n\nAn array is used to indicate that at least one of the authentication handlers should be successfully authenticated. An array consisting of arrays\nis used to indicate that at least one authentication handler from the sub-arrays should be successfully authenticated.\nbe successfully authorized. An array consisting of arrays is used to indicate that at least one scope from the sub-arrays\nshould successfully be authorized"
+            "label":"ListenerAuth",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Authentication configurations for the listener.\n"
             },
-            "sortText": "120",
-            "insertText": "ListenerAuth",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ListenerAuth",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ListenerSecureSocket",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configures the SSL/TLS options to be used for HTTP service.\n\nTLS_ECDHE_RSA_WITH_AES_128_CBC_SHA)"
+            "label":"ListenerSecureSocket",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configures the SSL/TLS options to be used for HTTP service.\n"
             },
-            "sortText": "120",
-            "insertText": "ListenerSecureSocket",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ListenerSecureSocket",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "KeepAlive",
-            "detail": "Union",
-            "documentation": {
-                "left": "Defines the possible values for the keep-alive configuration in service and client endpoints."
+            "label":"KeepAlive",
+            "detail":"Union",
+            "documentation":{
+                "left":"Defines the possible values for the keep-alive configuration in service and client endpoints."
             },
-            "sortText": "120",
-            "insertText": "KeepAlive",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"KeepAlive",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketCaller",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a WebSocket caller."
+            "label":"WebSocketCaller",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a WebSocket caller."
             },
-            "sortText": "120",
-            "insertText": "WebSocketCaller",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketCaller",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a WebSocket client endpoint."
+            "label":"WebSocketClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a WebSocket client endpoint."
             },
-            "sortText": "120",
-            "insertText": "WebSocketClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error.If the value < 0, then the value sets to the default value(300)."
+            "label":"WebSocketClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for the WebSocket client endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "WebSocketClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketRetryConfig",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Retry configurations for WebSocket.\n\npersist"
+            "label":"WebSocketRetryConfig",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Retry configurations for WebSocket.\n"
             },
-            "sortText": "120",
-            "insertText": "WebSocketRetryConfig",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketRetryConfig",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsConnectionClosureError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised during failures in connection closure"
+            "label":"WsConnectionClosureError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised during failures in connection closure"
             },
-            "sortText": "120",
-            "insertText": "WsConnectionClosureError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsConnectionClosureError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsInvalidHandshakeError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised during the handshake when the WebSocket upgrade fails"
+            "label":"WsInvalidHandshakeError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised during the handshake when the WebSocket upgrade fails"
             },
-            "sortText": "120",
-            "insertText": "WsInvalidHandshakeError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsInvalidHandshakeError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsPayloadTooBigError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised when receiving a frame with a payload exceeding the maximum size"
+            "label":"WsPayloadTooBigError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised when receiving a frame with a payload exceeding the maximum size"
             },
-            "sortText": "120",
-            "insertText": "WsPayloadTooBigError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsPayloadTooBigError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsProtocolError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised when the other side breaks the protocol"
+            "label":"WsProtocolError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised when the other side breaks the protocol"
             },
-            "sortText": "120",
-            "insertText": "WsProtocolError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsProtocolError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsConnectionError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised during connection failures"
+            "label":"WsConnectionError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised during connection failures"
             },
-            "sortText": "120",
-            "insertText": "WsConnectionError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsConnectionError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsInvalidContinuationFrameError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised when an out of order/invalid continuation frame is received"
+            "label":"WsInvalidContinuationFrameError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised when an out of order/invalid continuation frame is received"
             },
-            "sortText": "120",
-            "insertText": "WsInvalidContinuationFrameError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsInvalidContinuationFrameError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WsGenericError",
-            "kind": "Event",
-            "detail": "Error",
-            "documentation": {
-                "left": "Raised for errors not captured by the specific errors"
+            "label":"WsGenericError",
+            "kind":"Event",
+            "detail":"Error",
+            "documentation":{
+                "left":"Raised for errors not captured by the specific errors"
             },
-            "sortText": "120",
-            "insertText": "WsGenericError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WsGenericError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketError",
-            "kind": "Event",
-            "detail": "Union",
-            "documentation": {
-                "left": "The union of all the WebSocket related errors"
+            "label":"WebSocketError",
+            "kind":"Event",
+            "detail":"Union",
+            "documentation":{
+                "left":"The union of all the WebSocket related errors"
             },
-            "sortText": "120",
-            "insertText": "WebSocketError",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketError",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketFailoverClient",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "A WebSocket client endpoint, which provides failover support for multiple WebSocket targets."
+            "label":"WebSocketFailoverClient",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"A WebSocket client endpoint, which provides failover support for multiple WebSocket targets."
             },
-            "sortText": "120",
-            "insertText": "WebSocketFailoverClient",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketFailoverClient",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "WebSocketFailoverClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Configurations for the WebSocket client endpoint.\n\nreceipt of messages from the server\nof the client service will be triggered\nThis is set to `true` by default. If changed to `false`, the ready() function of the\n`WebSocketFailoverClient` needs to be called once to start receiving messages\nIf this is not set, is negative, or is zero, the default frame size of 65536 will be used.\nthe webSocket handshake. If the timeout exceeds, then the connection is terminated with\nan error. If the value < 0, then the value sets to the default value(300)"
+            "label":"WebSocketFailoverClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Configurations for the WebSocket client endpoint.\n"
             },
-            "sortText": "120",
-            "insertText": "WebSocketFailoverClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"WebSocketFailoverClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthnFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of the Authentication filter.\n"
+            "label":"AuthnFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of the Authentication filter.\n"
             },
-            "sortText": "120",
-            "insertText": "AuthnFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AuthnFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "AuthzFilter",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of the Authorization filter.\n"
+            "label":"AuthzFilter",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of the Authorization filter.\n"
             },
-            "sortText": "120",
-            "insertText": "AuthzFilter",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"AuthzFilter",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "BasicAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Defines the Basic Auth header handler for inbound and outbound HTTP traffic."
+            "label":"BasicAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Defines the Basic Auth header handler for inbound and outbound HTTP traffic.\n"
             },
-            "sortText": "120",
-            "insertText": "BasicAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"BasicAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "BearerAuthHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic."
+            "label":"BearerAuthHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Representation of the Bearer Auth header handler for both inbound and outbound HTTP traffic.\n"
             },
-            "sortText": "120",
-            "insertText": "BearerAuthHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"BearerAuthHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ClientConfiguration",
-            "kind": "Struct",
-            "detail": "Record",
-            "documentation": {
-                "left": "Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
+            "label":"ClientConfiguration",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.\nFollowing fields are inherited from the other configuration records in addition to the Client specific\nconfigs.\n\n|                                                         |\n|:------------------------------------------------------- |\n| httpVersion - Copied from CommonClientConfiguration     |\n| http1Settings - Copied from CommonClientConfiguration   |\n| http2Settings - Copied from CommonClientConfiguration   |\n| timeoutInMillis - Copied from CommonClientConfiguration |\n| forwarded - Copied from CommonClientConfiguration       |\n| followRedirects - Copied from CommonClientConfiguration |\n| poolConfig - Copied from CommonClientConfiguration      |\n| cache - Copied from CommonClientConfiguration           |\n| compression - Copied from CommonClientConfiguration     |\n| auth - Copied from CommonClientConfiguration            |\n| circuitBreaker - Copied from CommonClientConfiguration  |\n| retryConfig - Copied from CommonClientConfiguration     |\n| cookieConfig - Copied from CommonClientConfiguration    |"
             },
-            "sortText": "120",
-            "insertText": "ClientConfiguration",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ClientConfiguration",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "CsvPersistentCookieHandler",
-            "kind": "Interface",
-            "detail": "Object",
-            "documentation": {
-                "left": "Represents a default persistent cookie handler, which stores persistent cookies in a CSV file.\n"
+            "label":"CsvPersistentCookieHandler",
+            "kind":"Interface",
+            "detail":"Object",
+            "documentation":{
+                "left":"Represents a default persistent cookie handler, which stores persistent cookies in a CSV file.\n"
             },
-            "sortText": "120",
-            "insertText": "CsvPersistentCookieHandler",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"CsvPersistentCookieHandler",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "RequestMessage",
-            "kind": "Enum",
-            "detail": "Union",
-            "documentation": {
-                "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+            "label":"RequestMessage",
+            "kind":"Enum",
+            "detail":"Union",
+            "documentation":{
+                "left":"The types of messages that are accepted by HTTP `client` when sending out the outbound request."
             },
-            "sortText": "120",
-            "insertText": "RequestMessage",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"RequestMessage",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "ResponseMessage",
-            "kind": "Enum",
-            "detail": "Union",
-            "documentation": {
-                "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+            "label":"ResponseMessage",
+            "kind":"Enum",
+            "detail":"Union",
+            "documentation":{
+                "left":"The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
             },
-            "sortText": "120",
-            "insertText": "ResponseMessage",
-            "insertTextFormat": "Snippet"
+            "sortText":"120",
+            "insertText":"ResponseMessage",
+            "insertTextFormat":"Snippet"
         },
         {
-            "label": "extractAuthorizationHeaderValue(http:Request req)(string)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
+            "label":"extractAuthorizationHeaderValue(http:Request req)(string)",
+            "kind":"Function",
+            "detail":"Function",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"**Package:** _ballerina/http_  \n  \nExtracts the Authorization header value from the request.\n  \n**Params**  \n- `http:Request` req: The `Request` instance  \n  \n**Returns** `string`   \n- Value of the Authorization header  \n  \n"
                 }
             },
-            "sortText": "120",
-            "insertText": "extractAuthorizationHeaderValue(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
+            "sortText":"120",
+            "insertText":"extractAuthorizationHeaderValue(${1})",
+            "insertTextFormat":"Snippet",
+            "command":{
+                "title":"editor.action.triggerParameterHints",
+                "command":"editor.action.triggerParameterHints"
             }
         },
         {
-            "label": "isResourceSecured(http:FilterContext context)(boolean)",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
+            "label":"isResourceSecured(http:FilterContext context)(boolean)",
+            "kind":"Function",
+            "detail":"Function",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"**Package:** _ballerina/http_  \n  \nChecks whether the calling resource is secured by evaluating the authentication hierarchy.\n  \n**Params**  \n- `http:FilterContext` context: The `FilterContext` instance  \n  \n**Returns** `boolean`   \n- The status of calling resource is secured or not  \n  \n"
                 }
             },
-            "sortText": "120",
-            "insertText": "isResourceSecured(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
+            "sortText":"120",
+            "insertText":"isResourceSecured(${1})",
+            "insertTextFormat":"Snippet",
+            "command":{
+                "title":"editor.action.triggerParameterHints",
+                "command":"editor.action.triggerParameterHints"
             }
         },
         {
-            "label": "createHttpCachingClient(string url, http:ClientConfiguration config, http:CacheConfig cacheConfig)((http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n\nor else an `http:ClientError`\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n  \n"
+            "label":"createHttpCachingClient(string url, http:ClientConfiguration config, http:CacheConfig cacheConfig)((http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "kind":"Function",
+            "detail":"Function",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of caching HTTP responses.\n  \n**Params**  \n- `string` url: The URL of the HTTP endpoint to connect  \n- `http:ClientConfiguration` config: The configurations for the client endpoint associated with the caching client  \n- `http:CacheConfig` cacheConfig: The configurations for the HTTP cache to be used with the caching client  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- An `http:HttpCachingClient` instance, which wraps the base `http:Client` with a caching layer   \n           or else an `http:ClientError`  \n  \n"
                 }
             },
-            "sortText": "120",
-            "insertText": "createHttpCachingClient(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
+            "sortText":"120",
+            "insertText":"createHttpCachingClient(${1})",
+            "insertTextFormat":"Snippet",
+            "command":{
+                "title":"editor.action.triggerParameterHints",
+                "command":"editor.action.triggerParameterHints"
             }
         },
         {
-            "label": "parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
+            "label":"parseHeader(string headerValue)(([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "kind":"Function",
+            "detail":"Function",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"**Package:** _ballerina/http_  \n  \nParses the given header value to extract its value and parameter map.\n  \n**Params**  \n- `string` headerValue: The header value  \n  \n**Returns** `([string,map<any>]|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- A tuple containing the value and its parameter map or else an `http:ClientError` if the header parsing fails  \n  \n"
                 }
             },
-            "sortText": "120",
-            "insertText": "parseHeader(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
+            "sortText":"120",
+            "insertText":"parseHeader(${1})",
+            "insertTextFormat":"Snippet",
+            "command":{
+                "title":"editor.action.triggerParameterHints",
+                "command":"editor.action.triggerParameterHints"
             }
         },
         {
-            "label": "invokeEndpoint(string path, http:Request outRequest, (FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE) requestAction, http:HttpClient httpClient, string verb)((http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
+            "label":"invokeEndpoint(string path, http:Request outRequest, (FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE) requestAction, http:HttpClient httpClient, string verb)((http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "kind":"Function",
+            "detail":"Function",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"**Package:** _ballerina/http_  \n  \nThe HEAD remote function implementation of the Circuit Breaker. This wraps the `head` function of the underlying\nHTTP remote function provider.  \n**Params**  \n- `string` path: Resource path  \n- `http:Request` outRequest: A Request struct  \n- `(FORWARD|GET|POST|DELETE|OPTIONS|PUT|PATCH|HEAD|SUBMIT|NONE)` requestAction: `HttpOperation` related to the request  \n- `http:HttpClient` httpClient: HTTP client which uses to call the relevant functions  \n- `string` verb: HTTP verb used for submit method(Defaultable)  \n  \n**Returns** `(http:Response|http:HttpFuture|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- The response for the request or an `http:ClientError` if failed to establish communication with the upstream server  \n  \n"
                 }
             },
-            "sortText": "120",
-            "insertText": "invokeEndpoint(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
+            "sortText":"120",
+            "insertText":"invokeEndpoint(${1})",
+            "insertTextFormat":"Snippet",
+            "command":{
+                "title":"editor.action.triggerParameterHints",
+                "command":"editor.action.triggerParameterHints"
             }
         },
         {
-            "label": "createHttpSecureClient(string url, http:ClientConfiguration config)((http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
-            "kind": "Function",
-            "detail": "Function",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": "**Package:** _ballerina/http:1.0.0_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
+            "label":"createHttpSecureClient(string url, http:ClientConfiguration config)((http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError))",
+            "kind":"Function",
+            "detail":"Function",
+            "documentation":{
+                "right":{
+                    "kind":"markdown",
+                    "value":"**Package:** _ballerina/http_  \n  \nCreates an HTTP client capable of securing HTTP requests with authentication.\n  \n**Params**  \n- `string` url: Base URL  \n- `http:ClientConfiguration` config: Client endpoint configurations  \n  \n**Returns** `(http:HttpClient|http:FailoverAllEndpointsFailedError|http:FailoverActionFailedError|http:UpstreamServiceUnavailableError|http:AllLoadBalanceEndpointsFailedError|http:AllRetryAttemptsFailed|http:IdleTimeoutError|http:AuthenticationError|http:AuthorizationError|http:InitializingOutboundRequestError|http:WritingOutboundRequestHeadersError|http:WritingOutboundRequestBodyError|http:InitializingInboundResponseError|http:ReadingInboundResponseHeadersError|http:ReadingInboundResponseBodyError|http:UnsupportedActionError|http:Http2ClientError|http:MaximumWaitTimeExceededError|http:SslError|http:GenericClientError|http:CookieHandlingError)`   \n- Created secure HTTP client  \n  \n"
                 }
             },
-            "sortText": "120",
-            "insertText": "createHttpSecureClient(${1})",
-            "insertTextFormat": "Snippet",
-            "command": {
-                "title": "editor.action.triggerParameterHints",
-                "command": "editor.action.triggerParameterHints"
+            "sortText":"120",
+            "insertText":"createHttpSecureClient(${1})",
+            "insertTextFormat":"Snippet",
+            "command":{
+                "title":"editor.action.triggerParameterHints",
+                "command":"editor.action.triggerParameterHints"
             }
         }
     ]

--- a/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
@@ -330,12 +330,17 @@ public type ClientSecureSocket record {|
 |};
 
 # Provides configurations for controlling the endpoint's behaviour in response to HTTP redirect related responses.
+# The response status codes of 301, 302, and 303 are redirected using a GET request while 300, 305, 307, and 308
+# status codes use the original request HTTP method during redirection.
 #
 # + enabled - Enable/disable redirection
 # + maxCount - Maximum number of redirects to follow
+# + allowAuthHeaders - By default Authorization and Proxy-Authorization headers are removed from the redirect requests.
+#                      Set it to true if Auth headers are needed to be sent during the redirection
 public type FollowRedirects record {|
     boolean enabled = false;
     int maxCount = 5;
+    boolean allowAuthHeaders = false;
 |};
 
 # Proxy server configurations to be used with the HTTP client endpoint.

--- a/stdlib/http/src/main/ballerina/src/http/http_commons.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_commons.bal
@@ -141,6 +141,8 @@ public type ResponseMessage Response|string|xml|json|byte[]|io:ReadableByteChann
 # `NONE`: No operation should be performed
 public type HttpOperation HTTP_FORWARD|HTTP_GET|HTTP_POST|HTTP_DELETE|HTTP_OPTIONS|HTTP_PUT|HTTP_PATCH|HTTP_HEAD
                                                                                                 |HTTP_SUBMIT|HTTP_NONE;
+# Defines the safe HTTP operations which do not modify resource representation.
+type safeHttpOperation HTTP_GET|HTTP_HEAD|HTTP_OPTIONS;
 
 // Common type used for HttpFuture and Response used for resiliency clients.
 type HttpResponse Response|HttpFuture;

--- a/stdlib/http/src/main/ballerina/src/http/http_headers.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_headers.bal
@@ -72,6 +72,9 @@ public const string LOCATION = "location";
 # HTTP header key `pragma`. Used in dealing with HTTP 1.0 caches which do not understand the `cache-control` header.
 public const string PRAGMA = "pragma";
 
+# HTTP header key `proxy-authorization`. Contains the credentials to authenticate a user agent to a proxy serve.
+public const string PROXY_AUTHORIZATION = "proxy-authorization";
+
 # HTTP header key `server`. Specifies the details of the origin server.
 public const string SERVER = "server";
 

--- a/stdlib/http/src/main/ballerina/src/http/redirect/redirect_client.bal
+++ b/stdlib/http/src/main/ballerina/src/http/redirect/redirect_client.bal
@@ -51,7 +51,7 @@ public type RedirectClient client object {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function get(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public function get(string path, public RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_GET);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -67,7 +67,7 @@ public type RedirectClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function post(string path, RequestMessage message) returns Response|ClientError {
+    public function post(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result =  performRedirectIfEligible(self, path, <Request>message, HTTP_POST);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -83,7 +83,7 @@ public type RedirectClient client object {
     # + message - An optional HTTP outbound request message or or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel`, or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function head(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public function head(string path, public RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_HEAD);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -99,7 +99,7 @@ public type RedirectClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function put(string path, RequestMessage message) returns Response|ClientError {
+    public function put(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PUT);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -125,7 +125,8 @@ public type RedirectClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public remote function execute(string httpVerb, string path, RequestMessage message) returns Response|ClientError {
+    public remote function execute(string httpVerb, string path, RequestMessage message) returns @tainted
+            Response|ClientError {
         Request request = <Request>message;
         //Redirection is performed only for HTTP methods
         if (HTTP_NONE == extractHttpOperation(httpVerb)) {
@@ -147,7 +148,7 @@ public type RedirectClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function patch(string path, RequestMessage message) returns Response|ClientError {
+    public function patch(string path, RequestMessage message) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_PATCH);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -163,7 +164,7 @@ public type RedirectClient client object {
     # + message - An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`,
     #             `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function delete(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public function delete(string path, public RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_DELETE);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -179,7 +180,7 @@ public type RedirectClient client object {
     # + message - An optional HTTP outbound request message or any payload of type `string`, `xml`, `json`,
     #             `byte[]`, `io:ReadableByteChannel` or `mime:Entity[]`
     # + return - An `http:Response` message or else an `http:ClientError` if the invocation fails
-    public function options(string path, public RequestMessage message = ()) returns Response|ClientError {
+    public function options(string path, public RequestMessage message = ()) returns @tainted Response|ClientError {
         var result = performRedirectIfEligible(self, path, <Request>message, HTTP_OPTIONS);
         if (result is HttpFuture) {
             return getInvalidTypeError();
@@ -244,13 +245,22 @@ public type RedirectClient client object {
 
 //Invoke relevant HTTP client action and check the response for redirect eligibility.
 function performRedirectIfEligible(RedirectClient redirectClient, string path, Request request,
-                                   HttpOperation httpOperation) returns HttpResponse|ClientError {
+                                   HttpOperation httpOperation) returns @tainted HttpResponse|ClientError {
     string originalUrl = redirectClient.url + path;
     log:printDebug(function() returns string {
         return "Checking redirect eligibility for original request " + originalUrl;
     });
-    HttpResponse|ClientError result = invokeEndpoint(path, request, httpOperation, redirectClient.httpClient);
-    return checkRedirectEligibility(result, originalUrl, httpOperation, request, redirectClient);
+
+    Request inRequest = request;
+    if !(httpOperation is safeHttpOperation) {
+        // When performing redirect operation for non-safe method, message needs to be built before sending out the
+        // to keep the request message to subsequent redirect.
+        var binaryPayload = check inRequest.getBinaryPayload();
+        // Build message for for multipart requests
+        inRequest = check populateMultipartRequest(inRequest);
+    }
+    HttpResponse|ClientError result = invokeEndpoint(path, inRequest, httpOperation, redirectClient.httpClient);
+    return checkRedirectEligibility(result, originalUrl, httpOperation, inRequest, redirectClient);
 }
 
 //Inspect the response for redirect eligibility.
@@ -339,7 +349,8 @@ function performRedirection(string location, RedirectClient redirectClient, Http
         log:printDebug(function() returns string {
                 return "Redirect using new clientEP : " + location;
             });
-        HttpResponse|ClientError result = invokeEndpoint("", createRedirectRequest(response.statusCode, request),
+        HttpResponse|ClientError result = invokeEndpoint("",
+            createRedirectRequest(request, redirectClient.redirectConfig.allowAuthHeaders),
             redirectMethod, retryClient);
         return checkRedirectEligibility(result, location, redirectMethod, request, redirectClient);
     } else {
@@ -367,36 +378,38 @@ function createNewEndpointConfig(ClientConfiguration config) returns ClientConfi
     return newEpConfig;
 }
 
-//Get the HTTP method that should be used for redirection based on the status code.
+// Get the HTTP method that should be used for redirection based on the status code.
+// As per rfc7231 and rfc7538,
+// +-------------------------------------------+-----------+-----------+
+// |                                           | Permanent | Temporary |
+// +-------------------------------------------+-----------+-----------+
+// | Allows changing the request method from   | 301       | 302       |
+// | POST to GET                               |           |           |
+// | Does not allow changing the request       | 308       | 307       |
+// | method from POST to GET                   |           |           |
+// +-------------------------------------------+-----------+-----------+
 function getRedirectMethod(HttpOperation httpVerb, Response response) returns HttpOperation|() {
     int statusCode = response.statusCode;
-    if ((statusCode == STATUS_MULTIPLE_CHOICES || statusCode == STATUS_USE_PROXY || statusCode == STATUS_TEMPORARY_REDIRECT
-            || statusCode == STATUS_PERMANENT_REDIRECT) && (httpVerb == HTTP_GET || httpVerb == HTTP_HEAD)) {
-        return httpVerb;
-    } else if ((statusCode == STATUS_MOVED_PERMANENTLY || statusCode == STATUS_FOUND) &&
-        (httpVerb == HTTP_GET || httpVerb == HTTP_HEAD)) {
+    if (statusCode == STATUS_MOVED_PERMANENTLY || statusCode == STATUS_FOUND || statusCode == STATUS_SEE_OTHER) {
         return HTTP_GET;
-    } else if (statusCode == STATUS_SEE_OTHER) {
-        return HTTP_GET;
-    } else {
-        return ();
     }
+    if (statusCode == STATUS_TEMPORARY_REDIRECT || statusCode == STATUS_PERMANENT_REDIRECT ||
+               statusCode == STATUS_MULTIPLE_CHOICES || statusCode == STATUS_USE_PROXY) {
+        return httpVerb;
+    }
+    log:printDebug(function() returns string {
+        return "unsupported redirect status code" + statusCode.toString();
+    });
+    return ();
 }
 
-function createRedirectRequest(int statusCode, Request request) returns Request {
-    Request redirectRequest = new;
-    string[] headerNames = <@untainted string[]> request.getHeaderNames();
-    foreach var headerName in headerNames {
-        string[] headerValues = request.getHeaders(headerName);
-        foreach var headerValue in headerValues {
-            redirectRequest.addHeader(headerName, headerValue);
-        }
+function createRedirectRequest(Request request, boolean allowAuthHeaders) returns Request {
+    if (allowAuthHeaders) {
+        return request;
     }
-    if (statusCode == STATUS_SEE_OTHER) {
-        redirectRequest.removeHeader(TRANSFER_ENCODING);
-        redirectRequest.removeHeader(CONTENT_LENGTH);
-    }
-    return redirectRequest;
+    request.removeHeader(AUTHORIZATION);
+    request.removeHeader(PROXY_AUTHORIZATION);
+    return request;
 }
 
 function isAbsolute(string locationUrl) returns boolean {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/RedirectTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/sample/RedirectTestCase.java
@@ -123,4 +123,32 @@ public class RedirectTestCase extends HttpBaseTest {
         Assert.assertEquals(response.getData(), "HTTPs Result:https://localhost:9104/redirect3/result",
                 "Incorrect resolvedRequestedURI");
     }
+
+    @Test(description = "Test non-safe method redirect to an HTTP location.")
+    public void testRedirectWithPOST() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
+                                                                                         "service1/doPost"));
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(),
+                            "Received:Payload redirected:Proxy:http://localhost:9102/redirect2/echo",
+                            "Incorrect resolvedRequestedURI");
+    }
+
+    @Test(description = "Test non-safe method redirect to an HTTPs location.")
+    public void testWithHTTPs() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
+                                                                                         "service1/doSecurePut"));
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "Received:Secure payload:No Proxy:http://localhost:9102/redirect2/echo",
+                            "Incorrect resolvedRequestedURI");
+    }
+
+    @Test(description = "Test mutlipart redirect.")
+    public void testMutlipartRedirect() throws IOException {
+        HttpResponse response = HttpClientRequest.doGet(serverInstance.getServiceURLHttp(servicePort,
+                                                                                         "service1/testMultipart"));
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "{\"name\":\"wso2\"}:http://localhost:9102/redirect2/echo",
+                            "Incorrect resolvedRequestedURI");
+    }
 }

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/11_http_redirects.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/11_http_redirects.bal
@@ -17,6 +17,7 @@
 import ballerina/config;
 import ballerina/http;
 import ballerina/io;
+import ballerina/mime;
 
 listener http:Listener serviceEndpoint2 = new(9102);
 
@@ -45,6 +46,10 @@ http:ClientConfiguration endPoint3Config = {
     followRedirects: { enabled: true }
 };
 
+http:ClientConfiguration endPoint4Config = {
+    followRedirects: { enabled: true, allowAuthHeaders : true }
+};
+
 http:ClientConfiguration endPoint5Config = {
     followRedirects: { enabled: true },
     secureSocket: {
@@ -55,6 +60,12 @@ http:ClientConfiguration endPoint5Config = {
     }
 };
 
+http:Client endPoint1 = new("http://localhost:9103", endPoint1Config );
+http:Client endPoint2 = new("http://localhost:9103", endPoint2Config );
+http:Client endPoint3 = new("http://localhost:9102", endPoint3Config );
+http:Client endPoint4 = new("http://localhost:9103");
+http:Client endPoint5 = new("https://localhost:9104", endPoint5Config );
+
 @http:ServiceConfig {
     basePath: "/service1"
 }
@@ -64,7 +75,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/"
     }
     resource function redirectClient(http:Caller caller, http:Request req) {
-        http:Client endPoint1 = new("http://localhost:9103", endPoint1Config );
         var response = endPoint1->get("/redirect1");
         http:Response finalResponse = new;
         if (response is http:Response) {
@@ -80,7 +90,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/maxRedirect"
     }
     resource function maxRedirectClient(http:Caller caller, http:Request req) {
-        http:Client endPoint1 = new("http://localhost:9103", endPoint1Config );
         var response = endPoint1->get("/redirect1/round1");
         if (response is http:Response) {
             string value = "";
@@ -99,7 +108,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/crossDomain"
     }
     resource function crossDomain(http:Caller caller, http:Request req) {
-        http:Client endPoint2 = new("http://localhost:9103", endPoint2Config );
         var response = endPoint2->get("/redirect1/round1");
         if (response is http:Response) {
             var value = response.getTextPayload();
@@ -119,7 +127,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/noRedirect"
     }
     resource function NoRedirect(http:Caller caller, http:Request req) {
-        http:Client endPoint3 = new("http://localhost:9102", endPoint3Config );
         var response = endPoint3->get("/redirect2");
         if (response is http:Response) {
             var value = response.getTextPayload();
@@ -139,7 +146,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/qpWithRelativePath"
     }
     resource function qpWithRelativePath(http:Caller caller, http:Request req) {
-        http:Client endPoint2 = new("http://localhost:9103", endPoint2Config );
         var response = endPoint2->get("/redirect1/qpWithRelativePath");
         if (response is http:Response) {
             var value = response.getTextPayload();
@@ -159,7 +165,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/qpWithAbsolutePath"
     }
     resource function qpWithAbsolutePath(http:Caller caller, http:Request req) {
-        http:Client endPoint2 = new("http://localhost:9103", endPoint2Config );
         var response = endPoint2->get("/redirect1/qpWithAbsolutePath");
         if (response is http:Response) {
             var value = response.getTextPayload();
@@ -179,7 +184,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/originalRequestWithQP"
     }
     resource function originalRequestWithQP(http:Caller caller, http:Request req) {
-        http:Client endPoint2 = new("http://localhost:9103", endPoint2Config );
         var response = endPoint2->get("/redirect1/round4?key=value&lang=ballerina");
         if (response is http:Response) {
             var value = response.getTextPayload();
@@ -199,7 +203,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/test303"
     }
     resource function test303(http:Caller caller, http:Request req) {
-        http:Client endPoint3 = new("http://localhost:9102", endPoint3Config );
         var response = endPoint3->post("/redirect2/test303", "Test value!");
         if (response is http:Response) {
             var value = response.getTextPayload();
@@ -219,7 +222,6 @@ service testRedirect on serviceEndpoint3 {
         path: "/redirectOff"
     }
     resource function redirectOff(http:Caller caller, http:Request req) {
-        http:Client endPoint4 = new("http://localhost:9103");
         var response = endPoint4->get("/redirect1/round1");
         if (response is http:Response) {
             string value = "";
@@ -238,8 +240,79 @@ service testRedirect on serviceEndpoint3 {
         path: "/httpsRedirect"
     }
     resource function redirectWithHTTPs(http:Caller caller, http:Request req) {
-        http:Client endPoint5 = new("https://localhost:9104", endPoint5Config );
         var response = endPoint5->get("/redirect3");
+        if (response is http:Response) {
+            var value = response.getTextPayload();
+            if (value is string) {
+                value = value + ":" + response.resolvedRequestedURI;
+                checkpanic caller->respond(<@untainted> value);
+            } else {
+                io:println("Payload error!");
+            }
+        } else {
+            io:println("Connector error!");
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/doPost"
+    }
+    resource function PostClearText(http:Caller caller, http:Request request) {
+        http:Client endPoint4 = new("http://localhost:9103", endPoint4Config );
+        http:Request req = new;
+        req.setHeader("Proxy-Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
+        req.setTextPayload("Payload redirected");
+        var response = endPoint4->post("/redirect1/handlePost", req);
+        if (response is http:Response) {
+            var value = response.getTextPayload();
+            if (value is string) {
+                value = value + ":" + response.resolvedRequestedURI;
+                checkpanic caller->respond(<@untainted> value);
+            } else {
+                io:println("Payload error!");
+            }
+        } else {
+            io:println("Connector error!");
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/doSecurePut"
+    }
+    resource function testSecurePut(http:Caller caller, http:Request request) {
+        http:Request req = new;
+        req.setHeader("Proxy-Authorization", "Basic YWxhZGRpbjpvcGVuc2VzYW1l");
+        req.setTextPayload("Secure payload");
+        var response = endPoint5->put("/redirect3/handlePost", req);
+        if (response is http:Response) {
+            var value = response.getTextPayload();
+            if (value is string) {
+                value = value + ":" + response.resolvedRequestedURI;
+                checkpanic caller->respond(<@untainted> value);
+            } else {
+                io:println("Payload error!");
+            }
+        } else {
+            io:println("Connector error!");
+        }
+    }
+
+    @http:ResourceConfig {
+        methods: ["GET"],
+        path: "/testMultipart"
+    }
+    resource function PostMultipart(http:Caller caller, http:Request req) {
+        http:Client endPoint3 = new("http://localhost:9103", endPoint3Config );
+        mime:Entity jsonBodyPart = new;
+        jsonBodyPart.setContentDisposition(getContentDisposition("json part"));
+        jsonBodyPart.setJson({"name": "wso2"});
+        mime:Entity[] bodyParts = [jsonBodyPart];
+        http:Request request = new;
+        request.setBodyParts(bodyParts, contentType = mime:MULTIPART_FORM_DATA);
+
+        var response = endPoint3->post("/redirect1/handlePost", request);
         if (response is http:Response) {
             var value = response.getTextPayload();
             if (value is string) {
@@ -344,6 +417,15 @@ service redirect1 on serviceEndpoint3 {
         string returnVal = (arr1 is string[] ? arr1[0] : "") + ":" + (arr2 is string[] ? arr2[0] : "");
         checkpanic caller->respond(<@untainted> returnVal);
     }
+
+    @http:ResourceConfig {
+        methods: ["POST", "PUT"]
+    }
+    resource function handlePost(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        checkpanic caller->redirect(res, http:REDIRECT_TEMPORARY_REDIRECT_307, [
+                "http://localhost:9102/redirect2/echo"]);
+    }
 }
 
 @http:ServiceConfig {
@@ -369,6 +451,39 @@ service redirect2 on serviceEndpoint2 {
         http:Response res = new;
         checkpanic caller->redirect(res, http:REDIRECT_SEE_OTHER_303, ["/redirect2"]);
     }
+
+    @http:ResourceConfig {
+        methods: ["POST", "PUT"]
+    }
+    resource function echo(http:Caller caller, http:Request req) {
+        string hasAuthHeader = "No Proxy";
+        if (req.hasHeader("Proxy-Authorization")) {
+            hasAuthHeader = "Proxy";
+        }
+        var value = req.getTextPayload();
+        if (value is string) {
+            value = "Received:" + value + ":" + hasAuthHeader;
+            checkpanic caller->respond(<@untainted> value);
+        } else {
+            http:Response res = new;
+            var bodyParts = req.getBodyParts();
+            if (bodyParts is mime:Entity[]) {
+                foreach var part in bodyParts {
+                    var payload = part.getJson();
+                    if (payload is json) {
+                        res.setPayload(<@untainted> payload);
+                    } else {
+                        res.setPayload(<@untainted> <string> payload.detail()?.message);
+                    }
+                    break; //Accepts only one part
+                }
+            } else {
+                res.setPayload("Payload retrieval error!");
+                res.statusCode = 500;
+            }
+            checkpanic caller->respond(res);
+        }
+    }
 }
 
 @http:ServiceConfig {
@@ -393,4 +508,20 @@ service redirect3 on httpsEP {
     resource function finalResult(http:Caller caller, http:Request req) {
         checkpanic caller->respond("HTTPs Result");
     }
+
+    @http:ResourceConfig {
+        methods: ["PUT"]
+    }
+    resource function handlePost(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        checkpanic caller->redirect(res, http:REDIRECT_PERMANENT_REDIRECT_308, [
+                "http://localhost:9103/redirect1/handlePost"]);
+    }
+}
+
+function getContentDisposition(string partName) returns mime:ContentDisposition {
+    mime:ContentDisposition contentDisposition = new;
+    contentDisposition.name = partName;
+    contentDisposition.disposition = "form-data";
+    return contentDisposition;
 }


### PR DESCRIPTION
## Purpose
> Duplicate of #24734 to the 1.2.x branch

> Existing implementation serves auto redirection only for GET and HEAD methods as there was a requirement of getting user consent before performing redirection for non-safe HTTP methods in rfc2616. But that requirement has been dropped in rfc7231 and if the user enables redirect config in the client configuration, then it also implies the consent as the redirection is disabled in HTTP client by default.

> Also, rfc7231 and rfc7538 specify that 307 and 308 should not allow changing the request method from POST to GET. That means a POST request should be repeated using another POST request during the redirection.

> Hence the PR is to improve the HTTP client redirect logic to allow non-safe HTTP method (POST, PUT, ...) redirection for the 307(Temporary Redirect) and 308(Permanent Redirect) response status codes. 

> Add new config field  `boolean allowAuthHeaders = false;` is introduced and By default Authorization, Proxy-Authenticate, Proxy-Authorization, and WWW-Authenticate headers are removed from the redirect requests. Send them if it set to true during the redirection

Fixes #24681


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
