### PR TITLE
Fix StringLiteral as expression lhs

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -6243,10 +6243,13 @@ public class BallerinaParser extends AbstractParser {
     private STNode parseStringLiteral() {
         STToken token = peek();
         if (token.kind == SyntaxKind.STRING_LITERAL) {
-            return consume();
+            return parseBasicLiteral();
         } else {
             Solution sol = recover(token, ParserRuleContext.STRING_LITERAL);
-            return sol.recoveredNode;
+            if (sol.action == Action.REMOVE) {
+                return sol.recoveredNode;
+            }
+            return STNodeFactory.createBasicLiteralNode(sol.recoveredNode.kind, sol.recoveredNode);
         }
     }
 

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -4936,13 +4936,15 @@ public class BallerinaParser extends AbstractParser {
         }
     }
 
+    private STNode parseBasicLiteral() {
+        return parseBasicLiteral(consume());
+    }
     /**
      * Parse basic literals. It is assumed that we come here after validation.
      *
      * @return Parsed node
      */
-    private STNode parseBasicLiteral() {
-        STToken literalToken = consume();
+    private STNode parseBasicLiteral(STToken literalToken) {
         return STNodeFactory.createBasicLiteralNode(literalToken.kind, literalToken);
     }
 
@@ -6243,13 +6245,10 @@ public class BallerinaParser extends AbstractParser {
     private STNode parseStringLiteral() {
         STToken token = peek();
         if (token.kind == SyntaxKind.STRING_LITERAL) {
-            return parseBasicLiteral();
+            return consume();
         } else {
             Solution sol = recover(token, ParserRuleContext.STRING_LITERAL);
-            if (sol.action == Action.REMOVE) {
-                return sol.recoveredNode;
-            }
-            return STNodeFactory.createBasicLiteralNode(sol.recoveredNode.kind, sol.recoveredNode);
+            return sol.recoveredNode;
         }
     }
 
@@ -15873,6 +15872,7 @@ public class BallerinaParser extends AbstractParser {
                 return parseIdentifierRhsInStmtStartingBrace(readonlyKeyword);
             case STRING_LITERAL:
                 STNode key = parseStringLiteral();
+                key = parseBasicLiteral((STToken)key);
                 if (peek().kind == SyntaxKind.COLON_TOKEN) {
                     readonlyKeyword = STNodeFactory.createEmptyNode();
                     STNode colon = parseColon();

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -4936,15 +4936,13 @@ public class BallerinaParser extends AbstractParser {
         }
     }
 
-    private STNode parseBasicLiteral() {
-        return parseBasicLiteral(consume());
-    }
     /**
      * Parse basic literals. It is assumed that we come here after validation.
      *
      * @return Parsed node
      */
-    private STNode parseBasicLiteral(STToken literalToken) {
+    private STNode parseBasicLiteral() {
+        STToken literalToken = consume();
         return STNodeFactory.createBasicLiteralNode(literalToken.kind, literalToken);
     }
 
@@ -15872,13 +15870,13 @@ public class BallerinaParser extends AbstractParser {
                 return parseIdentifierRhsInStmtStartingBrace(readonlyKeyword);
             case STRING_LITERAL:
                 STNode key = parseStringLiteral();
-                key = parseBasicLiteral((STToken) key);
                 if (peek().kind == SyntaxKind.COLON_TOKEN) {
                     readonlyKeyword = STNodeFactory.createEmptyNode();
                     STNode colon = parseColon();
                     STNode valueExpr = parseExpression();
                     return STNodeFactory.createSpecificFieldNode(readonlyKeyword, key, colon, valueExpr);
                 }
+                key = STNodeFactory.createBasicLiteralNode(key.kind, key);
                 switchContext(ParserRuleContext.BLOCK_STMT);
                 startContext(ParserRuleContext.AMBIGUOUS_STMT);
                 STNode expr = parseExpressionRhs(DEFAULT_OP_PRECEDENCE, key, false, true);

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -15872,7 +15872,7 @@ public class BallerinaParser extends AbstractParser {
                 return parseIdentifierRhsInStmtStartingBrace(readonlyKeyword);
             case STRING_LITERAL:
                 STNode key = parseStringLiteral();
-                key = parseBasicLiteral((STToken)key);
+                key = parseBasicLiteral((STToken) key);
                 if (peek().kind == SyntaxKind.COLON_TOKEN) {
                     readonlyKeyword = STNodeFactory.createEmptyNode();
                     STNode colon = parseColon();

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/declarations/FunctionDefinitionTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/declarations/FunctionDefinitionTest.java
@@ -141,4 +141,9 @@ public class FunctionDefinitionTest extends AbstractDeclarationTest {
     public void testIncompleteExternalFunctionBodyRecovery() {
         testFile("func-definition/func_def_source_23.bal", "func-definition/func_def_assert_23.json");
     }
+
+    @Test
+    public void testFunctionWithInvalidExpressionStatement() {
+        testFile("func-definition/func_def_source_24.bal", "func-definition/func_def_assert_24.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/CallStatementTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/CallStatementTest.java
@@ -36,6 +36,11 @@ public class CallStatementTest extends AbstractStatementTest {
         testFile("call-stmt/call_stmt_source_02.bal", "call-stmt/call_stmt_assert_02.json");
     }
 
+    @Test
+    public void testCallStmtWithMethodCall() {
+        testFile("call-stmt/call_stmt_source_08.bal", "call-stmt/call_stmt_assert_08.json");
+    }
+
     // Recovery tests
 
     @Test

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_24.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_24.json
@@ -1,0 +1,181 @@
+{
+  "kind": "MODULE_PART",
+  "hasDiagnostics": true,
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "LIST",
+      "hasDiagnostics": true,
+      "children": [
+        {
+          "kind": "FUNCTION_DEFINITION",
+          "hasDiagnostics": true,
+          "children": [
+            {
+              "kind": "METADATA",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                }
+              ]
+            },
+            {
+              "kind": "PUBLIC_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "FUNCTION_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "main"
+            },
+            {
+              "kind": "FUNCTION_SIGNATURE",
+              "children": [
+                {
+                  "kind": "OPEN_PAREN_TOKEN"
+                },
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "CLOSE_PAREN_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "FUNCTION_BODY_BLOCK",
+              "hasDiagnostics": true,
+              "children": [
+                {
+                  "kind": "OPEN_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                },
+                {
+                  "kind": "LIST",
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "BLOCK_STATEMENT",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "OPEN_BRACE_TOKEN",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "LIST",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "INVALID_EXPRESSION_STATEMENT",
+                              "hasDiagnostics": true,
+                              "diagnostics": [
+                                "ERROR_INVALID_EXPRESSION_STATEMENT"
+                              ],
+                              "children": [
+                                {
+                                  "kind": "STRING_LITERAL",
+                                  "children": [
+                                    {
+                                      "kind": "STRING_LITERAL",
+                                      "value": "Name"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "SEMICOLON_TOKEN",
+                                  "isMissing": true,
+                                  "hasDiagnostics": true,
+                                  "diagnostics": [
+                                    "ERROR_MISSING_SEMICOLON_TOKEN"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "CLOSE_BRACE_TOKEN"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_BRACE_TOKEN",
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_INVALID_TOKEN"
+                  ],
+                  "leadingMinutiae": [
+                    {
+                      "kind": "INVALID_NODE_MINUTIAE",
+                      "invalidNode": {
+                        "kind": "SEMICOLON_TOKEN",
+                        "trailingMinutiae": [
+                          {
+                            "kind": "END_OF_LINE_MINUTIAE",
+                            "value": "\n"
+                          }
+                        ]
+                      }
+                    }
+                  ],
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "EOF_TOKEN",
+      "leadingMinutiae": [
+        {
+          "kind": "END_OF_LINE_MINUTIAE",
+          "value": "\n"
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_24.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_24.bal
@@ -1,0 +1,4 @@
+public function main() {
+    {"Name"};
+}
+

--- a/compiler/ballerina-parser/src/test/resources/statements/call-stmt/call_stmt_assert_08.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/call-stmt/call_stmt_assert_08.json
@@ -1,0 +1,201 @@
+{
+  "kind": "FUNCTION_DEFINITION",
+  "children": [
+    {
+      "kind": "METADATA",
+      "children": [
+        {
+          "kind": "LIST",
+          "children": []
+        }
+      ]
+    },
+    {
+      "kind": "PUBLIC_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "IDENTIFIER_TOKEN",
+      "value": "main"
+    },
+    {
+      "kind": "FUNCTION_SIGNATURE",
+      "children": [
+        {
+          "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": []
+        },
+        {
+          "kind": "CLOSE_PAREN_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "WHITESPACE_MINUTIAE",
+              "value": " "
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_BODY_BLOCK",
+      "children": [
+        {
+          "kind": "OPEN_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "kind": "LIST",
+          "children": [
+            {
+              "kind": "CALL_STATEMENT",
+              "children": [
+                {
+                  "kind": "METHOD_CALL",
+                  "children": [
+                    {
+                      "kind": "MAPPING_CONSTRUCTOR",
+                      "children": [
+                        {
+                          "kind": "OPEN_BRACE_TOKEN",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "LIST",
+                          "children": [
+                            {
+                              "kind": "SPECIFIC_FIELD",
+                              "children": [
+                                {
+                                  "kind": "STRING_LITERAL",
+                                  "value": "Name"
+                                },
+                                {
+                                  "kind": "COLON_TOKEN"
+                                },
+                                {
+                                  "kind": "SIMPLE_NAME_REFERENCE",
+                                  "children": [
+                                    {
+                                      "kind": "IDENTIFIER_TOKEN",
+                                      "value": "a"
+                                    }
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "CLOSE_BRACE_TOKEN"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "DOT_TOKEN"
+                    },
+                    {
+                      "kind": "SIMPLE_NAME_REFERENCE",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "foo"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "OPEN_PAREN_TOKEN"
+                    },
+                    {
+                      "kind": "LIST",
+                      "children": [
+                        {
+                          "kind": "POSITIONAL_ARG",
+                          "children": [
+                            {
+                              "kind": "SIMPLE_NAME_REFERENCE",
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "value": "c"
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "COMMA_TOKEN"
+                        },
+                        {
+                          "kind": "POSITIONAL_ARG",
+                          "children": [
+                            {
+                              "kind": "SIMPLE_NAME_REFERENCE",
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "value": "d"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CLOSE_PAREN_TOKEN"
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/call-stmt/call_stmt_source_08.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/call-stmt/call_stmt_source_08.bal
@@ -1,0 +1,3 @@
+public function main() {
+    {"Name":a}.foo(c,d);
+}


### PR DESCRIPTION
## Purpose
Wrapped stringliteral token with basicLiteralNode when it is used as expressionLhs

Fixes #24377

## Approach
Wrapped the StringLiteralToken with basicLiteralToken when its used as an expression LHS. Added parser tests to test for this.

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
