### PR TITLE
Add runtime jar with distribution module as well

### DIFF
--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/JarResolverImpl.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/JarResolverImpl.java
@@ -130,7 +130,7 @@ public class JarResolverImpl implements JarResolver {
         // copy platform libs for all modules(imported modules as well)
         addPlatformLibs(packageID, modulePlatformLibs);
         Path runtimeJar = getRuntimeJar();
-        if (runtimeJar != null && !isModuleInDistribution(packageID)) {
+        if (runtimeJar != null) {
             modulePlatformLibs.add(getRuntimeJar());
         }
 


### PR DESCRIPTION
## Purpose
> Runtime jar is not getting added to the list of nativeDependencies if it is a module inside the distribution. But it should be added to compile this module. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/25309

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
