### PR TITLE
Add unused import check in to if and foreach

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedNodeVisitor.java
@@ -432,7 +432,10 @@ public class UnusedNodeVisitor extends BaseNodeVisitor {
 
     @Override
     public void visit(BLangIf ifNode) {
-        // No implementation
+        ifNode.getBody().accept(this);
+        if (ifNode.getElseStatement() != null) {
+            ifNode.getElseStatement().accept(this);
+        }
     }
 
     @Override
@@ -447,7 +450,7 @@ public class UnusedNodeVisitor extends BaseNodeVisitor {
 
     @Override
     public void visit(BLangForeach foreach) {
-        // No implementation
+        foreach.body.accept(this);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
This will fix the unused import search not looking in if and foreach.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
