### PR TITLE
Use a parent strand for each iteration in langlib functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -1428,7 +1428,7 @@ public class JvmInstructionGen {
             this.mv.visitMethodInsn(INVOKESPECIAL,
                                     getTypeValueClassName(objectType.tsymbol.pkgID, toNameString(objectType)),
                                     "setOnInitialization",
-                                    String.format("(L%s;L%s;)V", JvmConstants.B_STRING_VALUE, OBJECT), true);
+                                    String.format("(L%s;L%s;)V", JvmConstants.B_STRING_VALUE, OBJECT), false);
             return;
         }
 

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.array;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BArrayType;
 import org.ballerinalang.jvm.values.ArrayValue;
@@ -53,9 +54,11 @@ public class Filter {
         int size = arr.size();
         AtomicInteger newArraySize = new AtomicInteger(-1);
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(), arr.get(index.incrementAndGet()),
+                                                       () -> new Object[]{parentStrand, arr.get(index.incrementAndGet()),
                                                                true},
                                                        result -> {
                                                            if ((Boolean) result) {

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
@@ -54,7 +54,7 @@ public class Filter {
         int size = arr.size();
         AtomicInteger newArraySize = new AtomicInteger(-1);
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.array;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.values.ArrayValue;
@@ -53,9 +54,11 @@ public class ForEach {
         BType arrType = arr.getType();
         GetFunction getFn = getElementAccessFunction(arrType, "forEach()");
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(),
+                                                       () -> new Object[]{parentStrand,
                                                                getFn.get(arr, index.incrementAndGet()), true},
                                                        result -> {
                                                        }, () -> null);

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
@@ -54,7 +54,7 @@ public class ForEach {
         BType arrType = arr.getType();
         GetFunction getFn = getElementAccessFunction(arrType, "forEach()");
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.array;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BArrayType;
 import org.ballerinalang.jvm.types.BFunctionType;
@@ -72,9 +73,11 @@ public class Map {
                 throw createOpNotSupportedError(arrType, "map()");
         }
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(),
+                                                       () -> new Object[]{parentStrand,
                                                                getFn.get(arr, index.incrementAndGet()), true},
                                                        result -> retArr.add(index.get(), result),
                                                        () -> retArr);

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
@@ -73,7 +73,7 @@ public class Map {
                 throw createOpNotSupportedError(arrType, "map()");
         }
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reduce.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reduce.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.array;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.values.ArrayValue;
@@ -57,9 +58,11 @@ public class Reduce {
         GetFunction getFn = getElementAccessFunction(arrType, "reduce()");
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(), accum.get(), true,
+                                                       () -> new Object[]{parentStrand, accum.get(), true,
                                                                getFn.get(arr, index.incrementAndGet()), true},
                                                        accum::set, accum::get);
         return accum.get();

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
@@ -71,7 +71,7 @@ public class Filter {
         MapValue<Object, Object> newMap = new MapValueImpl<>(newMapType);
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.map;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BMapType;
 import org.ballerinalang.jvm.types.BRecordType;
@@ -70,9 +71,11 @@ public class Filter {
         MapValue<Object, Object> newMap = new MapValueImpl<>(newMapType);
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(),
+                                                       () -> new Object[]{parentStrand,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
                                                        result -> {
                                                            if ((Boolean) result) {

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
@@ -49,7 +49,7 @@ public class ForEach {
     public static void forEach(MapValue<?, ?> m, FPValue<Object, Object> func) {
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.map;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
 import org.ballerinalang.jvm.values.MapValue;
@@ -48,9 +49,11 @@ public class ForEach {
     public static void forEach(MapValue<?, ?> m, FPValue<Object, Object> func) {
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(),
+                                                       () -> new Object[]{parentStrand,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
                                                        result -> {
                                                        }, () -> null);

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
@@ -55,7 +55,7 @@ public class Map {
         MapValue<Object, Object> newMap = new MapValueImpl<>(newMapType);
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.map;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BFunctionType;
 import org.ballerinalang.jvm.types.BMapType;
@@ -54,9 +55,11 @@ public class Map {
         MapValue<Object, Object> newMap = new MapValueImpl<>(newMapType);
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(),
+                                                       () -> new Object[]{parentStrand,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
                                                        result -> newMap
                                                                .put(m.getKeys()[index.get()], result),

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
@@ -54,7 +54,7 @@ public class Filter {
         TableValueImpl newTable = new TableValueImpl((BTableType) newTableType);
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
 
         BRuntime.getCurrentRuntime()

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
@@ -54,10 +54,12 @@ public class Filter {
         TableValueImpl newTable = new TableValueImpl((BTableType) newTableType);
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
 
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{Scheduler.getStrand(),
+                        () -> new Object[]{parentStrand,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         result -> {
                             if ((Boolean) result) {

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
@@ -49,9 +49,11 @@ public class Foreach {
     public static void forEach(TableValueImpl tbl, FPValue<Object, Object> func) {
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{Scheduler.getStrand(),
+                        () -> new Object[]{parentStrand,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         result -> {
                         }, () -> null);

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
@@ -49,7 +49,7 @@ public class Foreach {
     public static void forEach(TableValueImpl tbl, FPValue<Object, Object> func) {
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
@@ -59,7 +59,7 @@ public class Map {
         TableValueImpl newTable = new TableValueImpl(newTableType);
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
@@ -59,9 +59,11 @@ public class Map {
         TableValueImpl newTable = new TableValueImpl(newTableType);
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{Scheduler.getStrand(),
+                        () -> new Object[]{parentStrand,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         result -> newTable
                                 .put(tbl.getKeys()[index.get()], result),

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
@@ -53,7 +53,7 @@ public class Reduce {
         int size = tbl.values().size();
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
@@ -53,9 +53,11 @@ public class Reduce {
         int size = tbl.values().size();
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{Scheduler.getStrand(), accum.get(), true,
+                        () -> new Object[]{parentStrand, accum.get(), true,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         accum::set, accum::get);
         return accum.get();

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.xml;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
 import org.ballerinalang.jvm.values.XMLSequence;
@@ -68,9 +69,11 @@ public class Filter {
         List<BXML> elements = new ArrayList<>();
         int size = x.size();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{Scheduler.getStrand(),
+                                                       () -> new Object[]{parentStrand,
                                                                x.getItem(index.incrementAndGet()), true},
                                                        result -> {
                                                            if ((Boolean) result) {

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
@@ -69,7 +69,7 @@ public class Filter {
         List<BXML> elements = new ArrayList<>();
         int size = x.size();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.xml;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
 import org.ballerinalang.jvm.values.XMLValue;
@@ -53,9 +54,11 @@ public class ForEach {
             return;
         }
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, x.size(),
-                                                       () -> new Object[]{Scheduler.getStrand(), x.getItem(index.incrementAndGet()),
+                                                       () -> new Object[]{parentStrand, x.getItem(index.incrementAndGet()),
                                                                true},
                                                        result -> {
                                                        }, () -> null);

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
@@ -54,7 +54,7 @@ public class ForEach {
             return;
         }
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, x.size(),

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
@@ -60,7 +60,7 @@ public class Map {
         }
         List<BXML> elements = new ArrayList<>();
         AtomicInteger index = new AtomicInteger(-1);
-        // accessing the parent strand here to use it with each iteration of the reduce
+        // accessing the parent strand here to use it with each iteration 
         Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, x.size(),

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langlib.xml;
 
 import org.ballerinalang.jvm.BRuntime;
 import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
 import org.ballerinalang.jvm.values.XMLSequence;
@@ -59,9 +60,11 @@ public class Map {
         }
         List<BXML> elements = new ArrayList<>();
         AtomicInteger index = new AtomicInteger(-1);
+        // accessing the parent strand here to use it with each iteration of the reduce
+        Strand parentStrand = Scheduler.getStrand();
         BRuntime.getCurrentRuntime()
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, x.size(),
-                                                       () -> new Object[]{Scheduler.getStrand(), x.getItem(index.incrementAndGet()),
+                                                       () -> new Object[]{parentStrand, x.getItem(index.incrementAndGet()),
                                                                true},
                                                        result -> elements.add((XMLValue) result),
                                                        () -> new XMLSequence(elements));


### PR DESCRIPTION
## Purpose
> Fixes a few test case failing issues in the TypeParamTest for JDK 11.

Fixes #<Issue Number>

## Approach
> Used the same approach as in #25133 for all the other langlib functions.

## Samples

## Remarks
> This is an improvement similar to #25133, and only a partial fix to #25041. 
> TODO: Other langlib related test case failures are to be fixed. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
