### PR TITLE
Fixes setting next trx context as current, before trx statement finishes

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/scheduling/Strand.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/scheduling/Strand.java
@@ -124,7 +124,7 @@ public class Strand {
     }
 
     public boolean isInTransaction() {
-        return this.currentTrxContext != null;
+        return this.currentTrxContext != null && this.currentTrxContext.isTransactional();
     }
 
     @Deprecated

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/transactions/TransactionLocalContext.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/transactions/TransactionLocalContext.java
@@ -48,6 +48,7 @@ public class TransactionLocalContext {
     private Object rollbackOnlyError;
     private Object transactionData;
     private BArray transactionId;
+    private boolean isTransactional;
 
     private TransactionLocalContext(String globalTransactionId, String url, String protocol, Object infoRecord) {
         this.globalTransactionId = globalTransactionId;
@@ -60,6 +61,7 @@ public class TransactionLocalContext {
         this.transactionBlockIdStack = new Stack<>();
         this.transactionFailure = new Stack<>();
         this.rollbackOnlyError = null;
+        this.isTransactional = true;
         this.transactionId = BValueCreator.createArrayValue(globalTransactionId.getBytes());
         transactionResourceManager.transactionInfoMap.put(transactionId, infoRecord);
     }
@@ -229,6 +231,14 @@ public class TransactionLocalContext {
 
     public Object getInfoRecord() {
         return transactionResourceManager.transactionInfoMap.get(transactionId);
+    }
+
+    public boolean isTransactional() {
+        return isTransactional;
+    }
+
+    public void setTransactional(boolean transactional) {
+        isTransactional = transactional;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangPackageBuilder.java
@@ -3235,8 +3235,9 @@ public class BLangPackageBuilder {
         retryNode.pos = pos;
         retryNode.addWS(ws);
         retryNode.setRetrySpec((BLangRetrySpec) this.retrySpecNodeStack.pop());
-        BLangBlockFunctionBody blockFunctionBody = (BLangBlockFunctionBody) this.blockNodeStack.peek();
-        retryNode.setTransaction((BLangTransaction) blockFunctionBody.stmts.remove(blockFunctionBody.stmts.size() - 1));
+        BlockNode blockNode = this.blockNodeStack.peek();
+        retryNode.setTransaction((BLangTransaction) blockNode.getStatements()
+                .remove(blockNode.getStatements().size() - 1));
         addStmtToCurrentBlock(retryNode);
     }
 

--- a/langlib/lang.transaction/src/main/ballerina/src/lang.transaction/internal.bal
+++ b/langlib/lang.transaction/src/main/ballerina/src/lang.transaction/internal.bal
@@ -512,7 +512,7 @@ public function startTransaction(string transactionBlockId, Info? prevAttempt = 
 # + return - A string or an error representing the transaction end succcess status or failure respectively.
 public transactional function endTransaction(string transactionId, string transactionBlockId)
         returns @tainted string|error? {
-
+    setContextAsNonTransactional();
     if (getRollbackOnly()) {
         return getRollbackOnlyError();
     }
@@ -625,3 +625,5 @@ function uuid() returns string = external;
 function timeNow() returns int = external;
 
 function getRollbackOnlyError() returns error? = external;
+
+function setContextAsNonTransactional() = external;

--- a/langlib/lang.transaction/src/main/ballerina/src/lang.transaction/internal.bal
+++ b/langlib/lang.transaction/src/main/ballerina/src/lang.transaction/internal.bal
@@ -512,7 +512,6 @@ public function startTransaction(string transactionBlockId, Info? prevAttempt = 
 # + return - A string or an error representing the transaction end succcess status or failure respectively.
 public transactional function endTransaction(string transactionId, string transactionBlockId)
         returns @tainted string|error? {
-    setContextAsNonTransactional();
     if (getRollbackOnly()) {
         return getRollbackOnlyError();
     }
@@ -522,6 +521,8 @@ public transactional function endTransaction(string transactionId, string transa
         error err = error("Transaction: " + participatedTxnId + " not found");
         panic err;
     }
+
+    setContextAsNonTransactional();
 
     // Only the initiator can end the transaction. Here we check whether the entity trying to end the transaction is
     // an initiator or just a local participant

--- a/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/SetContextAsNonTransactional.java
+++ b/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/SetContextAsNonTransactional.java
@@ -19,9 +19,7 @@
 package org.ballerinalang.langlib.transaction;
 
 import org.ballerinalang.jvm.scheduling.Strand;
-import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.natives.annotations.BallerinaFunction;
-import org.ballerinalang.natives.annotations.ReturnType;
 
 import static org.ballerinalang.util.BLangCompilerConstants.TRANSACTION_VERSION;
 

--- a/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/SetContextAsNonTransactional.java
+++ b/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/SetContextAsNonTransactional.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.transaction;
+
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.model.types.TypeKind;
+import org.ballerinalang.natives.annotations.BallerinaFunction;
+import org.ballerinalang.natives.annotations.ReturnType;
+
+import static org.ballerinalang.util.BLangCompilerConstants.TRANSACTION_VERSION;
+
+/**
+ * Extern function transaction:setContextAsNonTransactional.
+ *
+ * @since 2.0.0-preview1
+ */
+@BallerinaFunction(
+        orgName = "ballerina", packageName = "lang.transaction", version = TRANSACTION_VERSION,
+        functionName = "setContextAsNonTransactional",
+        args = {},
+        isPublic = true
+)
+public class SetContextAsNonTransactional {
+
+    public static void setContextAsNonTransactional(Strand strand) {
+        strand.currentTrxContext.setTransactional(false);
+    }
+}

--- a/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/SetContextAsNonTransactional.java
+++ b/langlib/lang.transaction/src/main/java/org/ballerinalang/langlib/transaction/SetContextAsNonTransactional.java
@@ -26,7 +26,7 @@ import static org.ballerinalang.util.BLangCompilerConstants.TRANSACTION_VERSION;
 /**
  * Extern function transaction:setContextAsNonTransactional.
  *
- * @since 2.0.0-preview1
+ * @since Swan Lake
  */
 @BallerinaFunction(
         orgName = "ballerina", packageName = "lang.transaction", version = TRANSACTION_VERSION,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/NestedTransactionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/NestedTransactionTest.java
@@ -111,7 +111,7 @@ public class NestedTransactionTest {
         BRunUtil.invoke(programFile, "testTransactionLangLib");
     }
 
-    @Test(enabled = false) //TODO: issue #24545
+    @Test
     public void testWithinTrxMode() {
         BValue[] result = BRunUtil.invoke(programFile, "testWithinTrxMode");
         Assert.assertEquals(result[0].stringValue(), "trxStarted -> within invoked function "
@@ -119,7 +119,7 @@ public class NestedTransactionTest {
                 + "-> trxCommited -> strand in non-transactional mode -> trxEnded.");
     }
 
-    @Test(enabled = false) //TODO: issue #24545
+    @Test
     public void testUnreachableCode() {
         BValue[] result = BRunUtil.invoke(programFile, "testUnreachableCode");
         Assert.assertEquals(result[0].stringValue(), "trxStarted -> trxCommited -> trxEnded.");

--- a/tests/jballerina-unit-test/src/test/resources/testng-jballerina.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng-jballerina.xml
@@ -139,6 +139,7 @@
             <class name="org.ballerinalang.test.statements.transaction.SetRollbackOnlyTest" />
             <class name="org.ballerinalang.test.statements.transaction.RetryTransactionStmtTest" />
             <class name="org.ballerinalang.test.statements.transaction.NestedTransactionTest" />
+            <class name="org.ballerinalang.test.statements.transaction.NestedRetryTransactionStmtsTest" />
             <!--<class name="org.ballerinalang.test.closures.VarMutabilityClosureTest" />-->
             <!--<class name="org.ballerinalang.test.lock.LocksInMainTest">-->
             <!--<methods>-->


### PR DESCRIPTION
## Purpose
> Fixes setting next trx context as current, before transaction statement finishes

Fixes #24545

## Approach
> Clean context at end of transaction statement

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
