### PR TITLE
Remove unnecessary @tainted annotation from the return IO channels

### DIFF
--- a/stdlib/io/src/main/ballerina/src/io/open.bal
+++ b/stdlib/io/src/main/ballerina/src/io/open.bal
@@ -23,7 +23,7 @@ import ballerina/java;
 #
 # + path - Relative/absolute path string to locate the file
 # + return - The `ByteChannel` representation of the file resource or else an `io:Error` if any error occurred
-public function openReadableFile(@untainted string path) returns @tainted ReadableByteChannel|Error = @java:Method {
+public function openReadableFile(@untainted string path) returns ReadableByteChannel|Error = @java:Method {
     name: "openReadableFile",
     class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
@@ -37,7 +37,7 @@ public function openReadableFile(@untainted string path) returns @tainted Readab
 # + append - Whether to append to the end of file
 # + return - The `ByteChannel` representation of the file resource or else an `io:Error` if any error occurred
 public function openWritableFile(@untainted string path, boolean append = false)
-    returns @tainted WritableByteChannel|Error = @java:Method {
+    returns WritableByteChannel|Error = @java:Method {
     name: "openWritableFile",
     class: "org.ballerinalang.stdlib.io.nativeimpl.ByteChannelUtils"
 } external;
@@ -67,7 +67,7 @@ public function createReadableChannel(byte[] content) returns ReadableByteChanne
 public function openReadableCsvFile(@untainted string path,
                                     @untainted public Separator fieldSeparator = ",",
                                     @untainted public string charset = "UTF-8",
-                                    @untainted public int skipHeaders = 0) returns @tainted ReadableCSVChannel|Error {
+                                    @untainted public int skipHeaders = 0) returns ReadableCSVChannel|Error {
     ReadableByteChannel byteChannel = check openReadableFile(path);
     ReadableCharacterChannel charChannel = new(byteChannel, charset);
     return new ReadableCSVChannel(charChannel, fieldSeparator, skipHeaders);
@@ -86,7 +86,7 @@ public function openReadableCsvFile(@untainted string path,
 public function openWritableCsvFile(@untainted string path,
                                     @untainted public Separator fieldSeparator = ",",
                                     @untainted public string charset = "UTF-8",
-                                    @untainted public int skipHeaders = 0) returns @tainted WritableCSVChannel|Error {
+                                    @untainted public int skipHeaders = 0) returns WritableCSVChannel|Error {
     WritableByteChannel byteChannel = check openWritableFile(path);
     WritableCharacterChannel charChannel = new(byteChannel, charset);
     return new WritableCSVChannel(charChannel, fieldSeparator);

--- a/stdlib/io/src/test/resources/test-src/io/bytes_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/bytes_io.bal
@@ -19,17 +19,17 @@ import ballerina/io;
 io:ReadableByteChannel? rch = ();
 io:WritableByteChannel? wch = ();
 
-function initReadableChannel(string filePath) returns @tainted io:Error? {
+function initReadableChannel(string filePath) returns io:Error? {
     var result = io:openReadableFile(filePath);
     if (result is io:ReadableByteChannel) {
-        rch = <@untainted> result;
+        rch = result;
     } else {
         return result;
     }
 }
 
 function initWritableChannel(string filePath) {
-    wch = <@untainted io:WritableByteChannel> io:openWritableFile(filePath);
+    wch = <io:WritableByteChannel> io:openWritableFile(filePath);
 }
 
 function readBytes(int numberOfBytes) returns @tainted byte[]|io:Error {

--- a/stdlib/io/src/test/resources/test-src/io/char_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/char_io.bal
@@ -20,23 +20,23 @@ io:ReadableCharacterChannel? rch = ();
 io:WritableCharacterChannel? wch = ();
 io:WritableCharacterChannel? wca = ();
 
-function initReadableChannel(string filePath, string encoding) returns @tainted io:Error? {
+function initReadableChannel(string filePath, string encoding) returns io:Error? {
     var byteChannel = io:openReadableFile(filePath);
     if (byteChannel is io:ReadableByteChannel) {
-        rch = <@untainted> new io:ReadableCharacterChannel(byteChannel, encoding);
+        rch = new io:ReadableCharacterChannel(byteChannel, encoding);
     } else {
         return byteChannel;
     }
 }
 
-function initWritableChannel(string filePath, string encoding) returns @tainted io:Error? {
+function initWritableChannel(string filePath, string encoding) returns io:Error? {
     io:WritableByteChannel byteChannel = check io:openWritableFile(filePath);
-    wch = <@untainted> new io:WritableCharacterChannel(byteChannel, encoding);
+    wch = new io:WritableCharacterChannel(byteChannel, encoding);
 }
 
-function initWritableChannelToAppend(string filePath, string encoding) returns @tainted io:Error? {
+function initWritableChannelToAppend(string filePath, string encoding) returns io:Error? {
     io:WritableByteChannel byteChannel = check io:openWritableFile(filePath, true);
-    wca = <@untainted> new io:WritableCharacterChannel(byteChannel, encoding);
+    wca = new io:WritableCharacterChannel(byteChannel, encoding);
 }
 
 function readCharacters(int numberOfCharacters) returns @tainted string|error {

--- a/stdlib/io/src/test/resources/test-src/io/csv_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/csv_io.bal
@@ -56,10 +56,10 @@ type CommonApp record {
 io:ReadableCSVChannel? rch = ();
 io:WritableCSVChannel? wch = ();
 
-function initReadableCsvChannel(string filePath, string encoding, io:Separator fieldSeparator) returns @tainted error? {
+function initReadableCsvChannel(string filePath, string encoding, io:Separator fieldSeparator) returns error? {
     var byteChannel = io:openReadableFile(filePath);
     if (byteChannel is io:ReadableByteChannel) {
-        io:ReadableCharacterChannel charChannel = new io:ReadableCharacterChannel(<@untainted>byteChannel, encoding);
+        io:ReadableCharacterChannel charChannel = new io:ReadableCharacterChannel(byteChannel, encoding);
         rch = new io:ReadableCSVChannel(charChannel, fieldSeparator);
     } else {
         return byteChannel;
@@ -67,13 +67,13 @@ function initReadableCsvChannel(string filePath, string encoding, io:Separator f
 }
 
 function initWritableCsvChannel(string filePath, string encoding, io:Separator fieldSeparator) returns error? {
-    io:WritableByteChannel byteChannel = check <@untainted>io:openWritableFile(filePath);
+    io:WritableByteChannel byteChannel = check io:openWritableFile(filePath);
     io:WritableCharacterChannel charChannel = new io:WritableCharacterChannel(byteChannel, encoding);
     wch = new io:WritableCSVChannel(charChannel, fieldSeparator);
 }
 
 function initOpenCsvChannel(string filePath, string encoding, io:Separator fieldSeparator, int nHeaders = 0) returns error? {
-    var byteChannel = <@untainted>io:openReadableFile(filePath);
+    var byteChannel = io:openReadableFile(filePath);
     if (byteChannel is io:ReadableByteChannel) {
         io:ReadableCharacterChannel charChannel = new io:ReadableCharacterChannel(byteChannel, encoding);
         rch = new io:ReadableCSVChannel(charChannel, fieldSeparator, nHeaders);

--- a/stdlib/io/src/test/resources/test-src/io/data_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/data_io.bal
@@ -16,14 +16,14 @@
 
 import ballerina/io;
 
-function testWriteFixedSignedInt(int value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
+function testWriteFixedSignedInt(int value, string path, io:ByteOrder byteOrder) returns io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeInt64(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadFixedSignedInt(string path, io:ByteOrder byteOrder) returns @tainted int|error {
+function testReadFixedSignedInt(string path, io:ByteOrder byteOrder) returns int|error {
     var ch = io:openReadableFile(path);
     if (ch is io:ReadableByteChannel) {
         io:ReadableDataChannel dataChannel = new(ch, byteOrder);
@@ -35,14 +35,14 @@ function testReadFixedSignedInt(string path, io:ByteOrder byteOrder) returns @ta
     }
 }
 
-function testWriteVarInt(int value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
+function testWriteVarInt(int value, string path, io:ByteOrder byteOrder) returns io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeVarInt(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadVarInt(string path, io:ByteOrder byteOrder) returns @tainted int|io:Error {
+function testReadVarInt(string path, io:ByteOrder byteOrder) returns int|io:Error {
     var ch = io:openReadableFile(path);
     if (ch is io:ReadableByteChannel) {
         io:ReadableDataChannel dataChannel = new(ch, byteOrder);
@@ -54,14 +54,14 @@ function testReadVarInt(string path, io:ByteOrder byteOrder) returns @tainted in
     }
 }
 
-function testWriteFixedFloat(float value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
+function testWriteFixedFloat(float value, string path, io:ByteOrder byteOrder) returns io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeFloat64(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadFixedFloat(string path, io:ByteOrder byteOrder) returns @tainted float|io:Error {
+function testReadFixedFloat(string path, io:ByteOrder byteOrder) returns float|io:Error {
     var ch = io:openReadableFile(path);
     if (ch is io:ReadableByteChannel) {
         io:ReadableDataChannel dataChannel = new(ch, byteOrder);
@@ -73,14 +73,14 @@ function testReadFixedFloat(string path, io:ByteOrder byteOrder) returns @tainte
     }
 }
 
-function testWriteBool(boolean value, string path, io:ByteOrder byteOrder) returns @tainted io:Error? {
+function testWriteBool(boolean value, string path, io:ByteOrder byteOrder) returns io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = dataChannel.writeBool(value);
     var closeResult = dataChannel.close();
 }
 
-function testReadBool(string path, io:ByteOrder byteOrder) returns @tainted boolean|io:Error {
+function testReadBool(string path, io:ByteOrder byteOrder) returns boolean|io:Error {
     var ch = io:openReadableFile(path);
     if (ch is io:ReadableByteChannel) {
         io:ReadableDataChannel dataChannel = new(ch, byteOrder);
@@ -92,7 +92,7 @@ function testReadBool(string path, io:ByteOrder byteOrder) returns @tainted bool
     }
 }
 
-function testWriteString(string path, string content, string encoding, io:ByteOrder byteOrder) returns @tainted io:Error? {
+function testWriteString(string path, string content, string encoding, io:ByteOrder byteOrder) returns io:Error? {
     io:WritableByteChannel ch = check io:openWritableFile(path);
     io:WritableDataChannel dataChannel = new(ch, byteOrder);
     var result = check dataChannel.writeString(content, encoding);
@@ -100,7 +100,7 @@ function testWriteString(string path, string content, string encoding, io:ByteOr
     return result;
 }
 
-function testReadString(string path, int nBytes, string encoding, io:ByteOrder byteOrder) returns @tainted string|io:Error {
+function testReadString(string path, int nBytes, string encoding, io:ByteOrder byteOrder) returns string|io:Error {
     var ch = io:openReadableFile(path);
     if (ch is io:ReadableByteChannel) {
         io:ReadableDataChannel dataChannel = new(ch, byteOrder);

--- a/stdlib/io/src/test/resources/test-src/io/record_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/record_io.bal
@@ -20,21 +20,21 @@ io:ReadableTextRecordChannel? rch = ();
 io:WritableTextRecordChannel? wch = ();
 
 function initReadableChannel(string filePath, string encoding, string recordSeparator,
-                                    string fieldSeparator) returns @tainted error? {
+                                    string fieldSeparator) returns error? {
     var byteChannel = io:openReadableFile(filePath);
     if (byteChannel is error) {
         return byteChannel;
     } else {
         io:ReadableCharacterChannel charChannel = new io:ReadableCharacterChannel(byteChannel, encoding);
-        rch = <@untainted io:ReadableTextRecordChannel> new io:ReadableTextRecordChannel(charChannel, fieldSeparator, recordSeparator);
+        rch = <io:ReadableTextRecordChannel> new io:ReadableTextRecordChannel(charChannel, fieldSeparator, recordSeparator);
     }
 }
 
 function initWritableChannel(string filePath, string encoding, string recordSeparator,
-                             string fieldSeparator) returns @tainted io:Error? {
+                             string fieldSeparator) returns io:Error? {
     io:WritableByteChannel byteChannel = check io:openWritableFile(filePath);
     io:WritableCharacterChannel charChannel = new io:WritableCharacterChannel(byteChannel, encoding);
-    wch = <@untainted io:WritableTextRecordChannel> new io:WritableTextRecordChannel(charChannel, fieldSeparator, recordSeparator);
+    wch = <io:WritableTextRecordChannel> new io:WritableTextRecordChannel(charChannel, fieldSeparator, recordSeparator);
 }
 
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24750

## Approach
Remove unnecessary `@tainted` annotation from the return channels.

## Samples
Do not need to use `@tainted` when open and close I/O channels.

```ballerina
public function main() returns error? {
    string srcPath = "src/resources/bal.jpg";
    string dstPath = "src/resources/balCopy.jpg";
    
    io:ReadableByteChannel srcCh = check io:openReadableFile(srcPath);
    io:WritableByteChannel dstCh = check io:openWritableFile(dstPath);

    var v1 = srcCh.close();
    var v2 = dstCh.close();
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
