### PR TITLE
Use TypeParameterNode in ParameterizedTypeDescriptorNode

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2723,7 +2723,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
         BLangConstrainedType constrainedType = (BLangConstrainedType) TreeBuilder.createConstrainedTypeNode();
         constrainedType.type = refType;
-        constrainedType.constraint = createTypeNode(parameterizedTypeDescNode.typeNode());
+        constrainedType.constraint = createTypeNode(parameterizedTypeDescNode.typeParameter().typeNode());
         constrainedType.pos = getPosition(parameterizedTypeDescNode);
         return constrainedType;
     }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -7890,11 +7890,8 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseParameterizedTypeDescriptor() {
         STNode parameterizedTypeKeyword = parseParameterizedTypeKeyword();
-        STNode ltToken = parseLTToken();
-        STNode typeNode = parseTypeDescriptor(ParserRuleContext.TYPE_DESC_IN_ANGLE_BRACKETS);
-        STNode gtToken = parseGTToken();
-        return STNodeFactory.createParameterizedTypeDescriptorNode(parameterizedTypeKeyword, ltToken, typeNode,
-                gtToken);
+        STNode typeParameter = parseTypeParameter();
+        return STNodeFactory.createParameterizedTypeDescriptorNode(parameterizedTypeKeyword, typeParameter);
     }
 
     /**

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STNodeFactory.java
@@ -869,15 +869,11 @@ public class STNodeFactory extends STAbstractNodeFactory {
 
     public static STNode createParameterizedTypeDescriptorNode(
             STNode parameterizedType,
-            STNode ltToken,
-            STNode typeNode,
-            STNode gtToken) {
+            STNode typeParameter) {
 
         return new STParameterizedTypeDescriptorNode(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken);
+                typeParameter);
     }
 
     public static STNode createNilLiteralNode(

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STParameterizedTypeDescriptorNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STParameterizedTypeDescriptorNode.java
@@ -32,69 +32,49 @@ import java.util.Collections;
  */
 public class STParameterizedTypeDescriptorNode extends STTypeDescriptorNode {
     public final STNode parameterizedType;
-    public final STNode ltToken;
-    public final STNode typeNode;
-    public final STNode gtToken;
+    public final STNode typeParameter;
 
     STParameterizedTypeDescriptorNode(
             STNode parameterizedType,
-            STNode ltToken,
-            STNode typeNode,
-            STNode gtToken) {
+            STNode typeParameter) {
         this(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken,
+                typeParameter,
                 Collections.emptyList());
     }
 
     STParameterizedTypeDescriptorNode(
             STNode parameterizedType,
-            STNode ltToken,
-            STNode typeNode,
-            STNode gtToken,
+            STNode typeParameter,
             Collection<STNodeDiagnostic> diagnostics) {
         super(SyntaxKind.PARAMETERIZED_TYPE_DESC, diagnostics);
         this.parameterizedType = parameterizedType;
-        this.ltToken = ltToken;
-        this.typeNode = typeNode;
-        this.gtToken = gtToken;
+        this.typeParameter = typeParameter;
 
         addChildren(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken);
+                typeParameter);
     }
 
     public STNode modifyWith(Collection<STNodeDiagnostic> diagnostics) {
         return new STParameterizedTypeDescriptorNode(
                 this.parameterizedType,
-                this.ltToken,
-                this.typeNode,
-                this.gtToken,
+                this.typeParameter,
                 diagnostics);
     }
 
     public STParameterizedTypeDescriptorNode modify(
             STNode parameterizedType,
-            STNode ltToken,
-            STNode typeNode,
-            STNode gtToken) {
+            STNode typeParameter) {
         if (checkForReferenceEquality(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken)) {
+                typeParameter)) {
             return this;
         }
 
         return new STParameterizedTypeDescriptorNode(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken,
+                typeParameter,
                 diagnostics);
     }
 

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STTreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/tree/STTreeModifier.java
@@ -921,14 +921,10 @@ public abstract class STTreeModifier extends STNodeTransformer<STNode> {
     public STParameterizedTypeDescriptorNode transform(
             STParameterizedTypeDescriptorNode parameterizedTypeDescriptorNode) {
         STNode parameterizedType = modifyNode(parameterizedTypeDescriptorNode.parameterizedType);
-        STNode ltToken = modifyNode(parameterizedTypeDescriptorNode.ltToken);
-        STNode typeNode = modifyNode(parameterizedTypeDescriptorNode.typeNode);
-        STNode gtToken = modifyNode(parameterizedTypeDescriptorNode.gtToken);
+        STNode typeParameter = modifyNode(parameterizedTypeDescriptorNode.typeParameter);
         return parameterizedTypeDescriptorNode.modify(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken);
+                typeParameter);
     }
 
     @Override

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/NodeFactory.java
@@ -1140,19 +1140,13 @@ public abstract class NodeFactory extends AbstractNodeFactory {
 
     public static ParameterizedTypeDescriptorNode createParameterizedTypeDescriptorNode(
             Token parameterizedType,
-            Token ltToken,
-            Node typeNode,
-            Token gtToken) {
+            TypeParameterNode typeParameter) {
         Objects.requireNonNull(parameterizedType, "parameterizedType must not be null");
-        Objects.requireNonNull(ltToken, "ltToken must not be null");
-        Objects.requireNonNull(typeNode, "typeNode must not be null");
-        Objects.requireNonNull(gtToken, "gtToken must not be null");
+        Objects.requireNonNull(typeParameter, "typeParameter must not be null");
 
         STNode stParameterizedTypeDescriptorNode = STNodeFactory.createParameterizedTypeDescriptorNode(
                 parameterizedType.internalNode(),
-                ltToken.internalNode(),
-                typeNode.internalNode(),
-                gtToken.internalNode());
+                typeParameter.internalNode());
         return stParameterizedTypeDescriptorNode.createUnlinkedFacade();
     }
 
@@ -1799,7 +1793,7 @@ public abstract class NodeFactory extends AbstractNodeFactory {
 
     public static TypeParameterNode createTypeParameterNode(
             Token ltToken,
-            Node typeNode,
+            TypeDescriptorNode typeNode,
             Token gtToken) {
         Objects.requireNonNull(ltToken, "ltToken must not be null");
         Objects.requireNonNull(typeNode, "typeNode must not be null");

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ParameterizedTypeDescriptorNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/ParameterizedTypeDescriptorNode.java
@@ -36,16 +36,8 @@ public class ParameterizedTypeDescriptorNode extends TypeDescriptorNode {
         return childInBucket(0);
     }
 
-    public Token ltToken() {
+    public TypeParameterNode typeParameter() {
         return childInBucket(1);
-    }
-
-    public Node typeNode() {
-        return childInBucket(2);
-    }
-
-    public Token gtToken() {
-        return childInBucket(3);
     }
 
     @Override
@@ -62,29 +54,21 @@ public class ParameterizedTypeDescriptorNode extends TypeDescriptorNode {
     protected String[] childNames() {
         return new String[]{
                 "parameterizedType",
-                "ltToken",
-                "typeNode",
-                "gtToken"};
+                "typeParameter"};
     }
 
     public ParameterizedTypeDescriptorNode modify(
             Token parameterizedType,
-            Token ltToken,
-            Node typeNode,
-            Token gtToken) {
+            TypeParameterNode typeParameter) {
         if (checkForReferenceEquality(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken)) {
+                typeParameter)) {
             return this;
         }
 
         return NodeFactory.createParameterizedTypeDescriptorNode(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken);
+                typeParameter);
     }
 
     public ParameterizedTypeDescriptorNodeModifier modify() {
@@ -99,16 +83,12 @@ public class ParameterizedTypeDescriptorNode extends TypeDescriptorNode {
     public static class ParameterizedTypeDescriptorNodeModifier {
         private final ParameterizedTypeDescriptorNode oldNode;
         private Token parameterizedType;
-        private Token ltToken;
-        private Node typeNode;
-        private Token gtToken;
+        private TypeParameterNode typeParameter;
 
         public ParameterizedTypeDescriptorNodeModifier(ParameterizedTypeDescriptorNode oldNode) {
             this.oldNode = oldNode;
             this.parameterizedType = oldNode.parameterizedType();
-            this.ltToken = oldNode.ltToken();
-            this.typeNode = oldNode.typeNode();
-            this.gtToken = oldNode.gtToken();
+            this.typeParameter = oldNode.typeParameter();
         }
 
         public ParameterizedTypeDescriptorNodeModifier withParameterizedType(
@@ -118,33 +98,17 @@ public class ParameterizedTypeDescriptorNode extends TypeDescriptorNode {
             return this;
         }
 
-        public ParameterizedTypeDescriptorNodeModifier withLtToken(
-                Token ltToken) {
-            Objects.requireNonNull(ltToken, "ltToken must not be null");
-            this.ltToken = ltToken;
-            return this;
-        }
-
-        public ParameterizedTypeDescriptorNodeModifier withTypeNode(
-                Node typeNode) {
-            Objects.requireNonNull(typeNode, "typeNode must not be null");
-            this.typeNode = typeNode;
-            return this;
-        }
-
-        public ParameterizedTypeDescriptorNodeModifier withGtToken(
-                Token gtToken) {
-            Objects.requireNonNull(gtToken, "gtToken must not be null");
-            this.gtToken = gtToken;
+        public ParameterizedTypeDescriptorNodeModifier withTypeParameter(
+                TypeParameterNode typeParameter) {
+            Objects.requireNonNull(typeParameter, "typeParameter must not be null");
+            this.typeParameter = typeParameter;
             return this;
         }
 
         public ParameterizedTypeDescriptorNode apply() {
             return oldNode.modify(
                     parameterizedType,
-                    ltToken,
-                    typeNode,
-                    gtToken);
+                    typeParameter);
         }
     }
 }

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TreeModifier.java
@@ -1173,17 +1173,11 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
             ParameterizedTypeDescriptorNode parameterizedTypeDescriptorNode) {
         Token parameterizedType =
                 modifyToken(parameterizedTypeDescriptorNode.parameterizedType());
-        Token ltToken =
-                modifyToken(parameterizedTypeDescriptorNode.ltToken());
-        Node typeNode =
-                modifyNode(parameterizedTypeDescriptorNode.typeNode());
-        Token gtToken =
-                modifyToken(parameterizedTypeDescriptorNode.gtToken());
+        TypeParameterNode typeParameter =
+                modifyNode(parameterizedTypeDescriptorNode.typeParameter());
         return parameterizedTypeDescriptorNode.modify(
                 parameterizedType,
-                ltToken,
-                typeNode,
-                gtToken);
+                typeParameter);
     }
 
     @Override
@@ -1837,7 +1831,7 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
             TypeParameterNode typeParameterNode) {
         Token ltToken =
                 modifyToken(typeParameterNode.ltToken());
-        Node typeNode =
+        TypeDescriptorNode typeNode =
                 modifyNode(typeParameterNode.typeNode());
         Token gtToken =
                 modifyToken(typeParameterNode.gtToken());

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TypeParameterNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/syntax/tree/TypeParameterNode.java
@@ -36,7 +36,7 @@ public class TypeParameterNode extends NonTerminalNode {
         return childInBucket(0);
     }
 
-    public Node typeNode() {
+    public TypeDescriptorNode typeNode() {
         return childInBucket(1);
     }
 
@@ -64,7 +64,7 @@ public class TypeParameterNode extends NonTerminalNode {
 
     public TypeParameterNode modify(
             Token ltToken,
-            Node typeNode,
+            TypeDescriptorNode typeNode,
             Token gtToken) {
         if (checkForReferenceEquality(
                 ltToken,
@@ -91,7 +91,7 @@ public class TypeParameterNode extends NonTerminalNode {
     public static class TypeParameterNodeModifier {
         private final TypeParameterNode oldNode;
         private Token ltToken;
-        private Node typeNode;
+        private TypeDescriptorNode typeNode;
         private Token gtToken;
 
         public TypeParameterNodeModifier(TypeParameterNode oldNode) {
@@ -109,7 +109,7 @@ public class TypeParameterNode extends NonTerminalNode {
         }
 
         public TypeParameterNodeModifier withTypeNode(
-                Node typeNode) {
+                TypeDescriptorNode typeNode) {
             Objects.requireNonNull(typeNode, "typeNode must not be null");
             this.typeNode = typeNode;
             return this;

--- a/compiler/ballerina-parser/src/test/resources/expressions/binary-expr/range_expr_assert_4.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/binary-expr/range_expr_assert_4.json
@@ -39,18 +39,23 @@
                   "kind": "MAP_KEYWORD"
                 },
                 {
-                  "kind": "LT_TOKEN"
-                },
-                {
-                  "kind": "INT_TYPE_DESC",
+                  "kind": "TYPE_PARAMETER",
                   "children": [
                     {
-                      "kind": "INT_KEYWORD"
+                      "kind": "LT_TOKEN"
+                    },
+                    {
+                      "kind": "INT_TYPE_DESC",
+                      "children": [
+                        {
+                          "kind": "INT_KEYWORD"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "GT_TOKEN"
                     }
                   ]
-                },
-                {
-                  "kind": "GT_TOKEN"
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/expressions/binary-expr/shift_expr_assert_6.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/binary-expr/shift_expr_assert_6.json
@@ -42,18 +42,23 @@
                       "kind": "MAP_KEYWORD"
                     },
                     {
-                      "kind": "LT_TOKEN"
-                    },
-                    {
-                      "kind": "INT_TYPE_DESC",
+                      "kind": "TYPE_PARAMETER",
                       "children": [
                         {
-                          "kind": "INT_KEYWORD"
+                          "kind": "LT_TOKEN"
+                        },
+                        {
+                          "kind": "INT_TYPE_DESC",
+                          "children": [
+                            {
+                              "kind": "INT_KEYWORD"
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "GT_TOKEN"
                         }
                       ]
-                    },
-                    {
-                      "kind": "GT_TOKEN"
                     }
                   ]
                 }

--- a/compiler/ballerina-parser/src/test/resources/expressions/binary-expr/shift_expr_assert_7.json
+++ b/compiler/ballerina-parser/src/test/resources/expressions/binary-expr/shift_expr_assert_7.json
@@ -21,22 +21,35 @@
                   "kind": "MAP_KEYWORD"
                 },
                 {
-                  "kind": "LT_TOKEN"
-                },
-                {
-                  "kind": "PARAMETERIZED_TYPE_DESC",
+                  "kind": "TYPE_PARAMETER",
                   "children": [
-                    {
-                      "kind": "MAP_KEYWORD"
-                    },
                     {
                       "kind": "LT_TOKEN"
                     },
                     {
-                      "kind": "INT_TYPE_DESC",
+                      "kind": "PARAMETERIZED_TYPE_DESC",
                       "children": [
                         {
-                          "kind": "INT_KEYWORD"
+                          "kind": "MAP_KEYWORD"
+                        },
+                        {
+                          "kind": "TYPE_PARAMETER",
+                          "children": [
+                            {
+                              "kind": "LT_TOKEN"
+                            },
+                            {
+                              "kind": "INT_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "INT_KEYWORD"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "GT_TOKEN"
+                            }
+                          ]
                         }
                       ]
                     },
@@ -44,9 +57,6 @@
                       "kind": "GT_TOKEN"
                     }
                   ]
-                },
-                {
-                  "kind": "GT_TOKEN"
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/intersection-type/intersection_type_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/types/intersection-type/intersection_type_assert_01.json
@@ -266,22 +266,27 @@
                               ]
                             },
                             {
-                              "kind": "LT_TOKEN"
-                            },
-                            {
-                              "kind": "STRING_TYPE_DESC",
+                              "kind": "TYPE_PARAMETER",
                               "children": [
                                 {
-                                  "kind": "STRING_KEYWORD"
-                                }
-                              ]
-                            },
-                            {
-                              "kind": "GT_TOKEN",
-                              "trailingMinutiae": [
+                                  "kind": "LT_TOKEN"
+                                },
                                 {
-                                  "kind": "WHITESPACE_MINUTIAE",
-                                  "value": " "
+                                  "kind": "STRING_TYPE_DESC",
+                                  "children": [
+                                    {
+                                      "kind": "STRING_KEYWORD"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "GT_TOKEN",
+                                  "trailingMinutiae": [
+                                    {
+                                      "kind": "WHITESPACE_MINUTIAE",
+                                      "value": " "
+                                    }
+                                  ]
                                 }
                               ]
                             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_01.json
@@ -81,22 +81,27 @@
                           ]
                         },
                         {
-                          "kind": "LT_TOKEN"
-                        },
-                        {
-                          "kind": "STRING_TYPE_DESC",
+                          "kind": "TYPE_PARAMETER",
                           "children": [
                             {
-                              "kind": "STRING_KEYWORD"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "GT_TOKEN",
-                          "trailingMinutiae": [
+                              "kind": "LT_TOKEN"
+                            },
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
+                              "kind": "STRING_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "STRING_KEYWORD"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "GT_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
                             }
                           ]
                         }
@@ -147,155 +152,11 @@
                           ]
                         },
                         {
-                          "kind": "LT_TOKEN"
-                        },
-                        {
-                          "kind": "SIMPLE_NAME_REFERENCE",
+                          "kind": "TYPE_PARAMETER",
                           "children": [
                             {
-                              "kind": "IDENTIFIER_TOKEN",
-                              "value": "T"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "GT_TOKEN",
-                          "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "CAPTURE_BINDING_PATTERN",
-                      "children": [
-                        {
-                          "kind": "IDENTIFIER_TOKEN",
-                          "value": "a"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "SEMICOLON_TOKEN",
-                  "trailingMinutiae": [
-                    {
-                      "kind": "END_OF_LINE_MINUTIAE",
-                      "value": "\n"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "LOCAL_VAR_DECL",
-              "children": [
-                {
-                  "kind": "LIST",
-                  "children": []
-                },
-                {
-                  "kind": "TYPED_BINDING_PATTERN",
-                  "children": [
-                    {
-                      "kind": "PARAMETERIZED_TYPE_DESC",
-                      "children": [
-                        {
-                          "kind": "FUTURE_KEYWORD",
-                          "leadingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": "    "
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "LT_TOKEN"
-                        },
-                        {
-                          "kind": "ARRAY_TYPE_DESC",
-                          "children": [
-                            {
-                              "kind": "STRING_TYPE_DESC",
-                              "children": [
-                                {
-                                  "kind": "STRING_KEYWORD"
-                                }
-                              ]
+                              "kind": "LT_TOKEN"
                             },
-                            {
-                              "kind": "OPEN_BRACKET_TOKEN"
-                            },
-                            {
-                              "kind": "CLOSE_BRACKET_TOKEN"
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "GT_TOKEN",
-                          "trailingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
-                            }
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "kind": "CAPTURE_BINDING_PATTERN",
-                      "children": [
-                        {
-                          "kind": "IDENTIFIER_TOKEN",
-                          "value": "a"
-                        }
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "kind": "SEMICOLON_TOKEN",
-                  "trailingMinutiae": [
-                    {
-                      "kind": "END_OF_LINE_MINUTIAE",
-                      "value": "\n"
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "LOCAL_VAR_DECL",
-              "children": [
-                {
-                  "kind": "LIST",
-                  "children": []
-                },
-                {
-                  "kind": "TYPED_BINDING_PATTERN",
-                  "children": [
-                    {
-                      "kind": "PARAMETERIZED_TYPE_DESC",
-                      "children": [
-                        {
-                          "kind": "FUTURE_KEYWORD",
-                          "leadingMinutiae": [
-                            {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": "    "
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "LT_TOKEN"
-                        },
-                        {
-                          "kind": "OPTIONAL_TYPE_DESC",
-                          "children": [
                             {
                               "kind": "SIMPLE_NAME_REFERENCE",
                               "children": [
@@ -306,16 +167,175 @@
                               ]
                             },
                             {
-                              "kind": "QUESTION_MARK_TOKEN"
+                              "kind": "GT_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CAPTURE_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "a"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "children": [
+                    {
+                      "kind": "PARAMETERIZED_TYPE_DESC",
+                      "children": [
+                        {
+                          "kind": "FUTURE_KEYWORD",
+                          "leadingMinutiae": [
+                            {
+                              "kind": "WHITESPACE_MINUTIAE",
+                              "value": "    "
                             }
                           ]
                         },
                         {
-                          "kind": "GT_TOKEN",
-                          "trailingMinutiae": [
+                          "kind": "TYPE_PARAMETER",
+                          "children": [
+                            {
+                              "kind": "LT_TOKEN"
+                            },
+                            {
+                              "kind": "ARRAY_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "STRING_TYPE_DESC",
+                                  "children": [
+                                    {
+                                      "kind": "STRING_KEYWORD"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "OPEN_BRACKET_TOKEN"
+                                },
+                                {
+                                  "kind": "CLOSE_BRACKET_TOKEN"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "GT_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "CAPTURE_BINDING_PATTERN",
+                      "children": [
+                        {
+                          "kind": "IDENTIFIER_TOKEN",
+                          "value": "a"
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "SEMICOLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "LOCAL_VAR_DECL",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "TYPED_BINDING_PATTERN",
+                  "children": [
+                    {
+                      "kind": "PARAMETERIZED_TYPE_DESC",
+                      "children": [
+                        {
+                          "kind": "FUTURE_KEYWORD",
+                          "leadingMinutiae": [
                             {
                               "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
+                              "value": "    "
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "TYPE_PARAMETER",
+                          "children": [
+                            {
+                              "kind": "LT_TOKEN"
+                            },
+                            {
+                              "kind": "OPTIONAL_TYPE_DESC",
+                              "children": [
+                                {
+                                  "kind": "SIMPLE_NAME_REFERENCE",
+                                  "children": [
+                                    {
+                                      "kind": "IDENTIFIER_TOKEN",
+                                      "value": "T"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "QUESTION_MARK_TOKEN"
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "GT_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
                             }
                           ]
                         }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_02.json
@@ -11,22 +11,27 @@
               "kind": "MAP_KEYWORD"
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "STRING_TYPE_DESC",
+              "kind": "TYPE_PARAMETER",
               "children": [
                 {
-                  "kind": "STRING_KEYWORD"
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "trailingMinutiae": [
+                  "kind": "LT_TOKEN"
+                },
                 {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                  "kind": "STRING_TYPE_DESC",
+                  "children": [
+                    {
+                      "kind": "STRING_KEYWORD"
+                    }
+                  ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_03.json
@@ -11,23 +11,28 @@
               "kind": "FUTURE_KEYWORD"
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "SIMPLE_NAME_REFERENCE",
+              "kind": "TYPE_PARAMETER",
               "children": [
                 {
-                  "kind": "IDENTIFIER_TOKEN",
-                  "value": "T"
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "trailingMinutiae": [
+                  "kind": "LT_TOKEN"
+                },
                 {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                  "kind": "SIMPLE_NAME_REFERENCE",
+                  "children": [
+                    {
+                      "kind": "IDENTIFIER_TOKEN",
+                      "value": "T"
+                    }
+                  ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_04.json
@@ -11,30 +11,35 @@
               "kind": "MAP_KEYWORD"
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "OPTIONAL_TYPE_DESC",
+              "kind": "TYPE_PARAMETER",
               "children": [
                 {
-                  "kind": "STRING_TYPE_DESC",
+                  "kind": "LT_TOKEN"
+                },
+                {
+                  "kind": "OPTIONAL_TYPE_DESC",
                   "children": [
                     {
-                      "kind": "STRING_KEYWORD"
+                      "kind": "STRING_TYPE_DESC",
+                      "children": [
+                        {
+                          "kind": "STRING_KEYWORD"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "QUESTION_MARK_TOKEN"
                     }
                   ]
                 },
                 {
-                  "kind": "QUESTION_MARK_TOKEN"
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "trailingMinutiae": [
-                {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                  "kind": "GT_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_06.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_06.json
@@ -14,28 +14,34 @@
               "kind": "MAP_KEYWORD"
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "INT_TYPE_DESC",
+              "kind": "TYPE_PARAMETER",
+              "hasDiagnostics": true,
               "children": [
                 {
-                  "kind": "INT_KEYWORD",
-                  "trailingMinutiae": [
+                  "kind": "LT_TOKEN"
+                },
+                {
+                  "kind": "INT_TYPE_DESC",
+                  "children": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
+                      "kind": "INT_KEYWORD",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
                     }
                   ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_MISSING_GT_TOKEN"
+                  ]
                 }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "isMissing": true,
-              "hasDiagnostics": true,
-              "diagnostics": [
-                "ERROR_MISSING_GT_TOKEN"
               ]
             }
           ]

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_08.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_08.json
@@ -20,27 +20,33 @@
               ]
             },
             {
-              "kind": "LT_TOKEN",
-              "isMissing": true,
+              "kind": "TYPE_PARAMETER",
               "hasDiagnostics": true,
-              "diagnostics": [
-                "ERROR_MISSING_LT_TOKEN"
-              ]
-            },
-            {
-              "kind": "INT_TYPE_DESC",
               "children": [
                 {
-                  "kind": "INT_KEYWORD"
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "trailingMinutiae": [
+                  "kind": "LT_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_MISSING_LT_TOKEN"
+                  ]
+                },
                 {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                  "kind": "INT_TYPE_DESC",
+                  "children": [
+                    {
+                      "kind": "INT_KEYWORD"
+                    }
+                  ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_09.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_09.json
@@ -20,33 +20,39 @@
               ]
             },
             {
-              "kind": "LT_TOKEN",
-              "isMissing": true,
+              "kind": "TYPE_PARAMETER",
               "hasDiagnostics": true,
-              "diagnostics": [
-                "ERROR_MISSING_LT_TOKEN"
-              ]
-            },
-            {
-              "kind": "INT_TYPE_DESC",
               "children": [
                 {
-                  "kind": "INT_KEYWORD",
-                  "trailingMinutiae": [
+                  "kind": "LT_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_MISSING_LT_TOKEN"
+                  ]
+                },
+                {
+                  "kind": "INT_TYPE_DESC",
+                  "children": [
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
+                      "kind": "INT_KEYWORD",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
                     }
                   ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_MISSING_GT_TOKEN"
+                  ]
                 }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "isMissing": true,
-              "hasDiagnostics": true,
-              "diagnostics": [
-                "ERROR_MISSING_GT_TOKEN"
               ]
             }
           ]

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_10.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_10.json
@@ -14,28 +14,34 @@
               "kind": "MAP_KEYWORD"
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "TYPE_DESC",
+              "kind": "TYPE_PARAMETER",
               "hasDiagnostics": true,
               "children": [
                 {
-                  "kind": "TYPE_DESC",
-                  "isMissing": true,
-                  "hasDiagnostics": true,
-                  "diagnostics": [
-                    "ERROR_MISSING_TYPE_DESC"
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "trailingMinutiae": [
+                  "kind": "LT_TOKEN"
+                },
                 {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                  "kind": "TYPE_DESC",
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "TYPE_DESC",
+                      "isMissing": true,
+                      "hasDiagnostics": true,
+                      "diagnostics": [
+                        "ERROR_MISSING_TYPE_DESC"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_11.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_11.json
@@ -70,22 +70,27 @@
                   "kind": "MAP_KEYWORD"
                 },
                 {
-                  "kind": "LT_TOKEN"
-                },
-                {
-                  "kind": "INT_TYPE_DESC",
+                  "kind": "TYPE_PARAMETER",
                   "children": [
                     {
-                      "kind": "INT_KEYWORD"
-                    }
-                  ]
-                },
-                {
-                  "kind": "GT_TOKEN",
-                  "trailingMinutiae": [
+                      "kind": "LT_TOKEN"
+                    },
                     {
-                      "kind": "WHITESPACE_MINUTIAE",
-                      "value": " "
+                      "kind": "INT_TYPE_DESC",
+                      "children": [
+                        {
+                          "kind": "INT_KEYWORD"
+                        }
+                      ]
+                    },
+                    {
+                      "kind": "GT_TOKEN",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
                     }
                   ]
                 }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_12.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_12.json
@@ -19,22 +19,27 @@
               ]
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "INT_TYPE_DESC",
+              "kind": "TYPE_PARAMETER",
               "children": [
                 {
-                  "kind": "INT_KEYWORD"
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "trailingMinutiae": [
+                  "kind": "LT_TOKEN"
+                },
                 {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                  "kind": "INT_TYPE_DESC",
+                  "children": [
+                    {
+                      "kind": "INT_KEYWORD"
+                    }
+                  ]
+                },
+                {
+                  "kind": "GT_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_13.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_13.json
@@ -14,45 +14,51 @@
               "kind": "MAP_KEYWORD"
             },
             {
-              "kind": "LT_TOKEN"
-            },
-            {
-              "kind": "TYPE_DESC",
+              "kind": "TYPE_PARAMETER",
               "hasDiagnostics": true,
               "children": [
                 {
+                  "kind": "LT_TOKEN"
+                },
+                {
                   "kind": "TYPE_DESC",
-                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "TYPE_DESC",
+                      "isMissing": true,
+                      "hasDiagnostics": true,
+                      "diagnostics": [
+                        "ERROR_MISSING_TYPE_DESC"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "GT_TOKEN",
                   "hasDiagnostics": true,
                   "diagnostics": [
-                    "ERROR_MISSING_TYPE_DESC"
-                  ]
-                }
-              ]
-            },
-            {
-              "kind": "GT_TOKEN",
-              "hasDiagnostics": true,
-              "diagnostics": [
-                "ERROR_INVALID_TOKEN"
-              ],
-              "leadingMinutiae": [
-                {
-                  "kind": "INVALID_NODE_MINUTIAE",
-                  "invalidNode": {
-                    "kind": "INVALID_TOKEN_MINUTIAE_NODE",
-                    "children": [
-                      {
-                        "kind": "PERCENT_TOKEN"
+                    "ERROR_INVALID_TOKEN"
+                  ],
+                  "leadingMinutiae": [
+                    {
+                      "kind": "INVALID_NODE_MINUTIAE",
+                      "invalidNode": {
+                        "kind": "INVALID_TOKEN_MINUTIAE_NODE",
+                        "children": [
+                          {
+                            "kind": "PERCENT_TOKEN"
+                          }
+                        ]
                       }
-                    ]
-                  }
-                }
-              ],
-              "trailingMinutiae": [
-                {
-                  "kind": "WHITESPACE_MINUTIAE",
-                  "value": " "
+                    }
+                  ],
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
                 }
               ]
             }

--- a/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_14.json
+++ b/compiler/ballerina-parser/src/test/resources/types/parameterized-type/parameterized_type_assert_14.json
@@ -83,28 +83,34 @@
                           ]
                         },
                         {
-                          "kind": "LT_TOKEN"
-                        },
-                        {
-                          "kind": "TYPE_DESC",
+                          "kind": "TYPE_PARAMETER",
                           "hasDiagnostics": true,
                           "children": [
                             {
-                              "kind": "TYPE_DESC",
-                              "isMissing": true,
-                              "hasDiagnostics": true,
-                              "diagnostics": [
-                                "ERROR_MISSING_TYPE_DESC"
-                              ]
-                            }
-                          ]
-                        },
-                        {
-                          "kind": "GT_TOKEN",
-                          "trailingMinutiae": [
+                              "kind": "LT_TOKEN"
+                            },
                             {
-                              "kind": "WHITESPACE_MINUTIAE",
-                              "value": " "
+                              "kind": "TYPE_DESC",
+                              "hasDiagnostics": true,
+                              "children": [
+                                {
+                                  "kind": "TYPE_DESC",
+                                  "isMissing": true,
+                                  "hasDiagnostics": true,
+                                  "diagnostics": [
+                                    "ERROR_MISSING_TYPE_DESC"
+                                  ]
+                                }
+                              ]
+                            },
+                            {
+                              "kind": "GT_TOKEN",
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": " "
+                                }
+                              ]
                             }
                           ]
                         }

--- a/compiler/ballerina-parser/src/test/resources/types/union-type/union_type_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/types/union-type/union_type_assert_01.json
@@ -242,18 +242,23 @@
                               ]
                             },
                             {
-                              "kind": "LT_TOKEN"
-                            },
-                            {
-                              "kind": "STRING_TYPE_DESC",
+                              "kind": "TYPE_PARAMETER",
                               "children": [
                                 {
-                                  "kind": "STRING_KEYWORD"
+                                  "kind": "LT_TOKEN"
+                                },
+                                {
+                                  "kind": "STRING_TYPE_DESC",
+                                  "children": [
+                                    {
+                                      "kind": "STRING_KEYWORD"
+                                    }
+                                  ]
+                                },
+                                {
+                                  "kind": "GT_TOKEN"
                                 }
                               ]
-                            },
-                            {
-                              "kind": "GT_TOKEN"
                             }
                           ]
                         },

--- a/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
+++ b/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
@@ -1558,16 +1558,8 @@
                     "type": "Token"
                 },
                 {
-                    "name": "ltToken",
-                    "type": "Token"
-                },
-                {
-                    "name": "typeNode",
-                    "type": "Node"
-                },
-                {
-                    "name": "gtToken",
-                    "type": "Token"
+                    "name": "typeParameter",
+                    "type": "TypeParameterNode"
                 }
             ]
         },
@@ -2450,7 +2442,7 @@
                 },
                 {
                     "name": "typeNode",
-                    "type": "Node"
+                    "type": "TypeDescriptorNode"
                 },
                 {
                     "name": "gtToken",

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1636,18 +1636,27 @@ public class FormattingTreeModifier extends TreeModifier {
     public ParameterizedTypeDescriptorNode transform(ParameterizedTypeDescriptorNode parameterizedTypeDescriptorNode) {
         int startCol = getStartColumn(parameterizedTypeDescriptorNode, parameterizedTypeDescriptorNode.kind(), true);
         Token parameterizedType = getToken(parameterizedTypeDescriptorNode.parameterizedType());
-        Token ltToken = getToken(parameterizedTypeDescriptorNode.ltToken());
-        Node typeNode = this.modifyNode(parameterizedTypeDescriptorNode.typeNode());
-        Token gtToken = getToken(parameterizedTypeDescriptorNode.gtToken());
+        TypeParameterNode typeParameter = this.modifyNode(parameterizedTypeDescriptorNode.typeParameter());
+
+        return parameterizedTypeDescriptorNode.modify()
+                .withParameterizedType(formatToken(parameterizedType, startCol, 0, 0, 0))
+                .withTypeParameter(typeParameter)
+                .apply();
+    }
+
+    @Override
+    public TypeParameterNode transform(TypeParameterNode typeParameterNode) {
+        Token ltToken = getToken(typeParameterNode.ltToken());
+        TypeDescriptorNode typeNode = this.modifyNode(typeParameterNode.typeNode());
+        Token gtToken = getToken(typeParameterNode.gtToken());
 
         if (typeNode != null) {
-            parameterizedTypeDescriptorNode = parameterizedTypeDescriptorNode.modify()
+            typeParameterNode = typeParameterNode.modify()
                     .withTypeNode(typeNode)
                     .apply();
         }
 
-        return parameterizedTypeDescriptorNode.modify()
-                .withParameterizedType(formatToken(parameterizedType, startCol, 0, 0, 0))
+        return typeParameterNode.modify()
                 .withLtToken(formatToken(ltToken, 0, 0, 0, 0))
                 .withGtToken(formatToken(gtToken, 0, 0, 0, 0))
                 .apply();


### PR DESCRIPTION
## Purpose
To Use TypeParameterNode in ParameterizedTypeDescriptorNode

Fixes #23253 

## Approach
Change the Structure of ParameterizedTypeDescriptorNode to include
TypeParameterNode

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
