### PR TITLE
Remove --dump-llvm-ir flag from CLI

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -149,9 +149,6 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--dump-bir", hidden = true)
     private boolean dumpBIR;
 
-    @CommandLine.Option(names = "--dump-llvm-ir", hidden = true)
-    private boolean dumpLLVMIR;
-
     @CommandLine.Option(names = "--no-optimize-llvm", hidden = true)
     private boolean noOptimizeLlvm;
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
@@ -99,9 +99,6 @@ public class RunCommand implements BLauncherCmd {
             description = "Compile Ballerina program to a native binary")
     private boolean nativeBinary;
 
-    @CommandLine.Option(names = "--dump-llvm-ir", hidden = true)
-    private boolean dumpLLVMIR;
-
     @CommandLine.Option(names = "--no-optimize-llvm", hidden = true)
     private boolean noOptimizeLLVM;
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/TestCommand.java
@@ -120,9 +120,6 @@ public class TestCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--dump-bir", hidden = true)
     private boolean dumpBIR;
 
-    @CommandLine.Option(names = "--dump-llvm-ir", hidden = true)
-    private boolean dumpLLVMIR;
-
     @CommandLine.Option(names = "--no-optimize-llvm", hidden = true)
     private boolean noOptimizeLLVM;
 


### PR DESCRIPTION
## Purpose
> Remove `--dump-llvm-ir` flag from CLI since it is not used anymore.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/24259

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
