### PR TITLE
Remove the Java Arrays BBE Link from the Module in Swan Lake API Docs

### DIFF
--- a/stdlib/java.arrays/src/main/ballerina/src/java.arrays/Module.md
+++ b/stdlib/java.arrays/src/main/ballerina/src/java.arrays/Module.md
@@ -2,4 +2,4 @@
 
 This module provides APIs to create new Java array instances, get elements from arrays, set elements, etc. 
 
-For information on the operations, which you can perform with the java.arrays module, see the below **Functions**. For an example on the usage of the operations, see the [Java Arrays Example](https://ballerina.io/swan-lake/learn/by-example/java-arrays.html).
+For information on the operations, which you can perform with the java.arrays module, see the below **Functions**. 


### PR DESCRIPTION
## Purpose
Remove the Java Arrays BBE link from the module in Swan Lake API Docs.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
