### PR TITLE
Remove `cleanTargetDirTask` from DocCommand

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -309,7 +309,6 @@ public class DocCommand implements BLauncherCmd {
         buildContext.setErr(errStream);
         
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
-                .addTask(new CleanTargetDirTask())   // clean the target directory(projects only)
                 .addTask(new CreateTargetDirTask()) // create target directory.
                 .addTask(new ResolveMavenDependenciesTask()) // resolve maven dependencies in Ballerina.toml
                 .addTask(new CompileTask()) // compile the modules

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/DocCommand.java
@@ -24,7 +24,6 @@ import org.ballerinalang.packerina.JarResolverImpl;
 import org.ballerinalang.packerina.TaskExecutor;
 import org.ballerinalang.packerina.buildcontext.BuildContext;
 import org.ballerinalang.packerina.buildcontext.BuildContextField;
-import org.ballerinalang.packerina.task.CleanTargetDirTask;
 import org.ballerinalang.packerina.task.CompileTask;
 import org.ballerinalang.packerina.task.CreateDocsTask;
 import org.ballerinalang.packerina.task.CreateTargetDirTask;


### PR DESCRIPTION
## Purpose
> Remove `cleanTargetDirTask` from `DocCommand` to avoid removing generated BIR and Jar in the target directory when Generating API docs with `doc` command

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24884

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
