### PR TITLE
Fix name capture issue from object method symbol

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -102,7 +102,10 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
                 String mName = ((SimpleNameReferenceNode) ((MethodCallExpressionNode) expr)
                         .methodName()).name().text();
                 return filtered.stream()
-                        .filter(scopeEntry -> scopeEntry.symbol.getName().getValue().equals(mName))
+                        .filter(scopeEntry -> {
+                            String[] nameComps = scopeEntry.symbol.getName().getValue().split("\\.");
+                            return nameComps[nameComps.length - 1].equals(mName);
+                        })
                         .findFirst()
                         .map(entry -> this.getEntriesForSymbol(mName, ((BInvokableSymbol) entry.symbol).retType, ctx))
                         .orElseGet(ArrayList::new);


### PR DESCRIPTION
## Purpose
> Consider the following source snippet,

```
import ballerina/http;

public function main() returns @tainted error? {
	http:Client clientEP = new("");

	http:Response getResult = check clientEP->get("/");

	if (getResult.getTextPayload() is string) {
		getResult.getTextPayload().<cursor>
 	} else {

 	}
}
```

Completions are not provided for the given location. With this PR, fix the issue when capturing the name of the object method symbol.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
