### PR TITLE
Fix issue api docs consider period inside code as a end of line

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Writer.java
@@ -119,7 +119,7 @@ public class Writer {
                 //remove anything with <pre> tag
                 String newDescription = description.replaceAll("<pre>(.|\\n)*?<\\/pre>", "");
                 // select only the first sentence
-                String[] splits = newDescription.split("\\.", 2);
+                String[] splits = newDescription.split("\\. ", 2);
                 if (splits.length < 2) {
                     return splits[0];
                 } else {


### PR DESCRIPTION
## Purpose
> Fix issue API docs consider period inside code as an end of line
Eg: `org.yaml.snakeyaml.Yaml`

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24125

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
