### PR TITLE
Enable read and write IO APIs to a properties file

### DIFF
--- a/stdlib/io/src/main/ballerina/src/io/readable_character_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/readable_character_channel.bal
@@ -32,44 +32,65 @@ public type ReadableCharacterChannel object {
         initReadableCharacterChannel(self, byteChannel, charset);
     }
 
-# Reads a given number of characters. This will attempt to read up to the `numberOfChars` characters of the channel.
-# An `io:EofError` will return once the channel reaches the end.
-# ```ballerina
-# string|io:Error result = readableCharChannel.read(1000);
-# ```
-#
-# + numberOfChars - Number of characters, which should be read
-# + return - Content, which is read, an `EofError` once the channel reaches the end or else an `io:Error`
+    # Reads a given number of characters. This will attempt to read up to the `numberOfChars` characters of the channel.
+    # An `io:EofError` will return once the channel reaches the end.
+    # ```ballerina
+    # string|io:Error result = readableCharChannel.read(1000);
+    # ```
+    #
+    # + numberOfChars - Number of characters, which should be read
+    # + return - Content, which is read, an `EofError` once the channel reaches the end or else an `io:Error`
     public function read(@untainted int numberOfChars) returns @tainted string|Error {
         return readExtern(self, numberOfChars);
     }
 
-# Reads a JSON from the given channel.
-# ```ballerina
-# json|io:Error result = readableCharChannel.readJson();
-# ```
-#
-# + return - The read JSON string or else an `io:Error`
+    # Reads a JSON from the given channel.
+    # ```ballerina
+    # json|io:Error result = readableCharChannel.readJson();
+    # ```
+    #
+    # + return - The read JSON string or else an `io:Error`
     public function readJson() returns @tainted json|Error {
         return readJsonExtern(self);
     }
 
-# Reads an XML from the given channel.
-# ```ballerina
-# json|io:Error result = readableCharChannel.readXml();
-# ```
-#
-# + return - The read XML or else an `io:Error`
+    # Reads an XML from the given channel.
+    # ```ballerina
+    # json|io:Error result = readableCharChannel.readXml();
+    # ```
+    #
+    # + return - The read XML or else an `io:Error`
     public function readXml() returns @tainted xml|Error {
         return readXmlExtern(self);
     }
 
-# Closes a given character channel.
-# ```ballerina
-# io:Error? err = readableCharChannel.close();
-# ```
-#
-# + return - If an error occurred while writing
+    # Reads a property from a .properties file with a default value.
+    # ```ballerina
+    # string|io:Error result = readableCharChannel.readProperty(key, defaultValue);
+    # ```
+    # + key - The property key needs to read.
+    # + defaultValue - Default value to be return.
+    # + return - The read property value or else an `io:Error`
+    public function readProperty(string key, string defaultValue="") returns @tainted string|Error {
+        return readPropertyExtern(self, key, defaultValue);
+    }
+
+    # Reads all properties from a .properties file.
+    # ```ballerina
+    # map<string>|io:Error result = readableCharChannel.readAllProperties();
+    # ```
+    #
+    # + return - A map that contains all properties
+    public function readAllProperties() returns @tainted map<string>|Error {
+        return readAllPropertiesExtern(self);
+    }
+
+    # Closes a given character channel.
+    # ```ballerina
+    # io:Error? err = readableCharChannel.close();
+    # ```
+    #
+    # + return - If an error occurred while writing
     public function close() returns Error? {
         return closeReadableCharacterChannel(self);
     }
@@ -94,6 +115,17 @@ function readJsonExtern(ReadableCharacterChannel characterChannel) returns @tain
 
 function readXmlExtern(ReadableCharacterChannel characterChannel) returns @tainted xml|Error = @java:Method {
     name: "readXml",
+    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+} external;
+
+function readPropertyExtern(ReadableCharacterChannel characterChannel, string key, string defaultValue) returns
+                            @tainted string|Error = @java:Method {
+    name: "readProperty",
+    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+} external;
+
+function readAllPropertiesExtern(ReadableCharacterChannel characterChannel) returns @tainted map<string>|Error = @java:Method {
+    name: "readAllProperties",
     class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 

--- a/stdlib/io/src/main/ballerina/src/io/writable_character_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/writable_character_channel.bal
@@ -32,46 +32,57 @@ public type WritableCharacterChannel object {
         initWritableCharacterChannel(self, bChannel, charset);
     }
 
-# Writes a given sequence of characters (string).
-# ```ballerina
-# int|io:Error result = writableCharChannel.write("Content", 0);
-# ```
-#
-# + content - Content, which should be written
-# + startOffset - Number of characters, which should be offset when writing the content
-# + return - Content length that written or else `io:Error`
+    # Writes a given sequence of characters (string).
+    # ```ballerina
+    # int|io:Error result = writableCharChannel.write("Content", 0);
+    # ```
+    #
+    # + content - Content, which should be written
+    # + startOffset - Number of characters, which should be offset when writing the content
+    # + return - Content length that written or else `io:Error`
     public function write(string content, int startOffset) returns int|Error {
         return writeExtern(self, content, startOffset);
     }
 
-# Writes a given JSON to the given channel.
-# ```ballerina
-# io:Error? err = writableCharChannel.writeJson(inputJson, 0);
-# ```
-#
-# + content - The JSON, which should be written
-# + return - If an `io:Error` occurred while writing
+    # Writes a given JSON to the given channel.
+    # ```ballerina
+    # io:Error? err = writableCharChannel.writeJson(inputJson, 0);
+    # ```
+    #
+    # + content - The JSON, which should be written
+    # + return - If an `io:Error` occurred while writing
     public function writeJson(json content) returns Error? {
         return writeJsonExtern(self, content);
     }
 
-# Writes a given XML to the channel.
-# ```ballerina
-# io:Error? err = writableCharChannel.writeXml(inputXml, 0);
-# ```
-# 
-# + content - The XML, which should be written
-# + return - `()` or else `io:Error` if any error occurred
+    # Writes a given XML to the channel.
+    # ```ballerina
+    # io:Error? err = writableCharChannel.writeXml(inputXml, 0);
+    # ```
+    #
+    # + content - The XML, which should be written
+    # + return - `()` or else `io:Error` if any error occurred
     public function writeXml(xml content) returns Error? {
         return writeXmlExtern(self, content);
     }
 
-# Closes a given `WritableCharacterChannel` channel.
-# ```ballerina
-# io:Error err = writableCharChannel.close();
-# ```
-#
-# + return - `()` or else an `io:Error` if any error occurred
+    # Writes a given key-valued pair `map<string>` to a property file.
+    # ```ballerina
+    # io:Error? err = writableCharChannel.writeProperties(properties);
+    # ```
+    # + properties - The map<string> that contains keys and values.
+    # + comment - Comment describing the property list
+    # + return - `()` or else `io:Error` if any error occurred
+    public function writeProperties(map<string> properties, string comments) returns Error? {
+        return writePropertiesExtern(self, properties, comments);
+    }
+
+    # Closes a given `WritableCharacterChannel` channel.
+    # ```ballerina
+    # io:Error err = writableCharChannel.close();
+    # ```
+    #
+    # + return - `()` or else an `io:Error` if any error occurred
     public function close() returns Error? {
         return closeWritableCharacterChannel(self);
     }
@@ -96,6 +107,12 @@ function writeJsonExtern(WritableCharacterChannel characterChannel, json content
 
 function writeXmlExtern(WritableCharacterChannel characterChannel, xml content) returns Error? = @java:Method {
     name: "writeXml",
+    class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
+} external;
+
+function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties,
+                                string comments) returns Error? = @java:Method {
+    name: "writeProperties",
     class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;
 

--- a/stdlib/io/src/main/ballerina/src/io/writable_character_channel.bal
+++ b/stdlib/io/src/main/ballerina/src/io/writable_character_channel.bal
@@ -73,8 +73,8 @@ public type WritableCharacterChannel object {
     # + properties - The map<string> that contains keys and values.
     # + comment - Comment describing the property list
     # + return - `()` or else `io:Error` if any error occurred
-    public function writeProperties(map<string> properties, string comments) returns Error? {
-        return writePropertiesExtern(self, properties, comments);
+    public function writeProperties(map<string> properties, string comment) returns Error? {
+        return writePropertiesExtern(self, properties, comment);
     }
 
     # Closes a given `WritableCharacterChannel` channel.
@@ -111,7 +111,7 @@ function writeXmlExtern(WritableCharacterChannel characterChannel, xml content) 
 } external;
 
 function writePropertiesExtern(WritableCharacterChannel characterChannel, map<string> properties,
-                                string comments) returns Error? = @java:Method {
+                                string comment) returns Error? = @java:Method {
     name: "writeProperties",
     class: "org.ballerinalang.stdlib.io.nativeimpl.CharacterChannelUtils"
 } external;

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
@@ -170,11 +170,11 @@ public class CharacterChannelUtils {
     }
 
     public static Object writeProperties(ObjectValue characterChannelObj,
-                                         BMap<BString, BString> propertyMap, BString comments) {
+                                         BMap<BString, BString> propertyMap, BString comment) {
         try {
             CharacterChannel characterChannel = (CharacterChannel) characterChannelObj
                     .getNativeData(CHARACTER_CHANNEL_NAME);
-            PropertyUtils.writePropertyContent(characterChannel, propertyMap, comments);
+            PropertyUtils.writePropertyContent(characterChannel, propertyMap, comment);
         } catch (IOException e) {
             return IOUtils.createError(e);
         }

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/nativeimpl/CharacterChannelUtils.java
@@ -23,6 +23,7 @@ import org.ballerinalang.jvm.XMLFactory;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.XMLValue;
+import org.ballerinalang.jvm.values.api.BMap;
 import org.ballerinalang.jvm.values.api.BString;
 import org.ballerinalang.jvm.values.utils.StringUtils;
 import org.ballerinalang.stdlib.io.channels.base.Channel;
@@ -31,6 +32,7 @@ import org.ballerinalang.stdlib.io.readers.CharacterChannelReader;
 import org.ballerinalang.stdlib.io.utils.BallerinaIOException;
 import org.ballerinalang.stdlib.io.utils.IOConstants;
 import org.ballerinalang.stdlib.io.utils.IOUtils;
+import org.ballerinalang.stdlib.io.utils.PropertyUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,6 +106,26 @@ public class CharacterChannelUtils {
         }
     }
 
+    public static Object readProperty(ObjectValue channel, BString key, BString defaultValue) {
+        CharacterChannel charChannel = (CharacterChannel) channel.getNativeData(CHARACTER_CHANNEL_NAME);
+        CharacterChannelReader reader = new CharacterChannelReader(charChannel);
+        try {
+            return PropertyUtils.readProperty(reader, key, defaultValue, Integer.toString(charChannel.id()));
+        } catch (IOException e) {
+            return IOUtils.createError(e);
+        }
+    }
+
+    public static Object readAllProperties(ObjectValue channel) {
+        CharacterChannel charChannel = (CharacterChannel) channel.getNativeData(CHARACTER_CHANNEL_NAME);
+        CharacterChannelReader reader = new CharacterChannelReader(charChannel);
+        try {
+            return PropertyUtils.readAllProperties(reader, Integer.toString(charChannel.id()));
+        } catch (IOException e) {
+            return IOUtils.createError(e);
+        }
+    }
+
     public static Object close(ObjectValue channel) {
         CharacterChannel charChannel = (CharacterChannel) channel.getNativeData(CHARACTER_CHANNEL_NAME);
         try {
@@ -142,6 +164,18 @@ public class CharacterChannelUtils {
                     .getNativeData(CHARACTER_CHANNEL_NAME);
             IOUtils.writeFull(characterChannel, content.toString());
         } catch (BallerinaIOException e) {
+            return IOUtils.createError(e);
+        }
+        return null;
+    }
+
+    public static Object writeProperties(ObjectValue characterChannelObj,
+                                         BMap<BString, BString> propertyMap, BString comments) {
+        try {
+            CharacterChannel characterChannel = (CharacterChannel) characterChannelObj
+                    .getNativeData(CHARACTER_CHANNEL_NAME);
+            PropertyUtils.writePropertyContent(characterChannel, propertyMap, comments);
+        } catch (IOException e) {
             return IOUtils.createError(e);
         }
         return null;

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/PropertyUtils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/PropertyUtils.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.stdlib.io.utils;
+
+import org.ballerinalang.jvm.StringUtils;
+import org.ballerinalang.jvm.types.BMapType;
+import org.ballerinalang.jvm.types.BTypes;
+import org.ballerinalang.jvm.values.MapValue;
+import org.ballerinalang.jvm.values.MapValueImpl;
+import org.ballerinalang.jvm.values.MappingInitialValueEntry;
+import org.ballerinalang.jvm.values.api.BMap;
+import org.ballerinalang.jvm.values.api.BString;
+import org.ballerinalang.stdlib.io.channels.base.CharacterChannel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.nio.channels.Channels;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+/**
+ * The utility class used to execute read/write operations to a property file.
+ */
+public class PropertyUtils {
+    private static final Logger log = LoggerFactory.getLogger(PropertyUtils.class);
+    private static final BMapType mapType = new BMapType(BTypes.typeString);
+    private static Map<String, Properties> propertiesMap = new HashMap<>();
+
+    // Read a property related to a given key and return the BString value.
+    public static BString readProperty(Reader reader, BString key, BString defaultValue,
+                                       String propertiesId) throws IOException {
+        Properties readableProperties;
+        if (!propertiesMap.containsKey(propertiesId)) {
+            readableProperties = new Properties();
+            readableProperties.load(reader);
+            propertiesMap.put(propertiesId, readableProperties);
+        } else {
+            readableProperties = propertiesMap.get(propertiesId);
+        }
+        String value = readableProperties.getProperty(key.getValue(), defaultValue.getValue());
+        if (value != null) {
+            return org.ballerinalang.jvm.StringUtils.fromString(value);
+        }
+
+        return null;
+    }
+
+    // Read all properties and return as a ballerina map
+    public static MapValue<BString, BString> readAllProperties(Reader reader, String propertiesId) throws IOException {
+        Properties readableProperties;
+        if (!propertiesMap.containsKey(propertiesId)) {
+            readableProperties = new Properties();
+            readableProperties.load(reader);
+            propertiesMap.put(propertiesId, readableProperties);
+        } else {
+            readableProperties = propertiesMap.get(propertiesId);
+        }
+        MappingInitialValueEntry.KeyValueEntry[] keyValues = new MappingInitialValueEntry
+                .KeyValueEntry[readableProperties.stringPropertyNames().size()];
+        int i = 0;
+        for (Enumeration<?> e = readableProperties.propertyNames(); e.hasMoreElements(); ) {
+            String key = (String) e.nextElement();
+            String value = readableProperties.getProperty(key);
+            MappingInitialValueEntry.KeyValueEntry keyValue = new MappingInitialValueEntry.KeyValueEntry(
+                    StringUtils.fromString(key), StringUtils.fromString(value));
+            keyValues[i] = keyValue;
+            i++;
+        }
+        return new MapValueImpl<>(mapType, keyValues);
+    }
+
+
+    // Write properties map to a .properties file
+    public static void writePropertyContent(CharacterChannel characterChannel,
+                                                  BMap<BString, BString> propertiesMap,
+                                                  BString comments) throws IOException {
+
+        Properties writableProperties = new Properties();
+        Set<Map.Entry<BString, BString>> propertiesSet = propertiesMap.entrySet();
+        for (Map.Entry<BString, BString> entry : propertiesSet) {
+            writableProperties.setProperty(entry.getKey().getValue(), entry.getValue().getValue());
+        }
+        writableProperties.store(
+                Channels.newOutputStream(characterChannel.getChannel().getByteChannel()),
+                comments.getValue()
+        );
+    }
+}

--- a/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/PropertyUtils.java
+++ b/stdlib/io/src/main/java/org/ballerinalang/stdlib/io/utils/PropertyUtils.java
@@ -94,7 +94,7 @@ public class PropertyUtils {
     // Write properties map to a .properties file
     public static void writePropertyContent(CharacterChannel characterChannel,
                                                   BMap<BString, BString> propertiesMap,
-                                                  BString comments) throws IOException {
+                                                  BString comment) throws IOException {
 
         Properties writableProperties = new Properties();
         Set<Map.Entry<BString, BString>> propertiesSet = propertiesMap.entrySet();
@@ -103,7 +103,7 @@ public class PropertyUtils {
         }
         writableProperties.store(
                 Channels.newOutputStream(characterChannel.getChannel().getByteChannel()),
-                comments.getValue()
+                comment.getValue()
         );
     }
 }

--- a/stdlib/io/src/test/java/org/ballerinalang/stdlib/io/IOTest.java
+++ b/stdlib/io/src/test/java/org/ballerinalang/stdlib/io/IOTest.java
@@ -401,6 +401,75 @@ public class IOTest {
         Assert.assertTrue(result[0].stringValue().contains("Foo"));
     }
 
+    @Test(description = "Test 'readProperty' function in ballerina/io package")
+    public void testReadAvailableProperty() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/text/person.properties";
+        BString readCharacters;
+
+        //Will initialize the channel
+        BValue[] initArgs = { new BString(getAbsoluteFilePath(resourceToRead)), new BString("UTF-8") };
+        BRunUtil.invoke(characterInputOutputProgramFile, "initReadableChannel", initArgs);
+
+        BValue[] testArgs = { new BString("name")};
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "readAvailableProperty", testArgs);
+        readCharacters = (BString) returns[0];
+
+        String returnedString = readCharacters.stringValue();
+        String expectedString = "John Smith";
+        Assert.assertEquals(returnedString, expectedString);
+
+        BRunUtil.invoke(characterInputOutputProgramFile, "closeReadableChannel");
+    }
+
+    @Test(description = "Test 'readAllProperties' function in ballerina/io package")
+    public void testAllProperties() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/text/person.properties";
+        BBoolean succeed;
+
+        //Will initialize the channel
+        BValue[] initArgs = { new BString(getAbsoluteFilePath(resourceToRead)), new BString("UTF-8") };
+        BRunUtil.invoke(characterInputOutputProgramFile, "initReadableChannel", initArgs);
+
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "readAllProperties");
+        succeed = (BBoolean) returns[0];
+        Assert.assertTrue(succeed.booleanValue());
+
+        BRunUtil.invoke(characterInputOutputProgramFile, "closeReadableChannel");
+    }
+
+    @Test(description = "Negative test for 'readProperty' function in ballerina/io package")
+    public void testReadUnavailableProperty() throws URISyntaxException {
+        String resourceToRead = "datafiles/io/text/person.properties";
+        BBoolean succeed;
+
+        //Will initialize the channel
+        BValue[] initArgs = { new BString(getAbsoluteFilePath(resourceToRead)), new BString("UTF-8") };
+        BRunUtil.invoke(characterInputOutputProgramFile, "initReadableChannel", initArgs);
+
+        BValue[] testArgs = { new BString("key")};
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "readUnavailableProperty", testArgs);
+        succeed = (BBoolean) returns[0];
+        Assert.assertTrue(succeed.booleanValue());
+
+        BRunUtil.invoke(characterInputOutputProgramFile, "closeReadableChannel");
+    }
+
+    @Test(description = "Test 'writeProperties' function in ballerina/io package")
+    public void testWriteProperties() throws URISyntaxException {
+        String sourceToWrite = currentDirectoryPath + "/tmp_person.properties";
+        BBoolean succeed;
+
+        //Will initialize the channel
+        BValue[] args = { new BString(sourceToWrite), new BString("UTF-8") };
+        BRunUtil.invoke(characterInputOutputProgramFile, "initWritableChannel", args);
+
+        BValue[] returns = BRunUtil.invoke(characterInputOutputProgramFile, "writePropertiesFromMap");
+        succeed = (BBoolean) returns[0];
+        Assert.assertTrue(succeed.booleanValue());
+
+        BRunUtil.invoke(characterInputOutputProgramFile, "closeWritableChannel");
+    }
+
     private String readFileContent(String filePath) throws URISyntaxException {
         Path path = Paths.get(getAbsoluteFilePath(filePath));
         StringBuilder data = new StringBuilder();

--- a/stdlib/io/src/test/resources/datafiles/io/text/person.properties
+++ b/stdlib/io/src/test/resources/datafiles/io/text/person.properties
@@ -1,0 +1,3 @@
+name=John Smith
+age=26
+occupation=Software Engineer

--- a/stdlib/io/src/test/resources/test-src/io/char_io.bal
+++ b/stdlib/io/src/test/resources/test-src/io/char_io.bal
@@ -130,6 +130,57 @@ function readXml() returns @tainted xml|error {
     return e;
 }
 
+function readAvailableProperty(string key) returns @tainted string?|error {
+    var rCha = rch;
+    if(rCha is io:ReadableCharacterChannel) {
+        var result = rCha.readProperty(key);
+        return result;
+    }
+    io:GenericError e = io:GenericError("Character channel not initialized properly");
+    return e;
+}
+
+function readAllProperties() returns boolean {
+    var rCha = rch;
+    if(rCha is io:ReadableCharacterChannel) {
+        var results = rCha.readAllProperties();
+        if (results is map<string>) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function readUnavailableProperty(string key) returns boolean {
+    var rCha = rch;
+    if(rCha is io:ReadableCharacterChannel) {
+        string defaultValue = "Default";
+        var results = rCha.readProperty(key, defaultValue);
+        if (results is string) {
+            if (results == defaultValue) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+function writePropertiesFromMap() returns boolean {
+    var wCha = wch;
+    if (wCha is io:WritableCharacterChannel) {
+        map<string> properties = {
+            name: "Anna Johnson",
+            age: "25",
+            occupation: "Banker"
+        };
+        var writeResults = wCha.writeProperties(properties, "Comment");
+        if !(writeResults is io:Error) {
+            return true;
+        }
+    }
+    return false;
+}
+
 function writeJson(json content) {
     var wCha = wch;
     if(wCha is io:WritableCharacterChannel){


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/22615

## Approach
Enable the following APIs.
- `readProperty(key)`
- `readAllProperties()`
- `writeProperties(map<string> properties)`

## Samples

### Reading
```ballerina
string propertyFilePath = "<PATH_TO_PROPERTIES_FILE>/config.properties";
    
io:ReadableByteChannel rbc = check io:openReadableFile(propertyFilePath);
io:ReadableCharacterChannel rch = new (rbc, "UTF8");
io:println(rch.readProperty("name"));
```

```ballerina
string propertyFilePath = "<PATH_TO_PROPERTIES_FILE>/config.properties";
    
io:ReadableByteChannel rbc = check io:openReadableFile(propertyFilePath);
io:ReadableCharacterChannel rch = new (rbc, "UTF8");
io:println(rch.readAllProperties());
```

### Writing
```ballerina
string propertyFilePath = "<PATH_TO_PROPERTIES_FILE>/config.properties";

io:WritableByteChannel wbc = check io:openWritableFile(propertyFilePath);
io:WritableCharacterChannel wch = new (wbc, "UTF8");
map<string> properties = {
    name: "John Smith",
    age: "25",
    occupation: "Banker"
};

var writeResults = wch.writeProperties(properties);
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [x] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
