### PR TITLE
Remove unnecessary anon types being generated in API Docs

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -63,6 +63,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 /**
@@ -85,11 +87,10 @@ public class Generator {
 
         // Check for type definitions in the package
         for (BLangTypeDefinition typeDefinition : balPackage.getTypeDefinitions()) {
-            if (typeDefinition.getFlags().contains(Flag.PUBLIC)) {
+            if (typeDefinition.getFlags().contains(Flag.PUBLIC) &&
+                    !typeDefinition.getFlags().contains(Flag.ANONYMOUS)) {
                 createTypeDefModels(typeDefinition, module);
-                if (!typeDefinition.name.value.contains("$anonType$")) {
-                    hasPublicConstructs = true;
-                }
+                hasPublicConstructs = true;
             }
         }
 
@@ -98,6 +99,23 @@ public class Generator {
             if (function.getFlags().contains(Flag.PUBLIC) && !function.getFlags().contains(Flag.ATTACHED)) {
                 module.functions.add(createDocForFunction(function, module));
                 hasPublicConstructs = true;
+            }
+        }
+
+        // Create the anon types
+        while (!module.linkedAnonObjects.isEmpty()) {
+            String typeName = module.linkedAnonObjects.remove();
+            BLangTypeDefinition typeDef = null;
+            for (BLangTypeDefinition typeDefinition : balPackage.getTypeDefinitions()) {
+                if (typeDefinition.name != null) {
+                    if (typeDefinition.name.value.equals(typeName)) {
+                        typeDef = typeDefinition;
+                        break;
+                    }
+                }
+            }
+            if (typeDef != null) {
+                createTypeDefModels(typeDef, module);
             }
         }
 
@@ -254,6 +272,14 @@ public class Generator {
             BLangType returnType = functionNode.getReturnTypeNode();
             String dataType = getTypeName(returnType);
             if (!dataType.equals("null")) {
+                // add anonymous type to be created
+                if (dataType.contains("$anonType$")) {
+                    Pattern pattern = Pattern.compile("\\$anonType\\$\\d\\d?\\d?");
+                    Matcher match = pattern.matcher(dataType);
+                    if (match.find()) {
+                        module.linkedAnonObjects.add(match.group(0));
+                    }
+                }
                 String desc = returnParamAnnotation(functionNode);
                 Variable variable = new Variable(EMPTY_STRING, desc, false, Type.fromTypeNode(returnType, module.id));
                 returnParams.add(variable);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Module.java
@@ -19,7 +19,9 @@ import com.google.gson.annotations.Expose;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.Queue;
 
 /**
  * Represents a Ballerina Module.
@@ -60,4 +62,7 @@ public class Module {
 
     @Expose
     public List<Path> resources = new ArrayList<>();
+
+    public Queue<String> linkedAnonObjects = new LinkedList<>();
+
 }

--- a/misc/docerina/src/main/resources/template/html/currentModule.hbs
+++ b/misc/docerina/src/main/resources/template/html/currentModule.hbs
@@ -8,14 +8,18 @@
     {{/if}}
     <ul>
         {{#if module.records}}
-        <li>
-            <a data="records" href="{{ ../rootPath }}{{ ../module.id }}/index.html#records" onclick="menuLinkClick()">Records</a>
-        </li>
+            {{#unless (areAllAnonymous module.records) }}
+                <li>
+                    <a data="records" href="{{ ../rootPath }}{{ ../module.id }}/index.html#records" onclick="menuLinkClick()">Records</a>
+                </li>
+            {{/unless}}
         {{/if}}
         {{#if module.objects}}
-            <li>
-                <a  data="objects" href="{{ ../rootPath }}{{ ../module.id }}/index.html#objects" onclick="menuLinkClick()">Objects</a>
-            </li>
+            {{#unless (areAllAnonymous module.objects) }}
+                <li>
+                    <a  data="objects" href="{{ ../rootPath }}{{ ../module.id }}/index.html#objects" onclick="menuLinkClick()">Objects</a>
+                </li>
+            {{/unless}}
         {{/if}}
         {{#if module.clients}}
             <li>


### PR DESCRIPTION
## Purpose
> Add functionality to only generate anonymous types that are defined in functions.
For example:- The anon object here doesn't need to be generated in API Docs - https://github.com/ballerina-platform/ballerina-lang/blob/ffec462129c9f65bce19ff94ec36a54382c9a188/langlib/lang.stream/src/main/ballerina/src/lang.stream/stream.bal#L44 

Fixes #24984
Fixes #22757


## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
