### PR TITLE
Return only one result set in MSSQL call

### DIFF
--- a/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/CallStatement.java
+++ b/stdlib/jdbc/src/main/java/org/ballerinax/jdbc/statement/CallStatement.java
@@ -190,17 +190,23 @@ public class CallStatement extends AbstractSQLStatement {
                 // Current result is a ResultSet
                 result = stmt.getResultSet();
                 resultSets.add(result);
-                if (databaseProductName.contains(Constants.DatabaseNames.MYSQL)) {
-                    // TODO: "mysql" equality condition is part of the temporary fix to support returning the result
-                    // set in the case of stored procedures returning only one result set in MySQL. Refer
-                    // ballerina-platform/ballerina-lang#8643
+                if (databaseProductName.contains(Constants.DatabaseNames.MYSQL)
+                        || databaseProductName.contains(Constants.DatabaseNames.MSSQL_SERVER)) {
+                    // TODO: "mysql" & "mssql" equality condition is part of the temporary fix to support returning
+                    //  the result set in the case of stored procedures returning only one result set in MySQL. Refer
+                    //  ballerina-platform/ballerina-lang#12804
                     break;
                 }
             }
             // This point reaches if current result was an update count. So it is needed to capture any remaining
             // results
             try {
-                resultAndNoUpdateCount = stmt.getMoreResults(Statement.KEEP_CURRENT_RESULT);
+                // Check for only MSSQL since MySQL doesnt return update count for each statement.
+                if (databaseProductName.contains(Constants.DatabaseNames.MSSQL_SERVER)) {
+                    resultAndNoUpdateCount = stmt.getMoreResults();
+                } else {
+                    resultAndNoUpdateCount = stmt.getMoreResults(Statement.KEEP_CURRENT_RESULT);
+                }
             } catch (SQLException e) {
                 break;
             }


### PR DESCRIPTION
## Purpose
Fix connector throwing exception when invoking procedure call with update count and a result set.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24903

## Approach
By design, we have to keep the result sets open when processing. However, MsSQL does not support this. Thus as a temp fix, we are only returning one result set. This restriction will be fixed in Swan Lake connector.

## Remarks
1. https://github.com/ballerina-platform/ballerina-lang/issues/12804

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
