### PR TITLE
Refactor genJMethodForBFunc method of JvmMethodGen

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -1,0 +1,545 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.bir.codegen;
+
+import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.model.elements.PackageID;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.wso2.ballerinalang.compiler.bir.codegen.internal.AsyncDataCollector;
+import org.wso2.ballerinalang.compiler.bir.codegen.internal.LabelGenerator;
+import org.wso2.ballerinalang.compiler.bir.codegen.internal.ScheduleFunctionInfo;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.JType;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags;
+import org.wso2.ballerinalang.compiler.bir.model.BIRInstruction;
+import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
+import org.wso2.ballerinalang.compiler.util.TypeTags;
+import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
+import org.wso2.ballerinalang.util.Flags;
+
+import java.util.List;
+
+import static org.objectweb.asm.Opcodes.AASTORE;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ANEWARRAY;
+import static org.objectweb.asm.Opcodes.BIPUSH;
+import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.GOTO;
+import static org.objectweb.asm.Opcodes.ICONST_0;
+import static org.objectweb.asm.Opcodes.ICONST_1;
+import static org.objectweb.asm.Opcodes.IFNE;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.NEW;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_EXTENSION;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BTYPE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_STRING_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHANNEL_DETAILS;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONSTRUCTOR_INIT_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FILE_NAME_PERIOD_SEPERATOR;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_POINTER;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUTURE_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HANDLE_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JAVA_PACKAGE_SEPERATOR;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_CLASS;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_METADATA;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_METADATA_VAR_PREFIX;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STREAM_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TABLE_VALUE_IMPL;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WINDOWS_PATH_SEPERATOR;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_VALUE;
+
+/**
+ * The common functions used in CodeGen.
+ */
+public class JvmCodeGenUtil {
+    public static final ResolvedTypeBuilder TYPE_BUILDER = new ResolvedTypeBuilder();
+    public static final String INITIAL_MEHOD_DESC = "(Lorg/ballerinalang/jvm/scheduling/Strand;";
+
+    private JvmCodeGenUtil() {
+
+    }
+
+    static void visitInvokeDynamic(MethodVisitor mv, String currentClass, String lambdaName, int size) {
+        String mapDesc = getMapsDesc(size);
+        Handle handle = new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory",
+                                   "metafactory", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;" +
+                "Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;" +
+                "Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", false);
+
+        mv.visitInvokeDynamicInsn("apply", "(" + mapDesc + ")Ljava/util/function/Function;", handle,
+                                  Type.getType("(Ljava/lang/Object;)Ljava/lang/Object;"),
+                                  new Handle(Opcodes.H_INVOKESTATIC, currentClass, lambdaName, "(" + mapDesc + "[" +
+                        "Ljava/lang/Object;)Ljava/lang/Object;", false),
+                                  Type.getType("([Ljava/lang/Object;" + ")Ljava/lang/Object;"));
+    }
+
+    private static String getMapsDesc(long count) {
+        StringBuilder builder = new StringBuilder();
+        for (long i = count; i > 0; i--) {
+            builder.append("Lorg/ballerinalang/jvm/values/MapValue;");
+        }
+        return builder.toString();
+    }
+
+    static void createFunctionPointer(MethodVisitor mv, String className, String lambdaName) {
+        mv.visitTypeInsn(Opcodes.NEW, FUNCTION_POINTER);
+        mv.visitInsn(Opcodes.DUP);
+        visitInvokeDynamic(mv, className, cleanupFunctionName(lambdaName), 0);
+
+        // load null here for type, since these are fps created for internal usage.
+        mv.visitInsn(Opcodes.ACONST_NULL);
+        mv.visitInsn(Opcodes.ACONST_NULL);
+        mv.visitInsn(Opcodes.ICONST_0); // mark as not-concurrent ie: 'parent'
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, FUNCTION_POINTER, JVM_INIT_METHOD,
+                           String.format("(L%s;L%s;L%s;Z)V", FUNCTION, BTYPE, STRING_VALUE), false);
+    }
+
+    /**
+     * Cleanup type name by replacing '$' with '_'.
+     *
+     * @param name name to be replaced and cleaned
+     * @return cleaned name
+     */
+    static String cleanupTypeName(String name) {
+        return name.replaceAll("[/$ .]", "_");
+    }
+
+    static String cleanupPathSeparators(String name) {
+        name = cleanupBalExt(name);
+        return name.replace(WINDOWS_PATH_SEPERATOR, JAVA_PACKAGE_SEPERATOR);
+    }
+
+    private static String cleanupBalExt(String name) {
+        return name.replace(BAL_EXTENSION, "");
+    }
+
+    static String getFieldTypeSignature(BType bType) {
+        if (TypeTags.isIntegerTypeTag(bType.tag)) {
+            return "J";
+        } else if (TypeTags.isStringTypeTag(bType.tag)) {
+            return String.format("L%s;", B_STRING_VALUE);
+        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
+            return String.format("L%s;", XML_VALUE);
+        } else {
+            switch (bType.tag) {
+                case TypeTags.BYTE:
+                    return "I";
+                case TypeTags.FLOAT:
+                    return "D";
+                case TypeTags.DECIMAL:
+                    return String.format("L%s;", DECIMAL_VALUE);
+                case TypeTags.BOOLEAN:
+                    return "Z";
+                case TypeTags.NIL:
+                case TypeTags.NEVER:
+                case TypeTags.ANY:
+                case TypeTags.ANYDATA:
+                case TypeTags.UNION:
+                case TypeTags.INTERSECTION:
+                case TypeTags.JSON:
+                case TypeTags.FINITE:
+                case TypeTags.READONLY:
+                    return String.format("L%s;", OBJECT);
+                case TypeTags.MAP:
+                case TypeTags.RECORD:
+                    return String.format("L%s;", MAP_VALUE);
+                case TypeTags.STREAM:
+                    return String.format("L%s;", STREAM_VALUE);
+                case TypeTags.TABLE:
+                    return String.format("L%s;", TABLE_VALUE_IMPL);
+                case TypeTags.ARRAY:
+                case TypeTags.TUPLE:
+                    return String.format("L%s;", ARRAY_VALUE);
+                case TypeTags.ERROR:
+                    return String.format("L%s;", ERROR_VALUE);
+                case TypeTags.FUTURE:
+                    return String.format("L%s;", FUTURE_VALUE);
+                case TypeTags.OBJECT:
+                    return String.format("L%s;", OBJECT_VALUE);
+                case TypeTags.TYPEDESC:
+                    return String.format("L%s;", TYPEDESC_VALUE);
+                case TypeTags.INVOKABLE:
+                    return String.format("L%s;", FUNCTION_POINTER);
+                case TypeTags.HANDLE:
+                    return String.format("L%s;", HANDLE_VALUE);
+                case JTypeTags.JTYPE:
+                    return InteropMethodGen.getJTypeSignature((JType) bType);
+                default:
+                    throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE + bType);
+            }
+        }
+    }
+
+    static void generateDefaultConstructor(ClassWriter cw, String ownerClass) {
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC, JVM_INIT_METHOD, "()V", null, null);
+        mv.visitCode();
+        mv.visitVarInsn(Opcodes.ALOAD, 0);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, ownerClass, JVM_INIT_METHOD, "()V", false);
+        mv.visitInsn(Opcodes.RETURN);
+        mv.visitMaxs(1, 1);
+        mv.visitEnd();
+    }
+
+    static void generateStrandMetadata(MethodVisitor mv, String moduleClass,
+                                       BIRNode.BIRPackage module, AsyncDataCollector asyncDataCollector) {
+        asyncDataCollector.getStrandMetadata().forEach(
+                (varName, metaData) -> genStrandMetadataField(mv, moduleClass, module, varName, metaData));
+    }
+
+    private static void genStrandMetadataField(MethodVisitor mv, String moduleClass, BIRNode.BIRPackage module,
+                                               String varName, ScheduleFunctionInfo metaData) {
+
+        mv.visitTypeInsn(Opcodes.NEW, STRAND_METADATA);
+        mv.visitInsn(Opcodes.DUP);
+        mv.visitLdcInsn(module.org.value);
+        mv.visitLdcInsn(module.name.value);
+        mv.visitLdcInsn(module.version.value);
+        if (metaData.typeName == null) {
+            mv.visitInsn(Opcodes.ACONST_NULL);
+        } else {
+            mv.visitLdcInsn(metaData.typeName);
+        }
+        mv.visitLdcInsn(metaData.parentFunctionName);
+        mv.visitMethodInsn(Opcodes.INVOKESPECIAL, STRAND_METADATA,
+                           CONSTRUCTOR_INIT_METHOD, String.format("(L%s;L%s;L%s;L%s;L%s;)V", STRING_VALUE, STRING_VALUE,
+                                                                  STRING_VALUE, STRING_VALUE, STRING_VALUE), false);
+        mv.visitFieldInsn(Opcodes.PUTSTATIC, moduleClass, varName, String.format("L%s;", STRAND_METADATA));
+    }
+
+    static void visitStrandMetadataField(ClassWriter cw, AsyncDataCollector asyncDataCollector) {
+        asyncDataCollector.getStrandMetadata().keySet().forEach(varName -> visitStrandMetadataField(cw, varName));
+    }
+
+    private static void visitStrandMetadataField(ClassWriter cw, String varName) {
+        FieldVisitor fv = cw.visitField(Opcodes.ACC_STATIC, varName, String.format("L%s;", STRAND_METADATA), null,
+                                        null);
+        fv.visitEnd();
+    }
+
+    static String getStrandMetadataVarName(String parentFunction) {
+        return STRAND_METADATA_VAR_PREFIX + parentFunction + "$";
+    }
+
+    public static String cleanupFunctionName(String functionName) {
+        return functionName.replaceAll("[\\.:/<>]", "_");
+    }
+
+    static boolean isExternFunc(BIRNode.BIRFunction func) {
+        return (func.flags & Flags.NATIVE) == Flags.NATIVE;
+    }
+
+    public static String getPackageName(PackageID packageID) {
+        return getPackageName(packageID.orgName, packageID.name, packageID.version);
+    }
+
+    public static String getPackageName(BIRNode.BIRPackage module) {
+        return getPackageName(module.org, module.name, module.version);
+    }
+
+    public static String getPackageName(Name orgName, Name moduleName, Name version) {
+        return getPackageName(orgName.getValue(), moduleName.getValue(), version.getValue());
+    }
+
+    public static String getPackageName(String orgName, String moduleName, String version) {
+        String packageName = "";
+        if (!moduleName.equals(".")) {
+            if (!version.equals("")) {
+                packageName = cleanupName(version) + "/";
+            }
+            packageName = cleanupName(moduleName) + "/" + packageName;
+        }
+
+        if (!orgName.equalsIgnoreCase("$anon")) {
+            packageName = cleanupName(orgName) + "/" + packageName;
+        }
+
+        return packageName;
+    }
+
+    static String cleanupName(String name) {
+        return name.replace(".", "_");
+    }
+
+    static String getModuleLevelClassName(BIRNode.BIRPackage module, String sourceFileName) {
+        return getModuleLevelClassName(module.org.value, module.name.value, module.version.value, sourceFileName);
+    }
+
+    static String getModuleLevelClassName(String orgName, String moduleName, String version, String sourceFileName) {
+        return getModuleLevelClassName(orgName, moduleName, version, sourceFileName, "/");
+    }
+
+    static String getModuleLevelClassName(String orgName, String moduleName, String version, String sourceFileName,
+                                          String separator) {
+        String className = cleanupSourceFileName(sourceFileName);
+        // handle source file path start with '/'.
+        if (className.startsWith(JAVA_PACKAGE_SEPERATOR)) {
+            className = className.substring(1);
+        }
+
+        if (!moduleName.equals(".")) {
+            if (!version.equals("")) {
+                className = cleanupName(version) + separator + className;
+            }
+            className = cleanupName(moduleName) + separator + className;
+        }
+
+        if (!orgName.equalsIgnoreCase("$anon")) {
+            className = cleanupName(orgName) + separator + className;
+        }
+
+        return className;
+    }
+
+    private static String cleanupSourceFileName(String name) {
+        return name.replace(".", FILE_NAME_PERIOD_SEPERATOR);
+    }
+
+    public static String getMethodDesc(List<BType> paramTypes, BType retType) {
+        return INITIAL_MEHOD_DESC + populateMethodDesc(paramTypes) + generateReturnType(retType);
+    }
+
+    public static String getMethodDesc(List<BType> paramTypes, BType retType, BType attachedType) {
+        return INITIAL_MEHOD_DESC + getArgTypeSignature(attachedType) + populateMethodDesc(paramTypes) +
+                generateReturnType(retType);
+    }
+
+    public static String populateMethodDesc(List<BType> paramTypes) {
+        StringBuilder descBuilder = new StringBuilder();
+        for (BType type : paramTypes) {
+            descBuilder.append(getArgTypeSignature(type));
+        }
+        return descBuilder.toString();
+    }
+
+    public static String getArgTypeSignature(BType bType) {
+        if (TypeTags.isIntegerTypeTag(bType.tag)) {
+            return "J";
+        } else if (TypeTags.isStringTypeTag(bType.tag)) {
+            return String.format("L%s;", B_STRING_VALUE);
+        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
+            return String.format("L%s;", XML_VALUE);
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                return "I";
+            case TypeTags.FLOAT:
+                return "D";
+            case TypeTags.DECIMAL:
+                return String.format("L%s;", DECIMAL_VALUE);
+            case TypeTags.BOOLEAN:
+                return "Z";
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.ANY:
+            case TypeTags.READONLY:
+                return String.format("L%s;", OBJECT);
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                return String.format("L%s;", ARRAY_VALUE);
+            case TypeTags.ERROR:
+                return String.format("L%s;", ERROR_VALUE);
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                return String.format("L%s;", MAP_VALUE);
+            case TypeTags.FUTURE:
+                return String.format("L%s;", FUTURE_VALUE);
+            case TypeTags.STREAM:
+                return String.format("L%s;", STREAM_VALUE);
+            case TypeTags.TABLE:
+                return String.format("L%s;", TABLE_VALUE_IMPL);
+            case TypeTags.INVOKABLE:
+                return String.format("L%s;", FUNCTION_POINTER);
+            case TypeTags.TYPEDESC:
+                return String.format("L%s;", TYPEDESC_VALUE);
+            case TypeTags.OBJECT:
+                return String.format("L%s;", OBJECT_VALUE);
+            case TypeTags.HANDLE:
+                return String.format("L%s;", HANDLE_VALUE);
+            default:
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
+                                                         String.format("%s", bType));
+        }
+    }
+
+    public static String generateReturnType(BType bType) {
+        bType = JvmCodeGenUtil.TYPE_BUILDER.build(bType);
+        if (bType == null || bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
+            return String.format(")L%s;", OBJECT);
+        } else if (TypeTags.isIntegerTypeTag(bType.tag)) {
+            return ")J";
+        } else if (TypeTags.isStringTypeTag(bType.tag)) {
+            return String.format(")L%s;", B_STRING_VALUE);
+        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
+            return String.format(")L%s;", XML_VALUE);
+        }
+
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                return ")I";
+            case TypeTags.FLOAT:
+                return ")D";
+            case TypeTags.DECIMAL:
+                return String.format(")L%s;", DECIMAL_VALUE);
+            case TypeTags.BOOLEAN:
+                return ")Z";
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                return String.format(")L%s;", ARRAY_VALUE);
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                return String.format(")L%s;", MAP_VALUE);
+            case TypeTags.ERROR:
+                return String.format(")L%s;", ERROR_VALUE);
+            case TypeTags.STREAM:
+                return String.format(")L%s;", STREAM_VALUE);
+            case TypeTags.TABLE:
+                return String.format(")L%s;", TABLE_VALUE_IMPL);
+            case TypeTags.FUTURE:
+                return String.format(")L%s;", FUTURE_VALUE);
+            case TypeTags.TYPEDESC:
+                return String.format(")L%s;", TYPEDESC_VALUE);
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.READONLY:
+                return String.format(")L%s;", OBJECT);
+            case TypeTags.OBJECT:
+                return String.format(")L%s;", OBJECT_VALUE);
+            case TypeTags.INVOKABLE:
+                return String.format(")L%s;", FUNCTION_POINTER);
+            case TypeTags.HANDLE:
+                return String.format(")L%s;", HANDLE_VALUE);
+            default:
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE + bType);
+        }
+    }
+
+    static String cleanupObjectTypeName(String typeName) {
+        int index = typeName.lastIndexOf(".");
+        if (index > 0) {
+            return typeName.substring(index + 1);
+        } else {
+            return typeName;
+        }
+    }
+
+    static void loadChannelDetails(MethodVisitor mv, List<BIRNode.ChannelDetails> channels) {
+        mv.visitIntInsn(BIPUSH, channels.size());
+        mv.visitTypeInsn(ANEWARRAY, CHANNEL_DETAILS);
+        int index = 0;
+        for (BIRNode.ChannelDetails ch : channels) {
+            mv.visitInsn(DUP);
+            mv.visitIntInsn(BIPUSH, index);
+            index += 1;
+
+            mv.visitTypeInsn(NEW, CHANNEL_DETAILS);
+            mv.visitInsn(DUP);
+            mv.visitLdcInsn(ch.name);
+
+            if (ch.channelInSameStrand) {
+                mv.visitInsn(ICONST_1);
+            } else {
+                mv.visitInsn(ICONST_0);
+            }
+
+            if (ch.send) {
+                mv.visitInsn(ICONST_1);
+            } else {
+                mv.visitInsn(ICONST_0);
+            }
+
+            mv.visitMethodInsn(INVOKESPECIAL, CHANNEL_DETAILS, JVM_INIT_METHOD,
+                    String.format("(L%s;ZZ)V", STRING_VALUE), false);
+            mv.visitInsn(AASTORE);
+        }
+    }
+
+    public static String toNameString(BType t) {
+        return t.tsymbol.name.value;
+    }
+
+    public static boolean isBallerinaBuiltinModule(String orgName, String moduleName) {
+        return orgName.equals("ballerina") && moduleName.equals("builtin");
+    }
+
+    public static void generateBbInstructions(MethodVisitor mv, LabelGenerator labelGen, JvmInstructionGen instGen,
+                                              int localVarOffset, AsyncDataCollector asyncDataCollector,
+                                              String funcName,
+                                              BIRNode.BIRBasicBlock bb) {
+        int insCount = bb.instructions.size();
+        for (int i = 0; i < insCount; i++) {
+            Label insLabel = labelGen.getLabel(funcName + bb.id.value + "ins" + i);
+            mv.visitLabel(insLabel);
+            BIRInstruction inst = bb.instructions.get(i);
+            if (inst != null) {
+                generateDiagnosticPos(((BIRNode) inst).pos, mv);
+                instGen.generateInstructions(localVarOffset, asyncDataCollector, inst);
+            }
+        }
+    }
+
+    public static void generateDiagnosticPos(DiagnosticPos pos, MethodVisitor mv) {
+        if (pos != null && pos.sLine != 0x80000000) {
+            Label label = new Label();
+            mv.visitLabel(label);
+            mv.visitLineNumber(pos.sLine, label);
+        }
+    }
+
+    public static void genYieldCheck(MethodVisitor mv, LabelGenerator labelGen, BIRNode.BIRBasicBlock thenBB,
+                                     String funcName, int localVarOffset) {
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "isYielded", "()Z", false);
+        Label yieldLabel = labelGen.getLabel(funcName + "yield");
+        mv.visitJumpInsn(IFNE, yieldLabel);
+
+        // goto thenBB
+        Label gotoLabel = labelGen.getLabel(funcName + thenBB.id.value);
+        mv.visitJumpInsn(GOTO, gotoLabel);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -105,10 +105,9 @@ public class JvmConstants {
     public static final String TYPE_CHECKER = "org/ballerinalang/jvm/TypeChecker";
     public static final String SCHEDULER = "org/ballerinalang/jvm/scheduling/Scheduler";
     public static final String JSON_UTILS = "org/ballerinalang/jvm/JSONUtils";
-    public static final String STRAND = "org/ballerinalang/jvm/scheduling/Strand";
+    public static final String STRAND_CLASS = "org/ballerinalang/jvm/scheduling/Strand";
     public static final String STRAND_METADATA = "org/ballerinalang/jvm/scheduling/StrandMetadata";
     public static final String TYPE_CONVERTER = "org/ballerinalang/jvm/TypeConverter";
-    public static final String LIST_UTILS = "org/ballerinalang/jvm/Lists";
     public static final String STRAND_STATE = "org/ballerinalang/jvm/scheduling/State";
     public static final String VALUE_CREATOR = "org/ballerinalang/jvm/values/ValueCreator";
     public static final String XML_FACTORY = "org/ballerinalang/jvm/XMLFactory";
@@ -131,7 +130,6 @@ public class JvmConstants {
 
     // other java classes
     public static final String OBJECT = "java/lang/Object";
-    public static final String MATH = "java/lang/Math";
     public static final String MAP = "java/util/Map";
     public static final String LINKED_HASH_MAP = "java/util/LinkedHashMap";
     public static final String ARRAY_LIST = "java/util/ArrayList";
@@ -139,17 +137,14 @@ public class JvmConstants {
     public static final String SET = "java/util/Set";
     public static final String LINKED_HASH_SET = "java/util/LinkedHashSet";
     public static final String STRING_BUILDER = "java/lang/StringBuilder";
-    public static final String STRING_JOINER = "java/util/StringJoiner";
     public static final String COMPARABLE = "java/lang/Comparable";
     public static final String FUNCTION = "java/util/function/Function";
-    public static final String EXCEPTION = "java/lang/Exception";
     public static final String LONG_STREAM = "java/util/stream/LongStream";
     public static final String JAVA_THREAD = "java/lang/Thread";
     public static final String JAVA_RUNTIME = "java/lang/Runtime";
     public static final String MAP_ENTRY = "java/util/Map$Entry";
     public static final String MAP_SIMPLE_ENTRY = "java/util/AbstractMap$SimpleEntry";
     public static final String COLLECTION = "java/util/Collection";
-    public static final String BIG_DECIMAL = "java/math/BigDecimal";
     public static final String NUMBER = "java/lang/Number";
     public static final String HASH_MAP = "java/util/HashMap";
 
@@ -167,8 +162,6 @@ public class JvmConstants {
     public static final String PRINT_STACK_TRACE_METHOD = "printStackTrace";
     public static final String SET_DETAIL_TYPE_METHOD = "setDetailType";
     public static final String SET_TYPEID_SET_METHOD = "setTypeIdSet";
-    public static final String ERROR_REASON_METHOD_TOO_LARGE = "MethodTooLarge";
-    public static final String ERROR_REASON_CLASS_TOO_LARGE = "ClassTooLarge";
     public static final String TRAP_ERROR_METHOD = "trapError";
     public static final String BLOCKED_ON_EXTERN_FIELD = "blockedOnExtern";
     public static final String IS_BLOCKED_ON_EXTERN_FIELD = "isBlockedOnExtern";
@@ -203,8 +196,6 @@ public class JvmConstants {
     public static final String BUILT_IN_PACKAGE_NAME = "lang.annotations";
     public static final String MODULE_START_ATTEMPTED = "$moduleStartAttempted";
     public static final String MODULE_STARTED = "$moduleStarted";
-    public static final String START_FUNCTION_SUFFIX = "<start>";
-    public static final String STOP_FUNCTION_SUFFIX = "<stop>";
     public static final String DESUGARED_BB_ID_NAME = "desugaredBB";
     public static final String WRAPPER_GEN_BB_ID_NAME = "wrapperGen";
     public static final String JVM_INIT_METHOD = "<init>";
@@ -230,7 +221,7 @@ public class JvmConstants {
     public static final String CREATE_OBJECT_VALUE = "createObjectValue";
 
     // strand data related constants
-    public static final String STRAND_ANNOTATION = "strand";
+    public static final String STRAND = "strand";
     public static final String STRAND_THREAD = "thread";
     public static final String STRAND_NAME = "name";
     public static final String STRAND_POLICY_NAME = "policy";
@@ -239,7 +230,6 @@ public class JvmConstants {
     public static final String DEFAULT_STRAND_DISPATCHER = "DEFAULT";
 
     // observability related constants
-    public static final String OBSERVER_CONTEXT = "org/ballerinalang/jvm/observability/ObserverContext";
     public static final String OBSERVE_UTILS = "org/ballerinalang/jvm/observability/ObserveUtils";
     public static final String START_RESOURCE_OBSERVATION_METHOD = "startResourceObservation";
     public static final String START_CALLABLE_OBSERVATION_METHOD = "startCallableObservation";
@@ -262,7 +252,11 @@ public class JvmConstants {
     public static final int TYPE_FLAG_PURETYPE = 4;
 
     // ballerina error reasons for ASM operations.
-    public static final String METHOD_TOO_LARGE = "MethodTooLarge";
     public static final String CLASS_TOO_LARGE = "ClassTooLarge";
 
+
+    public static final String TYPE_NOT_SUPPORTED_MESSAGE = "JVM generation is not supported for type ";
+
+    private JvmConstants() {
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -15,8 +15,10 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.wso2.ballerinalang.compiler.bir.codegen;
 
+import org.ballerinalang.compiler.BLangCompilerException;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunctionParameter;
@@ -38,13 +40,8 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DESUGARED_BB_ID_NAME;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupFunctionName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getBasicBlock;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFunction;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFunctionParam;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getVariableDcl;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Branch;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.GOTO;
 
@@ -57,15 +54,14 @@ public class JvmDesugarPhase {
 
     public static void addDefaultableBooleanVarsToSignature(BIRFunction func, BType booleanType) {
 
-        BIRFunction currentFunc = getFunction(func);
-        currentFunc.type = new BInvokableType(currentFunc.type.paramTypes, currentFunc.type.restType,
-                currentFunc.type.retType, currentFunc.type.tsymbol);
-        BInvokableType type = currentFunc.type;
-        currentFunc.type.paramTypes = updateParamTypesWithDefaultableBooleanVar(currentFunc.type.paramTypes,
-                type != null ? type.restType : type, booleanType);
+        func.type = new BInvokableType(func.type.paramTypes, func.type.restType,
+                                       func.type.retType, func.type.tsymbol);
+        BInvokableType type = func.type;
+        func.type.paramTypes = updateParamTypesWithDefaultableBooleanVar(func.type.paramTypes,
+                                                                         type.restType, booleanType);
         int index = 0;
         List<BIRVariableDcl> updatedVars = new ArrayList<>();
-        List<BIRVariableDcl> localVars = currentFunc.localVars;
+        List<BIRVariableDcl> localVars = func.localVars;
         int nameIndex = 0;
 
         for (BIRVariableDcl localVar : localVars) {
@@ -84,7 +80,7 @@ public class JvmDesugarPhase {
             updatedVars.add(index, booleanVar);
             index += 1;
         }
-        currentFunc.localVars = updatedVars;
+        func.localVars = updatedVars;
     }
 
     public static void enrichWithDefaultableParamInits(BIRFunction currentFunc, JvmMethodGen jvmMethodGen) {
@@ -93,7 +89,7 @@ public class JvmDesugarPhase {
         List<BIRFunctionParameter> functionParams = new ArrayList<>();
         List<BIRVariableDcl> localVars = currentFunc.localVars;
         while (k < localVars.size()) {
-            BIRVariableDcl localVar = getVariableDcl(localVars.get(k));
+            BIRVariableDcl localVar = localVars.get(k);
             if (localVar instanceof BIRFunctionParameter) {
                 functionParams.add((BIRFunctionParameter) localVar);
             }
@@ -117,14 +113,12 @@ public class JvmDesugarPhase {
                 UnaryOP notOp = new UnaryOP(pos, InstructionKind.NOT, boolRef, boolRef);
                 nextBB.instructions.add(notOp);
                 List<BIRBasicBlock> bbArray = currentFunc.parameters.get(funcParam);
-                BIRBasicBlock trueBB = getBasicBlock(bbArray.get(0));
-                for (BIRBasicBlock defaultBB : bbArray) {
-                    basicBlocks.add(getBasicBlock(defaultBB));
-                }
+                BIRBasicBlock trueBB = bbArray.get(0);
+                basicBlocks.addAll(bbArray);
                 BIRBasicBlock falseBB = insertAndGetNextBasicBlock(basicBlocks, DESUGARED_BB_ID_NAME, jvmMethodGen);
                 nextBB.terminator = new Branch(pos, boolRef, trueBB, falseBB);
 
-                BIRBasicBlock lastBB = getBasicBlock(bbArray.get(bbArray.size() - 1));
+                BIRBasicBlock lastBB = bbArray.get(bbArray.size() - 1);
                 lastBB.terminator = new GOTO(pos, falseBB);
 
                 nextBB = falseBB;
@@ -141,7 +135,7 @@ public class JvmDesugarPhase {
             return;
         }
 
-        BIRBasicBlock firstBB = getBasicBlock(currentFunc.basicBlocks.get(0));
+        BIRBasicBlock firstBB = currentFunc.basicBlocks.get(0);
 
         nextBB.terminator = new GOTO(pos, firstBB);
         basicBlocks.addAll(currentFunc.basicBlocks);
@@ -206,7 +200,7 @@ public class JvmDesugarPhase {
 
         // Rename the function name by appending the record name to it.
         // This done to avoid frame class name overlapping.
-        func.name = new Name(cleanupFunctionName(toNameString(recordType) + func.name.value));
+        func.name = new Name(JvmCodeGenUtil.cleanupFunctionName(toNameString(recordType) + func.name.value));
 
         // change the kind of receiver to 'ARG'
         receiver.kind = VarKind.ARG;
@@ -234,5 +228,16 @@ public class JvmDesugarPhase {
             index += 1;
         }
         func.localVars = updatedLocalVars;
+    }
+
+    private static BIRFunctionParameter getFunctionParam(BIRFunctionParameter localVar) {
+        if (localVar == null) {
+            throw new BLangCompilerException("Invalid function parameter");
+        }
+
+        return localVar;
+    }
+
+    private JvmDesugarPhase() {
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -19,11 +19,8 @@ package org.wso2.ballerinalang.compiler.bir.codegen;
 
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.model.elements.PackageID;
-import org.objectweb.asm.Handle;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.AsyncDataCollector;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.BIRVarToJVMIndexMap;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JCast;
@@ -31,6 +28,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.interop.JInsKind;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JInstruction;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JType;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags;
+import org.wso2.ballerinalang.compiler.bir.model.BIRInstruction;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.FieldAccess;
@@ -124,6 +122,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCastGen.generateChe
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCastGen.generateCheckCastToByte;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCastGen.generatePlatformCheckCast;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCastGen.getTargetClass;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANNOTATION_MAP_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANNOTATION_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_TYPE;
@@ -155,7 +154,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT_TYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SHORT_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_CLASS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TABLE_TYPE;
@@ -170,8 +169,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE_CHEC
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_FACTORY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_QNAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.duplicateServiceTypeWithAnnots;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.loadType;
@@ -187,12 +184,12 @@ public class JvmInstructionGen {
 
     //this anytype is currently set from package gen class
     static BType anyType;
-    private MethodVisitor mv;
-    private BIRVarToJVMIndexMap indexMap;
-    private String currentPackageName;
-    private BIRNode.BIRPackage currentPackage;
-    private JvmPackageGen jvmPackageGen;
-    private SymbolTable symbolTable;
+    private final MethodVisitor mv;
+    private final BIRVarToJVMIndexMap indexMap;
+    private final String currentPackageName;
+    private final BIRNode.BIRPackage currentPackage;
+    private final JvmPackageGen jvmPackageGen;
+    private final SymbolTable symbolTable;
 
     public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, BIRNode.BIRPackage currentPackage,
                              JvmPackageGen jvmPackageGen) {
@@ -202,22 +199,7 @@ public class JvmInstructionGen {
         this.currentPackage = currentPackage;
         this.jvmPackageGen = jvmPackageGen;
         this.symbolTable = jvmPackageGen.symbolTable;
-        this.currentPackageName = getPackageName(currentPackage.org.value, currentPackage.name.value,
-                                                 currentPackage.version.value);
-    }
-
-    static void addBoxInsn(MethodVisitor mv, BType bType) {
-
-        if (bType != null) {
-            generateCast(mv, bType, anyType);
-        }
-    }
-
-    public static void addUnboxInsn(MethodVisitor mv, BType bType) {
-
-        if (bType != null) {
-            generateCast(mv, anyType, bType);
-        }
+        this.currentPackageName = JvmCodeGenUtil.getPackageName(currentPackage);
     }
 
     static void addJUnboxInsn(MethodVisitor mv, JType jType) {
@@ -290,7 +272,7 @@ public class JvmInstructionGen {
                 mv.visitVarInsn(ALOAD, valueIndex);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", jType));
         }
     }
@@ -327,7 +309,7 @@ public class JvmInstructionGen {
                 mv.visitVarInsn(ASTORE, valueIndex);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", jType));
         }
     }
@@ -445,32 +427,7 @@ public class JvmInstructionGen {
         }
     }
 
-    static void visitInvokeDyn(MethodVisitor mv, String currentClass, String lambdaName, int size) {
-
-        String mapDesc = getMapsDesc(size);
-        Handle handle = new Handle(Opcodes.H_INVOKESTATIC, "java/lang/invoke/LambdaMetafactory",
-                "metafactory", "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;" +
-                "Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;" +
-                "Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;", false);
-
-        mv.visitInvokeDynamicInsn("apply", "(" + mapDesc + ")Ljava/util/function/Function;", handle,
-                Type.getType("(Ljava/lang/Object;)Ljava/lang/Object;"),
-                new Handle(Opcodes.H_INVOKESTATIC, currentClass, lambdaName, "(" + mapDesc + "[" +
-                        "Ljava/lang/Object;)Ljava/lang/Object;", false),
-                Type.getType("([Ljava/lang/Object;" + ")Ljava/lang/Object;"));
-    }
-
-    private static String getMapsDesc(long count) {
-
-        StringBuilder builder = new StringBuilder();
-        for (long i = count; i > 0; i--) {
-            builder.append("Lorg/ballerinalang/jvm/values/MapValue;");
-        }
-        return builder.toString();
-    }
-
-    public void generateVarLoad(MethodVisitor mv, BIRNode.BIRVariableDcl varDcl, String currentPackageName,
-                                int valueIndex) {
+    public void generateVarLoad(MethodVisitor mv, BIRNode.BIRVariableDcl varDcl, int valueIndex) {
 
         BType bType = varDcl.type;
 
@@ -478,7 +435,7 @@ public class JvmInstructionGen {
             case GLOBAL: {
                 BIRNode.BIRGlobalVariableDcl globalVar = (BIRNode.BIRGlobalVariableDcl) varDcl;
                 PackageID modId = globalVar.pkgId;
-                String moduleName = getPackageName(modId.orgName, modId.name, modId.version);
+                String moduleName = JvmCodeGenUtil.getPackageName(modId);
 
                 String varName = varDcl.name.value;
                 String className = jvmPackageGen.lookupGlobalVarClassName(moduleName, varName);
@@ -493,7 +450,7 @@ public class JvmInstructionGen {
             case CONSTANT: {
                 String varName = varDcl.name.value;
                 PackageID moduleId = ((BIRNode.BIRGlobalVariableDcl) varDcl).pkgId;
-                String pkgName = getPackageName(moduleId.orgName, moduleId.name, moduleId.version);
+                String pkgName = JvmCodeGenUtil.getPackageName(moduleId);
                 String className = jvmPackageGen.lookupGlobalVarClassName(pkgName, varName);
                 String typeSig = getTypeDesc(bType);
                 mv.visitFieldInsn(GETSTATIC, className, varName, typeSig);
@@ -550,13 +507,12 @@ public class JvmInstructionGen {
                 generateJVarLoad(mv, (JType) bType, currentPackageName, valueIndex);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", bType));
         }
     }
 
-    public void generateVarStore(MethodVisitor mv, BIRNode.BIRVariableDcl varDcl, String currentPackageName,
-                                 int valueIndex) {
+    public void generateVarStore(MethodVisitor mv, BIRNode.BIRVariableDcl varDcl, int valueIndex) {
 
         BType bType = varDcl.type;
 
@@ -569,7 +525,7 @@ public class JvmInstructionGen {
         } else if (varDcl.kind == VarKind.CONSTANT) {
             String varName = varDcl.name.value;
             PackageID moduleId = ((BIRNode.BIRGlobalVariableDcl) varDcl).pkgId;
-            String pkgName = getPackageName(moduleId.orgName, moduleId.name, moduleId.version);
+            String pkgName = JvmCodeGenUtil.getPackageName(moduleId);
             String className = jvmPackageGen.lookupGlobalVarClassName(pkgName, varName);
             String typeSig = getTypeDesc(bType);
             mv.visitFieldInsn(PUTSTATIC, className, varName, typeSig);
@@ -623,7 +579,7 @@ public class JvmInstructionGen {
                 generateJVarStore(mv, (JType) bType, currentPackageName, valueIndex);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", bType));
         }
     }
@@ -1007,7 +963,7 @@ public class JvmInstructionGen {
                 "(L%s;L%s;)L%s;", TYPEDESC_VALUE, JvmConstants.B_STRING_VALUE, OBJECT), false);
 
         BType targetType = binaryIns.lhsOp.variableDcl.type;
-        addUnboxInsn(this.mv, targetType);
+        JvmCastGen.addUnboxInsn(this.mv, targetType);
         this.storeToVar(binaryIns.lhsOp.variableDcl);
     }
 
@@ -1032,7 +988,7 @@ public class JvmInstructionGen {
             this.mv.visitMethodInsn(INVOKESTATIC, XML_FACTORY, "concatenate",
                     String.format("(L%s;L%s;)L%s;", XML_VALUE, XML_VALUE, XML_VALUE), false);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
+            throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                     String.format("%s", binaryIns.lhsOp.variableDcl.type));
         }
 
@@ -1051,7 +1007,7 @@ public class JvmInstructionGen {
             this.mv.visitMethodInsn(INVOKEVIRTUAL, DECIMAL_VALUE, "subtract",
                     String.format("(L%s;)L%s;", DECIMAL_VALUE, DECIMAL_VALUE), false);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
+            throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                     String.format("%s", binaryIns.lhsOp.variableDcl.type));
         }
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1069,7 +1025,7 @@ public class JvmInstructionGen {
             this.mv.visitMethodInsn(INVOKEVIRTUAL, DECIMAL_VALUE, "divide",
                     String.format("(L%s;)L%s;", DECIMAL_VALUE, DECIMAL_VALUE), false);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
+            throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                     String.format("%s", binaryIns.lhsOp.variableDcl.type));
         }
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1087,7 +1043,7 @@ public class JvmInstructionGen {
             this.mv.visitMethodInsn(INVOKEVIRTUAL, DECIMAL_VALUE, "multiply",
                     String.format("(L%s;)L%s;", DECIMAL_VALUE, DECIMAL_VALUE), false);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
+            throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                     String.format("%s", binaryIns.lhsOp.variableDcl.type));
         }
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1105,7 +1061,7 @@ public class JvmInstructionGen {
             this.mv.visitMethodInsn(INVOKEVIRTUAL, DECIMAL_VALUE, "remainder",
                     String.format("(L%s;)L%s;", DECIMAL_VALUE, DECIMAL_VALUE), false);
         } else {
-            throw new BLangCompilerException("JVM generation is not supported for type " +
+            throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                     String.format("%s", binaryIns.lhsOp.variableDcl.type));
         }
         this.storeToVar(binaryIns.lhsOp.variableDcl);
@@ -1267,7 +1223,7 @@ public class JvmInstructionGen {
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
 
-        return this.indexMap.getIndex(varDcl);
+        return this.indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
     }
 
     void generateMapNewIns(BIRNonTerminator.NewStructure mapNewIns, int localVarOffset) {
@@ -1297,7 +1253,7 @@ public class JvmInstructionGen {
         }
 
         this.mv.visitMethodInsn(INVOKEINTERFACE, TYPEDESC_VALUE, "instantiate",
-                String.format("(L%s;[L%s;)L%s;", STRAND, BINITIAL_VALUE_ENTRY, OBJECT), true);
+                                String.format("(L%s;[L%s;)L%s;", STRAND_CLASS, BINITIAL_VALUE_ENTRY, OBJECT), true);
         this.storeToVar(mapNewIns.lhsOp.variableDcl);
     }
 
@@ -1308,11 +1264,11 @@ public class JvmInstructionGen {
 
         BIRNode.BIRVariableDcl keyOpVarDecl = keyValueEntry.keyOp.variableDcl;
         this.loadVar(keyOpVarDecl);
-        addBoxInsn(this.mv, keyOpVarDecl.type);
+        JvmCastGen.addBoxInsn(this.mv, keyOpVarDecl.type);
 
         BIRNode.BIRVariableDcl valueOpVarDecl = keyValueEntry.valueOp.variableDcl;
         this.loadVar(valueOpVarDecl);
-        addBoxInsn(this.mv, valueOpVarDecl.type);
+        JvmCastGen.addBoxInsn(this.mv, valueOpVarDecl.type);
 
         mv.visitMethodInsn(INVOKESPECIAL, MAPPING_INITIAL_KEY_VALUE_ENTRY, JVM_INIT_METHOD,
                            String.format("(L%s;L%s;)V", OBJECT, OBJECT), false);
@@ -1342,7 +1298,7 @@ public class JvmInstructionGen {
         // visit value_expr
         BType valueType = mapStoreIns.rhsOp.variableDcl.type;
         this.loadVar(mapStoreIns.rhsOp.variableDcl);
-        addBoxInsn(this.mv, valueType);
+        JvmCastGen.addBoxInsn(this.mv, valueType);
 
         if (varRefType.tag == TypeTags.JSON) {
             this.mv.visitMethodInsn(INVOKESTATIC, JSON_UTILS, "setElement",
@@ -1362,7 +1318,7 @@ public class JvmInstructionGen {
         // visit map_ref
         this.loadVar(mapLoadIns.rhsOp.variableDcl);
         BType varRefType = mapLoadIns.rhsOp.variableDcl.type;
-        addUnboxInsn(this.mv, varRefType);
+        JvmCastGen.addUnboxInsn(this.mv, varRefType);
 
         // visit key_expr
         this.loadVar(mapLoadIns.keyOp.variableDcl);
@@ -1391,7 +1347,7 @@ public class JvmInstructionGen {
 
         // store in the target reg
         BType targetType = mapLoadIns.lhsOp.variableDcl.type;
-        addUnboxInsn(this.mv, targetType);
+        JvmCastGen.addUnboxInsn(this.mv, targetType);
         this.storeToVar(mapLoadIns.lhsOp.variableDcl);
     }
 
@@ -1406,7 +1362,7 @@ public class JvmInstructionGen {
         this.mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "get",
                                     String.format("(L%s;)L%s;", JvmConstants.B_STRING_VALUE, OBJECT), true);
         BType targetType = objectLoadIns.lhsOp.variableDcl.type;
-        addUnboxInsn(this.mv, targetType);
+        JvmCastGen.addUnboxInsn(this.mv, targetType);
 
         // store in the target reg
         this.storeToVar(objectLoadIns.lhsOp.variableDcl);
@@ -1422,7 +1378,7 @@ public class JvmInstructionGen {
         // visit value_expr
         BType valueType = objectStoreIns.rhsOp.variableDcl.type;
         this.loadVar(objectStoreIns.rhsOp.variableDcl);
-        addBoxInsn(this.mv, valueType);
+        JvmCastGen.addBoxInsn(this.mv, valueType);
 
         // invoke set() method
         if (objectStoreIns.onInitialization) {
@@ -1520,7 +1476,7 @@ public class JvmInstructionGen {
                 this.mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getRefValue",
                         String.format("(J)L%s;", OBJECT), true);
             }
-            addUnboxInsn(this.mv, bType);
+            JvmCastGen.addUnboxInsn(this.mv, bType);
         } else if (TypeTags.isIntegerTypeTag(bType.tag)) {
             this.mv.visitMethodInsn(INVOKEINTERFACE, ARRAY_VALUE, "getInt", "(J)J", true);
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
@@ -1545,7 +1501,7 @@ public class JvmInstructionGen {
             if (targetTypeClass != null) {
                 this.mv.visitTypeInsn(CHECKCAST, targetTypeClass);
             } else {
-                addUnboxInsn(this.mv, bType);
+                JvmCastGen.addUnboxInsn(this.mv, bType);
             }
         }
         this.storeToVar(inst.lhsOp.variableDcl);
@@ -1569,7 +1525,7 @@ public class JvmInstructionGen {
         this.loadVar(inst.rhsOp.variableDcl);
         this.mv.visitTypeInsn(CHECKCAST, TABLE_VALUE);
         this.loadVar(inst.keyOp.variableDcl);
-        addBoxInsn(this.mv, inst.keyOp.variableDcl.type);
+        JvmCastGen.addBoxInsn(this.mv, inst.keyOp.variableDcl.type);
         BType bType = inst.lhsOp.variableDcl.type;
         this.mv.visitMethodInsn(INVOKEINTERFACE, TABLE_VALUE, "getOrThrow",
                 String.format("(L%s;)L%s;", OBJECT, OBJECT), true);
@@ -1578,7 +1534,7 @@ public class JvmInstructionGen {
         if (targetTypeClass != null) {
             this.mv.visitTypeInsn(CHECKCAST, targetTypeClass);
         } else {
-            addUnboxInsn(this.mv, bType);
+            JvmCastGen.addUnboxInsn(this.mv, bType);
         }
 
         this.storeToVar(inst.lhsOp.variableDcl);
@@ -1589,10 +1545,10 @@ public class JvmInstructionGen {
         this.loadVar(inst.lhsOp.variableDcl);
         this.loadVar(inst.keyOp.variableDcl);
         BType keyType = inst.keyOp.variableDcl.type;
-        addBoxInsn(this.mv, keyType);
+        JvmCastGen.addBoxInsn(this.mv, keyType);
         BType valueType = inst.rhsOp.variableDcl.type;
         this.loadVar(inst.rhsOp.variableDcl);
-        addBoxInsn(this.mv, valueType);
+        JvmCastGen.addBoxInsn(this.mv, valueType);
 
         this.mv.visitMethodInsn(INVOKESTATIC, TABLE_UTILS, "handleTableStore",
                 String.format("(L%s;L%s;L%s;)V", TABLE_VALUE, OBJECT, OBJECT), false);
@@ -1685,7 +1641,7 @@ public class JvmInstructionGen {
 
         String lambdaName = inst.funcName.value + "$lambda" + asyncDataCollector.getLambdaIndex() + "$";
         asyncDataCollector.incrementLambdaIndex();
-        String pkgName = JvmPackageGen.getPackageName(inst.pkgId.orgName, inst.pkgId.name, inst.pkgId.version);
+        String pkgName = JvmCodeGenUtil.getPackageName(inst.pkgId);
 
         BType returnType = inst.lhsOp.variableDcl.type;
         if (returnType.tag != TypeTags.INVOKABLE) {
@@ -1698,7 +1654,8 @@ public class JvmInstructionGen {
             }
         }
 
-        visitInvokeDyn(mv, asyncDataCollector.getEnclosingClass(), lambdaName, inst.closureMaps.size());
+        JvmCodeGenUtil.visitInvokeDynamic(mv, asyncDataCollector.getEnclosingClass(), lambdaName,
+                                          inst.closureMaps.size());
         loadType(this.mv, returnType);
         if (inst.strandName != null) {
             mv.visitLdcInsn(inst.strandName);
@@ -1884,7 +1841,7 @@ public class JvmInstructionGen {
     void generateTypeofIns(BIRNonTerminator.UnaryOP unaryOp) {
 
         this.loadVar(unaryOp.rhsOp.variableDcl);
-        addBoxInsn(this.mv, unaryOp.rhsOp.variableDcl.type);
+        JvmCastGen.addBoxInsn(this.mv, unaryOp.rhsOp.variableDcl.type);
         this.mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "getTypedesc",
                 String.format("(L%s;)L%s;", OBJECT, TYPEDESC_VALUE), false);
         this.storeToVar(unaryOp.lhsOp.variableDcl);
@@ -1957,13 +1914,11 @@ public class JvmInstructionGen {
     }
 
     private void loadVar(BIRNode.BIRVariableDcl varDcl) {
-
-        generateVarLoad(this.mv, varDcl, this.currentPackageName, this.getJVMIndexOfVarRef(varDcl));
+        generateVarLoad(this.mv, varDcl, this.getJVMIndexOfVarRef(varDcl));
     }
 
     private void storeToVar(BIRNode.BIRVariableDcl varDcl) {
-
-        generateVarStore(this.mv, varDcl, this.currentPackageName, this.getJVMIndexOfVarRef(varDcl));
+        generateVarStore(this.mv, varDcl, this.getJVMIndexOfVarRef(varDcl));
     }
 
     void generateConstantLoadIns(BIRNonTerminator.ConstantLoad loadIns) {
@@ -1990,12 +1945,132 @@ public class JvmInstructionGen {
 
             BIRNode.BIRVariableDcl varDecl = initialValueOp.variableDcl;
             this.loadVar(varDecl);
-            addBoxInsn(this.mv, varDecl.type);
+            JvmCastGen.addBoxInsn(this.mv, varDecl.type);
 
             mv.visitMethodInsn(INVOKESPECIAL, LIST_INITIAL_EXPRESSION_ENTRY, JVM_INIT_METHOD,
                                String.format("(L%s;)V", OBJECT), false);
 
             mv.visitInsn(AASTORE);
+        }
+    }
+
+    void generateInstructions(int localVarOffset, AsyncDataCollector asyncDataCollector, BIRInstruction inst) {
+        if (inst instanceof BIRNonTerminator.BinaryOp) {
+            generateBinaryOpIns((BIRNonTerminator.BinaryOp) inst);
+        } else {
+            switch (inst.getKind()) {
+                case MOVE:
+                    generateMoveIns((BIRNonTerminator.Move) inst);
+                    break;
+                case CONST_LOAD:
+                    generateConstantLoadIns((BIRNonTerminator.ConstantLoad) inst);
+                    break;
+                case NEW_STRUCTURE:
+                    generateMapNewIns((BIRNonTerminator.NewStructure) inst, localVarOffset);
+                    break;
+                case NEW_INSTANCE:
+                    generateObjectNewIns((BIRNonTerminator.NewInstance) inst, localVarOffset);
+                    break;
+                case MAP_STORE:
+                    generateMapStoreIns((FieldAccess) inst);
+                    break;
+                case NEW_TABLE:
+                    generateTableNewIns((NewTable) inst);
+                    break;
+                case TABLE_STORE:
+                    generateTableStoreIns((FieldAccess) inst);
+                    break;
+                case TABLE_LOAD:
+                    generateTableLoadIns((FieldAccess) inst);
+                    break;
+                case NEW_ARRAY:
+                    generateArrayNewIns((BIRNonTerminator.NewArray) inst);
+                    break;
+                case ARRAY_STORE:
+                    generateArrayStoreIns((FieldAccess) inst);
+                    break;
+                case MAP_LOAD:
+                    generateMapLoadIns((FieldAccess) inst);
+                    break;
+                case ARRAY_LOAD:
+                    generateArrayValueLoad((FieldAccess) inst);
+                    break;
+                case NEW_ERROR:
+                    generateNewErrorIns((BIRNonTerminator.NewError) inst);
+                    break;
+                case TYPE_CAST:
+                    generateCastIns((BIRNonTerminator.TypeCast) inst);
+                    break;
+                case IS_LIKE:
+                    generateIsLikeIns((BIRNonTerminator.IsLike) inst);
+                    break;
+                case TYPE_TEST:
+                    generateTypeTestIns((BIRNonTerminator.TypeTest) inst);
+                    break;
+                case OBJECT_STORE:
+                    generateObjectStoreIns((FieldAccess) inst);
+                    break;
+                case OBJECT_LOAD:
+                    generateObjectLoadIns((FieldAccess) inst);
+                    break;
+                case NEW_XML_ELEMENT:
+                    generateNewXMLElementIns((BIRNonTerminator.NewXMLElement) inst);
+                    break;
+                case NEW_XML_TEXT:
+                    generateNewXMLTextIns((BIRNonTerminator.NewXMLText) inst);
+                    break;
+                case NEW_XML_COMMENT:
+                    generateNewXMLCommentIns((BIRNonTerminator.NewXMLComment) inst);
+                    break;
+                case NEW_XML_PI:
+                    generateNewXMLProcIns((BIRNonTerminator.NewXMLProcIns) inst);
+                    break;
+                case NEW_XML_QNAME:
+                    generateNewXMLQNameIns((BIRNonTerminator.NewXMLQName) inst);
+                    break;
+                case NEW_STRING_XML_QNAME:
+                    generateNewStringXMLQNameIns((BIRNonTerminator.NewStringXMLQName) inst);
+                    break;
+                case XML_SEQ_STORE:
+                    generateXMLStoreIns((BIRNonTerminator.XMLAccess) inst);
+                    break;
+                case XML_SEQ_LOAD:
+                case XML_LOAD:
+                    generateXMLLoadIns((FieldAccess) inst);
+                    break;
+                case XML_LOAD_ALL:
+                    generateXMLLoadAllIns((BIRNonTerminator.XMLAccess) inst);
+                    break;
+                case XML_ATTRIBUTE_STORE:
+                    generateXMLAttrStoreIns((FieldAccess) inst);
+                    break;
+                case XML_ATTRIBUTE_LOAD:
+                    generateXMLAttrLoadIns((FieldAccess) inst);
+                    break;
+                case FP_LOAD:
+                    generateFPLoadIns((BIRNonTerminator.FPLoad) inst, asyncDataCollector);
+                    break;
+                case STRING_LOAD:
+                    generateStringLoadIns((FieldAccess) inst);
+                    break;
+                case TYPEOF:
+                    generateTypeofIns((BIRNonTerminator.UnaryOP) inst);
+                    break;
+                case NOT:
+                    generateNotIns((BIRNonTerminator.UnaryOP) inst);
+                    break;
+                case NEW_TYPEDESC:
+                    generateNewTypedescIns((BIRNonTerminator.NewTypeDesc) inst);
+                    break;
+                case NEGATE:
+                    generateNegateIns((BIRNonTerminator.UnaryOP) inst);
+                    break;
+                case PLATFORM:
+                    generatePlatformIns((JInstruction) inst);
+                    break;
+                default:
+                    throw new BLangCompilerException("JVM generation is not supported for operation " + inst);
+            }
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -15,6 +15,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.wso2.ballerinalang.compiler.bir.codegen;
 
 import org.ballerinalang.compiler.BLangCompilerException;
@@ -23,6 +24,7 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.AsyncDataCollector;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.BIRVarToJVMIndexMap;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.FunctionParamComparator;
@@ -30,11 +32,11 @@ import org.wso2.ballerinalang.compiler.bir.codegen.internal.JavaClass;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.LabelGenerator;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.ScheduleFunctionInfo;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.BIRFunctionWrapper;
-import org.wso2.ballerinalang.compiler.bir.codegen.interop.JInstruction;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JType;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags;
 import org.wso2.ballerinalang.compiler.bir.model.BIRInstruction;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationArrayValue;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationLiteralValue;
@@ -46,7 +48,6 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunctionParameter;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRPackage;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.BinaryOp;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.AsyncCall;
@@ -58,7 +59,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
@@ -66,9 +66,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.util.Name;
-import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
-import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -80,7 +78,6 @@ import java.util.Map;
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.AALOAD;
 import static org.objectweb.asm.Opcodes.AASTORE;
-import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
 import static org.objectweb.asm.Opcodes.ACC_SUPER;
 import static org.objectweb.asm.Opcodes.ACONST_NULL;
@@ -107,7 +104,6 @@ import static org.objectweb.asm.Opcodes.ICONST_0;
 import static org.objectweb.asm.Opcodes.ICONST_1;
 import static org.objectweb.asm.Opcodes.IFEQ;
 import static org.objectweb.asm.Opcodes.IFGT;
-import static org.objectweb.asm.Opcodes.IFNE;
 import static org.objectweb.asm.Opcodes.IFNULL;
 import static org.objectweb.asm.Opcodes.ILOAD;
 import static org.objectweb.asm.Opcodes.INVOKEINTERFACE;
@@ -137,17 +133,14 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BLOCKED_O
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BTYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BUILT_IN_PACKAGE_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_ERROR;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHANNEL_DETAILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.COMPATIBILITY_CHECKER;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONSTRUCTOR_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CREATE_TYPES_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CURRENT_MODULE_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DEFAULTABLE_ARGS_ANOT_FIELD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DEFAULTABLE_ARGS_ANOT_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION_POINTER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUTURE_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HANDLE_RETURNED_ERROR_METHOD;
@@ -155,7 +148,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HANDLE_ST
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HANDLE_THROWABLE_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HANDLE_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.IS_BLOCKED_ON_EXTERN_FIELD;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JAVA_PACKAGE_SEPERATOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JAVA_RUNTIME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JAVA_THREAD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
@@ -174,53 +166,18 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RUNTIME_U
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULER_START_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULE_FUNCTION_METHOD;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.START_FUNCTION_SUFFIX;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STOP_FUNCTION_SUFFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_CLASS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_METADATA;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_METADATA_VAR_PREFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STREAM_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TABLE_VALUE_IMPL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.THROWABLE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CREATOR;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WINDOWS_PATH_SEPERATOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_VALUE;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.visitInvokeDyn;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getModuleLevelClassName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.packageToModuleId;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.cleanupObjectTypeName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.loadChannelDetails;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.toNameString;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.loadLocalType;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.loadType;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.genJMethodForBExternalFunc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.isBallerinaBuiltinModule;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.getJTypeSignature;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.getSignatureForJType;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.ConstantLoad;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.FPLoad;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.FieldAccess;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.IsLike;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.Move;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewArray;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewError;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewInstance;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewStringXMLQName;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewStructure;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewTable;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewTypeDesc;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewXMLComment;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewXMLElement;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewXMLProcIns;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewXMLQName;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.NewXMLText;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.TypeCast;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.TypeTest;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.UnaryOP;
-import static org.wso2.ballerinalang.compiler.bir.model.BIRNonTerminator.XMLAccess;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Branch;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Call;
 import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Return;
@@ -232,13 +189,17 @@ import static org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Return;
  */
 public class JvmMethodGen {
 
-    private static final FunctionParamComparator FUNCTION_PARAM_COMPARATOR = new FunctionParamComparator();
-    private static ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
+    private static final String START_FUNCTION_SUFFIX = "<start>";
+    private static final String STOP_FUNCTION_SUFFIX = "<stop>";
+
+    public static final String STATE = "state";
+    public static final String FRAMES = "frames";
+    public static final String RESUME_INDEX = "resumeIndex";
     private int nextId = -1;
     private int nextVarId = -1;
-    private JvmPackageGen jvmPackageGen;
-    private SymbolTable symbolTable;
-    private BUnionType errorOrNilType;
+    private final JvmPackageGen jvmPackageGen;
+    private final SymbolTable symbolTable;
+    private final BUnionType errorOrNilType;
 
     JvmMethodGen(JvmPackageGen jvmPackageGen) {
 
@@ -247,22 +208,265 @@ public class JvmMethodGen {
         this.errorOrNilType = BUnionType.create(null, symbolTable.errorType, symbolTable.nilType);
     }
 
-    private static int[] toIntArray(List<Integer> states) {
+    public void genJMethodForBFunc(BIRFunction func, ClassWriter cw, BIRPackage module, String moduleClassName,
+                                   BType attachedType, AsyncDataCollector asyncDataCollector) {
 
-        int[] ints = new int[states.size()];
-        for (int i = 0; i < states.size(); i++) {
-            ints[i] = states.get(i);
+        BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
+        BIRVariableDcl strandVar = new BIRVariableDcl(symbolTable.stringType, new Name(STRAND), VarScope.FUNCTION,
+                                                      VarKind.ARG);
+        indexMap.addToMapIfNotFoundAndGetIndex(strandVar);
+
+        // generate method desc
+        int access = Opcodes.ACC_PUBLIC;
+        int localVarOffset;
+        if (attachedType != null) {
+            localVarOffset = 1;
+            // add the self as the first local var
+            BIRVariableDcl selfVar = new BIRVariableDcl(symbolTable.anyType, new Name("self"), VarScope.FUNCTION,
+                                                        VarKind.ARG);
+            indexMap.addToMapIfNotFoundAndGetIndex(selfVar);
+        } else {
+            localVarOffset = 0;
+            access += ACC_STATIC;
         }
-        return ints;
+
+        String funcName = JvmCodeGenUtil.cleanupFunctionName(func.name.value);
+        BType retType = getReturnType(func);
+        String desc = JvmCodeGenUtil.getMethodDesc(func.type.paramTypes, retType);
+        MethodVisitor mv = cw.visitMethod(access, funcName, desc, null, null);
+        mv.visitCode();
+
+        visitModuleStartFunction(module, funcName, mv);
+
+        Label methodStartLabel = new Label();
+        mv.visitLabel(methodStartLabel);
+
+        // set channel details to strand.
+        setChannelDetailsToStrand(func, localVarOffset, mv);
+
+        // panic if this strand is cancelled
+        checkStrandCancelled(mv, localVarOffset);
+
+        genLocalVars(indexMap, mv, func.localVars);
+
+        int returnVarRefIndex = getReturnVarRefIndex(func, indexMap, retType, mv);
+        int stateVarIndex = getStateVarIndex(indexMap, mv);
+
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, RESUME_INDEX, "I");
+
+        LabelGenerator labelGen = new LabelGenerator();
+        Label resumeLabel = labelGen.getLabel(funcName + "resume");
+        mv.visitJumpInsn(IFGT, resumeLabel);
+
+        Label varinitLabel = labelGen.getLabel(funcName + "varinit");
+        mv.visitLabel(varinitLabel);
+
+        // process basic blocks
+        List<Label> labels = new ArrayList<>();
+        List<Integer> states = new ArrayList<>();
+
+        addCasesForBasicBlocks(func, funcName, labelGen, labels, states);
+
+        JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, module, jvmPackageGen);
+        JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
+        JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, module, instGen,
+                                                        jvmPackageGen);
+
+        mv.visitVarInsn(ILOAD, stateVarIndex);
+        Label yieldLable = labelGen.getLabel(funcName + "yield");
+        mv.visitLookupSwitchInsn(yieldLable, toIntArray(states), labels.toArray(new Label[0]));
+
+        generateBasicBlocks(mv, labelGen, errorGen, instGen, termGen, func, returnVarRefIndex,
+                            stateVarIndex, localVarOffset, module, attachedType,
+                            moduleClassName, asyncDataCollector);
+        mv.visitLabel(resumeLabel);
+        String frameName = getFrameClassName(JvmCodeGenUtil.getPackageName(module), funcName, attachedType);
+        genGetFrameOnResumeIndex(localVarOffset, mv, frameName);
+
+        generateFrameClassFieldLoad(func.localVars, mv, indexMap, frameName);
+        mv.visitFieldInsn(GETFIELD, frameName, STATE, "I");
+        mv.visitVarInsn(ISTORE, stateVarIndex);
+        mv.visitJumpInsn(GOTO, varinitLabel);
+
+        mv.visitLabel(yieldLable);
+        mv.visitTypeInsn(NEW, frameName);
+        mv.visitInsn(DUP);
+        mv.visitMethodInsn(INVOKESPECIAL, frameName, JVM_INIT_METHOD, "()V", false);
+
+        generateFrameClassFieldUpdate(func.localVars, mv, indexMap, frameName);
+
+        mv.visitInsn(DUP);
+        mv.visitVarInsn(ILOAD, stateVarIndex);
+        mv.visitFieldInsn(PUTFIELD, frameName, STATE, "I");
+
+        generateGetFrame(indexMap, localVarOffset, mv);
+
+        Label methodEndLabel = new Label();
+        mv.visitLabel(methodEndLabel);
+        termGen.genReturnTerm(returnVarRefIndex, func);
+
+        // Create Local Variable Table
+        createLocalVariableTable(func, indexMap, localVarOffset, mv, methodStartLabel, labelGen, methodEndLabel);
+
+        mv.visitMaxs(0, 0);
+        mv.visitEnd();
     }
 
-    private static void generateFrameClassFieldLoad(List<BIRVariableDcl> localVars, MethodVisitor mv,
-                                                    BIRVarToJVMIndexMap indexMap, String frameName) {
+    private void generateGetFrame(BIRVarToJVMIndexMap indexMap, int localVarOffset, MethodVisitor mv) {
+        BIRVariableDcl frameVar = new BIRVariableDcl(symbolTable.stringType, new Name("frame"), null, VarKind.TEMP);
+        int frameVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(frameVar);
+        mv.visitVarInsn(ASTORE, frameVarIndex);
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, FRAMES, "[Ljava/lang/Object;");
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        mv.visitInsn(DUP);
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, RESUME_INDEX, "I");
+        mv.visitInsn(DUP_X1);
+        mv.visitInsn(ICONST_1);
+        mv.visitInsn(IADD);
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, RESUME_INDEX, "I");
+        mv.visitVarInsn(ALOAD, frameVarIndex);
+        mv.visitInsn(AASTORE);
+    }
 
-        int k = 0;
-        while (k < localVars.size()) {
-            BIRVariableDcl localVar = getVariableDcl(localVars.get(k));
-            int index = indexMap.getIndex(localVar);
+    private void createLocalVariableTable(BIRFunction func, BIRVarToJVMIndexMap indexMap, int localVarOffset,
+                                          MethodVisitor mv, Label methodStartLabel, LabelGenerator labelGen,
+                                          Label methodEndLabel) {
+        String funcName = JvmCodeGenUtil.cleanupFunctionName(func.name.value);
+        // Add strand variable to LVT
+        mv.visitLocalVariable("__strand", String.format("L%s;", STRAND_CLASS), null, methodStartLabel, methodEndLabel,
+                              localVarOffset);
+        for (int i = localVarOffset; i < func.localVars.size(); i++) {
+            BIRVariableDcl localVar = func.localVars.get(i);
+            Label startLabel = methodStartLabel;
+            Label endLabel = methodEndLabel;
+            if (!isLocalOrArg(localVar)) {
+                continue;
+            }
+            // local vars have visible range information
+            if (localVar.kind == VarKind.LOCAL) {
+                int insOffset = localVar.insOffset;
+                if (localVar.startBB != null) {
+                    startLabel = labelGen.getLabel(funcName + localVar.startBB.id.value + "ins" + insOffset);
+                }
+                if (localVar.endBB != null) {
+                    endLabel = labelGen.getLabel(funcName + localVar.endBB.id.value + "beforeTerm");
+                }
+            }
+            String metaVarName = localVar.metaVarName;
+            if (isCompilerAddedVars(metaVarName)) {
+                mv.visitLocalVariable(metaVarName, getJVMTypeSign(localVar.type), null,
+                                      startLabel, endLabel, indexMap.addToMapIfNotFoundAndGetIndex(localVar));
+            }
+        }
+    }
+
+    private boolean isLocalOrArg(BIRVariableDcl localVar) {
+        boolean synArg = localVar.type.tag == TypeTags.BOOLEAN && localVar.name.value.startsWith("%syn");
+        return !synArg && (localVar.kind == VarKind.LOCAL || localVar.kind == VarKind.ARG);
+    }
+
+    private boolean isCompilerAddedVars(String metaVarName) {
+        return metaVarName != null && !"".equals(metaVarName) &&
+                // filter out compiler added vars
+                !((metaVarName.startsWith("$") && metaVarName.endsWith("$"))
+                        || (metaVarName.startsWith("$$") && metaVarName.endsWith("$$"))
+                        || metaVarName.startsWith("_$$_"));
+    }
+
+
+    private void genGetFrameOnResumeIndex(int localVarOffset, MethodVisitor mv, String frameName) {
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, FRAMES, "[Ljava/lang/Object;");
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        mv.visitInsn(DUP);
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, RESUME_INDEX, "I");
+        mv.visitInsn(ICONST_1);
+        mv.visitInsn(ISUB);
+        mv.visitInsn(DUP_X1);
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, RESUME_INDEX, "I");
+        mv.visitInsn(AALOAD);
+        mv.visitTypeInsn(CHECKCAST, frameName);
+    }
+
+    private void addCasesForBasicBlocks(BIRFunction func, String funcName, LabelGenerator labelGen, List<Label> lables,
+                                        List<Integer> states) {
+        int caseIndex = 0;
+        for (int i = 0; i < func.basicBlocks.size(); i++) {
+            BIRBasicBlock bb = func.basicBlocks.get(i);
+            if (i == 0) {
+                lables.add(caseIndex, labelGen.getLabel(funcName + bb.id.value));
+                states.add(caseIndex, caseIndex);
+                caseIndex += 1;
+            }
+            lables.add(caseIndex, labelGen.getLabel(funcName + bb.id.value + "beforeTerm"));
+            states.add(caseIndex, caseIndex);
+            caseIndex += 1;
+        }
+    }
+
+    private int getStateVarIndex(BIRVarToJVMIndexMap indexMap, MethodVisitor mv) {
+        BIRVariableDcl stateVar = new BIRVariableDcl(symbolTable.stringType, //should  be javaInt
+                                                     new Name(STATE), null, VarKind.TEMP);
+        int stateVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(stateVar);
+        mv.visitInsn(ICONST_0);
+        mv.visitVarInsn(ISTORE, stateVarIndex);
+        return stateVarIndex;
+    }
+
+    private int getReturnVarRefIndex(BIRFunction func, BIRVarToJVMIndexMap indexMap, BType retType, MethodVisitor mv) {
+        BIRVariableDcl varDcl = func.localVars.get(0);
+        int returnVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
+        genDefaultValue(mv, retType, returnVarRefIndex);
+        return returnVarRefIndex;
+    }
+
+    private void genLocalVars(BIRVarToJVMIndexMap indexMap, MethodVisitor mv, List<BIRVariableDcl> localVars) {
+        localVars.sort(new FunctionParamComparator());
+        for (int i = 1; i < localVars.size(); i++) {
+            BIRVariableDcl localVar = localVars.get(i);
+            int index = indexMap.addToMapIfNotFoundAndGetIndex(localVar);
+            if (localVar.kind != VarKind.ARG) {
+                BType bType = localVar.type;
+                genDefaultValue(mv, bType, index);
+            }
+        }
+    }
+
+    private void setChannelDetailsToStrand(BIRFunction func, int localVarOffset, MethodVisitor mv) {
+        // these channel info is required to notify datachannels, when there is a panic
+        // we cannot set this during strand creation, because function call do not have this info.
+        if (func.workerChannels.length <= 0) {
+            return;
+        }
+        mv.visitVarInsn(ALOAD, localVarOffset);
+        JvmCodeGenUtil.loadChannelDetails(mv, Arrays.asList(func.workerChannels));
+        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "updateChannelDetails",
+                           String.format("([L%s;)V", CHANNEL_DETAILS), false);
+    }
+
+    private void visitModuleStartFunction(BIRPackage module, String funcName, MethodVisitor mv) {
+        if (!isModuleStartFunction(module, funcName)) {
+            return;
+        }
+        mv.visitInsn(ICONST_1);
+        mv.visitFieldInsn(PUTSTATIC, JvmCodeGenUtil.getModuleLevelClassName(module, MODULE_INIT_CLASS_NAME),
+                          MODULE_START_ATTEMPTED, "Z");
+    }
+
+    private BType getReturnType(BIRFunction func) {
+        BType retType = func.type.retType;
+        if (JvmCodeGenUtil.isExternFunc(func) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
+            retType = JvmCodeGenUtil.TYPE_BUILDER.build(func.type.retType);
+        }
+        return retType;
+    }
+
+    private void generateFrameClassFieldLoad(List<BIRVariableDcl> localVars, MethodVisitor mv,
+                                             BIRVarToJVMIndexMap indexMap, String frameName) {
+        for (BIRVariableDcl localVar : localVars) {
+            int index = indexMap.addToMapIfNotFoundAndGetIndex(localVar);
             BType bType = localVar.type;
             mv.visitInsn(DUP);
 
@@ -271,127 +475,121 @@ public class JvmMethodGen {
                 mv.visitVarInsn(LSTORE, index);
             } else if (TypeTags.isStringTypeTag(bType.tag)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", JvmConstants.B_STRING_VALUE));
+                                  String.format("L%s;", JvmConstants.B_STRING_VALUE));
                 mv.visitVarInsn(ASTORE, index);
             } else if (TypeTags.isXMLTypeTag(bType.tag)) {
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", XML_VALUE));
+                                  String.format("L%s;", XML_VALUE));
                 mv.visitVarInsn(ASTORE, index);
             } else {
-                switch (bType.tag) {
-                    case TypeTags.BYTE:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-                        mv.visitVarInsn(ISTORE, index);
-                        break;
-                    case TypeTags.FLOAT:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
-                        mv.visitVarInsn(DSTORE, index);
-                        break;
-                    case TypeTags.DECIMAL:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", DECIMAL_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.BOOLEAN:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
-                        mv.visitVarInsn(ISTORE, index);
-                        break;
-                    case TypeTags.MAP:
-                    case TypeTags.RECORD:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", MAP_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.STREAM:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", STREAM_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.TABLE:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", TABLE_VALUE_IMPL));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.ARRAY:
-                    case TypeTags.TUPLE:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", ARRAY_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.OBJECT:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", OBJECT_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.ERROR:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", ERROR_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.FUTURE:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", FUTURE_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.INVOKABLE:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", FUNCTION_POINTER));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.TYPEDESC:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", TYPEDESC_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.NIL:
-                    case TypeTags.NEVER:
-                    case TypeTags.ANY:
-                    case TypeTags.ANYDATA:
-                    case TypeTags.UNION:
-                    case TypeTags.INTERSECTION:
-                    case TypeTags.JSON:
-                    case TypeTags.FINITE:
-                    case TypeTags.READONLY:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", OBJECT));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case TypeTags.HANDLE:
-                        mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", HANDLE_VALUE));
-                        mv.visitVarInsn(ASTORE, index);
-                        break;
-                    case JTypeTags.JTYPE:
-                        generateFrameClassJFieldLoad(localVar, mv, index, frameName);
-                        break;
-                    default:
-                        throw new BLangCompilerException("JVM generation is not supported for type " +
-                                String.format("%s", bType));
-                }
+                generateFrameClassFieldLoadByTypeTag(mv, frameName, localVar, index, bType);
             }
-            k = k + 1;
         }
 
     }
 
-    private static void generateFrameClassJFieldLoad(BIRVariableDcl localVar, MethodVisitor mv,
-                                                     int index, String frameName) {
+    private void generateFrameClassFieldLoadByTypeTag(MethodVisitor mv, String frameName, BIRVariableDcl localVar,
+                                                      int index, BType bType) {
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case TypeTags.FLOAT:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
+                mv.visitVarInsn(DSTORE, index);
+                break;
+            case TypeTags.DECIMAL:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", DECIMAL_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
+                mv.visitVarInsn(ISTORE, index);
+                break;
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", MAP_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.STREAM:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", STREAM_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.TABLE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", TABLE_VALUE_IMPL));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", ARRAY_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.OBJECT:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", OBJECT_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.ERROR:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", ERROR_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.FUTURE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", FUTURE_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.INVOKABLE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", FUNCTION_POINTER));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.TYPEDESC:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", TYPEDESC_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.READONLY:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", OBJECT));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case TypeTags.HANDLE:
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", HANDLE_VALUE));
+                mv.visitVarInsn(ASTORE, index);
+                break;
+            case JTypeTags.JTYPE:
+                generateFrameClassJFieldLoad(localVar, mv, index, frameName);
+                break;
+            default:
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE + bType);
+        }
+    }
+
+    private void generateFrameClassJFieldLoad(BIRVariableDcl localVar, MethodVisitor mv,
+                                              int index, String frameName) {
 
         JType jType = (JType) localVar.type;
 
         switch (jType.jTag) {
             case JTypeTags.JBYTE:
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JCHAR:
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JSHORT:
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JINT:
                 mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
                 mv.visitVarInsn(ISTORE, index);
@@ -414,22 +612,20 @@ public class JvmMethodGen {
                 break;
             case JTypeTags.JARRAY:
             case JTypeTags.JREF:
-                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"), getJTypeSignature(jType));
+                mv.visitFieldInsn(GETFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  InteropMethodGen.getJTypeSignature(jType));
                 mv.visitVarInsn(ASTORE, index);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", jType));
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
+                                                         String.format("%s", jType));
         }
     }
 
-    private static void generateFrameClassFieldUpdate(List<BIRVariableDcl> localVars, MethodVisitor mv,
+    private void generateFrameClassFieldUpdate(List<BIRVariableDcl> localVars, MethodVisitor mv,
                                                       BIRVarToJVMIndexMap indexMap, String frameName) {
-
-        int k = 0;
-        while (k < localVars.size()) {
-            BIRVariableDcl localVar = getVariableDcl(localVars.get(k));
-            int index = indexMap.getIndex(localVar);
+        for (BIRVariableDcl localVar : localVars) {
+            int index = indexMap.addToMapIfNotFoundAndGetIndex(localVar);
             mv.visitInsn(DUP);
 
             BType bType = localVar.type;
@@ -439,111 +635,114 @@ public class JvmMethodGen {
             } else if (TypeTags.isStringTypeTag(bType.tag)) {
                 mv.visitVarInsn(ALOAD, index);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", JvmConstants.B_STRING_VALUE));
+                                  String.format("L%s;", JvmConstants.B_STRING_VALUE));
             } else if (TypeTags.isXMLTypeTag(bType.tag)) {
                 mv.visitVarInsn(ALOAD, index);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                        String.format("L%s;", XML_VALUE));
+                                  String.format("L%s;", XML_VALUE));
             } else {
-                switch (bType.tag) {
-                    case TypeTags.BYTE:
-                        mv.visitVarInsn(ILOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
-                        break;
-                    case TypeTags.FLOAT:
-                        mv.visitVarInsn(DLOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
-                        break;
-                    case TypeTags.DECIMAL:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", DECIMAL_VALUE));
-                        break;
-                    case TypeTags.BOOLEAN:
-                        mv.visitVarInsn(ILOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
-                        break;
-                    case TypeTags.MAP:
-                    case TypeTags.RECORD:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", MAP_VALUE));
-                        break;
-                    case TypeTags.STREAM:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", STREAM_VALUE));
-                        break;
-                    case TypeTags.TABLE:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", TABLE_VALUE_IMPL));
-                        break;
-                    case TypeTags.ARRAY:
-                    case TypeTags.TUPLE:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", ARRAY_VALUE));
-                        break;
-                    case TypeTags.ERROR:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", ERROR_VALUE));
-                        break;
-                    case TypeTags.FUTURE:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", FUTURE_VALUE));
-                        break;
-                    case TypeTags.TYPEDESC:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitTypeInsn(CHECKCAST, TYPEDESC_VALUE);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", TYPEDESC_VALUE));
-                        break;
-                    case TypeTags.OBJECT:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", OBJECT_VALUE));
-                        break;
-                    case TypeTags.INVOKABLE:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", FUNCTION_POINTER));
-                        break;
-                    case TypeTags.NIL:
-                    case TypeTags.NEVER:
-                    case TypeTags.ANY:
-                    case TypeTags.ANYDATA:
-                    case TypeTags.UNION:
-                    case TypeTags.INTERSECTION:
-                    case TypeTags.JSON:
-                    case TypeTags.FINITE:
-                    case TypeTags.READONLY:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", OBJECT));
-                        break;
-                    case TypeTags.HANDLE:
-                        mv.visitVarInsn(ALOAD, index);
-                        mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
-                                String.format("L%s;", HANDLE_VALUE));
-                        break;
-                    case JTypeTags.JTYPE:
-                        generateFrameClassJFieldUpdate(localVar, mv, index, frameName);
-                        break;
-                    default:
-                        throw new BLangCompilerException("JVM generation is not supported for type " +
-                                String.format("%s", bType));
-                }
+                generateFrameClassFieldUpdateByTypeTag(mv, frameName, localVar, index, bType);
             }
-            k = k + 1;
         }
     }
 
-    private static void generateFrameClassJFieldUpdate(BIRVariableDcl localVar, MethodVisitor mv,
-                                                       int index, String frameName) {
+    private void generateFrameClassFieldUpdateByTypeTag(MethodVisitor mv, String frameName, BIRVariableDcl localVar,
+                                                        int index, BType bType) {
+        switch (bType.tag) {
+            case TypeTags.BYTE:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "I");
+                break;
+            case TypeTags.FLOAT:
+                mv.visitVarInsn(DLOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "D");
+                break;
+            case TypeTags.DECIMAL:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", DECIMAL_VALUE));
+                break;
+            case TypeTags.BOOLEAN:
+                mv.visitVarInsn(ILOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "Z");
+                break;
+            case TypeTags.MAP:
+            case TypeTags.RECORD:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", MAP_VALUE));
+                break;
+            case TypeTags.STREAM:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", STREAM_VALUE));
+                break;
+            case TypeTags.TABLE:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", TABLE_VALUE_IMPL));
+                break;
+            case TypeTags.ARRAY:
+            case TypeTags.TUPLE:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", ARRAY_VALUE));
+                break;
+            case TypeTags.ERROR:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", ERROR_VALUE));
+                break;
+            case TypeTags.FUTURE:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", FUTURE_VALUE));
+                break;
+            case TypeTags.TYPEDESC:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitTypeInsn(CHECKCAST, TYPEDESC_VALUE);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", TYPEDESC_VALUE));
+                break;
+            case TypeTags.OBJECT:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", OBJECT_VALUE));
+                break;
+            case TypeTags.INVOKABLE:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", FUNCTION_POINTER));
+                break;
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.JSON:
+            case TypeTags.FINITE:
+            case TypeTags.READONLY:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", OBJECT));
+                break;
+            case TypeTags.HANDLE:
+                mv.visitVarInsn(ALOAD, index);
+                mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"),
+                                  String.format("L%s;", HANDLE_VALUE));
+                break;
+            case JTypeTags.JTYPE:
+                generateFrameClassJFieldUpdate(localVar, mv, index, frameName);
+                break;
+            default:
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
+                                                         String.format("%s", bType));
+        }
+    }
 
+    private void generateFrameClassJFieldUpdate(BIRVariableDcl localVar, MethodVisitor mv,
+                                                       int index, String frameName) {
         JType jType = (JType) localVar.type;
         switch (jType.jTag) {
             case JTypeTags.JBYTE:
@@ -580,20 +779,19 @@ public class JvmMethodGen {
                 break;
             case JTypeTags.JARRAY:
             case JTypeTags.JREF:
-                String classSig = getJTypeSignature(jType);
-                String className = getSignatureForJType(jType);
+                String classSig = InteropMethodGen.getJTypeSignature(jType);
+                String className = InteropMethodGen.getSignatureForJType(jType);
                 mv.visitVarInsn(ALOAD, index);
                 mv.visitTypeInsn(CHECKCAST, className);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), classSig);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", jType));
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
+                                                         String.format("%s", jType));
         }
     }
 
-    private static String getJVMTypeSign(BType bType) {
-
+    private String getJVMTypeSign(BType bType) {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             return "J";
         } else if (TypeTags.isStringTypeTag(bType.tag)) {
@@ -660,7 +858,7 @@ public class JvmMethodGen {
                 jvmType = String.format("L%s;", OBJECT);
                 break;
             case JTypeTags.JTYPE:
-                jvmType = getJTypeSignature((JType) bType);
+                jvmType = InteropMethodGen.getJTypeSignature((JType) bType);
                 break;
             default:
                 throw new BLangCompilerException("JVM code generation is not supported for type " +
@@ -670,21 +868,7 @@ public class JvmMethodGen {
         return jvmType;
     }
 
-    private static void genYieldCheck(MethodVisitor mv, LabelGenerator labelGen, BIRBasicBlock thenBB, String funcName,
-                                      int localVarOffset) {
-
-        mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "isYielded", "()Z", false);
-        Label yieldLabel = labelGen.getLabel(funcName + "yield");
-        mv.visitJumpInsn(IFNE, yieldLabel);
-
-        // goto thenBB
-        Label gotoLabel = labelGen.getLabel(funcName + thenBB.id.value);
-        mv.visitJumpInsn(GOTO, gotoLabel);
-    }
-
-    private static void generateObjectArgs(MethodVisitor mv, int paramIndex) {
-
+    private void generateObjectArgs(MethodVisitor mv, int paramIndex) {
         mv.visitInsn(DUP);
         mv.visitIntInsn(BIPUSH, paramIndex - 2);
         mv.visitVarInsn(ALOAD, 0);
@@ -693,12 +877,11 @@ public class JvmMethodGen {
         mv.visitInsn(AASTORE);
     }
 
-    private static void handleErrorFromFutureValue(MethodVisitor mv) {
-
+    private void handleErrorFromFutureValue(MethodVisitor mv) {
         mv.visitInsn(DUP);
         mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "strand", String.format("L%s;", STRAND));
-        mv.visitFieldInsn(GETFIELD, STRAND, "scheduler", String.format("L%s;", SCHEDULER));
+        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, STRAND, String.format("L%s;", STRAND_CLASS));
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "scheduler", String.format("L%s;", SCHEDULER));
         mv.visitMethodInsn(INVOKEVIRTUAL, SCHEDULER, SCHEDULER_START_METHOD, "()V", false);
         mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, PANIC_FIELD, String.format("L%s;", THROWABLE));
 
@@ -707,33 +890,29 @@ public class JvmMethodGen {
         mv.visitJumpInsn(IFNULL, labelIf);
         mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, PANIC_FIELD, String.format("L%s;", THROWABLE));
         mv.visitMethodInsn(INVOKESTATIC, RUNTIME_UTILS, HANDLE_THROWABLE_METHOD,
-                String.format("(L%s;)V", THROWABLE), false);
+                           String.format("(L%s;)V", THROWABLE), false);
         mv.visitInsn(RETURN);
         mv.visitLabel(labelIf);
     }
 
-    private static void initConfigurations(MethodVisitor mv) {
-
+    private void initConfigurations(MethodVisitor mv) {
         mv.visitVarInsn(ALOAD, 0);
         mv.visitMethodInsn(INVOKESTATIC, LAUNCH_UTILS,
                 "initConfigurations", String.format("([L%s;)[L%s;", STRING_VALUE, STRING_VALUE), false);
         mv.visitVarInsn(ASTORE, 0);
     }
 
-    private static void startListeners(MethodVisitor mv, boolean isServiceEPAvailable) {
-
+    private void startListeners(MethodVisitor mv, boolean isServiceEPAvailable) {
         mv.visitLdcInsn(isServiceEPAvailable);
         mv.visitMethodInsn(INVOKESTATIC, LAUNCH_UTILS, "startListeners", "(Z)V", false);
     }
 
-    private static void stopListeners(MethodVisitor mv, boolean isServiceEPAvailable) {
-
+    private void stopListeners(MethodVisitor mv, boolean isServiceEPAvailable) {
         mv.visitLdcInsn(isServiceEPAvailable);
         mv.visitMethodInsn(INVOKESTATIC, LAUNCH_UTILS, "stopListeners", "(Z)V", false);
     }
 
-    private static void registerShutdownListener(MethodVisitor mv, String initClass) {
-
+    private void registerShutdownListener(MethodVisitor mv, String initClass) {
         String shutdownClassName = initClass + "$SignalListener";
         mv.visitMethodInsn(INVOKESTATIC, JAVA_RUNTIME, "getRuntime", String.format("()L%s;", JAVA_RUNTIME), false);
         mv.visitTypeInsn(NEW, shutdownClassName);
@@ -743,27 +922,25 @@ public class JvmMethodGen {
                 false);
     }
 
-    private static void loadCLIArgsForMain(MethodVisitor mv, List<BIRFunctionParameter> params,
+    private void loadCLIArgsForMain(MethodVisitor mv, List<BIRFunctionParameter> params,
                                            boolean hasRestParam,
                                            List<BIRAnnotationAttachment> annotAttachments) {
-
         // get defaultable arg names from function annotation
         List<String> defaultableNames = new ArrayList<>();
         int defaultableIndex = 0;
         for (BIRAnnotationAttachment attachment : annotAttachments) {
-            if (attachment == null || !attachment.annotTagRef.value.equals(DEFAULTABLE_ARGS_ANOT_NAME)) {
-                continue;
+            if (attachment != null && attachment.annotTagRef.value.equals(DEFAULTABLE_ARGS_ANOT_NAME)) {
+                BIRAnnotationRecordValue annotRecValue = (BIRAnnotationRecordValue) attachment.annotValues.get(0);
+                Map<String, BIRAnnotationValue> annotFieldMap = annotRecValue.annotValueEntryMap;
+                BIRAnnotationArrayValue annotArrayValue =
+                        (BIRAnnotationArrayValue) annotFieldMap.get(DEFAULTABLE_ARGS_ANOT_FIELD);
+                for (BIRAnnotationValue entryOptional : annotArrayValue.annotArrayValue) {
+                    BIRAnnotationLiteralValue argValue = (BIRAnnotationLiteralValue) entryOptional;
+                    defaultableNames.add(defaultableIndex, (String) argValue.value);
+                    defaultableIndex += 1;
+                }
+                break;
             }
-            BIRAnnotationRecordValue annotRecValue = (BIRAnnotationRecordValue) attachment.annotValues.get(0);
-            Map<String, BIRAnnotationValue> annotFieldMap = annotRecValue.annotValueEntryMap;
-            BIRAnnotationArrayValue annotArrayValue =
-                    (BIRAnnotationArrayValue) annotFieldMap.get(DEFAULTABLE_ARGS_ANOT_FIELD);
-            for (BIRAnnotationValue entryOptional : annotArrayValue.annotArrayValue) {
-                BIRAnnotationLiteralValue argValue = (BIRAnnotationLiteralValue) entryOptional;
-                defaultableNames.add(defaultableIndex, (String) argValue.value);
-                defaultableIndex += 1;
-            }
-            break;
         }
         // create function info array
         mv.visitIntInsn(BIPUSH, params.size());
@@ -784,8 +961,7 @@ public class JvmMethodGen {
                 }
                 mv.visitLdcInsn(defaultableNames.get(defaultableIndex));
                 defaultableIndex += 1;
-                // var varIndex = indexMap.getIndex(param);
-                loadType(mv, param.type);
+                JvmTypeGen.loadType(mv, param.type);
             }
             mv.visitMethodInsn(INVOKESPECIAL, String.format("%s$ParamInfo", RUNTIME_UTILS), JVM_INIT_METHOD,
                     String.format("(ZL%s;L%s;)V", STRING_VALUE, BTYPE), false);
@@ -805,28 +981,30 @@ public class JvmMethodGen {
                 String.format("([L%s$ParamInfo;[L%s;Z)[L%s;", RUNTIME_UTILS, STRING_VALUE, OBJECT), false);
     }
 
-    private static void generateLambdaForDepModStopFunc(ClassWriter cw, String funcName, String initClass) {
-
+    private void generateLambdaForDepModStopFunc(ClassWriter cw, String funcName, String initClass) {
         MethodVisitor mv;
-        mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC,
-                String.format("$lambda$%s", funcName),
-                String.format("([L%s;)L%s;", OBJECT, OBJECT), null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC,
+                            String.format("$lambda$%s", funcName),
+                            String.format("([L%s;)L%s;", OBJECT, OBJECT), null, null);
         mv.visitCode();
 
         //load strand as first arg
         mv.visitVarInsn(ALOAD, 0);
         mv.visitInsn(ICONST_0);
         mv.visitInsn(AALOAD);
-        mv.visitTypeInsn(CHECKCAST, STRAND);
+        mv.visitTypeInsn(CHECKCAST, STRAND_CLASS);
 
-        mv.visitMethodInsn(INVOKESTATIC, initClass, funcName, String.format("(L%s;)L%s;", STRAND, OBJECT), false);
+        mv.visitMethodInsn(INVOKESTATIC, initClass, funcName, String.format("(L%s;)L%s;", STRAND_CLASS, OBJECT), false);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
     }
 
-    private static boolean hasInitFunction(BIRPackage pkg) {
+    void loadLocalType(MethodVisitor mv, BIRTypeDefinition typeDefinition) {
+        JvmTypeGen.loadType(mv, typeDefinition.type);
+    }
 
+    private boolean hasInitFunction(BIRPackage pkg) {
         for (BIRFunction func : pkg.functions) {
             if (func != null && isModuleInitFunction(pkg, func)) {
                 return true;
@@ -835,21 +1013,19 @@ public class JvmMethodGen {
         return false;
     }
 
-    private static boolean isModuleInitFunction(BIRPackage module, BIRFunction func) {
-
+    private boolean isModuleInitFunction(BIRPackage module, BIRFunction func) {
         return func.name.value.equals(calculateModuleInitFuncName(packageToModuleId(module)));
     }
 
-    private static boolean isModuleTestInitFunction(BIRPackage module, BIRFunction func) {
-
+    private boolean isModuleTestInitFunction(BIRPackage module, BIRFunction func) {
         return func.name.value.equals(calculateModuleSpecialFuncName(packageToModuleId(module), "<testinit>"));
     }
-    private static String calculateModuleInitFuncName(PackageID id) {
 
+    private String calculateModuleInitFuncName(PackageID id) {
         return calculateModuleSpecialFuncName(id, JVM_INIT_METHOD);
     }
 
-    private static String calculateModuleSpecialFuncName(PackageID id, String funcSuffix) {
+    private String calculateModuleSpecialFuncName(PackageID id, String funcSuffix) {
 
         String orgName = id.orgName.value;
         String moduleName = id.name.value;
@@ -871,10 +1047,9 @@ public class JvmMethodGen {
         return funcName;
     }
 
-    private static void scheduleStopMethod(MethodVisitor mv, String initClass, String stopFuncName,
-                                           int schedulerIndex, int futureIndex, String moduleClass,
-                                           AsyncDataCollector asyncDataCollector) {
-
+    private void scheduleStopMethod(MethodVisitor mv, String initClass, String stopFuncName,
+                                    int schedulerIndex, int futureIndex, String moduleClass,
+                                    AsyncDataCollector asyncDataCollector) {
         String lambdaFuncName = "$lambda$" + stopFuncName;
         // Create a schedular. A new schedular is used here, to make the stop function to not to
         // depend/wait on whatever is being running on the background. eg: a busy loop in the main.
@@ -888,24 +1063,24 @@ public class JvmMethodGen {
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
 
         // create FP value
-        createFunctionPointer(mv, initClass, lambdaFuncName, 0);
+        JvmCodeGenUtil.createFunctionPointer(mv, initClass, lambdaFuncName);
 
         // no parent strand
         mv.visitInsn(ACONST_NULL);
-        loadType(mv, new BNilType());
+        JvmTypeGen.loadType(mv, new BNilType());
         submitToScheduler(mv, initClass, "stop", asyncDataCollector);
         mv.visitVarInsn(ASTORE, futureIndex);
 
         mv.visitVarInsn(ALOAD, futureIndex);
 
-        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "strand", String.format("L%s;", STRAND));
+        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, STRAND, String.format("L%s;", STRAND_CLASS));
         mv.visitIntInsn(BIPUSH, 100);
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
-        mv.visitFieldInsn(PUTFIELD, STRAND, "frames", String.format("[L%s;", OBJECT));
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, FRAMES, String.format("[L%s;", OBJECT));
 
         mv.visitVarInsn(ALOAD, futureIndex);
-        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "strand", String.format("L%s;", STRAND));
-        mv.visitFieldInsn(GETFIELD, STRAND, "scheduler", String.format("L%s;", SCHEDULER));
+        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, STRAND, String.format("L%s;", STRAND_CLASS));
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "scheduler", String.format("L%s;", SCHEDULER));
         mv.visitMethodInsn(INVOKEVIRTUAL, SCHEDULER, SCHEDULER_START_METHOD, "()V", false);
 
         mv.visitVarInsn(ALOAD, futureIndex);
@@ -923,15 +1098,13 @@ public class JvmMethodGen {
         mv.visitLabel(labelIf);
     }
 
-    private static void generateJavaCompatibilityCheck(MethodVisitor mv) {
-
+    private void generateJavaCompatibilityCheck(MethodVisitor mv) {
         mv.visitLdcInsn(getJavaVersion());
         mv.visitMethodInsn(INVOKESTATIC, COMPATIBILITY_CHECKER, "verifyJavaCompatibility",
-                String.format("(L%s;)V", STRING_VALUE), false);
+                           String.format("(L%s;)V", STRING_VALUE), false);
     }
 
-    private static String getJavaVersion() {
-
+    private String getJavaVersion() {
         String versionProperty = "java.version";
         String javaVersion = System.getProperty(versionProperty);
         if (javaVersion != null) {
@@ -941,17 +1114,12 @@ public class JvmMethodGen {
         }
     }
 
-    private static void genDefaultValue(MethodVisitor mv, BType bType, int index) {
-
+    private void genDefaultValue(MethodVisitor mv, BType bType, int index) {
         if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitInsn(LCONST_0);
             mv.visitVarInsn(LSTORE, index);
             return;
-        } else if (TypeTags.isStringTypeTag(bType.tag)) {
-            mv.visitInsn(ACONST_NULL);
-            mv.visitVarInsn(ASTORE, index);
-            return;
-        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
+        } else if (TypeTags.isStringTypeTag(bType.tag) || TypeTags.isXMLTypeTag(bType.tag)) {
             mv.visitInsn(ACONST_NULL);
             mv.visitVarInsn(ASTORE, index);
             return;
@@ -959,16 +1127,13 @@ public class JvmMethodGen {
 
         switch (bType.tag) {
             case TypeTags.BYTE:
+            case TypeTags.BOOLEAN:
                 mv.visitInsn(ICONST_0);
                 mv.visitVarInsn(ISTORE, index);
                 break;
             case TypeTags.FLOAT:
                 mv.visitInsn(DCONST_0);
                 mv.visitVarInsn(DSTORE, index);
-                break;
-            case TypeTags.BOOLEAN:
-                mv.visitInsn(ICONST_0);
-                mv.visitVarInsn(ISTORE, index);
                 break;
             case TypeTags.MAP:
             case TypeTags.ARRAY:
@@ -1000,27 +1165,18 @@ public class JvmMethodGen {
                 genJDefaultValue(mv, (JType) bType, index);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", bType));
         }
     }
 
-    private static void genJDefaultValue(MethodVisitor mv, JType jType, int index) {
-
+    private void genJDefaultValue(MethodVisitor mv, JType jType, int index) {
         switch (jType.jTag) {
             case JTypeTags.JBYTE:
-                mv.visitInsn(ICONST_0);
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JCHAR:
-                mv.visitInsn(ICONST_0);
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JSHORT:
-                mv.visitInsn(ICONST_0);
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JINT:
+            case JTypeTags.JBOOLEAN:
                 mv.visitInsn(ICONST_0);
                 mv.visitVarInsn(ISTORE, index);
                 break;
@@ -1036,126 +1192,18 @@ public class JvmMethodGen {
                 mv.visitInsn(DCONST_0);
                 mv.visitVarInsn(DSTORE, index);
                 break;
-            case JTypeTags.JBOOLEAN:
-                mv.visitInsn(ICONST_0);
-                mv.visitVarInsn(ISTORE, index);
-                break;
             case JTypeTags.JARRAY:
             case JTypeTags.JREF:
                 mv.visitInsn(ACONST_NULL);
                 mv.visitVarInsn(ASTORE, index);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", jType));
         }
     }
 
-    static void loadDefaultValue(MethodVisitor mv, BType bType) {
-
-        if (TypeTags.isIntegerTypeTag(bType.tag) || bType.tag == TypeTags.BYTE) {
-            mv.visitInsn(LCONST_0);
-            return;
-        } else if (TypeTags.isStringTypeTag(bType.tag) || TypeTags.isXMLTypeTag(bType.tag)) {
-            mv.visitInsn(ACONST_NULL);
-            return;
-        }
-
-        switch (bType.tag) {
-            case TypeTags.FLOAT:
-                mv.visitInsn(DCONST_0);
-                break;
-            case TypeTags.BOOLEAN:
-                mv.visitInsn(ICONST_0);
-                break;
-            case TypeTags.MAP:
-            case TypeTags.ARRAY:
-            case TypeTags.ERROR:
-            case TypeTags.NIL:
-            case TypeTags.NEVER:
-            case TypeTags.ANY:
-            case TypeTags.ANYDATA:
-            case TypeTags.OBJECT:
-            case TypeTags.UNION:
-            case TypeTags.INTERSECTION:
-            case TypeTags.RECORD:
-            case TypeTags.TUPLE:
-            case TypeTags.FUTURE:
-            case TypeTags.JSON:
-            case TypeTags.INVOKABLE:
-            case TypeTags.FINITE:
-            case TypeTags.HANDLE:
-            case TypeTags.TYPEDESC:
-            case TypeTags.READONLY:
-                mv.visitInsn(ACONST_NULL);
-                break;
-            case JTypeTags.JTYPE:
-                loadDefaultJValue(mv, (JType) bType);
-                break;
-            default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", bType));
-        }
-    }
-
-    private static void loadDefaultJValue(MethodVisitor mv, JType jType) {
-
-        switch (jType.jTag) {
-            case JTypeTags.JBYTE:
-                mv.visitInsn(ICONST_0);
-                break;
-            case JTypeTags.JCHAR:
-                mv.visitInsn(ICONST_0);
-                break;
-            case JTypeTags.JSHORT:
-                mv.visitInsn(ICONST_0);
-                break;
-            case JTypeTags.JINT:
-                mv.visitInsn(ICONST_0);
-                break;
-            case JTypeTags.JLONG:
-                mv.visitInsn(LCONST_0);
-                break;
-            case JTypeTags.JFLOAT:
-                mv.visitInsn(FCONST_0);
-                break;
-            case JTypeTags.JDOUBLE:
-                mv.visitInsn(DCONST_0);
-                break;
-            case JTypeTags.JBOOLEAN:
-                mv.visitInsn(ICONST_0);
-                break;
-            case JTypeTags.JARRAY:
-            case JTypeTags.JREF:
-                mv.visitInsn(ACONST_NULL);
-                break;
-            default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", jType));
-        }
-    }
-
-    public static String getMethodDesc(List<BType> paramTypes, BType retType, BType attachedType, boolean isExtern) {
-
-        StringBuilder desc = new StringBuilder("(Lorg/ballerinalang/jvm/scheduling/Strand;");
-
-        if (attachedType != null) {
-            desc.append(getArgTypeSignature(attachedType));
-        }
-
-        int i = 0;
-        while (i < paramTypes.size()) {
-            BType paramType = getType(paramTypes.get(i));
-            desc.append(getArgTypeSignature(paramType));
-            i += 1;
-        }
-        String returnType = generateReturnType(retType, isExtern);
-        desc.append(returnType);
-
-        return desc.toString();
-    }
-
-    private static String getLambdaMethodDesc(List<BType> paramTypes, BType retType, int closureMapsCount) {
+    private String getLambdaMethodDesc(List<BType> paramTypes, BType retType, int closureMapsCount) {
 
         StringBuilder desc = new StringBuilder("(Lorg/ballerinalang/jvm/scheduling/Strand;");
         int j = 0;
@@ -1166,446 +1214,31 @@ public class JvmMethodGen {
 
         int i = 0;
         while (i < paramTypes.size()) {
-            BType paramType = getType(paramTypes.get(i));
-            desc.append(getArgTypeSignature(paramType));
+            BType paramType = paramTypes.get(i);
+            desc.append(JvmCodeGenUtil.getArgTypeSignature(paramType));
             i += 1;
         }
-        String returnType = generateReturnType(retType, false);
+        String returnType = JvmCodeGenUtil.generateReturnType(retType);
         desc.append(returnType);
 
         return desc.toString();
     }
 
-    private static String getArgTypeSignature(BType bType) {
-
-        if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            return "J";
-        } else if (TypeTags.isStringTypeTag(bType.tag)) {
-            return String.format("L%s;", B_STRING_VALUE);
-        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
-            return String.format("L%s;", XML_VALUE);
-        }
-
-        switch (bType.tag) {
-            case TypeTags.BYTE:
-                return "I";
-            case TypeTags.FLOAT:
-                return "D";
-            case TypeTags.DECIMAL:
-                return String.format("L%s;", DECIMAL_VALUE);
-            case TypeTags.BOOLEAN:
-                return "Z";
-            case TypeTags.NIL:
-            case TypeTags.NEVER:
-                return String.format("L%s;", OBJECT);
-            case TypeTags.ARRAY:
-            case TypeTags.TUPLE:
-                return String.format("L%s;", ARRAY_VALUE);
-            case TypeTags.ERROR:
-                return String.format("L%s;", ERROR_VALUE);
-            case TypeTags.ANYDATA:
-            case TypeTags.UNION:
-            case TypeTags.INTERSECTION:
-            case TypeTags.JSON:
-            case TypeTags.FINITE:
-            case TypeTags.ANY:
-            case TypeTags.READONLY:
-                return String.format("L%s;", OBJECT);
-            case TypeTags.MAP:
-            case TypeTags.RECORD:
-                return String.format("L%s;", MAP_VALUE);
-            case TypeTags.FUTURE:
-                return String.format("L%s;", FUTURE_VALUE);
-            case TypeTags.STREAM:
-                return String.format("L%s;", STREAM_VALUE);
-            case TypeTags.TABLE:
-                return String.format("L%s;", TABLE_VALUE_IMPL);
-            case TypeTags.INVOKABLE:
-                return String.format("L%s;", FUNCTION_POINTER);
-            case TypeTags.TYPEDESC:
-                return String.format("L%s;", TYPEDESC_VALUE);
-            case TypeTags.OBJECT:
-                return String.format("L%s;", OBJECT_VALUE);
-            case TypeTags.HANDLE:
-                return String.format("L%s;", HANDLE_VALUE);
-            default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", bType));
-        }
-    }
-
-    private static String generateReturnType(BType bType, boolean isExtern) {
-        bType = typeBuilder.build(bType);
-
-        if (bType == null || bType.tag == TypeTags.NIL || bType.tag == TypeTags.NEVER) {
-            if (isExtern) {
-                return ")V";
-            }
-            return String.format(")L%s;", OBJECT);
-        } else if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            return ")J";
-        } else if (TypeTags.isStringTypeTag(bType.tag)) {
-            return String.format(")L%s;", B_STRING_VALUE);
-        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
-            return String.format(")L%s;", XML_VALUE);
-        }
-
-        switch (bType.tag) {
-            case TypeTags.BYTE:
-                return ")I";
-            case TypeTags.FLOAT:
-                return ")D";
-            case TypeTags.DECIMAL:
-                return String.format(")L%s;", DECIMAL_VALUE);
-            case TypeTags.BOOLEAN:
-                return ")Z";
-            case TypeTags.ARRAY:
-            case TypeTags.TUPLE:
-                return String.format(")L%s;", ARRAY_VALUE);
-            case TypeTags.MAP:
-            case TypeTags.RECORD:
-                return String.format(")L%s;", MAP_VALUE);
-            case TypeTags.ERROR:
-                return String.format(")L%s;", ERROR_VALUE);
-            case TypeTags.STREAM:
-                return String.format(")L%s;", STREAM_VALUE);
-            case TypeTags.TABLE:
-                return String.format(")L%s;", TABLE_VALUE_IMPL);
-            case TypeTags.FUTURE:
-                return String.format(")L%s;", FUTURE_VALUE);
-            case TypeTags.TYPEDESC:
-                return String.format(")L%s;", TYPEDESC_VALUE);
-            case TypeTags.ANY:
-            case TypeTags.ANYDATA:
-            case TypeTags.UNION:
-            case TypeTags.INTERSECTION:
-            case TypeTags.JSON:
-            case TypeTags.FINITE:
-            case TypeTags.READONLY:
-                return String.format(")L%s;", OBJECT);
-            case TypeTags.OBJECT:
-                return String.format(")L%s;", OBJECT_VALUE);
-            case TypeTags.INVOKABLE:
-                return String.format(")L%s;", FUNCTION_POINTER);
-            case TypeTags.HANDLE:
-                return String.format(")L%s;", HANDLE_VALUE);
-            default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
-                        String.format("%s", bType));
-        }
-    }
-
-    static BIRFunction getMainFunc(List<BIRFunction> funcs) {
-
-        BIRFunction userMainFunc = null;
-        for (BIRFunction func : funcs) {
-            if (func != null && func.name.value.equals("main")) {
-                userMainFunc = func;
-                break;
-            }
-        }
-
-        return userMainFunc;
-    }
-
-    static void createFunctionPointer(MethodVisitor mv, String klass, String lambdaName, int closureMapCount) {
-
-        mv.visitTypeInsn(NEW, FUNCTION_POINTER);
-        mv.visitInsn(DUP);
-        visitInvokeDyn(mv, klass, cleanupFunctionName(lambdaName), closureMapCount);
-
-        // load null here for type, since these are fp's created for internal usages.
-        mv.visitInsn(ACONST_NULL);
-        mv.visitInsn(ACONST_NULL);
-        mv.visitInsn(ICONST_0); // mark as not-concurrent ie: 'parent'
-        mv.visitMethodInsn(INVOKESPECIAL, FUNCTION_POINTER, JVM_INIT_METHOD,
-                           String.format("(L%s;L%s;L%s;Z)V", FUNCTION, BTYPE, STRING_VALUE), false);
-    }
-
-    private static String getFrameClassName(String pkgName, String funcName, BType attachedType) {
-
+    private String getFrameClassName(String pkgName, String funcName, BType attachedType) {
         String frameClassName = pkgName;
-        if (attachedType != null) {
-            if (attachedType.tag == TypeTags.OBJECT) {
-                frameClassName += cleanupTypeName(toNameString(attachedType)) + "_";
-            } else if (attachedType instanceof BServiceType) {
-                frameClassName += cleanupTypeName(toNameString(attachedType)) + "_";
-            } else if (attachedType.tag == TypeTags.RECORD) {
-                frameClassName += cleanupTypeName(toNameString(attachedType)) + "_";
-            }
+        if (attachedType != null && (attachedType.tag == TypeTags.OBJECT || attachedType instanceof BServiceType ||
+                attachedType.tag == TypeTags.RECORD)) {
+            frameClassName += JvmCodeGenUtil.cleanupTypeName(JvmCodeGenUtil.toNameString(attachedType)) + "_";
         }
 
-        return frameClassName + cleanupFunctionName(funcName) + "Frame";
+        return frameClassName + JvmCodeGenUtil.cleanupFunctionName(funcName) + "Frame";
     }
 
-    /**
-     * Cleanup type name by replacing '$' with '_'.
-     *
-     * @param name name to be replaced and cleaned
-     * @return cleaned name
-     */
-    static String cleanupTypeName(String name) {
-        return name.replaceAll("[/$ .]", "_");
+    private PackageID packageToModuleId(BIRPackage mod) {
+        return new PackageID(mod.org, mod.name, mod.version);
     }
 
-    static String cleanupBalExt(String name) {
-
-        return name.replace(BAL_EXTENSION, "");
-    }
-
-    static String cleanupPathSeperators(String name) {
-        //TODO: should use file_path:getPathSeparator();
-        return name.replace(WINDOWS_PATH_SEPERATOR, JAVA_PACKAGE_SEPERATOR);
-    }
-
-    static void generateField(ClassWriter cw, BType bType, String fieldName, boolean isPackage) {
-
-        String typeSig;
-        if (TypeTags.isIntegerTypeTag(bType.tag)) {
-            typeSig = "J";
-        } else if (TypeTags.isStringTypeTag(bType.tag)) {
-            typeSig = String.format("L%s;", B_STRING_VALUE);
-        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
-            typeSig = String.format("L%s;", XML_VALUE);
-        } else {
-            switch (bType.tag) {
-                case TypeTags.BYTE:
-                    typeSig = "I";
-                    break;
-                case TypeTags.FLOAT:
-                    typeSig = "D";
-                    break;
-                case TypeTags.DECIMAL:
-                    typeSig = String.format("L%s;", DECIMAL_VALUE);
-                    break;
-                case TypeTags.BOOLEAN:
-                    typeSig = "Z";
-                    break;
-                case TypeTags.NIL:
-                case TypeTags.NEVER:
-                    typeSig = String.format("L%s;", OBJECT);
-                    break;
-                case TypeTags.MAP:
-                    typeSig = String.format("L%s;", MAP_VALUE);
-                    break;
-                case TypeTags.STREAM:
-                    typeSig = String.format("L%s;", STREAM_VALUE);
-                    break;
-                case TypeTags.TABLE:
-                    typeSig = String.format("L%s;", TABLE_VALUE_IMPL);
-                    break;
-                case TypeTags.RECORD:
-                    typeSig = String.format("L%s;", MAP_VALUE);
-                    break;
-                case TypeTags.ARRAY:
-                case TypeTags.TUPLE:
-                    typeSig = String.format("L%s;", ARRAY_VALUE);
-                    break;
-                case TypeTags.ERROR:
-                    typeSig = String.format("L%s;", ERROR_VALUE);
-                    break;
-                case TypeTags.FUTURE:
-                    typeSig = String.format("L%s;", FUTURE_VALUE);
-                    break;
-                case TypeTags.OBJECT:
-                    typeSig = String.format("L%s;", OBJECT_VALUE);
-                    break;
-                case TypeTags.TYPEDESC:
-                    typeSig = String.format("L%s;", TYPEDESC_VALUE);
-                    break;
-                case TypeTags.ANY:
-                case TypeTags.ANYDATA:
-                case TypeTags.UNION:
-                case TypeTags.INTERSECTION:
-                case TypeTags.JSON:
-                case TypeTags.FINITE:
-                case TypeTags.READONLY:
-                    typeSig = String.format("L%s;", OBJECT);
-                    break;
-                case TypeTags.INVOKABLE:
-                    typeSig = String.format("L%s;", FUNCTION_POINTER);
-                    break;
-                case TypeTags.HANDLE:
-                    typeSig = String.format("L%s;", HANDLE_VALUE);
-                    break;
-                case JTypeTags.JTYPE:
-                    typeSig = getJTypeSignature((JType) bType);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for type " +
-                            String.format("%s", bType));
-            }
-        }
-
-        FieldVisitor fv;
-        if (isPackage) {
-            fv = cw.visitField(ACC_PUBLIC + ACC_STATIC, fieldName, typeSig, null, null);
-        } else {
-            fv = cw.visitField(ACC_PUBLIC, fieldName, typeSig, null, null);
-        }
-        fv.visitEnd();
-    }
-
-    static void generateDefaultConstructor(ClassWriter cw, String ownerClass) {
-
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, JVM_INIT_METHOD, "()V", null, null);
-        mv.visitCode();
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKESPECIAL, ownerClass, JVM_INIT_METHOD, "()V", false);
-        mv.visitInsn(RETURN);
-        mv.visitMaxs(1, 1);
-        mv.visitEnd();
-    }
-
-    private static void generateDiagnosticPos(DiagnosticPos pos, MethodVisitor mv) {
-
-        if (pos != null && pos.sLine != 0x80000000) {
-            Label label = new Label();
-            mv.visitLabel(label);
-            mv.visitLineNumber(pos.sLine, label);
-        }
-    }
-
-    static void generateStrandMetadata(MethodVisitor mv, String moduleClass,
-                                       BIRPackage module, AsyncDataCollector asyncDataCollector) {
-
-        asyncDataCollector.getStrandMetadata().forEach((varName, metaData) -> {
-            genStrandMetadataField(mv, moduleClass, module, varName, metaData);
-        });
-    }
-
-    static void genStrandMetadataField(MethodVisitor mv, String moduleClass, BIRPackage module,
-                                               String varName, ScheduleFunctionInfo metaData) {
-
-        mv.visitTypeInsn(NEW, STRAND_METADATA);
-        mv.visitInsn(DUP);
-        mv.visitLdcInsn(module.org.value);
-        mv.visitLdcInsn(module.name.value);
-        mv.visitLdcInsn(module.version.value);
-        if (metaData.typeName == null) {
-            mv.visitInsn(ACONST_NULL);
-        } else {
-            mv.visitLdcInsn(metaData.typeName);
-        }
-        mv.visitLdcInsn(metaData.parentFunctionName);
-        mv.visitMethodInsn(INVOKESPECIAL, STRAND_METADATA,
-                           CONSTRUCTOR_INIT_METHOD, String.format("(L%s;L%s;L%s;L%s;L%s;)V", STRING_VALUE, STRING_VALUE,
-                                                                  STRING_VALUE, STRING_VALUE, STRING_VALUE), false);
-        mv.visitFieldInsn(PUTSTATIC, moduleClass, varName, String.format("L%s;", STRAND_METADATA));
-    }
-
-    static void visitStrandMetadataField(ClassWriter cw, AsyncDataCollector asyncDataCollector) {
-        asyncDataCollector.getStrandMetadata().keySet().forEach(varName -> {
-            visitStrandMetadataField(cw, varName);
-        });
-
-    }
-
-    static void visitStrandMetadataField(ClassWriter cw, String varName) {
-        FieldVisitor fv = cw.visitField(ACC_STATIC, varName, String.format("L%s;", STRAND_METADATA), null, null);
-        fv.visitEnd();
-    }
-
-    static String getStrandMetadataVarName(String parentFunction) {
-        return STRAND_METADATA_VAR_PREFIX + parentFunction + "$";
-    }
-
-    static String getStrandMetadataVarName(String typeName, String parentFunction) {
-        return STRAND_METADATA_VAR_PREFIX + cleanupTypeName(typeName) + "$" + parentFunction + "$";
-    }
-
-    static String cleanupFunctionName(String functionName) {
-
-        return functionName.replaceAll("[\\.:/<>]", "_");
-    }
-
-    public static BIRVariableDcl getVariableDcl(BIRVariableDcl localVar) {
-
-        if (localVar == null) {
-            throw new BLangCompilerException("Invalid variable declaration");
-        }
-
-        return localVar;
-    }
-
-    static BIRFunctionParameter getFunctionParam(BIRFunctionParameter localVar) {
-
-        if (localVar == null) {
-            throw new BLangCompilerException("Invalid function parameter");
-        }
-
-        return localVar;
-    }
-
-    static BIRBasicBlock getBasicBlock(BIRBasicBlock bb) {
-
-        if (bb == null) {
-            throw new BLangCompilerException("Invalid basic block");
-        }
-
-        return bb;
-    }
-
-    static BIRFunction getFunction(BIRFunction bfunction) {
-
-        if (bfunction == null) {
-            throw new BLangCompilerException("Invalid function");
-        }
-
-        return bfunction;
-    }
-
-    static BIRTypeDefinition getTypeDef(BIRTypeDefinition typeDef) {
-
-        if (typeDef == null) {
-            throw new BLangCompilerException("Invalid type definition");
-        }
-
-        return typeDef;
-    }
-
-    static BField getObjectField(BField objectField) {
-
-        if (objectField == null) {
-            throw new BLangCompilerException("Invalid object field");
-        }
-
-        return objectField;
-    }
-
-    static BField getRecordField(BField recordField) {
-
-        if (recordField != null) {
-            return recordField;
-        } else {
-            throw new BLangCompilerException("Invalid record field");
-        }
-    }
-
-    static boolean isExternFunc(BIRFunction func) {
-
-        return (func.flags & Flags.NATIVE) == Flags.NATIVE;
-    }
-
-    private static BIROperand getVarRef(BIROperand varRef) {
-
-        if (varRef == null) {
-            throw new BLangCompilerException("Invalid variable reference");
-        } else {
-            return varRef;
-        }
-    }
-
-    static BType getType(BType bType) {
-
-        if (bType == null) {
-            throw new BLangCompilerException("Invalid type");
-        } else {
-            return bType;
-        }
-    }
-
-    private static String getMapValueDesc(int count) {
+    private String getMapValueDesc(int count) {
 
         int i = count;
         StringBuilder desc = new StringBuilder();
@@ -1617,502 +1250,93 @@ public class JvmMethodGen {
         return desc.toString();
     }
 
-    static List<BIRFunction> getFunctions(List<BIRFunction> functions) {
-
-        if (functions == null) {
-            throw new BLangCompilerException(String.format("Invalid functions: %s", functions));
-        } else {
-            return functions;
-        }
-    }
-
-    private static void checkStrandCancelled(MethodVisitor mv, int localVarOffset) {
-
+    private void checkStrandCancelled(MethodVisitor mv, int localVarOffset) {
         mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitFieldInsn(GETFIELD, STRAND, "cancel", "Z");
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "cancel", "Z");
         Label notCancelledLabel = new Label();
         mv.visitJumpInsn(IFEQ, notCancelledLabel);
         mv.visitMethodInsn(INVOKESTATIC, BAL_ERRORS, "createCancelledFutureError",
-                String.format("()L%s;", ERROR_VALUE), false);
+                           String.format("()L%s;", ERROR_VALUE), false);
         mv.visitInsn(ATHROW);
 
         mv.visitLabel(notCancelledLabel);
     }
 
-    public void resetIds() {
-
-        nextId = -1;
-        nextVarId = -1;
+    private int[] toIntArray(List<Integer> states) {
+        int[] ints = new int[states.size()];
+        for (int i = 0; i < states.size(); i++) {
+            ints[i] = states.get(i);
+        }
+        return ints;
     }
 
-    int incrementAndGetNextId() {
-
-        return nextId++;
+    private boolean isModuleStartFunction(BIRPackage module, String functionName) {
+        return functionName.equals(
+                JvmCodeGenUtil.cleanupFunctionName(calculateModuleSpecialFuncName(packageToModuleId(module),
+                                                                                  START_FUNCTION_SUFFIX)));
     }
 
-    void generateMethod(BIRFunction birFunc, ClassWriter cw, BIRPackage birModule, BType attachedType,
-                        String moduleClassName, String serviceName, AsyncDataCollector asyncDataCollector) {
+    public void generateBasicBlocks(MethodVisitor mv, LabelGenerator labelGen, JvmErrorGen errorGen,
+                                    JvmInstructionGen instGen, JvmTerminatorGen termGen, BIRFunction func,
+                                    int returnVarRefIndex, int stateVarIndex, int localVarOffset, BIRPackage module,
+                                    BType attachedType, String moduleClassName, AsyncDataCollector asyncDataCollector) {
 
-        if (isExternFunc(birFunc)) {
-            genJMethodForBExternalFunc(birFunc, cw, birModule, attachedType, this, jvmPackageGen,
-                                       moduleClassName, serviceName, asyncDataCollector);
-        } else {
-            genJMethodForBFunc(birFunc, cw, birModule, moduleClassName, attachedType,
-                               asyncDataCollector);
-        }
-    }
-
-    public void genJMethodForBFunc(BIRFunction func,
-                                   ClassWriter cw,
-                                   BIRPackage module,
-                                   String moduleClassName,
-                                   BType attachedType,
-                                   AsyncDataCollector asyncDataCollector) {
-
-        String currentPackageName = getPackageName(module.org.value, module.name.value, module.version.value);
-        BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
-        String funcName = cleanupFunctionName(func.name.value);
-        int returnVarRefIndex = -1;
-
-        BIRVariableDcl strandVar = new BIRVariableDcl(symbolTable.stringType, new Name("strand"),
-                VarScope.FUNCTION, VarKind.ARG);
-        int ignoreStrandVarIndex = indexMap.getIndex(strandVar);
-
-        // generate method desc
-        BType retType = func.type.retType;
-        if (isExternFunc(func) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.build(func.type.retType);
-        }
-
-        String desc = getMethodDesc(func.type.paramTypes, retType, null, false);
-        int access = ACC_PUBLIC;
-        int localVarOffset;
-        if (attachedType != null) {
-            localVarOffset = 1;
-
-            // add the self as the first local var
-            // TODO: find a better way
-            BIRVariableDcl selfVar = new BIRVariableDcl(symbolTable.anyType, new Name("self"),
-                    VarScope.FUNCTION, VarKind.ARG);
-            int ignoreSelfVarIndex = indexMap.getIndex(selfVar);
-        } else {
-            localVarOffset = 0;
-            access += ACC_STATIC;
-        }
-
-        MethodVisitor mv = cw.visitMethod(access, funcName, desc, null, null);
-        JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, module, jvmPackageGen);
-        JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, currentPackageName, instGen);
-        LabelGenerator labelGen = new LabelGenerator();
-
-        mv.visitCode();
-        if (isModuleStartFunction(module, funcName)) {
-            mv.visitInsn(ICONST_1);
-            mv.visitFieldInsn(PUTSTATIC, getModuleLevelClassName(module.org.value, module.name.value,
-                    module.version.value, MODULE_INIT_CLASS_NAME), MODULE_START_ATTEMPTED, "Z");
-        }
-
-        Label methodStartLabel = new Label();
-        mv.visitLabel(methodStartLabel);
-
-        // generate method body
-        int k = 1;
-
-        // set channel details to strand.
-        // these channel info is required to notify datachannels, when there is a panic
-        // we cannot set this during strand creation, because function call do not have this info.
-        if (func.workerChannels.length > 0) {
-            mv.visitVarInsn(ALOAD, localVarOffset);
-            loadChannelDetails(mv, Arrays.asList(func.workerChannels));
-            mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "updateChannelDetails",
-                    String.format("([L%s;)V", CHANNEL_DETAILS), false);
-        }
-
-        // panic if this strand is cancelled
-        checkStrandCancelled(mv, localVarOffset);
-
-        func.localVars.sort(FUNCTION_PARAM_COMPARATOR);
-
-        List<BIRVariableDcl> localVars = func.localVars;
-        while (k < localVars.size()) {
-            BIRVariableDcl localVar = getVariableDcl(localVars.get(k));
-            int index = indexMap.getIndex(localVar);
-            if (localVar.kind != VarKind.ARG) {
-                BType bType = localVar.type;
-                genDefaultValue(mv, bType, index);
-            }
-            k += 1;
-        }
-
-        BIRVariableDcl varDcl = getVariableDcl(localVars.get(0));
-        returnVarRefIndex = indexMap.getIndex(varDcl);
-        genDefaultValue(mv, retType, returnVarRefIndex);
-
-        BIRVariableDcl stateVar = new BIRVariableDcl(symbolTable.stringType, //should  be javaInt
-                new Name("state"), null, VarKind.TEMP);
-        int stateVarIndex = indexMap.getIndex(stateVar);
-        mv.visitInsn(ICONST_0);
-        mv.visitVarInsn(ISTORE, stateVarIndex);
-
-        mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitFieldInsn(GETFIELD, "org/ballerinalang/jvm/scheduling/Strand", "resumeIndex", "I");
-        Label resumeLable = labelGen.getLabel(funcName + "resume");
-        mv.visitJumpInsn(IFGT, resumeLable);
-
-        Label varinitLable = labelGen.getLabel(funcName + "varinit");
-        mv.visitLabel(varinitLable);
-
-        // uncomment to test yield
-        // mv.visitFieldInsn(GETSTATIC, className, "i", "I");
-        // mv.visitInsn(ICONST_1);
-        // mv.visitInsn(IADD);
-        // mv.visitFieldInsn(PUTSTATIC, className, "i", "I");
-
-        // process basic blocks
-        List<BIRBasicBlock> basicBlocks = func.basicBlocks;
-
-        List<Label> lables = new ArrayList<>();
-        List<Integer> states = new ArrayList<>();
-
-        int i = 0;
+        String funcName = JvmCodeGenUtil.cleanupFunctionName(func.name.value);
         int caseIndex = 0;
-        while (i < basicBlocks.size()) {
-            BIRBasicBlock bb = getBasicBlock(basicBlocks.get(i));
-            if (i == 0) {
-                lables.add(caseIndex, labelGen.getLabel(funcName + bb.id.value));
-                states.add(caseIndex, caseIndex);
-                caseIndex += 1;
-            }
-            lables.add(caseIndex, labelGen.getLabel(funcName + bb.id.value + "beforeTerm"));
-            states.add(caseIndex, caseIndex);
-            caseIndex += 1;
-            i = i + 1;
-        }
-
-        JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, module, instGen,
-                jvmPackageGen);
-
-        // uncomment to test yield
-        // mv.visitFieldInsn(GETSTATIC, className, "i", "I");
-        // mv.visitIntInsn(BIPUSH, 100);
-        // jvm:Label l0 = labelGen.getLabel(funcName + "l0");
-        // mv.visitJumpInsn(IF_ICMPNE, l0);
-        // mv.visitVarInsn(ALOAD, 0);
-        // mv.visitInsn(ICONST_1);
-        // mv.visitFieldInsn(PUTFIELD, "org/ballerinalang/jvm/scheduling/Strand", "yield", "Z");
-        // termGen.genReturnTerm({kind:"RETURN"}, returnVarRefIndex, func);
-        // mv.visitLabel(l0);
-
-        mv.visitVarInsn(ILOAD, stateVarIndex);
-        Label yieldLable = labelGen.getLabel(funcName + "yield");
-        mv.visitLookupSwitchInsn(yieldLable, toIntArray(states), lables.toArray(new Label[0]));
-
-        generateBasicBlocks(mv, basicBlocks, labelGen, errorGen, instGen, termGen, func, returnVarRefIndex,
-                            stateVarIndex, localVarOffset, false, module, attachedType,
-                            moduleClassName, asyncDataCollector);
-
-        String frameName = getFrameClassName(currentPackageName, funcName, attachedType);
-        mv.visitLabel(resumeLable);
-        mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitFieldInsn(GETFIELD, "org/ballerinalang/jvm/scheduling/Strand", "frames", "[Ljava/lang/Object;");
-        mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, "org/ballerinalang/jvm/scheduling/Strand", "resumeIndex", "I");
-        mv.visitInsn(ICONST_1);
-        mv.visitInsn(ISUB);
-        mv.visitInsn(DUP_X1);
-        mv.visitFieldInsn(PUTFIELD, "org/ballerinalang/jvm/scheduling/Strand", "resumeIndex", "I");
-        mv.visitInsn(AALOAD);
-        mv.visitTypeInsn(CHECKCAST, frameName);
-
-        generateFrameClassFieldLoad(localVars, mv, indexMap, frameName);
-        mv.visitFieldInsn(GETFIELD, frameName, "state", "I");
-        mv.visitVarInsn(ISTORE, stateVarIndex);
-        mv.visitJumpInsn(GOTO, varinitLable);
-
-        mv.visitLabel(yieldLable);
-        mv.visitTypeInsn(NEW, frameName);
-        mv.visitInsn(DUP);
-        mv.visitMethodInsn(INVOKESPECIAL, frameName, JVM_INIT_METHOD, "()V", false);
-
-        generateFrameClassFieldUpdate(localVars, mv, indexMap, frameName);
-
-        mv.visitInsn(DUP);
-        mv.visitVarInsn(ILOAD, stateVarIndex);
-        mv.visitFieldInsn(PUTFIELD, frameName, "state", "I");
-
-        BIRVariableDcl frameVar = new BIRVariableDcl(symbolTable.stringType, new Name("frame"), null, VarKind.TEMP);
-        int frameVarIndex = indexMap.getIndex(frameVar);
-        mv.visitVarInsn(ASTORE, frameVarIndex);
-
-        mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitFieldInsn(GETFIELD, "org/ballerinalang/jvm/scheduling/Strand", "frames", "[Ljava/lang/Object;");
-        mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, "org/ballerinalang/jvm/scheduling/Strand", "resumeIndex", "I");
-        mv.visitInsn(DUP_X1);
-        mv.visitInsn(ICONST_1);
-        mv.visitInsn(IADD);
-        mv.visitFieldInsn(PUTFIELD, "org/ballerinalang/jvm/scheduling/Strand", "resumeIndex", "I");
-        mv.visitVarInsn(ALOAD, frameVarIndex);
-        mv.visitInsn(AASTORE);
-
-        Label methodEndLabel = new Label();
-        mv.visitLabel(methodEndLabel);
-        termGen.genReturnTerm(new Return(null), returnVarRefIndex, func);
-
-        // Create Local Variable Table
-        k = localVarOffset;
-        // Add strand variable to LVT
-        mv.visitLocalVariable("__strand", String.format("L%s;", STRAND), null, methodStartLabel, methodEndLabel,
-                localVarOffset);
-        while (k < localVars.size()) {
-            BIRVariableDcl localVar = getVariableDcl(localVars.get(k));
-            Label startLabel = methodStartLabel;
-            Label endLabel = methodEndLabel;
-            boolean tmpBoolParam = localVar.type.tag == TypeTags.BOOLEAN && localVar.name.value.startsWith("%syn");
-            if (!tmpBoolParam && (localVar.kind == VarKind.LOCAL || localVar.kind == VarKind.ARG)) {
-                // local vars have visible range information
-                if (localVar.kind == VarKind.LOCAL) {
-                    int insOffset = localVar.insOffset;
-                    if (localVar.startBB != null) {
-                        startLabel = labelGen.getLabel(funcName + localVar.startBB.id.value + "ins" + insOffset);
-                    }
-                    if (localVar.endBB != null) {
-                        endLabel = labelGen.getLabel(funcName + localVar.endBB.id.value + "beforeTerm");
-                    }
-                }
-                String metaVarName = localVar.metaVarName;
-                if (metaVarName != null && !"".equals(metaVarName) &&
-                        // filter out compiler added vars
-                        !((metaVarName.startsWith("$") && metaVarName.endsWith("$"))
-                                || (metaVarName.startsWith("$$") && metaVarName.endsWith("$$"))
-                                || metaVarName.startsWith("_$$_"))) {
-                    mv.visitLocalVariable(metaVarName, getJVMTypeSign(localVar.type), null,
-                            startLabel, endLabel, indexMap.getIndex(localVar));
-                }
-            }
-            k = k + 1;
-        }
-
-        mv.visitMaxs(0, 0);
-        mv.visitEnd();
-    }
-
-    private static boolean isModuleStartFunction(BIRPackage module, String functionName) {
-        return functionName.equals(cleanupFunctionName(calculateModuleSpecialFuncName(packageToModuleId(module),
-                START_FUNCTION_SUFFIX)));
-    }
-
-    public void generateBasicBlocks(MethodVisitor mv, List<BIRBasicBlock> basicBlocks,
-                                    LabelGenerator labelGen, JvmErrorGen errorGen,
-                                    JvmInstructionGen instGen, JvmTerminatorGen termGen,
-                                    BIRFunction func, int returnVarRefIndex, int stateVarIndex,
-                                    int localVarOffset, boolean isArg, BIRPackage module, BType attachedType,
-                                    String moduleClassName, AsyncDataCollector asyncDataCollector) {
-
-        int j = 0;
-        String funcName = cleanupFunctionName(func.name.value);
-
-        int caseIndex = 0;
-
-        while (j < basicBlocks.size()) {
-            BIRBasicBlock bb = getBasicBlock(basicBlocks.get(j));
-            String currentBBName = String.format("%s", bb.id.value);
-
+        for (int i = 0; i < func.basicBlocks.size(); i++) {
+            BIRBasicBlock bb = func.basicBlocks.get(i);
             // create jvm label
             Label bbLabel = labelGen.getLabel(funcName + bb.id.value);
             mv.visitLabel(bbLabel);
-            if (j == 0 && !isArg) {
-                // SIPUSH range is (-32768 to 32767) so if the state index goes beyond that, need to use visitLdcInsn
-                mv.visitIntInsn(SIPUSH, caseIndex);
-                mv.visitVarInsn(ISTORE, stateVarIndex);
+            if (i == 0) {
+                pushShort(mv, stateVarIndex, caseIndex);
                 caseIndex += 1;
             }
 
             // generate instructions
-            int m = 0;
-            int insCount = bb.instructions.size();
+            JvmCodeGenUtil.generateBbInstructions(mv, labelGen, instGen, localVarOffset, asyncDataCollector,
+                                                  funcName, bb);
 
-            InstructionKind insKind;
-            while (m < insCount) {
-                Label insLabel = labelGen.getLabel(funcName + bb.id.value + "ins" + m);
-                mv.visitLabel(insLabel);
-                BIRInstruction inst = bb.instructions.get(m);
-                if (inst == null) {
-                    continue;
-                } else {
-                    insKind = inst.getKind();
-                    generateDiagnosticPos(((BIRNode) inst).pos, mv);
-                }
-
-                generateInstructions(instGen, localVarOffset, asyncDataCollector, insKind, inst);
-                m += 1;
-            }
-
-            Label bbEndLable = labelGen.getLabel(funcName + bb.id.value + "beforeTerm");
-            mv.visitLabel(bbEndLable);
+            Label bbEndLabel = labelGen.getLabel(funcName + bb.id.value + "beforeTerm");
+            mv.visitLabel(bbEndLabel);
 
             BIRTerminator terminator = bb.terminator;
-            if (!isArg) {
-                // SIPUSH range is (-32768 to 32767) so if the state index goes beyond that, need to use visitLdcInsn
-                mv.visitIntInsn(SIPUSH, caseIndex);
-                mv.visitVarInsn(ISTORE, stateVarIndex);
-                caseIndex += 1;
-            }
+            pushShort(mv, stateVarIndex, caseIndex);
+            caseIndex += 1;
 
-            // process terminator
-            if (!isArg || (!(terminator instanceof Return))) {
-                generateDiagnosticPos(terminator.pos, mv);
-                if ((isModuleInitFunction(module, func) || isModuleTestInitFunction(module, func)) &&
-                        terminator instanceof Return) {
-                    generateAnnotLoad(mv, module.typeDefs, getPackageName(module.org.value, module.name.value,
-                                                                          module.version.value));
-                }
-                //set module start success to true for ___init class
-                if (isModuleStartFunction(module, funcName) && terminator.kind == InstructionKind.RETURN) {
-                    mv.visitInsn(ICONST_1);
-                    mv.visitFieldInsn(PUTSTATIC, getModuleLevelClassName(module.org.value, module.name.value,
-                            module.version.value, MODULE_INIT_CLASS_NAME), MODULE_STARTED, "Z");
-                }
-                termGen.genTerminator(terminator, moduleClassName, func, funcName, localVarOffset, returnVarRefIndex,
-                        attachedType, asyncDataCollector);
-            }
+            processTerminator(mv, func, module, funcName, terminator);
+            termGen.genTerminator(terminator, moduleClassName, func, funcName, localVarOffset, returnVarRefIndex,
+                                  attachedType, asyncDataCollector);
 
             errorGen.generateTryCatch(func, funcName, bb, termGen, labelGen);
 
             BIRBasicBlock thenBB = terminator.thenBB;
             if (thenBB != null) {
-                genYieldCheck(mv, termGen.getLabelGenerator(), thenBB, funcName, localVarOffset);
+                JvmCodeGenUtil.genYieldCheck(mv, termGen.getLabelGenerator(), thenBB, funcName, localVarOffset);
             }
-            j += 1;
         }
     }
 
-    private void generateInstructions(JvmInstructionGen instGen, int localVarOffset,
-                                      AsyncDataCollector asyncDataCollector, InstructionKind insKind,
-                                      BIRInstruction inst) {
-
-        if (inst instanceof BinaryOp) {
-            instGen.generateBinaryOpIns((BinaryOp) inst);
-        } else {
-            switch (insKind) {
-                case MOVE:
-                    instGen.generateMoveIns((Move) inst);
-                    break;
-                case CONST_LOAD:
-                    instGen.generateConstantLoadIns((ConstantLoad) inst);
-                    break;
-                case NEW_STRUCTURE:
-                    instGen.generateMapNewIns((NewStructure) inst, localVarOffset);
-                    break;
-                case NEW_INSTANCE:
-                    instGen.generateObjectNewIns((NewInstance) inst, localVarOffset);
-                    break;
-                case MAP_STORE:
-                    instGen.generateMapStoreIns((FieldAccess) inst);
-                    break;
-                case NEW_TABLE:
-                    instGen.generateTableNewIns((NewTable) inst);
-                    break;
-                case TABLE_STORE:
-                    instGen.generateTableStoreIns((FieldAccess) inst);
-                    break;
-                case TABLE_LOAD:
-                    instGen.generateTableLoadIns((FieldAccess) inst);
-                    break;
-                case NEW_ARRAY:
-                    instGen.generateArrayNewIns((NewArray) inst);
-                    break;
-                case ARRAY_STORE:
-                    instGen.generateArrayStoreIns((FieldAccess) inst);
-                    break;
-                case MAP_LOAD:
-                    instGen.generateMapLoadIns((FieldAccess) inst);
-                    break;
-                case ARRAY_LOAD:
-                    instGen.generateArrayValueLoad((FieldAccess) inst);
-                    break;
-                case NEW_ERROR:
-                    instGen.generateNewErrorIns((NewError) inst);
-                    break;
-                case TYPE_CAST:
-                    instGen.generateCastIns((TypeCast) inst);
-                    break;
-                case IS_LIKE:
-                    instGen.generateIsLikeIns((IsLike) inst);
-                    break;
-                case TYPE_TEST:
-                    instGen.generateTypeTestIns((TypeTest) inst);
-                    break;
-                case OBJECT_STORE:
-                    instGen.generateObjectStoreIns((FieldAccess) inst);
-                    break;
-                case OBJECT_LOAD:
-                    instGen.generateObjectLoadIns((FieldAccess) inst);
-                    break;
-                case NEW_XML_ELEMENT:
-                    instGen.generateNewXMLElementIns((NewXMLElement) inst);
-                    break;
-                case NEW_XML_TEXT:
-                    instGen.generateNewXMLTextIns((NewXMLText) inst);
-                    break;
-                case NEW_XML_COMMENT:
-                    instGen.generateNewXMLCommentIns((NewXMLComment) inst);
-                    break;
-                case NEW_XML_PI:
-                    instGen.generateNewXMLProcIns((NewXMLProcIns) inst);
-                    break;
-                case NEW_XML_QNAME:
-                    instGen.generateNewXMLQNameIns((NewXMLQName) inst);
-                    break;
-                case NEW_STRING_XML_QNAME:
-                    instGen.generateNewStringXMLQNameIns((NewStringXMLQName) inst);
-                    break;
-                case XML_SEQ_STORE:
-                    instGen.generateXMLStoreIns((XMLAccess) inst);
-                    break;
-                case XML_SEQ_LOAD:
-                    instGen.generateXMLLoadIns((FieldAccess) inst);
-                    break;
-                case XML_LOAD:
-                    instGen.generateXMLLoadIns((FieldAccess) inst);
-                    break;
-                case XML_LOAD_ALL:
-                    instGen.generateXMLLoadAllIns((XMLAccess) inst);
-                    break;
-                case XML_ATTRIBUTE_STORE:
-                    instGen.generateXMLAttrStoreIns((FieldAccess) inst);
-                    break;
-                case XML_ATTRIBUTE_LOAD:
-                    instGen.generateXMLAttrLoadIns((FieldAccess) inst);
-                    break;
-                case FP_LOAD:
-                    instGen.generateFPLoadIns((FPLoad) inst, asyncDataCollector);
-                    break;
-                case STRING_LOAD:
-                    instGen.generateStringLoadIns((FieldAccess) inst);
-                    break;
-                case TYPEOF:
-                    instGen.generateTypeofIns((UnaryOP) inst);
-                    break;
-                case NOT:
-                    instGen.generateNotIns((UnaryOP) inst);
-                    break;
-                case NEW_TYPEDESC:
-                    instGen.generateNewTypedescIns((NewTypeDesc) inst);
-                    break;
-                case NEGATE:
-                    instGen.generateNegateIns((UnaryOP) inst);
-                    break;
-                case PLATFORM:
-                    instGen.generatePlatformIns((JInstruction) inst);
-                    break;
-                default:
-                    throw new BLangCompilerException("JVM generation is not supported for operation " +
-                            String.format("%s", inst));
-            }
+    private void processTerminator(MethodVisitor mv, BIRFunction func, BIRPackage module, String funcName,
+                                   BIRTerminator terminator) {
+        JvmCodeGenUtil.generateDiagnosticPos(terminator.pos, mv);
+        if ((isModuleInitFunction(module, func) || isModuleTestInitFunction(module, func)) &&
+                terminator instanceof Return) {
+            generateAnnotLoad(mv, module.typeDefs, JvmCodeGenUtil.getPackageName(module));
         }
+        //set module start success to true for ___init class
+        if (isModuleStartFunction(module, funcName) && terminator.kind == InstructionKind.RETURN) {
+            mv.visitInsn(ICONST_1);
+            mv.visitFieldInsn(PUTSTATIC,
+                              JvmCodeGenUtil.getModuleLevelClassName(module, MODULE_INIT_CLASS_NAME),
+                              MODULE_STARTED, "Z");
+        }
+    }
+
+    private void pushShort(MethodVisitor mv, int stateVarIndex, int caseIndex) {
+        // SIPUSH range is (-32768 to 32767) so if the state index goes beyond that, need to use visitLdcInsn
+        mv.visitIntInsn(SIPUSH, caseIndex);
+        mv.visitVarInsn(ISTORE, stateVarIndex);
     }
 
     void generateLambdaMethod(BIRInstruction ins, ClassWriter cw, String lambdaName) {
@@ -2146,7 +1370,7 @@ public class JvmMethodGen {
         }
 
         boolean isExternFunction = isExternStaticFunctionCall(ins);
-        boolean isBuiltinModule = isBallerinaBuiltinModule(orgName, moduleName);
+        boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(orgName, moduleName);
 
         BType returnType;
         if (lhsType.tag == TypeTags.FUTURE) {
@@ -2158,7 +1382,7 @@ public class JvmMethodGen {
             }
         } else {
             throw new BLangCompilerException("JVM generation is not supported for async return type " +
-                    String.format("%s", lhsType));
+                                                     String.format("%s", lhsType));
         }
 
         int closureMapsCount = 0;
@@ -2168,8 +1392,8 @@ public class JvmMethodGen {
         String closureMapsDesc = getMapValueDesc(closureMapsCount);
 
         MethodVisitor mv;
-        mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, cleanupFunctionName(lambdaName),
-                String.format("(%s[L%s;)L%s;", closureMapsDesc, OBJECT, OBJECT), null, null);
+        mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC, JvmCodeGenUtil.cleanupFunctionName(lambdaName),
+                            String.format("(%s[L%s;)L%s;", closureMapsDesc, OBJECT, OBJECT), null, null);
 
         mv.visitCode();
         // load strand as first arg
@@ -2178,7 +1402,7 @@ public class JvmMethodGen {
         mv.visitVarInsn(ALOAD, closureMapsCount);
         mv.visitInsn(ICONST_0);
         mv.visitInsn(AALOAD);
-        mv.visitTypeInsn(CHECKCAST, STRAND);
+        mv.visitTypeInsn(CHECKCAST, STRAND_CLASS);
 
         if (isExternFunction) {
             generateBlockedOnExtern(closureMapsCount, mv);
@@ -2205,11 +1429,11 @@ public class JvmMethodGen {
                 // load and cast param values
                 int argIndex = 1;
                 for (BIROperand paramType : paramTypes) {
-                    BIROperand ref = getVarRef(paramType);
+                    BIROperand ref = paramType;
                     mv.visitVarInsn(ALOAD, 0);
                     mv.visitIntInsn(BIPUSH, argIndex);
                     mv.visitInsn(AALOAD);
-                    JvmInstructionGen.addUnboxInsn(mv, ref.variableDcl.type);
+                    JvmCastGen.addUnboxInsn(mv, ref.variableDcl.type);
                     paramBTypes.add(paramIndex - 1, paramType.variableDcl.type);
                     paramIndex += 1;
 
@@ -2235,12 +1459,11 @@ public class JvmMethodGen {
             // load and cast param values
 
             int argIndex = 1;
-            for (BIRVariableDcl paramType : paramTypes) {
-                BIRVariableDcl dcl = getVariableDcl(paramType);
+            for (BIRVariableDcl dcl : paramTypes) {
                 mv.visitVarInsn(ALOAD, closureMapsCount);
                 mv.visitIntInsn(BIPUSH, argIndex);
                 mv.visitInsn(AALOAD);
-                JvmInstructionGen.addUnboxInsn(mv, dcl.type);
+                JvmCastGen.addUnboxInsn(mv, dcl.type);
                 paramBTypes.add(paramIndex - 1, dcl.type);
                 paramIndex += 1;
                 i += 1;
@@ -2256,11 +1479,11 @@ public class JvmMethodGen {
         }
 
         if (isVirtual) {
-            String methodDesc = String.format("(L%s;L%s;[L%s;)L%s;", STRAND, STRING_VALUE, OBJECT, OBJECT);
+            String methodDesc = String.format("(L%s;L%s;[L%s;)L%s;", STRAND_CLASS, STRING_VALUE, OBJECT, OBJECT);
             mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "call", methodDesc, true);
         } else {
             String jvmClass;
-            String lookupKey = getPackageName(orgName, moduleName, version) + funcName;
+            String lookupKey = JvmCodeGenUtil.getPackageName(orgName, moduleName, version) + funcName;
             BIRFunctionWrapper functionWrapper = jvmPackageGen.lookupBIRFunctionWrapper(lookupKey);
             String methodDesc = getLambdaMethodDesc(paramBTypes, returnType, closureMapsCount);
             if (functionWrapper != null) {
@@ -2282,15 +1505,15 @@ public class JvmMethodGen {
                     balFileName = MODULE_INIT_CLASS_NAME;
                 }
 
-                jvmClass = getModuleLevelClassName(orgName, moduleName, version,
-                        cleanupPathSeperators(cleanupBalExt(balFileName)));
+                jvmClass = JvmCodeGenUtil.getModuleLevelClassName(orgName, moduleName, version, JvmCodeGenUtil
+                        .cleanupPathSeparators(balFileName));
             }
 
             mv.visitMethodInsn(INVOKESTATIC, jvmClass, funcName, methodDesc, false);
         }
 
         if (!isVirtual) {
-            JvmInstructionGen.addBoxInsn(mv, returnType);
+            JvmCastGen.addBoxInsn(mv, returnType);
         }
         mv.visitInsn(ARETURN);
         mv.visitMaxs(0, 0);
@@ -2303,28 +1526,28 @@ public class JvmMethodGen {
 
         mv.visitInsn(DUP);
 
-        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, IS_BLOCKED_ON_EXTERN_FIELD, "()Z", false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, IS_BLOCKED_ON_EXTERN_FIELD, "()Z", false);
         mv.visitJumpInsn(IFEQ, blockedOnExternLabel);
 
         mv.visitInsn(DUP);
         mv.visitInsn(ICONST_0);
-        mv.visitFieldInsn(PUTFIELD, STRAND, BLOCKED_ON_EXTERN_FIELD, "Z");
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, BLOCKED_ON_EXTERN_FIELD, "Z");
 
         mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, STRAND, PANIC_FIELD, String.format("L%s;", B_ERROR));
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, PANIC_FIELD, String.format("L%s;", B_ERROR));
         Label panicLabel = new Label();
         mv.visitJumpInsn(IFNULL, panicLabel);
         mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, STRAND, PANIC_FIELD, String.format("L%s;", B_ERROR));
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, PANIC_FIELD, String.format("L%s;", B_ERROR));
         mv.visitVarInsn(ASTORE, closureMapsCount + 1);
         mv.visitInsn(ACONST_NULL);
-        mv.visitFieldInsn(PUTFIELD, STRAND, PANIC_FIELD, String.format("L%s;", B_ERROR));
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, PANIC_FIELD, String.format("L%s;", B_ERROR));
         mv.visitVarInsn(ALOAD, closureMapsCount + 1);
         mv.visitInsn(ATHROW);
         mv.visitLabel(panicLabel);
 
         mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, STRAND, "returnValue", "Ljava/lang/Object;");
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue", "Ljava/lang/Object;");
         mv.visitInsn(ARETURN);
 
         mv.visitLabel(blockedOnExternLabel);
@@ -2337,15 +1560,15 @@ public class JvmMethodGen {
         mv.visitInsn(POP);
         mv.visitVarInsn(ALOAD, closureMapsCount);
         mv.visitInsn(ICONST_1);
-        BIROperand ref = getVarRef(ins.args.get(0));
+        BIROperand ref = ins.args.get(0);
         mv.visitInsn(AALOAD);
-        JvmInstructionGen.addUnboxInsn(mv, ref.variableDcl.type);
+        JvmCastGen.addUnboxInsn(mv, ref.variableDcl.type);
         mv.visitVarInsn(ALOAD, closureMapsCount);
         mv.visitInsn(ICONST_0);
         mv.visitInsn(AALOAD);
-        mv.visitTypeInsn(CHECKCAST, STRAND);
+        mv.visitTypeInsn(CHECKCAST, STRAND_CLASS);
 
-        mv.visitLdcInsn(cleanupObjectTypeName(ins.name.value));
+        mv.visitLdcInsn(JvmCodeGenUtil.cleanupObjectTypeName(ins.name.value));
         int objectArrayLength = paramTypes.size() - 1;
         if (!isBuiltinModule) {
             mv.visitIntInsn(BIPUSH, objectArrayLength * 2);
@@ -2386,11 +1609,10 @@ public class JvmMethodGen {
                         "instruction " + String.format("%s", callIns));
         }
 
-        String key = getPackageName(packageID.orgName.value, packageID.name.value,
-                                    packageID.version.value) + methodName;
+        String key = JvmCodeGenUtil.getPackageName(packageID) + methodName;
 
         BIRFunctionWrapper functionWrapper = jvmPackageGen.lookupBIRFunctionWrapper(key);
-        return functionWrapper != null && isExternFunc(functionWrapper.func);
+        return functionWrapper != null && JvmCodeGenUtil.isExternFunc(functionWrapper.func);
     }
 
     private void addBooleanTypeToLambdaParamTypes(MethodVisitor mv, int arrayIndex, int paramIndex) {
@@ -2398,13 +1620,14 @@ public class JvmMethodGen {
         mv.visitVarInsn(ALOAD, arrayIndex);
         mv.visitIntInsn(BIPUSH, paramIndex);
         mv.visitInsn(AALOAD);
-        JvmInstructionGen.addUnboxInsn(mv, symbolTable.booleanType);
+        JvmCastGen.addUnboxInsn(mv, symbolTable.booleanType);
     }
 
     void generateMainMethod(BIRFunction userMainFunc, ClassWriter cw, BIRPackage pkg,
                             String initClass, boolean serviceEPAvailable, AsyncDataCollector asyncDataCollector) {
 
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "main", "([Ljava/lang/String;)V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC, "main", "([Ljava/lang/String;)V", null,
+                                          null);
         mv.visitCode();
         Label tryCatchStart = new Label();
         Label tryCatchEnd = new Label();
@@ -2426,8 +1649,8 @@ public class JvmMethodGen {
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
         // add main string[] args param first
         BIRVariableDcl argsVar = new BIRVariableDcl(symbolTable.anyType, new Name("argsdummy"), VarScope.FUNCTION,
-                VarKind.ARG);
-        int ignoreArgsVarIndex = indexMap.getIndex(argsVar);
+                                                    VarKind.ARG);
+        indexMap.addToMapIfNotFoundAndGetIndex(argsVar);
         boolean isVoidFunction = userMainFunc != null && userMainFunc.type.retType.tag == TypeTags.NIL;
 
         mv.visitTypeInsn(NEW, SCHEDULER);
@@ -2435,8 +1658,8 @@ public class JvmMethodGen {
         mv.visitInsn(ICONST_0);
         mv.visitMethodInsn(INVOKESPECIAL, SCHEDULER, JVM_INIT_METHOD, "(Z)V", false);
         BIRVariableDcl schedulerVar = new BIRVariableDcl(symbolTable.anyType, new Name("schedulerdummy"),
-                VarScope.FUNCTION, VarKind.ARG);
-        int schedulerVarIndex = indexMap.getIndex(schedulerVar);
+                                                         VarScope.FUNCTION, VarKind.ARG);
+        int schedulerVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(schedulerVar);
         mv.visitVarInsn(ASTORE, schedulerVarIndex);
 
         if (hasInitFunction(pkg)) {
@@ -2448,25 +1671,25 @@ public class JvmMethodGen {
             String lambdaName = String.format("$lambda$%s$", MODULE_INIT);
 
             // create FP value
-            createFunctionPointer(mv, initClass, lambdaName, 0);
+            JvmCodeGenUtil.createFunctionPointer(mv, initClass, lambdaName);
 
             // no parent strand
             mv.visitInsn(ACONST_NULL);
             BType anyType = symbolTable.anyType;
-            loadType(mv, anyType);
+            JvmTypeGen.loadType(mv, anyType);
             // submit to scheduler
             submitToScheduler(mv, initClass, "<init>", asyncDataCollector);
             mv.visitInsn(DUP);
             mv.visitInsn(DUP);
-            mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "strand", String.format("L%s;", STRAND));
+            mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, STRAND, String.format("L%s;", STRAND_CLASS));
             mv.visitIntInsn(BIPUSH, 100);
             mv.visitTypeInsn(ANEWARRAY, OBJECT);
-            mv.visitFieldInsn(PUTFIELD, STRAND, "frames", String.format("[L%s;", OBJECT));
+            mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, FRAMES, String.format("[L%s;", OBJECT));
             handleErrorFromFutureValue(mv);
 
             BIRVariableDcl futureVar = new BIRVariableDcl(symbolTable.anyType, new Name("initdummy"),
-                    VarScope.FUNCTION, VarKind.ARG);
-            int futureVarIndex = indexMap.getIndex(futureVar);
+                                                          VarScope.FUNCTION, VarKind.ARG);
+            int futureVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(futureVar);
             mv.visitVarInsn(ASTORE, futureVarIndex);
             mv.visitVarInsn(ALOAD, futureVarIndex);
             mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "result", String.format("L%s;", OBJECT));
@@ -2482,30 +1705,30 @@ public class JvmMethodGen {
 
             // invoke the user's main method
             String lambdaName = "$lambda$main$";
-            createFunctionPointer(mv, initClass, lambdaName, 0);
+            JvmCodeGenUtil.createFunctionPointer(mv, initClass, lambdaName);
 
             // no parent strand
             mv.visitInsn(ACONST_NULL);
 
             //submit to the scheduler
             BType anyType = symbolTable.anyType;
-            loadType(mv, anyType);
+            JvmTypeGen.loadType(mv, anyType);
             submitToScheduler(mv, initClass, "main", asyncDataCollector);
             mv.visitInsn(DUP);
 
             mv.visitInsn(DUP);
-            mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "strand", String.format("L%s;", STRAND));
+            mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, STRAND, String.format("L%s;", STRAND_CLASS));
             mv.visitIntInsn(BIPUSH, 100);
             mv.visitTypeInsn(ANEWARRAY, OBJECT);
-            mv.visitFieldInsn(PUTFIELD, STRAND, "frames", String.format("[L%s;", OBJECT));
+            mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, FRAMES, String.format("[L%s;", OBJECT));
             handleErrorFromFutureValue(mv);
 
             // At this point we are done executing all the functions including asyncs
             if (!isVoidFunction) {
                 // store future value
                 BIRVariableDcl futureVar = new BIRVariableDcl(symbolTable.anyType, new Name("dummy"),
-                        VarScope.FUNCTION, VarKind.ARG);
-                int futureVarIndex = indexMap.getIndex(futureVar);
+                                                              VarScope.FUNCTION, VarKind.ARG);
+                int futureVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(futureVar);
                 mv.visitVarInsn(ASTORE, futureVarIndex);
                 mv.visitVarInsn(ALOAD, futureVarIndex);
                 mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "result", String.format("L%s;", OBJECT));
@@ -2550,25 +1773,25 @@ public class JvmMethodGen {
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
 
         // create FP value
-        createFunctionPointer(mv, initClass, startLambdaName, 0);
+        JvmCodeGenUtil.createFunctionPointer(mv, initClass, startLambdaName);
 
         // no parent strand
         mv.visitInsn(ACONST_NULL);
         BType anyType = symbolTable.anyType;
-        loadType(mv, anyType);
+        JvmTypeGen.loadType(mv, anyType);
         submitToScheduler(mv, initClass, "start", asyncDataCollector);
 
         mv.visitInsn(DUP);
         mv.visitInsn(DUP);
-        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "strand", String.format("L%s;", STRAND));
+        mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, STRAND, String.format("L%s;", STRAND_CLASS));
         mv.visitIntInsn(BIPUSH, 100);
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
-        mv.visitFieldInsn(PUTFIELD, STRAND, "frames", String.format("[L%s;", OBJECT));
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, FRAMES, String.format("[L%s;", OBJECT));
         handleErrorFromFutureValue(mv);
 
         BIRVariableDcl futureVar = new BIRVariableDcl(symbolTable.anyType, new Name("startdummy"), VarScope.FUNCTION,
-                VarKind.ARG);
-        int futureVarIndex = indexMap.getIndex(futureVar);
+                                                      VarKind.ARG);
+        int futureVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(futureVar);
         mv.visitVarInsn(ASTORE, futureVarIndex);
         mv.visitVarInsn(ALOAD, futureVarIndex);
         mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, "result", String.format("L%s;", OBJECT));
@@ -2597,32 +1820,31 @@ public class JvmMethodGen {
 
         BType returnType = userMainFunc.type.retType;
 
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "$lambda$main$",
-                String.format("([L%s;)L%s;", OBJECT, OBJECT), null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC, "$lambda$main$",
+                                          String.format("([L%s;)L%s;", OBJECT, OBJECT), null, null);
         mv.visitCode();
 
         //load strand as first arg
         mv.visitVarInsn(ALOAD, 0);
         mv.visitInsn(ICONST_0);
         mv.visitInsn(AALOAD);
-        mv.visitTypeInsn(CHECKCAST, STRAND);
+        mv.visitTypeInsn(CHECKCAST, STRAND_CLASS);
 
         // load and cast param values
         List<BType> paramTypes = userMainFunc.type.paramTypes;
 
         int paramIndex = 1;
-        for (BType paramType : paramTypes) {
-            BType pType = getType(paramType);
+        for (BType pType : paramTypes) {
             mv.visitVarInsn(ALOAD, 0);
             mv.visitIntInsn(BIPUSH, paramIndex);
             mv.visitInsn(AALOAD);
-            JvmInstructionGen.addUnboxInsn(mv, pType);
+            JvmCastGen.addUnboxInsn(mv, pType);
             paramIndex += 1;
         }
 
         mv.visitMethodInsn(INVOKESTATIC, mainClass, userMainFunc.name.value,
-                getMethodDesc(paramTypes, returnType, null, false), false);
-        JvmInstructionGen.addBoxInsn(mv, returnType);
+                           JvmCodeGenUtil.getMethodDesc(paramTypes, returnType), false);
+        JvmCastGen.addBoxInsn(mv, returnType);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
@@ -2649,33 +1871,30 @@ public class JvmMethodGen {
         PackageID currentModId = packageToModuleId(pkg);
         String fullFuncName = calculateModuleSpecialFuncName(currentModId, STOP_FUNCTION_SUFFIX);
 
-        generateLambdaForDepModStopFunc(cw, cleanupFunctionName(fullFuncName), initClass);
+        generateLambdaForDepModStopFunc(cw, JvmCodeGenUtil.cleanupFunctionName(fullFuncName), initClass);
 
         for (PackageID id : depMods) {
             fullFuncName = calculateModuleSpecialFuncName(id, STOP_FUNCTION_SUFFIX);
-            // String lookupKey = getPackageName(id.orgName, id.name, id.version) + fullFuncName;
-
-            // String jvmClass = lookupFullQualifiedClassName(lookupKey);
-            String jvmClass = getPackageName(id.orgName, id.name, id.version) + MODULE_INIT_CLASS_NAME;
-            generateLambdaForDepModStopFunc(cw, cleanupFunctionName(fullFuncName), jvmClass);
+            String jvmClass = JvmCodeGenUtil.getPackageName(id) + MODULE_INIT_CLASS_NAME;
+            generateLambdaForDepModStopFunc(cw, JvmCodeGenUtil.cleanupFunctionName(fullFuncName), jvmClass);
         }
     }
 
     private void generateLambdaForModuleFunction(ClassWriter cw, String funcName, String initClass) {
 
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC,
-                String.format("$lambda$%s$", funcName),
-                String.format("([L%s;)L%s;", OBJECT, OBJECT), null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC,
+                                          String.format("$lambda$%s$", funcName),
+                                          String.format("([L%s;)L%s;", OBJECT, OBJECT), null, null);
         mv.visitCode();
 
         //load strand as first arg
         mv.visitVarInsn(ALOAD, 0);
         mv.visitInsn(ICONST_0);
         mv.visitInsn(AALOAD);
-        mv.visitTypeInsn(CHECKCAST, STRAND);
+        mv.visitTypeInsn(CHECKCAST, STRAND_CLASS);
 
-        mv.visitMethodInsn(INVOKESTATIC, initClass, funcName, String.format("(L%s;)L%s;", STRAND, OBJECT), false);
-        JvmInstructionGen.addBoxInsn(mv, errorOrNilType);
+        mv.visitMethodInsn(INVOKESTATIC, initClass, funcName, String.format("(L%s;)L%s;", STRAND_CLASS, OBJECT), false);
+        JvmCastGen.addBoxInsn(mv, errorOrNilType);
         mv.visitInsn(ARETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
@@ -2735,14 +1954,14 @@ public class JvmMethodGen {
         BIRFunction modInitFunc = new BIRFunction(null, new Name(funcName), 0,
                 new BInvokableType(Collections.emptyList(), null, errorOrNilType, null), null, 0, null);
         modInitFunc.localVars.add(retVar);
-        BIRBasicBlock ignoreNextBB = addAndGetNextBasicBlock(modInitFunc);
+        addAndGetNextBasicBlock(modInitFunc);
 
         BIRVariableDcl boolVal = addAndGetNextVar(modInitFunc, symbolTable.booleanType);
         BIROperand boolRef = new BIROperand(boolVal);
 
         for (PackageID id : imprtMods) {
             String initFuncName = calculateModuleSpecialFuncName(id, initName);
-            BIRBasicBlock ignoreBB = addCheckedInvocation(modInitFunc, id, initFuncName, retVarRef, boolRef);
+            addCheckedInvocation(modInitFunc, id, initFuncName, retVarRef, boolRef);
         }
 
         PackageID currentModId = packageToModuleId(pkg);
@@ -2821,14 +2040,11 @@ public class JvmMethodGen {
             if (optionalTypeDef.isBuiltin) {
                 continue;
             }
-            BIRTypeDefinition typeDef = getTypeDef(optionalTypeDef);
-            BType bType = typeDef.type;
-
-            if (bType.tag == TypeTags.FINITE || bType instanceof BServiceType) {
-                continue;
+            BType bType = optionalTypeDef.type;
+            if (bType.tag != TypeTags.FINITE && !(bType instanceof BServiceType)) {
+                loadAnnots(mv, typePkgName, optionalTypeDef);
             }
 
-            loadAnnots(mv, typePkgName, typeDef);
         }
     }
 
@@ -2865,31 +2081,29 @@ public class JvmMethodGen {
         }
     }
 
-    private void generateFrameClassForFunction(BIRPackage pkg, BIRFunction func,
-                                               Map<String, byte[]> pkgEntries,
+    private void generateFrameClassForFunction(BIRPackage pkg, BIRFunction func, Map<String, byte[]> pkgEntries,
                                                BType attachedType) {
-
-        String pkgName = getPackageName(pkg.org.value, pkg.name.value, pkg.version.value);
-        BIRFunction currentFunc = getFunction(func);
-        String frameClassName = getFrameClassName(pkgName, currentFunc.name.value, attachedType);
+        String frameClassName = getFrameClassName(JvmCodeGenUtil.getPackageName(pkg), func.name.value,
+                                                  attachedType);
         ClassWriter cw = new BallerinaClassWriter(COMPUTE_FRAMES);
-        if (currentFunc.pos != null && currentFunc.pos.src != null) {
-            cw.visitSource(currentFunc.pos.src.cUnitName, null);
+        if (func.pos != null && func.pos.src != null) {
+            cw.visitSource(func.pos.src.cUnitName, null);
         }
-        cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, frameClassName, null, OBJECT, null);
-        generateDefaultConstructor(cw, OBJECT);
+        cw.visit(V1_8, Opcodes.ACC_PUBLIC + ACC_SUPER, frameClassName, null, OBJECT, null);
+        JvmCodeGenUtil.generateDefaultConstructor(cw, OBJECT);
 
         int k = 0;
-        List<BIRVariableDcl> localVars = currentFunc.localVars;
+        List<BIRVariableDcl> localVars = func.localVars;
         while (k < localVars.size()) {
-            BIRVariableDcl localVar = getVariableDcl(localVars.get(k));
+            BIRVariableDcl localVar = localVars.get(k);
             BType bType = localVar.type;
             String fieldName = localVar.name.value.replace("%", "_");
-            generateField(cw, bType, fieldName, false);
+            String typeSig = JvmCodeGenUtil.getFieldTypeSignature(bType);
+            cw.visitField(Opcodes.ACC_PUBLIC, fieldName, typeSig, null, null).visitEnd();
             k = k + 1;
         }
 
-        FieldVisitor fv = cw.visitField(ACC_PUBLIC, "state", "I", null, null);
+        FieldVisitor fv = cw.visitField(Opcodes.ACC_PUBLIC, STATE, "I", null, null);
         fv.visitEnd();
 
         cw.visitEnd();
@@ -2904,12 +2118,11 @@ public class JvmMethodGen {
         String orgName = module.org.value;
         String moduleName = module.name.value;
         String version = module.version.value;
-        String pkgName = getPackageName(orgName, moduleName, version);
 
         // Using object return type since this is similar to a ballerina function without a return.
         // A ballerina function with no returns is equivalent to a function with nil-return.
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, CURRENT_MODULE_INIT,
-                String.format("(L%s;)L%s;", STRAND, OBJECT), null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC, CURRENT_MODULE_INIT,
+                                          String.format("(L%s;)L%s;", STRAND_CLASS, OBJECT), null, null);
         mv.visitCode();
 
         mv.visitMethodInsn(INVOKESTATIC, typeOwnerClass, CREATE_TYPES_METHOD, "()V", false);
@@ -2934,22 +2147,17 @@ public class JvmMethodGen {
 
     void generateExecutionStopMethod(ClassWriter cw, String initClass, BIRPackage module, List<PackageID> imprtMods,
                                      AsyncDataCollector asyncDataCollector) {
-
-        String orgName = module.org.value;
-        String moduleName = module.name.value;
-        String version = module.version.value;
-        String pkgName = getPackageName(orgName, moduleName, version);
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, MODULE_STOP, "()V", null, null);
+        MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC, MODULE_STOP, "()V", null, null);
         mv.visitCode();
 
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
 
         BIRVariableDcl argsVar = new BIRVariableDcl(symbolTable.anyType, new Name("schedulerVar"),
-                VarScope.FUNCTION, VarKind.ARG);
-        int schedulerIndex = indexMap.getIndex(argsVar);
+                                                    VarScope.FUNCTION, VarKind.ARG);
+        int schedulerIndex = indexMap.addToMapIfNotFoundAndGetIndex(argsVar);
         BIRVariableDcl futureVar = new BIRVariableDcl(symbolTable.anyType, new Name("futureVar"),
-                VarScope.FUNCTION, VarKind.ARG);
-        int futureIndex = indexMap.getIndex(futureVar);
+                                                      VarScope.FUNCTION, VarKind.ARG);
+        int futureIndex = indexMap.addToMapIfNotFoundAndGetIndex(futureVar);
 
         mv.visitTypeInsn(NEW, SCHEDULER);
         mv.visitInsn(DUP);
@@ -2961,20 +2169,18 @@ public class JvmMethodGen {
 
 
         PackageID currentModId = packageToModuleId(module);
-        String moduleInitClass = getModuleLevelClassName(currentModId.orgName.value, currentModId.name.value,
-                currentModId.version.value, MODULE_INIT_CLASS_NAME);
+        String moduleInitClass = getModuleInitClassName(currentModId);
         String fullFuncName = calculateModuleSpecialFuncName(currentModId, STOP_FUNCTION_SUFFIX);
 
-        scheduleStopMethod(mv, initClass, cleanupFunctionName(fullFuncName), schedulerIndex, futureIndex,
-                           moduleInitClass, asyncDataCollector);
+        scheduleStopMethod(mv, initClass, JvmCodeGenUtil.cleanupFunctionName(fullFuncName), schedulerIndex,
+                           futureIndex, moduleInitClass, asyncDataCollector);
         int i = imprtMods.size() - 1;
         while (i >= 0) {
             PackageID id = imprtMods.get(i);
             i -= 1;
             fullFuncName = calculateModuleSpecialFuncName(id, STOP_FUNCTION_SUFFIX);
-            moduleInitClass = getModuleLevelClassName(id.orgName.value, id.name.value, id.version.value,
-                    MODULE_INIT_CLASS_NAME);
-            scheduleStopMethod(mv, initClass, cleanupFunctionName(fullFuncName), schedulerIndex,
+            moduleInitClass = getModuleInitClassName(id);
+            scheduleStopMethod(mv, initClass, JvmCodeGenUtil.cleanupFunctionName(fullFuncName), schedulerIndex,
                                futureIndex, moduleInitClass, asyncDataCollector);
         }
         mv.visitInsn(RETURN);
@@ -2982,14 +2188,40 @@ public class JvmMethodGen {
         mv.visitEnd();
     }
 
-    private static void submitToScheduler(MethodVisitor mv, String moduleClassName,
-                                          String workerName, AsyncDataCollector asyncDataCollector) {
-        String metaDataVarName = getStrandMetadataVarName("main");
+    private String getModuleInitClassName(PackageID id) {
+        return JvmCodeGenUtil.getModuleLevelClassName(id.orgName.value, id.name.value, id.version.value,
+                                                      MODULE_INIT_CLASS_NAME);
+    }
+
+    private void submitToScheduler(MethodVisitor mv, String moduleClassName,
+                                   String workerName, AsyncDataCollector asyncDataCollector) {
+        String metaDataVarName = JvmCodeGenUtil.getStrandMetadataVarName("main");
         asyncDataCollector.getStrandMetadata().putIfAbsent(metaDataVarName, new ScheduleFunctionInfo("main"));
         mv.visitLdcInsn(workerName);
         mv.visitFieldInsn(GETSTATIC, moduleClassName, metaDataVarName, String.format("L%s;", STRAND_METADATA));
         mv.visitMethodInsn(INVOKEVIRTUAL, SCHEDULER, SCHEDULE_FUNCTION_METHOD,
-                           String.format("([L%s;L%s;L%s;L%s;L%s;L%s;)L%s;", OBJECT, FUNCTION_POINTER, STRAND, BTYPE,
-                                         STRING_VALUE, STRAND_METADATA, FUTURE_VALUE), false);
+                           String.format("([L%s;L%s;L%s;L%s;L%s;L%s;)L%s;", OBJECT, FUNCTION_POINTER, STRAND_CLASS,
+                                         BTYPE, STRING_VALUE, STRAND_METADATA, FUTURE_VALUE), false);
     }
+
+    public void resetIds() {
+        nextId = -1;
+        nextVarId = -1;
+    }
+
+    int incrementAndGetNextId() {
+        return nextId++;
+    }
+
+    void generateMethod(BIRFunction birFunc, ClassWriter cw, BIRPackage birModule, BType attachedType,
+                        String moduleClassName, AsyncDataCollector asyncDataCollector) {
+        if (JvmCodeGenUtil.isExternFunc(birFunc)) {
+            ExternalMethodGen.genJMethodForBExternalFunc(birFunc, cw, birModule, attachedType, this, jvmPackageGen,
+                                                         moduleClassName, asyncDataCollector);
+        } else {
+            genJMethodForBFunc(birFunc, cw, birModule, moduleClassName, attachedType,
+                               asyncDataCollector);
+        }
+    }
+
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -88,7 +88,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.REPORT_ER
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.START_CALLABLE_OBSERVATION_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.START_RESOURCE_OBSERVATION_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STOP_OBSERVATION_METHOD;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
 
 /**
  * BIR desugar to inject observations class.
@@ -778,8 +777,9 @@ class JvmObservabilityGen {
         boolean isRemote = callIns.calleeFlags.contains(Flag.REMOTE);
         boolean isObservableAnnotationPresent = false;
         for (BIRAnnotationAttachment annot : callIns.calleeAnnotAttachments) {
-            if (OBSERVABLE_ANNOTATION.equals(getPackageName(annot.packageID.orgName, annot.packageID.name, Names.EMPTY)
-                    + annot.annotTagRef.value)) {
+            if (OBSERVABLE_ANNOTATION.equals(
+                    JvmCodeGenUtil.getPackageName(annot.packageID.orgName, annot.packageID.name, Names.EMPTY) +
+                            annot.annotTagRef.value)) {
                 isObservableAnnotationPresent = true;
                 break;
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -48,7 +48,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
@@ -84,10 +83,10 @@ import static org.objectweb.asm.Opcodes.NEW;
 import static org.objectweb.asm.Opcodes.PUTSTATIC;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_8;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.isExternFunc;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BALLERINA;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CURRENT_MODULE_INIT;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FILE_NAME_PERIOD_SEPERATOR;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JAVA_PACKAGE_SEPERATOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JAVA_THREAD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LOCK_STORE;
@@ -101,19 +100,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SERVICE_E
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CREATOR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.addDefaultableBooleanVarsToSignature;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.rewriteRecordInits;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupBalExt;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupPathSeperators;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.generateDefaultConstructor;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.generateField;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.generateStrandMetadata;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFunction;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFunctions;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMainFunc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMethodDesc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getTypeDef;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.isExternFunc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.visitStrandMetadataField;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.generateCreateTypesMethod;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.generateUserDefinedTypeFields;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.generateValueCreatorMethods;
@@ -122,7 +108,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.getTypeVal
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.injectDefaultParamInitsToAttachedFuncs;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.createExternalFunctionWrapper;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.injectDefaultParamInits;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.isBallerinaBuiltinModule;
 
 /**
  * BIR module to JVM byte code generation class.
@@ -222,7 +207,9 @@ public class JvmPackageGen {
 
         String varName = globalVar.name.value;
         BType bType = globalVar.type;
-        generateField(cw, bType, varName, true);
+        String typeSig = JvmCodeGenUtil.getFieldTypeSignature(bType);
+        cw.visitField(ACC_PUBLIC + ACC_STATIC, varName, typeSig, null, null).visitEnd();
+
     }
 
     private static void generateLockForVariable(ClassWriter cw) {
@@ -250,7 +237,7 @@ public class JvmPackageGen {
             setServiceEPAvailableField(cw, mv, serviceEPAvailable, className);
             setModuleStatusField(cw, mv, className);
         }
-        generateStrandMetadata(mv, className, module, asyncDataCollector);
+        JvmCodeGenUtil.generateStrandMetadata(mv, className, module, asyncDataCollector);
         mv.visitInsn(RETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
@@ -291,63 +278,6 @@ public class JvmPackageGen {
         return "$lock" + varName;
     }
 
-    static String getModuleLevelClassName(String orgName, String moduleName, String version, String sourceFileName) {
-        return getModuleLevelClassName(orgName, moduleName, version, sourceFileName, "/");
-    }
-
-    static String getModuleLevelClassName(String orgName, String moduleName, String version, String sourceFileName,
-            String separator) {
-        String className = cleanupSourceFileName(sourceFileName);
-        // handle source file path start with '/'.
-        if (className.startsWith(JAVA_PACKAGE_SEPERATOR)) {
-            className = className.substring(1);
-        }
-
-        if (!moduleName.equals(".")) {
-            if (!version.equals("")) {
-                className = cleanupName(version) + separator + className;
-            }
-            className = cleanupName(moduleName) + separator + className;
-        }
-
-        if (!orgName.equalsIgnoreCase("$anon")) {
-            className = cleanupName(orgName) + separator + className;
-        }
-
-        return className;
-    }
-
-    public static String getPackageName(Name orgName, Name moduleName, Name version) {
-        return getPackageName(orgName.getValue(), moduleName.getValue(), version.getValue());
-    }
-
-    public static String getPackageName(String orgName, String moduleName, String version) {
-
-        String packageName = "";
-        if (!moduleName.equals(".")) {
-            if (!version.equals("")) {
-                packageName = cleanupName(version) + "/";
-            }
-            packageName = cleanupName(moduleName) + "/" + packageName;
-        }
-
-        if (!orgName.equalsIgnoreCase("$anon")) {
-            packageName = cleanupName(orgName) + "/" + packageName;
-        }
-
-        return packageName;
-    }
-
-    private static String cleanupName(String name) {
-
-        return name.replace(".", "_");
-    }
-
-    private static String cleanupSourceFileName(String name) {
-
-        return name.replace(".", FILE_NAME_PERIOD_SEPERATOR);
-    }
-
     public static String cleanupPackageName(String pkgName) {
 
         int index = pkgName.lastIndexOf("/");
@@ -363,22 +293,20 @@ public class JvmPackageGen {
 
         BInvokableType functionTypeDesc = currentFunc.type;
         BIRVariableDcl receiver = currentFunc.receiver;
-        BType attachedType = receiver != null ? receiver.type : null;
 
         BType retType = functionTypeDesc.retType;
         if (isExternFunc(currentFunc) && Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
             retType = typeBuilder.build(retType);
         }
 
-        String jvmMethodDescription = getMethodDesc(functionTypeDesc.paramTypes, retType, attachedType, false);
-        String jvmMethodDescriptionBString = getMethodDesc(functionTypeDesc.paramTypes, retType, attachedType, false);
+        String jvmMethodDescription;
+        if (receiver == null) {
+            jvmMethodDescription = JvmCodeGenUtil.getMethodDesc(functionTypeDesc.paramTypes, retType);
+        } else {
+            jvmMethodDescription = JvmCodeGenUtil.getMethodDesc(functionTypeDesc.paramTypes, retType, receiver.type);
+        }
 
         return new BIRFunctionWrapper(orgName, moduleName, version, currentFunc, moduleClass, jvmMethodDescription);
-    }
-
-    static PackageID packageToModuleId(BIRPackage mod) {
-
-        return new PackageID(mod.org, mod.name, mod.version);
     }
 
     private static void generateShutdownSignalListener(String initClass, Map<String, byte[]> jarEntries) {
@@ -427,7 +355,7 @@ public class JvmPackageGen {
     private static BIRFunction findFunction(List<BIRFunction> functions, String funcName) {
 
         for (BIRFunction func : functions) {
-            if (JvmMethodGen.cleanupFunctionName(func.name.value).equals(funcName)) {
+            if (JvmCodeGenUtil.cleanupFunctionName(func.name.value).equals(funcName)) {
                 return func;
             }
         }
@@ -435,12 +363,20 @@ public class JvmPackageGen {
         throw new IllegalStateException("cannot find function: '" + funcName + "'");
     }
 
+    private BIRFunction getMainFunc(List<BIRFunction> funcs) {
+        BIRFunction userMainFunc = null;
+        for (BIRFunction func : funcs) {
+            if (func != null && func.name.value.equals("main")) {
+                userMainFunc = func;
+                break;
+            }
+        }
+
+        return userMainFunc;
+    }
+
     CompiledJarFile generate(BIRNode.BIRPackage module, InteropValidator interopValidator, boolean isEntry) {
 
-        String orgName = module.org.value;
-        String moduleName = module.name.value;
-        String version = module.version.value;
-        String pkgName = getPackageName(orgName, moduleName, version);
 
         Set<PackageID> moduleImports = new LinkedHashSet<>();
 
@@ -459,9 +395,10 @@ public class JvmPackageGen {
         JvmObservabilityGen jvmObservabilityGen = new JvmObservabilityGen(this);
         jvmObservabilityGen.rewriteObservableFunctions(module);
 
-        String moduleInitClass = getModuleLevelClassName(orgName, moduleName, version, MODULE_INIT_CLASS_NAME);
+        String moduleInitClass = JvmCodeGenUtil.getModuleLevelClassName(module, MODULE_INIT_CLASS_NAME);
+        String pkgName = JvmCodeGenUtil.getPackageName(module);
         Map<String, JavaClass> jvmClassMapping = generateClassNameLinking(module, pkgName, moduleInitClass,
-                interopValidator, isEntry);
+                                                                          interopValidator, isEntry);
         if (!isEntry || dlog.getErrorCount() > 0) {
             return new CompiledJarFile(Collections.emptyMap());
         }
@@ -498,8 +435,8 @@ public class JvmPackageGen {
         // clear class name mappings
         clearPackageGenInfo();
 
-        return new CompiledJarFile(getModuleLevelClassName(orgName, moduleName, version, MODULE_INIT_CLASS_NAME, "."),
-                jarEntries);
+        return new CompiledJarFile(JvmCodeGenUtil.getModuleLevelClassName(
+                module.org.value, module.name.value, module.version.value, MODULE_INIT_CLASS_NAME, "."), jarEntries);
     }
 
     private void generateModuleClasses(BIRPackage module, Map<String, byte[]> jarEntries, String moduleInitClass,
@@ -514,7 +451,7 @@ public class JvmPackageGen {
             boolean isInitClass = Objects.equals(moduleClass, moduleInitClass);
             if (isInitClass) {
                 cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, moduleClass, null, VALUE_CREATOR, null);
-                generateDefaultConstructor(cw, VALUE_CREATOR);
+                JvmCodeGenUtil.generateDefaultConstructor(cw, VALUE_CREATOR);
                 generateUserDefinedTypeFields(cw, module.typeDefs);
                 generateValueCreatorMethods(cw, module.typeDefs, module, moduleInitClass, symbolTable,
                                             asyncDataCollector);
@@ -528,8 +465,8 @@ public class JvmPackageGen {
                 BIRFunction mainFunc = getMainFunc(module.functions);
                 String mainClass = "";
                 if (mainFunc != null) {
-                    mainClass = getModuleLevelClassName(module.org.value, module.name.value,  module.version.value,
-                            cleanupPathSeperators(cleanupBalExt(mainFunc.pos.getSource().cUnitName)));
+                    mainClass = JvmCodeGenUtil.getModuleLevelClassName(module, JvmCodeGenUtil
+                            .cleanupPathSeparators(mainFunc.pos.getSource().cUnitName));
                 }
 
                 serviceEPAvailable = isServiceDefAvailable(module.typeDefs);
@@ -548,13 +485,12 @@ public class JvmPackageGen {
                                                          asyncDataCollector);
             } else {
                 cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, moduleClass, null, OBJECT, null);
-                generateDefaultConstructor(cw, OBJECT);
+                JvmCodeGenUtil.generateDefaultConstructor(cw, OBJECT);
             }
             cw.visitSource(javaClass.sourceFileName, null);
             // generate methods
             for (BIRFunction func : javaClass.functions) {
-                String workerName = getFunction(func).workerName == null ? null : func.workerName.value;
-                jvmMethodGen.generateMethod(getFunction(func), cw, module, null, moduleClass, workerName,
+                jvmMethodGen.generateMethod(func, cw, module, null, moduleClass,
                                             asyncDataCollector);
             }
             // generate lambdas created during generating methods
@@ -563,7 +499,7 @@ public class JvmPackageGen {
                 BIRInstruction call = lambda.getValue();
                 jvmMethodGen.generateLambdaMethod(call, cw, name);
             }
-            visitStrandMetadataField(cw, asyncDataCollector);
+            JvmCodeGenUtil.visitStrandMetadataField(cw, asyncDataCollector);
             generateStaticInitializer(cw, moduleClass, module, isInitClass, serviceEPAvailable,
                                       asyncDataCollector);
             cw.visitEnd();
@@ -647,32 +583,30 @@ public class JvmPackageGen {
         List<BIRTypeDefinition> typeDefs = module.typeDefs;
 
         for (BIRTypeDefinition optionalTypeDef : typeDefs) {
-            BIRTypeDefinition typeDef = getTypeDef(optionalTypeDef);
-            BType bType = typeDef.type;
+            BType bType = optionalTypeDef.type;
 
             if ((bType.tag != TypeTags.OBJECT ||
-                    Symbols.isFlagOn(((BObjectType) bType).tsymbol.flags, Flags.ABSTRACT)) &&
+                    Symbols.isFlagOn(bType.tsymbol.flags, Flags.ABSTRACT)) &&
                     !(bType instanceof BServiceType)) {
                 continue;
             }
 
-            List<BIRFunction> attachedFuncs = getFunctions(typeDef.attachedFuncs);
+            List<BIRFunction> attachedFuncs = optionalTypeDef.attachedFuncs;
             String typeName = toNameString(bType);
             for (BIRFunction func : attachedFuncs) {
 
                 // link the bir function for lookup
-                BIRFunction birFunc = getFunction(func);
-                String functionName = birFunc.name.value;
+                String functionName = func.name.value;
                 String lookupKey = typeName + "." + functionName;
 
                 String className = getTypeValueClassName(module, typeName);
                 try {
                     BIRFunctionWrapper birFuncWrapperOrError =
-                            getBirFunctionWrapper(interopValidator, isEntry, orgName, moduleName, version, birFunc,
+                            getBirFunctionWrapper(interopValidator, isEntry, orgName, moduleName, version, func,
                                                   className, lookupKey);
                     birFunctionMap.put(pkgName + lookupKey, birFuncWrapperOrError);
                 } catch (JInteropException e) {
-                    dlog.error(birFunc.pos, e.getCode(), e.getMessage());
+                    dlog.error(func.pos, e.getCode(), e.getMessage());
                 }
             }
         }
@@ -750,10 +684,10 @@ public class JvmPackageGen {
             } else {
                 balFileName = birFunc.pos.src.cUnitName;
             }
-            String birModuleClassName = getModuleLevelClassName(orgName, moduleName, version,
-                    cleanupPathSeperators(cleanupBalExt(balFileName)));
+            String birModuleClassName = JvmCodeGenUtil.getModuleLevelClassName(
+                    orgName, moduleName, version, JvmCodeGenUtil.cleanupPathSeparators(balFileName));
 
-            if (!isBallerinaBuiltinModule(orgName, moduleName)) {
+            if (!JvmCodeGenUtil.isBallerinaBuiltinModule(orgName, moduleName)) {
                 JavaClass javaClass = jvmClassMap.get(birModuleClassName);
                 if (javaClass != null) {
                     javaClass.functions.add(birFunc);
@@ -782,7 +716,7 @@ public class JvmPackageGen {
                                                      BIRFunction birFunc, String birModuleClassName,
                                                      String lookupKey) {
         BIRFunctionWrapper birFuncWrapperOrError;
-        if (isExternFunc(getFunction(birFunc)) && isEntry) {
+        if (isExternFunc(birFunc) && isEntry) {
             birFuncWrapperOrError = createExternalFunctionWrapper(interopValidator, birFunc, orgName,
                                                                   moduleName, version, birModuleClassName,
                                                                   lookupKey, this);
@@ -798,7 +732,7 @@ public class JvmPackageGen {
 
     public String lookupExternClassName(String pkgName, String functionName) {
 
-        return externClassMap.get(cleanupName(pkgName) + "/" + functionName);
+        return externClassMap.get(JvmCodeGenUtil.cleanupName(pkgName) + "/" + functionName);
     }
 
     public byte[] getBytes(ClassWriter cw, BIRNode node) {
@@ -885,7 +819,7 @@ public class JvmPackageGen {
 
         PackageID moduleId = packageSymbol.pkgID;
 
-        String pkgName = getPackageName(moduleId.orgName, moduleId.name, moduleId.version);
+        String pkgName = JvmCodeGenUtil.getPackageName(moduleId.orgName, moduleId.name, moduleId.version);
         if (!dependentModules.containsKey(pkgName)) {
             dependentModules.put(pkgName, moduleId);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.interop.BIRFunctionWrapper;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JIConstructorCall;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JIMethodCall;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JType;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JavaMethodCall;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
@@ -60,9 +61,11 @@ import static org.objectweb.asm.Opcodes.ASTORE;
 import static org.objectweb.asm.Opcodes.ATHROW;
 import static org.objectweb.asm.Opcodes.BIPUSH;
 import static org.objectweb.asm.Opcodes.CHECKCAST;
+import static org.objectweb.asm.Opcodes.DCONST_0;
 import static org.objectweb.asm.Opcodes.DLOAD;
 import static org.objectweb.asm.Opcodes.DRETURN;
 import static org.objectweb.asm.Opcodes.DUP;
+import static org.objectweb.asm.Opcodes.FCONST_0;
 import static org.objectweb.asm.Opcodes.GETFIELD;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
 import static org.objectweb.asm.Opcodes.GOTO;
@@ -80,6 +83,7 @@ import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.IRETURN;
 import static org.objectweb.asm.Opcodes.L2I;
+import static org.objectweb.asm.Opcodes.LCONST_0;
 import static org.objectweb.asm.Opcodes.LLOAD;
 import static org.objectweb.asm.Opcodes.LRETURN;
 import static org.objectweb.asm.Opcodes.NEW;
@@ -123,8 +127,9 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULER
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULE_FUNCTION_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SCHEDULE_LOCAL_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_ANNOTATION;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_CLASS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_METADATA;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_METADATA_VAR_PREFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_POLICY_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_THREAD;
@@ -134,18 +139,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WD_CHANNE
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_DATA_CHANNEL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.addJUnboxInsn;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupBalExt;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupFunctionName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupPathSeperators;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.createFunctionPointer;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMethodDesc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getStrandMetadataVarName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getVariableDcl;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.loadDefaultValue;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getModuleLevelClassName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.loadType;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.isBallerinaBuiltinModule;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.genVarArg;
 
 /**
@@ -178,7 +172,7 @@ public class JvmTerminatorGen {
         this.packageCache = jvmPackageGen.packageCache;
         this.jvmInstructionGen = jvmInstructionGen;
         this.symbolTable = jvmPackageGen.symbolTable;
-        this.currentPackageName = getPackageName(module.org.value, module.name.value, module.version.value);
+        this.currentPackageName = JvmCodeGenUtil.getPackageName(module);
         this.typeBuilder = new ResolvedTypeBuilder();
     }
 
@@ -186,59 +180,86 @@ public class JvmTerminatorGen {
                                              int localVarOffset) {
 
         mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "isYielded", "()Z", false);
+        mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "isYielded", "()Z", false);
         Label yieldLabel = labelGen.getLabel(funcName + "yield");
         mv.visitJumpInsn(IFNE, yieldLabel);
     }
 
-    static void loadChannelDetails(MethodVisitor mv, List<BIRNode.ChannelDetails> channels) {
+    private void loadDefaultValue(MethodVisitor mv, BType bType) {
+        if (TypeTags.isIntegerTypeTag(bType.tag) || bType.tag == TypeTags.BYTE) {
+            mv.visitInsn(LCONST_0);
+            return;
+        } else if (TypeTags.isStringTypeTag(bType.tag) || TypeTags.isXMLTypeTag(bType.tag)) {
+            mv.visitInsn(ACONST_NULL);
+            return;
+        }
 
-        mv.visitIntInsn(BIPUSH, channels.size());
-        mv.visitTypeInsn(ANEWARRAY, CHANNEL_DETAILS);
-        int index = 0;
-        for (BIRNode.ChannelDetails ch : channels) {
-            mv.visitInsn(DUP);
-            mv.visitIntInsn(BIPUSH, index);
-            index += 1;
-
-            mv.visitTypeInsn(NEW, CHANNEL_DETAILS);
-            mv.visitInsn(DUP);
-            mv.visitLdcInsn(ch.name);
-
-            if (ch.channelInSameStrand) {
-                mv.visitInsn(ICONST_1);
-            } else {
+        switch (bType.tag) {
+            case TypeTags.FLOAT:
+                mv.visitInsn(DCONST_0);
+                break;
+            case TypeTags.BOOLEAN:
                 mv.visitInsn(ICONST_0);
-            }
-
-            if (ch.send) {
-                mv.visitInsn(ICONST_1);
-            } else {
-                mv.visitInsn(ICONST_0);
-            }
-
-            mv.visitMethodInsn(INVOKESPECIAL, CHANNEL_DETAILS, JVM_INIT_METHOD,
-                    String.format("(L%s;ZZ)V", STRING_VALUE), false);
-            mv.visitInsn(AASTORE);
+                break;
+            case TypeTags.MAP:
+            case TypeTags.ARRAY:
+            case TypeTags.ERROR:
+            case TypeTags.NIL:
+            case TypeTags.NEVER:
+            case TypeTags.ANY:
+            case TypeTags.ANYDATA:
+            case TypeTags.OBJECT:
+            case TypeTags.UNION:
+            case TypeTags.INTERSECTION:
+            case TypeTags.RECORD:
+            case TypeTags.TUPLE:
+            case TypeTags.FUTURE:
+            case TypeTags.JSON:
+            case TypeTags.INVOKABLE:
+            case TypeTags.FINITE:
+            case TypeTags.HANDLE:
+            case TypeTags.TYPEDESC:
+            case TypeTags.READONLY:
+                mv.visitInsn(ACONST_NULL);
+                break;
+            case JTypeTags.JTYPE:
+                loadDefaultJValue(mv, (JType) bType);
+                break;
+            default:
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
+                                                         String.format("%s", bType));
         }
     }
 
-    static String cleanupObjectTypeName(String typeName) {
-
-        int index = typeName.lastIndexOf(".");
-        if (index > 0) {
-            return typeName.substring(index + 1);
-        } else {
-            return typeName;
+    private void loadDefaultJValue(MethodVisitor mv, JType jType) {
+        switch (jType.jTag) {
+            case JTypeTags.JBYTE:
+            case JTypeTags.JBOOLEAN:
+            case JTypeTags.JINT:
+            case JTypeTags.JSHORT:
+            case JTypeTags.JCHAR:
+                mv.visitInsn(ICONST_0);
+                break;
+            case JTypeTags.JLONG:
+                mv.visitInsn(LCONST_0);
+                break;
+            case JTypeTags.JFLOAT:
+                mv.visitInsn(FCONST_0);
+                break;
+            case JTypeTags.JDOUBLE:
+                mv.visitInsn(DCONST_0);
+                break;
+            case JTypeTags.JARRAY:
+            case JTypeTags.JREF:
+                mv.visitInsn(ACONST_NULL);
+                break;
+            default:
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
+                                                         String.format("%s", jType));
         }
     }
 
-    public static String toNameString(BType t) {
-
-        return t.tsymbol.name.value;
-    }
-
-    void genTerminator(BIRTerminator terminator, String moduleClassName, BIRNode.BIRFunction func,
+    public void genTerminator(BIRTerminator terminator, String moduleClassName, BIRNode.BIRFunction func,
                        String funcName, int localVarOffset, int returnVarRefIndex,
                        BType attachedType, AsyncDataCollector asyncDataCollector) {
 
@@ -263,7 +284,7 @@ public class JvmTerminatorGen {
                 this.genBranchTerm((BIRTerminator.Branch) terminator, funcName);
                 return;
             case RETURN:
-                this.genReturnTerm((BIRTerminator.Return) terminator, returnVarRefIndex, func);
+                this.genReturnTerm(returnVarRefIndex, func);
                 return;
             case PANIC:
                 this.errorGen.genPanic((BIRTerminator.Panic) terminator);
@@ -322,7 +343,7 @@ public class JvmTerminatorGen {
         this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_STORE, "getLockFromMap",
                 String.format("(L%s;)L%s;", STRING_VALUE, LOCK_VALUE), false);
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_VALUE, "lock", String.format("(L%s;)Z", STRAND), false);
+        this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_VALUE, "lock", String.format("(L%s;)Z", STRAND_CLASS), false);
         this.mv.visitInsn(POP);
         genYieldCheckForLock(this.mv, this.labelGen, funcName, localVarOffset);
         this.mv.visitJumpInsn(GOTO, gotoLabel);
@@ -362,9 +383,9 @@ public class JvmTerminatorGen {
         if (errorIncluded) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitVarInsn(ALOAD, 0);
-            loadChannelDetails(this.mv, channels);
+            JvmCodeGenUtil.loadChannelDetails(this.mv, channels);
             this.mv.visitMethodInsn(INVOKESTATIC, WORKER_UTILS, "handleWorkerError",
-                    String.format("(L%s;L%s;[L%s;)V", REF_VALUE, STRAND, CHANNEL_DETAILS), false);
+                                    String.format("(L%s;L%s;[L%s;)V", REF_VALUE, STRAND_CLASS, CHANNEL_DETAILS), false);
         }
     }
 
@@ -375,10 +396,11 @@ public class JvmTerminatorGen {
         }
 
         this.mv.visitVarInsn(ALOAD, 0);
-        loadChannelDetails(this.mv, channels);
+        JvmCodeGenUtil.loadChannelDetails(this.mv, channels);
         this.mv.visitVarInsn(ALOAD, retIndex);
-        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "handleChannelError", String.format("([L%s;L%s;)V",
-                CHANNEL_DETAILS, ERROR_VALUE), false);
+        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "handleChannelError", String.format("([L%s;L%s;)V",
+                                                                                                 CHANNEL_DETAILS,
+                                                                                                 ERROR_VALUE), false);
     }
 
     private void genBranchTerm(BIRTerminator.Branch branchIns, String funcName) {
@@ -418,9 +440,9 @@ public class JvmTerminatorGen {
 
         if (callIns.lhsOp != null && callIns.lhsOp.variableDcl != null) {
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND, "returnValue",
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue",
                                    "Ljava/lang/Object;");
-            JvmInstructionGen.addUnboxInsn(this.mv, callIns.lhsOp.variableDcl.type); // store return
+            JvmCastGen.addUnboxInsn(this.mv, callIns.lhsOp.variableDcl.type); // store return
             this.storeToVar(callIns.lhsOp.variableDcl);
         }
 
@@ -435,7 +457,7 @@ public class JvmTerminatorGen {
             // Below codes are not needed (as normal external funcs doesn't support attached invocations)
             // check whether function params already include the self
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            BIRNode.BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
+            BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
             this.loadVar(selfArg);
             this.mv.visitTypeInsn(CHECKCAST, OBJECT_VALUE);
             argIndex += 1;
@@ -466,8 +488,8 @@ public class JvmTerminatorGen {
         genHandlingBlockedOnExternal(localVarOffset, blockedOnExternLabel);
         if (callIns.lhsOp != null) {
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND, "returnValue",
-                    "Ljava/lang/Object;");
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue",
+                                   "Ljava/lang/Object;");
             // store return
             BIROperand lhsOpVarDcl = callIns.lhsOp;
             addJUnboxInsn(this.mv, ((JType) lhsOpVarDcl.variableDcl.type));
@@ -482,7 +504,7 @@ public class JvmTerminatorGen {
         int argIndex = 0;
         if (callIns.invocationType == INVOKEVIRTUAL || isInterface) {
             // check whether function params already include the self
-            BIRNode.BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
+            BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
             this.loadVar(selfArg);
             this.mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD, String.format("()L%s;", OBJECT),
                     false);
@@ -517,7 +539,7 @@ public class JvmTerminatorGen {
         }
         if (callIns.varArgExist) {
             BIROperand arg = callIns.args.get(argIndex);
-            int localVarIndex = this.indexMap.getIndex(arg.variableDcl);
+            int localVarIndex = this.indexMap.addToMapIfNotFoundAndGetIndex(arg.variableDcl);
             genVarArg(this.mv, this.indexMap, arg.variableDcl.type, callIns.varArgType, localVarIndex, symbolTable);
         }
 
@@ -541,8 +563,8 @@ public class JvmTerminatorGen {
         genHandlingBlockedOnExternal(localVarOffset, blockedOnExternLabel);
         if (callIns.lhsOp.variableDcl != null) {
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND, "returnValue", String.format("L%s;", OBJECT));
-            JvmInstructionGen.addUnboxInsn(this.mv, callIns.lhsOp.variableDcl.type);
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "returnValue", String.format("L%s;", OBJECT));
+            JvmCastGen.addUnboxInsn(this.mv, callIns.lhsOp.variableDcl.type);
             // store return
             BIRNode.BIRVariableDcl lhsOpVarDcl = callIns.lhsOp.variableDcl;
             this.storeToVar(lhsOpVarDcl);
@@ -580,24 +602,24 @@ public class JvmTerminatorGen {
 
     private void genHandlingBlockedOnExternal(int localVarOffset, Label blockedOnExternLabel) {
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, IS_BLOCKED_ON_EXTERN_FIELD, "()Z", false);
+        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, IS_BLOCKED_ON_EXTERN_FIELD, "()Z", false);
         this.mv.visitJumpInsn(IFEQ, blockedOnExternLabel);
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         this.mv.visitInsn(ICONST_0);
-        this.mv.visitFieldInsn(PUTFIELD, STRAND, BLOCKED_ON_EXTERN_FIELD, "Z");
+        this.mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, BLOCKED_ON_EXTERN_FIELD, "Z");
 
         // Throw error if strand has panic
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitFieldInsn(GETFIELD, STRAND, PANIC_FIELD, String.format("L%s;", B_ERROR));
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, PANIC_FIELD, String.format("L%s;", B_ERROR));
         Label panicLabel = new Label();
         mv.visitJumpInsn(IFNULL, panicLabel);
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        mv.visitFieldInsn(GETFIELD, STRAND, PANIC_FIELD, String.format("L%s;", B_ERROR));
+        mv.visitFieldInsn(GETFIELD, STRAND_CLASS, PANIC_FIELD, String.format("L%s;", B_ERROR));
         mv.visitInsn(DUP);
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         mv.visitInsn(ACONST_NULL);
-        mv.visitFieldInsn(PUTFIELD, STRAND, PANIC_FIELD, String.format("L%s;", B_ERROR));
+        mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, PANIC_FIELD, String.format("L%s;", B_ERROR));
         mv.visitInsn(ATHROW);
         mv.visitLabel(panicLabel);
     }
@@ -619,7 +641,7 @@ public class JvmTerminatorGen {
             return;
         }
 
-        BIRNode.BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
+        BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
         if (selfArg.type.tag == TypeTags.OBJECT) {
             this.genVirtualCall(callIns, orgName, moduleName, localVarOffset);
         } else {
@@ -650,7 +672,7 @@ public class JvmTerminatorGen {
                                String methodName, String methodLookupName) {
         // load strand
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        String lookupKey = getPackageName(orgName, moduleName, version) + methodLookupName;
+        String lookupKey = JvmCodeGenUtil.getPackageName(orgName, moduleName, version) + methodLookupName;
 
         int argsCount = callIns.args.size();
         int i = 0;
@@ -660,7 +682,7 @@ public class JvmTerminatorGen {
             this.loadBooleanArgToIndicateUserProvidedArg(orgName, moduleName, userProvidedArg);
             i += 1;
         }
-        String cleanMethodName = cleanupFunctionName(methodName);
+        String cleanMethodName = JvmCodeGenUtil.cleanupFunctionName(methodName);
         BIRFunctionWrapper functionWrapper = jvmPackageGen.lookupBIRFunctionWrapper(lookupKey);
         String methodDesc;
         String jvmClass;
@@ -685,18 +707,18 @@ public class JvmTerminatorGen {
                 balFileName = MODULE_INIT_CLASS_NAME;
             }
 
-            jvmClass = getModuleLevelClassName(orgName, moduleName, version,
-                                               cleanupPathSeperators(cleanupBalExt(balFileName)));
+            jvmClass = JvmCodeGenUtil.getModuleLevelClassName(orgName, moduleName, version,
+                                                              JvmCodeGenUtil.cleanupPathSeparators(balFileName));
             //TODO: add receiver:  BType attachedType = type.r != null ? receiver.type : null;
             BType retType = typeBuilder.build(type.retType);
-            methodDesc = getMethodDesc(params, retType, null, false);
+            methodDesc = JvmCodeGenUtil.getMethodDesc(params, retType);
         }
         this.mv.visitMethodInsn(INVOKESTATIC, jvmClass, cleanMethodName, methodDesc, false);
     }
 
     private void genVirtualCall(BIRTerminator.Call callIns, String orgName, String moduleName, int localVarOffset) {
         // load self
-        BIRNode.BIRVariableDcl selfArg = getVariableDcl(callIns.args.get(0).variableDcl);
+        BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
         this.loadVar(selfArg);
         this.mv.visitTypeInsn(CHECKCAST, OBJECT_VALUE);
 
@@ -704,7 +726,7 @@ public class JvmTerminatorGen {
         this.mv.visitVarInsn(ALOAD, localVarOffset);
 
         // load the function name as the second argument
-        this.mv.visitLdcInsn(cleanupObjectTypeName(callIns.name.value));
+        this.mv.visitLdcInsn(JvmCodeGenUtil.cleanupObjectTypeName(callIns.name.value));
 
         // create an Object[] for the rest params
         int argsCount = callIns.args.size() - 1;
@@ -725,7 +747,7 @@ public class JvmTerminatorGen {
             boolean userProvidedArg = this.visitArg(arg);
 
             // Add the to the rest params array
-            JvmInstructionGen.addBoxInsn(this.mv, arg.variableDcl.type);
+            JvmCastGen.addBoxInsn(this.mv, arg.variableDcl.type);
             this.mv.visitInsn(AASTORE);
 
             this.mv.visitInsn(DUP);
@@ -734,23 +756,23 @@ public class JvmTerminatorGen {
             j += 1;
 
             this.loadBooleanArgToIndicateUserProvidedArg(orgName, moduleName, userProvidedArg);
-            JvmInstructionGen.addBoxInsn(this.mv, symbolTable.booleanType);
+            JvmCastGen.addBoxInsn(this.mv, symbolTable.booleanType);
             this.mv.visitInsn(AASTORE);
 
             i += 1;
         }
 
         // call method
-        String methodDesc = String.format("(L%s;L%s;[L%s;)L%s;", STRAND, STRING_VALUE, OBJECT, OBJECT);
+        String methodDesc = String.format("(L%s;L%s;[L%s;)L%s;", STRAND_CLASS, STRING_VALUE, OBJECT, OBJECT);
         this.mv.visitMethodInsn(INVOKEINTERFACE, OBJECT_VALUE, "call", methodDesc, true);
 
         BType returnType = callIns.lhsOp.variableDcl.type;
-        JvmInstructionGen.addUnboxInsn(this.mv, returnType);
+        JvmCastGen.addUnboxInsn(this.mv, returnType);
     }
 
     private void loadBooleanArgToIndicateUserProvidedArg(String orgName, String moduleName, boolean userProvided) {
 
-        if (isBallerinaBuiltinModule(orgName, moduleName)) {
+        if (JvmCodeGenUtil.isBallerinaBuiltinModule(orgName, moduleName)) {
             return;
         }
         // Extra boolean is not gen for extern functions for now until the wrapper function is implemented.
@@ -763,8 +785,7 @@ public class JvmTerminatorGen {
     }
 
     private boolean visitArg(BIROperand arg) {
-
-        BIRNode.BIRVariableDcl varDcl = getVariableDcl(arg.variableDcl);
+        BIRNode.BIRVariableDcl varDcl = arg.variableDcl;
         if (varDcl.name.value.startsWith("_")) {
             loadDefaultValue(this.mv, varDcl.type);
             return false;
@@ -789,11 +810,11 @@ public class JvmTerminatorGen {
         this.mv.visitLdcInsn(GLOBAL_LOCK_NAME);
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_STORE, "panicIfInLock",
-                String.format("(L%s;L%s;)V", STRING_VALUE, STRAND), false);
+                                String.format("(L%s;L%s;)V", STRING_VALUE, STRAND_CLASS), false);
 
         // Load the scheduler from strand
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        this.mv.visitFieldInsn(GETFIELD, STRAND, "scheduler", String.format("L%s;", SCHEDULER));
+        this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "scheduler", String.format("L%s;", SCHEDULER));
 
         // create an Object[] for the rest params
         int argsCount = callIns.args.size();
@@ -810,7 +831,7 @@ public class JvmTerminatorGen {
 
             boolean userProvidedArg = this.visitArg(arg);
             // Add the to the rest params array
-            JvmInstructionGen.addBoxInsn(this.mv, arg.variableDcl.type);
+            JvmCastGen.addBoxInsn(this.mv, arg.variableDcl.type);
             this.mv.visitInsn(AASTORE);
             paramIndex += 1;
 
@@ -819,14 +840,14 @@ public class JvmTerminatorGen {
             this.mv.visitInsn(L2I);
 
             this.loadBooleanArgToIndicateUserProvidedArg(orgName, moduleName, userProvidedArg);
-            JvmInstructionGen.addBoxInsn(this.mv, symbolTable.booleanType);
+            JvmCastGen.addBoxInsn(this.mv, symbolTable.booleanType);
             this.mv.visitInsn(AASTORE);
             paramIndex += 1;
         }
         String funcName = callIns.name.value;
         String lambdaName = "$" + funcName + "$lambda$" + asyncDataCollector.getLambdaIndex() + "$";
 
-        createFunctionPointer(this.mv, asyncDataCollector.getEnclosingClass(), lambdaName, 0);
+        JvmCodeGenUtil.createFunctionPointer(this.mv, asyncDataCollector.getEnclosingClass(), lambdaName);
         asyncDataCollector.add(lambdaName, callIns);
         asyncDataCollector.incrementLambdaIndex();
 
@@ -836,7 +857,7 @@ public class JvmTerminatorGen {
         if (callIns.annotAttachments.size() > 0) {
             for (BIRNode.BIRAnnotationAttachment annotationAttachment : callIns.annotAttachments) {
                 if (annotationAttachment == null ||
-                        !STRAND_ANNOTATION.equals(annotationAttachment.annotTagRef.value) ||
+                        !STRAND.equals(annotationAttachment.annotTagRef.value) ||
                         !BALLERINA.equals(annotationAttachment.packageID.orgName.value) ||
                         !BUILT_IN_PACKAGE_NAME.equals(annotationAttachment.packageID.name.value)) {
                     continue;
@@ -911,24 +932,24 @@ public class JvmTerminatorGen {
             i += 1;
         }
 
-        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "handleWaitAny",
-                String.format("(L%s;)L%s$WaitResult;", LIST, STRAND), false);
+        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "handleWaitAny",
+                                String.format("(L%s;)L%s$WaitResult;", LIST, STRAND_CLASS), false);
         BIRNode.BIRVariableDcl tempVar = new BIRNode.BIRVariableDcl(symbolTable.anyType, new Name("waitResult"),
-                VarScope.FUNCTION, VarKind.ARG);
+                                                                    VarScope.FUNCTION, VarKind.ARG);
         int resultIndex = this.getJVMIndexOfVarRef(tempVar);
         this.mv.visitVarInsn(ASTORE, resultIndex);
 
         // assign result if result available
         Label afterIf = new Label();
         this.mv.visitVarInsn(ALOAD, resultIndex);
-        this.mv.visitFieldInsn(GETFIELD, String.format("%s$WaitResult", STRAND), "done", "Z");
+        this.mv.visitFieldInsn(GETFIELD, String.format("%s$WaitResult", STRAND_CLASS), "done", "Z");
         this.mv.visitJumpInsn(IFEQ, afterIf);
         Label withinIf = new Label();
         this.mv.visitLabel(withinIf);
         this.mv.visitVarInsn(ALOAD, resultIndex);
-        this.mv.visitFieldInsn(GETFIELD, String.format("%s$WaitResult", STRAND), "result",
-                String.format("L%s;", OBJECT));
-        JvmInstructionGen.addUnboxInsn(this.mv, waitInst.lhsOp.variableDcl.type);
+        this.mv.visitFieldInsn(GETFIELD, String.format("%s$WaitResult", STRAND_CLASS), "result",
+                               String.format("L%s;", OBJECT));
+        JvmCastGen.addUnboxInsn(this.mv, waitInst.lhsOp.variableDcl.type);
         this.storeToVar(waitInst.lhsOp.variableDcl);
         this.mv.visitLabel(afterIf);
     }
@@ -948,14 +969,15 @@ public class JvmTerminatorGen {
                 this.loadVar(futureRef.variableDcl);
             }
             this.mv.visitMethodInsn(INVOKEINTERFACE, MAP, "put", String.format("(L%s;L%s;)L%s;",
-                    OBJECT, OBJECT, OBJECT), true);
+                                                                               OBJECT, OBJECT, OBJECT), true);
             this.mv.visitInsn(POP);
             i += 1;
         }
 
         this.loadVar(waitAll.lhsOp.variableDcl);
-        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "handleWaitMultiple", String.format("(L%s;L%s;)V",
-                MAP, MAP_VALUE), false);
+        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "handleWaitMultiple", String.format("(L%s;L%s;)V",
+                                                                                                 MAP, MAP_VALUE),
+                                false);
     }
 
     private void genFPCallIns(BIRTerminator.FPCall fpCall, String moduleClassName, BType attachedType, String funcName,
@@ -969,11 +991,11 @@ public class JvmTerminatorGen {
             this.mv.visitLdcInsn(GLOBAL_LOCK_NAME);
             this.mv.visitVarInsn(ALOAD, localVarOffset);
             this.mv.visitMethodInsn(INVOKEVIRTUAL, LOCK_STORE, "panicIfInLock",
-                    String.format("(L%s;L%s;)V", STRING_VALUE, STRAND), false);
+                                    String.format("(L%s;L%s;)V", STRING_VALUE, STRAND_CLASS), false);
 
             // Load the scheduler from strand
             this.mv.visitVarInsn(ALOAD, localVarOffset);
-            this.mv.visitFieldInsn(GETFIELD, STRAND, "scheduler", String.format("L%s;", SCHEDULER));
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "scheduler", String.format("L%s;", SCHEDULER));
         } else {
             // load function ref, going to directly call the fp
             this.loadVar(fpCall.fp.variableDcl);
@@ -999,9 +1021,9 @@ public class JvmTerminatorGen {
         for (BIROperand arg : fpCall.args) {
             this.mv.visitInsn(DUP);
             this.mv.visitIntInsn(BIPUSH, paramIndex);
-            this.loadVar(getVariableDcl(arg.variableDcl));
+            this.loadVar(arg.variableDcl);
             BType bType = arg.variableDcl.type;
-            JvmInstructionGen.addBoxInsn(this.mv, bType);
+            JvmCastGen.addBoxInsn(this.mv, bType);
             this.mv.visitInsn(AASTORE);
             paramIndex += 1;
 
@@ -1058,7 +1080,7 @@ public class JvmTerminatorGen {
             // store result
             BType lhsType = fpCall.lhsOp.variableDcl.type;
             if (lhsType != null) {
-                JvmInstructionGen.addUnboxInsn(this.mv, lhsType);
+                JvmCastGen.addUnboxInsn(this.mv, lhsType);
             }
 
             BIRNode.BIRVariableDcl lhsVar = fpCall.lhsOp.variableDcl;
@@ -1075,7 +1097,7 @@ public class JvmTerminatorGen {
         this.mv.visitInsn(DUP);
         this.mv.visitIntInsn(BIPUSH, paramIndex);
         this.mv.visitInsn(ICONST_1);
-        JvmInstructionGen.addBoxInsn(this.mv, symbolTable.booleanType);
+        JvmCastGen.addBoxInsn(this.mv, symbolTable.booleanType);
         this.mv.visitInsn(AASTORE);
     }
 
@@ -1083,22 +1105,22 @@ public class JvmTerminatorGen {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         if (!ins.isSameStrand) {
-            this.mv.visitFieldInsn(GETFIELD, STRAND, "parent", String.format("L%s;", STRAND));
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "parent", String.format("L%s;", STRAND_CLASS));
         }
-        this.mv.visitFieldInsn(GETFIELD, STRAND, "wdChannels", String.format("L%s;", WD_CHANNELS));
+        this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "wdChannels", String.format("L%s;", WD_CHANNELS));
         this.mv.visitLdcInsn(ins.channel.value);
         this.mv.visitMethodInsn(INVOKEVIRTUAL, WD_CHANNELS, "getWorkerDataChannel", String.format("(L%s;)L%s;",
                 STRING_VALUE, WORKER_DATA_CHANNEL), false);
         this.loadVar(ins.data.variableDcl);
-        JvmInstructionGen.addBoxInsn(this.mv, ins.data.variableDcl.type);
+        JvmCastGen.addBoxInsn(this.mv, ins.data.variableDcl.type);
         this.mv.visitVarInsn(ALOAD, localVarOffset);
 
         if (!ins.isSync) {
-            this.mv.visitMethodInsn(INVOKEVIRTUAL, WORKER_DATA_CHANNEL, "sendData", String.format("(L%s;L%s;)V",
-                    OBJECT, STRAND), false);
+            this.mv.visitMethodInsn(INVOKEVIRTUAL, WORKER_DATA_CHANNEL, "sendData",
+                                    String.format("(L%s;L%s;)V", OBJECT, STRAND_CLASS), false);
         } else {
             this.mv.visitMethodInsn(INVOKEVIRTUAL, WORKER_DATA_CHANNEL, "syncSendData",
-                    String.format("(L%s;L%s;)L%s;", OBJECT, STRAND, OBJECT), false);
+                                    String.format("(L%s;L%s;)L%s;", OBJECT, STRAND_CLASS, OBJECT), false);
             BIROperand lhsOp = ins.lhsOp;
             if (lhsOp != null) {
                 this.storeToVar(lhsOp.variableDcl);
@@ -1110,16 +1132,17 @@ public class JvmTerminatorGen {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         if (!ins.isSameStrand) {
-            this.mv.visitFieldInsn(GETFIELD, STRAND, "parent", String.format("L%s;", STRAND));
+            this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "parent", String.format("L%s;", STRAND_CLASS));
         }
-        this.mv.visitFieldInsn(GETFIELD, STRAND, "wdChannels", String.format("L%s;", WD_CHANNELS));
+        this.mv.visitFieldInsn(GETFIELD, STRAND_CLASS, "wdChannels", String.format("L%s;", WD_CHANNELS));
         this.mv.visitLdcInsn(ins.workerName.value);
         this.mv.visitMethodInsn(INVOKEVIRTUAL, WD_CHANNELS, "getWorkerDataChannel", String.format("(L%s;)L%s;",
                 STRING_VALUE, WORKER_DATA_CHANNEL), false);
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         this.mv.visitMethodInsn(INVOKEVIRTUAL, WORKER_DATA_CHANNEL, "tryTakeData", String.format("(L%s;)L%s;",
-                STRAND, OBJECT), false);
+                                                                                                 STRAND_CLASS, OBJECT),
+                                false);
 
         BIRNode.BIRVariableDcl tempVar = new BIRNode.BIRVariableDcl(symbolTable.anyType, new Name("wrkMsg"),
                 VarScope.FUNCTION, VarKind.ARG);
@@ -1133,7 +1156,7 @@ public class JvmTerminatorGen {
         Label withinReceiveSuccess = new Label();
         this.mv.visitLabel(withinReceiveSuccess);
         this.mv.visitVarInsn(ALOAD, wrkResultIndex);
-        JvmInstructionGen.addUnboxInsn(this.mv, ins.lhsOp.variableDcl.type);
+        JvmCastGen.addUnboxInsn(this.mv, ins.lhsOp.variableDcl.type);
         this.storeToVar(ins.lhsOp.variableDcl);
 
         this.mv.visitLabel(jumpAfterReceive);
@@ -1142,9 +1165,9 @@ public class JvmTerminatorGen {
     private void genFlushIns(BIRTerminator.Flush ins, int localVarOffset) {
 
         this.mv.visitVarInsn(ALOAD, localVarOffset);
-        loadChannelDetails(this.mv, Arrays.asList(ins.channels));
-        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND, "handleFlush",
-                String.format("([L%s;)L%s;", CHANNEL_DETAILS, ERROR_VALUE), false);
+        JvmCodeGenUtil.loadChannelDetails(this.mv, Arrays.asList(ins.channels));
+        this.mv.visitMethodInsn(INVOKEVIRTUAL, STRAND_CLASS, "handleFlush",
+                                String.format("([L%s;)L%s;", CHANNEL_DETAILS, ERROR_VALUE), false);
         this.storeToVar(ins.lhsOp.variableDcl);
     }
 
@@ -1154,10 +1177,11 @@ public class JvmTerminatorGen {
         String metaDataVarName;
         ScheduleFunctionInfo strandMetaData;
         if (attachedType != null) {
-            metaDataVarName = getStrandMetadataVarName(attachedType.tsymbol.name.value, parentFunction);
+            metaDataVarName = getStrandMetadataVarName(attachedType.tsymbol.name.value,
+                                                                         parentFunction);
             strandMetaData = new ScheduleFunctionInfo(attachedType.tsymbol.name.value, parentFunction);
         } else {
-            metaDataVarName = getStrandMetadataVarName(parentFunction);
+            metaDataVarName = JvmCodeGenUtil.getStrandMetadataVarName(parentFunction);
             strandMetaData = new ScheduleFunctionInfo(parentFunction);
 
         }
@@ -1165,19 +1189,23 @@ public class JvmTerminatorGen {
         this.mv.visitFieldInsn(GETSTATIC, moduleClassName, metaDataVarName, String.format("L%s;", STRAND_METADATA));
         if (concurrent) {
             mv.visitMethodInsn(INVOKEVIRTUAL, SCHEDULER, SCHEDULE_FUNCTION_METHOD,
-                               String.format("([L%s;L%s;L%s;L%s;L%s;L%s;)L%s;", OBJECT, FUNCTION_POINTER, STRAND,
+                               String.format("([L%s;L%s;L%s;L%s;L%s;L%s;)L%s;", OBJECT, FUNCTION_POINTER, STRAND_CLASS,
                                              BTYPE, STRING_VALUE, STRAND_METADATA, FUTURE_VALUE), false);
         } else {
             mv.visitMethodInsn(INVOKEVIRTUAL, SCHEDULER, SCHEDULE_LOCAL_METHOD,
-                               String.format("([L%s;L%s;L%s;L%s;L%s;L%s;)L%s;", OBJECT, FUNCTION_POINTER, STRAND,
+                               String.format("([L%s;L%s;L%s;L%s;L%s;L%s;)L%s;", OBJECT, FUNCTION_POINTER, STRAND_CLASS,
                                              BTYPE, STRING_VALUE, STRAND_METADATA, FUTURE_VALUE), false);
         }
         // store return
         if (lhsOp.variableDcl != null) {
             BIRNode.BIRVariableDcl lhsOpVarDcl = lhsOp.variableDcl;
             // store the returned strand as the future
-            this.storeToVar(getVariableDcl(lhsOpVarDcl));
+            this.storeToVar(lhsOpVarDcl);
         }
+    }
+
+    static String getStrandMetadataVarName(String typeName, String parentFunction) {
+        return STRAND_METADATA_VAR_PREFIX + JvmCodeGenUtil.cleanupTypeName(typeName) + "$" + parentFunction + "$";
     }
 
     private void loadFpReturnType(BIROperand lhsOp) {
@@ -1193,20 +1221,20 @@ public class JvmTerminatorGen {
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
 
-        return this.indexMap.getIndex(varDcl);
+        return this.indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
     }
 
     private void loadVar(BIRNode.BIRVariableDcl varDcl) {
 
-        jvmInstructionGen.generateVarLoad(this.mv, varDcl, this.currentPackageName, this.getJVMIndexOfVarRef(varDcl));
+        jvmInstructionGen.generateVarLoad(this.mv, varDcl, this.getJVMIndexOfVarRef(varDcl));
     }
 
     private void storeToVar(BIRNode.BIRVariableDcl varDcl) {
 
-        jvmInstructionGen.generateVarStore(this.mv, varDcl, this.currentPackageName, this.getJVMIndexOfVarRef(varDcl));
+        jvmInstructionGen.generateVarStore(this.mv, varDcl, this.getJVMIndexOfVarRef(varDcl));
     }
 
-    public void genReturnTerm(BIRTerminator.Return returnIns, int returnVarRefIndex, BIRNode.BIRFunction func) {
+    public void genReturnTerm(int returnVarRefIndex, BIRNode.BIRFunction func) {
 
         BType bType = typeBuilder.build(func.type.retType);
 
@@ -1214,11 +1242,7 @@ public class JvmTerminatorGen {
             this.mv.visitVarInsn(LLOAD, returnVarRefIndex);
             this.mv.visitInsn(LRETURN);
             return;
-        } else if (TypeTags.isStringTypeTag(bType.tag)) {
-            this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
-            this.mv.visitInsn(ARETURN);
-            return;
-        } else if (TypeTags.isXMLTypeTag(bType.tag)) {
+        } else if (TypeTags.isStringTypeTag(bType.tag) || TypeTags.isXMLTypeTag(bType.tag)) {
             this.mv.visitVarInsn(ALOAD, returnVarRefIndex);
             this.mv.visitInsn(ARETURN);
             return;
@@ -1269,13 +1293,12 @@ public class JvmTerminatorGen {
                 this.mv.visitInsn(ARETURN);
                 break;
             default:
-                throw new BLangCompilerException("JVM generation is not supported for type " +
+                throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
                         String.format("%s", func.type.retType));
         }
     }
 
-    LabelGenerator getLabelGenerator() {
-
+    public LabelGenerator getLabelGenerator() {
         return this.labelGen;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -85,6 +85,7 @@ import static org.objectweb.asm.Opcodes.PUTFIELD;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.SWAP;
 import static org.objectweb.asm.Opcodes.V1_8;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ABSTRACT_OBJECT_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_LIST;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ERRORS;
@@ -111,7 +112,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT_TY
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.POPULATE_INITIAL_VALUES_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.SET;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_CLASS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_BUILDER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPEDESC_CLASS_PREFIX;
@@ -122,22 +123,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.UNSUPPORT
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_CLASS_PREFIX;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.addDefaultableBooleanVarsToSignature;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.enrichWithDefaultableParamInits;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.addBoxInsn;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.addUnboxInsn;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupFunctionName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.cleanupTypeName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.generateStrandMetadata;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getFunctions;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMethodDesc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getObjectField;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getRecordField;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getType;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getTypeDef;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.isExternFunc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.visitStrandMetadataField;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.computeLockNameFromString;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTerminatorGen.toNameString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.desugarOldExternFuncs;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.lookupBIRFunctionWrapper;
@@ -178,15 +164,10 @@ class JvmValueGen {
 
         List<BIRNode.BIRTypeDefinition> typeDefs = module.typeDefs;
         for (BIRNode.BIRTypeDefinition optionalTypeDef : typeDefs) {
-            BIRNode.BIRTypeDefinition typeDef = getTypeDef(optionalTypeDef);
-            BType bType = typeDef.type;
-            if (bType instanceof BServiceType) {
-                desugarObjectMethods(module, bType, typeDef.attachedFuncs, jvmMethodGen, jvmPackageGen);
-            } else if (bType.tag == TypeTags.OBJECT &&
-                    !Symbols.isFlagOn(((BObjectType) bType).tsymbol.flags, Flags.ABSTRACT)) {
-                desugarObjectMethods(module, bType, typeDef.attachedFuncs, jvmMethodGen, jvmPackageGen);
-            } else if (bType.tag == TypeTags.RECORD) {
-                desugarObjectMethods(module, bType, typeDef.attachedFuncs, jvmMethodGen, jvmPackageGen);
+            BType bType = optionalTypeDef.type;
+            if (bType instanceof BServiceType || (bType.tag == TypeTags.OBJECT && !Symbols.isFlagOn(
+                    bType.tsymbol.flags, Flags.ABSTRACT)) || bType.tag == TypeTags.RECORD) {
+                desugarObjectMethods(module, bType, optionalTypeDef.attachedFuncs, jvmMethodGen, jvmPackageGen);
             }
         }
     }
@@ -202,7 +183,7 @@ class JvmValueGen {
             if (birFunc == null) {
                 continue;
             }
-            if (isExternFunc(birFunc)) {
+            if (JvmCodeGenUtil.isExternFunc(birFunc)) {
                 BIRFunctionWrapper extFuncWrapper = lookupBIRFunctionWrapper(module, birFunc, bType, jvmPackageGen);
                 if (extFuncWrapper instanceof OldStyleExternalFunctionWrapper) {
                     desugarOldExternFuncs((OldStyleExternalFunctionWrapper) extFuncWrapper, birFunc, jvmMethodGen);
@@ -215,7 +196,7 @@ class JvmValueGen {
             } else {
                 addDefaultableBooleanVarsToSignature(birFunc, jvmPackageGen.symbolTable.booleanType);
             }
-            enrichWithDefaultableParamInits(JvmMethodGen.getFunction(birFunc), jvmMethodGen);
+            enrichWithDefaultableParamInits(birFunc, jvmMethodGen);
         }
     }
 
@@ -265,13 +246,13 @@ class JvmValueGen {
     static String getTypeDescClassName(Object module, String typeName) {
 
         String packageName = calculateJavaPkgName(module);
-        return packageName + TYPEDESC_CLASS_PREFIX + cleanupTypeName(typeName);
+        return packageName + TYPEDESC_CLASS_PREFIX + JvmCodeGenUtil.cleanupTypeName(typeName);
     }
 
     static String getTypeValueClassName(Object module, String typeName) {
 
         String packageName = calculateJavaPkgName(module);
-        return packageName + VALUE_CLASS_PREFIX + cleanupTypeName(typeName);
+        return packageName + VALUE_CLASS_PREFIX + JvmCodeGenUtil.cleanupTypeName(typeName);
     }
 
     private static String calculateJavaPkgName(Object module) {
@@ -279,10 +260,10 @@ class JvmValueGen {
         String packageName;
         if (module instanceof BIRNode.BIRPackage) {
             BIRNode.BIRPackage birPackage = (BIRNode.BIRPackage) module;
-            packageName = getPackageName(birPackage.org.value, birPackage.name.value, birPackage.version.value);
+            packageName = JvmCodeGenUtil.getPackageName(birPackage);
         } else if (module instanceof PackageID) {
             PackageID packageID = (PackageID) module;
-            packageName = getPackageName(packageID.orgName, packageID.name, packageID.version);
+            packageName = JvmCodeGenUtil.getPackageName(packageID);
         } else {
             throw new ClassCastException("module should be PackageID or BIRPackage but is : "
                     + (module == null ? "null" : module.getClass()));
@@ -347,14 +328,14 @@ class JvmValueGen {
     }
 
     private void createObjectMethods(ClassWriter cw, List<BIRNode.BIRFunction> attachedFuncs,
-                                     String moduleClassName, String typeName, BObjectType currentObjectType,
+                                     String moduleClassName, BObjectType currentObjectType,
                                      AsyncDataCollector asyncDataCollector) {
 
         for (BIRNode.BIRFunction func : attachedFuncs) {
             if (func == null) {
                 continue;
             }
-            jvmMethodGen.generateMethod(func, cw, module, currentObjectType, moduleClassName, typeName,
+            jvmMethodGen.generateMethod(func, cw, module, currentObjectType, moduleClassName,
                                         asyncDataCollector);
         }
     }
@@ -396,10 +377,8 @@ class JvmValueGen {
     private void createCallMethod(ClassWriter cw, List<BIRNode.BIRFunction> functions, String objClassName,
                                   boolean isService) {
 
-        List<BIRNode.BIRFunction> funcs = getFunctions(functions);
-
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "call",
-                String.format("(L%s;L%s;[L%s;)L%s;", STRAND, STRING_VALUE, OBJECT, OBJECT), null, null);
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "call", String.format(
+                "(L%s;L%s;[L%s;)L%s;", STRAND_CLASS, STRING_VALUE, OBJECT, OBJECT), null, null);
         mv.visitCode();
 
         int funcNameRegIndex = 2;
@@ -407,15 +386,15 @@ class JvmValueGen {
         Label defaultCaseLabel = new Label();
 
         // sort the fields before generating switch case
-        funcs.sort(NAME_HASH_COMPARATOR);
+        functions.sort(NAME_HASH_COMPARATOR);
 
-        List<Label> labels = createLabelsForSwitch(mv, funcNameRegIndex, funcs, defaultCaseLabel);
-        List<Label> targetLabels = createLabelsForEqualCheck(mv, funcNameRegIndex, funcs, labels,
-                defaultCaseLabel);
+        List<Label> labels = createLabelsForSwitch(mv, funcNameRegIndex, functions, defaultCaseLabel);
+        List<Label> targetLabels = createLabelsForEqualCheck(mv, funcNameRegIndex, functions, labels,
+                                                             defaultCaseLabel);
 
         // case body
         int i = 0;
-        for (BIRNode.BIRFunction optionalFunc : funcs) {
+        for (BIRNode.BIRFunction optionalFunc : functions) {
             BIRNode.BIRFunction func = getFunction(optionalFunc);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
@@ -426,7 +405,7 @@ class JvmValueGen {
             String methodSig;
 
             // use index access, since retType can be nil.
-            methodSig = getMethodDesc(paramTypes, retType, null, false);
+            methodSig = JvmCodeGenUtil.getMethodDesc(paramTypes, retType);
 
             // load self
             mv.visitVarInsn(ALOAD, 0);
@@ -435,7 +414,6 @@ class JvmValueGen {
             mv.visitVarInsn(ALOAD, 1);
             int j = 0;
             for (BType paramType : paramTypes) {
-                BType pType = getType(paramType);
                 // load parameters
                 mv.visitVarInsn(ALOAD, 3);
 
@@ -443,18 +421,20 @@ class JvmValueGen {
                 mv.visitLdcInsn((long) j);
                 mv.visitInsn(L2I);
                 mv.visitInsn(AALOAD);
-                addUnboxInsn(mv, pType);
+                JvmCastGen.addUnboxInsn(mv, paramType);
                 j += 1;
             }
 
-            mv.visitMethodInsn(INVOKEVIRTUAL, objClassName, cleanupFunctionName(func.name.value), methodSig, false);
+            mv.visitMethodInsn(INVOKEVIRTUAL, objClassName, JvmCodeGenUtil.cleanupFunctionName(func.name.value),
+                               methodSig, false);
             if (retType == null || retType.tag == TypeTags.NIL || retType.tag == TypeTags.NEVER) {
                 mv.visitInsn(ACONST_NULL);
             } else {
-                addBoxInsn(mv, retType);
+                JvmCastGen.addBoxInsn(mv, retType);
                 if (isService) {
                     mv.visitMethodInsn(INVOKESTATIC, BAL_ERRORS, "handleResourceError", String.format("(L%s;)L%s;",
-                            OBJECT, OBJECT), false);
+                                                                                                      OBJECT, OBJECT),
+                                       false);
                 }
             }
             mv.visitInsn(ARETURN);
@@ -462,7 +442,7 @@ class JvmValueGen {
         }
 
         createDefaultCase(mv, defaultCaseLabel, funcNameRegIndex);
-        mv.visitMaxs(funcs.size() + 10, funcs.size() + 10);
+        mv.visitMaxs(functions.size() + 10, functions.size() + 10);
         mv.visitEnd();
     }
 
@@ -490,12 +470,11 @@ class JvmValueGen {
 
         int i = 0;
         for (BField optionalField : sortedFields) {
-            BField field = getObjectField(optionalField);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
             mv.visitVarInsn(ALOAD, 0);
-            mv.visitFieldInsn(GETFIELD, className, field.name.value, getTypeDesc(field.type));
-            addBoxInsn(mv, field.type);
+            mv.visitFieldInsn(GETFIELD, className, optionalField.name.value, getTypeDesc(optionalField.type));
+            JvmCastGen.addBoxInsn(mv, optionalField.type);
             mv.visitInsn(ARETURN);
             i += 1;
         }
@@ -548,14 +527,13 @@ class JvmValueGen {
         // case body
         int i = 0;
         for (BField optionalField : sortedFields) {
-            BField field = getObjectField(optionalField);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, valueRegIndex);
-            addUnboxInsn(mv, field.type);
-            String filedName = field.name.value;
-            mv.visitFieldInsn(PUTFIELD, className, filedName, getTypeDesc(field.type));
+            JvmCastGen.addUnboxInsn(mv, optionalField.type);
+            String filedName = optionalField.name.value;
+            mv.visitFieldInsn(PUTFIELD, className, filedName, getTypeDesc(optionalField.type));
             mv.visitInsn(RETURN);
             i += 1;
         }
@@ -587,7 +565,8 @@ class JvmValueGen {
     private void createInstantiateMethod(ClassWriter cw, BRecordType recordType,
                                          BIRNode.BIRTypeDefinition typeDef) {
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "instantiate",
-                String.format("(L%s;[L%s;)L%s;", STRAND, BINITIAL_VALUE_ENTRY, OBJECT), null, null);
+                                          String.format("(L%s;[L%s;)L%s;", STRAND_CLASS, BINITIAL_VALUE_ENTRY, OBJECT),
+                                          null, null);
         mv.visitCode();
 
         String className = getTypeValueClassName(recordType.tsymbol.pkgID, toNameString(recordType));
@@ -612,7 +591,7 @@ class JvmValueGen {
                 String refTypeClassName = getTypeValueClassName(typeRef.tsymbol.pkgID, toNameString(typeRef));
                 mv.visitInsn(DUP2);
                 mv.visitMethodInsn(INVOKESTATIC, refTypeClassName, "$init",
-                                   String.format("(L%s;L%s;)V", STRAND, MAP_VALUE), false);
+                                   String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), false);
             }
         }
 
@@ -646,11 +625,11 @@ class JvmValueGen {
         } else {
             // record type is the original record-type of this type-label
             valueClassName = getTypeValueClassName(recordType.tsymbol.pkgID, toNameString(recordType));
-            initFuncName = cleanupFunctionName(recordType.name + "__init_");
+            initFuncName = JvmCodeGenUtil.cleanupFunctionName(recordType.name + "__init_");
         }
 
         mv.visitMethodInsn(INVOKESTATIC, valueClassName, initFuncName,
-                           String.format("(L%s;L%s;%s)L%s;", STRAND, MAP_VALUE, closureParamSignature, OBJECT),
+                           String.format("(L%s;L%s;%s)L%s;", STRAND_CLASS, MAP_VALUE, closureParamSignature, OBJECT),
                            false);
 
         mv.visitInsn(POP);
@@ -713,7 +692,7 @@ class JvmValueGen {
         this.createRecordConstructor(cw, BTYPE);
         this.createRecordInitWrapper(cw, className, typeDef);
         this.createLambdas(cw, asyncDataCollector);
-        visitStrandMetadataField(cw, asyncDataCollector);
+        JvmCodeGenUtil.visitStrandMetadataField(cw, asyncDataCollector);
         this.generateStaticInitializer(cw, className, module, asyncDataCollector);
         cw.visitEnd();
 
@@ -727,7 +706,7 @@ class JvmValueGen {
             if (func == null) {
                 continue;
             }
-            jvmMethodGen.generateMethod(func, cw, this.module, null, moduleClassName, "", asyncDataCollector);
+            jvmMethodGen.generateMethod(func, cw, this.module, null, moduleClassName, asyncDataCollector);
         }
     }
 
@@ -776,7 +755,7 @@ class JvmValueGen {
             return;
         }
         MethodVisitor mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
-        generateStrandMetadata(mv, moduleClass, module, asyncDataCollector);
+        JvmCodeGenUtil.generateStrandMetadata(mv, moduleClass, module, asyncDataCollector);
         mv.visitInsn(RETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
@@ -786,7 +765,7 @@ class JvmValueGen {
     private void createRecordInitWrapper(ClassWriter cw, String className, BIRNode.BIRTypeDefinition typeDef) {
 
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "$init",
-                                          String.format("(L%s;L%s;)V", STRAND, MAP_VALUE), null, null);
+                                          String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), null, null);
         mv.visitCode();
         // load strand
         mv.visitVarInsn(ALOAD, 0);
@@ -804,7 +783,7 @@ class JvmValueGen {
                                                             toNameString(typeRef));
             mv.visitInsn(DUP2);
             mv.visitMethodInsn(INVOKESTATIC, refTypeClassName, "$init",
-                               String.format("(L%s;L%s;)V", STRAND, MAP_VALUE), false);
+                               String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), false);
         }
 
         // Invoke the init-function of this type.
@@ -820,11 +799,11 @@ class JvmValueGen {
             // record type is the original record-type of this type-label
             BRecordType recordType = (BRecordType) typeDef.type;
             valueClassName = getTypeValueClassName(recordType.tsymbol.pkgID, toNameString(recordType));
-            initFuncName = cleanupFunctionName(recordType.name + "__init_");
+            initFuncName = JvmCodeGenUtil.cleanupFunctionName(recordType.name + "__init_");
         }
 
         mv.visitMethodInsn(INVOKESTATIC, valueClassName, initFuncName,
-                           String.format("(L%s;L%s;)L%s;", STRAND, MAP_VALUE, OBJECT), false);
+                           String.format("(L%s;L%s;)L%s;", STRAND_CLASS, MAP_VALUE, OBJECT), false);
         mv.visitInsn(POP);
 
         mv.visitInsn(RETURN);
@@ -886,14 +865,13 @@ class JvmValueGen {
 
         int i = 0;
         for (BField optionalField : sortedFields) {
-            BField field = getRecordField(optionalField);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
 
             // if the field is an optional-field, first check the 'isPresent' flag of that field.
             Label ifPresentLabel = new Label();
-            String fieldName = field.name.value;
-            if (this.isOptionalRecordField(field)) {
+            String fieldName = optionalField.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitFieldInsn(GETFIELD, className, this.getFieldIsPresentFlagName(fieldName),
                         getTypeDesc(booleanType));
@@ -905,8 +883,8 @@ class JvmValueGen {
             mv.visitLabel(ifPresentLabel);
             // return the value of the field
             mv.visitVarInsn(ALOAD, 0);
-            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(field.type));
-            addBoxInsn(mv, field.type);
+            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(optionalField.type));
+            JvmCastGen.addBoxInsn(mv, optionalField.type);
             mv.visitInsn(ARETURN);
             i += 1;
         }
@@ -946,23 +924,22 @@ class JvmValueGen {
         // case body
         int i = 0;
         for (BField optionalField : sortedFields) {
-            BField field = getRecordField(optionalField);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
 
             // load the existing value to return
-            String fieldName = field.name.value;
+            String fieldName = optionalField.name.value;
             mv.visitVarInsn(ALOAD, 0);
-            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(field.type));
-            addBoxInsn(mv, field.type);
+            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(optionalField.type));
+            JvmCastGen.addBoxInsn(mv, optionalField.type);
 
             mv.visitVarInsn(ALOAD, 0);
             mv.visitVarInsn(ALOAD, valueRegIndex);
-            addUnboxInsn(mv, field.type);
-            mv.visitFieldInsn(PUTFIELD, className, fieldName, getTypeDesc(field.type));
+            JvmCastGen.addUnboxInsn(mv, optionalField.type);
+            mv.visitFieldInsn(PUTFIELD, className, fieldName, getTypeDesc(optionalField.type));
 
             // if the field is an optional-field, then also set the isPresent flag of that field to true.
-            if (this.isOptionalRecordField(field)) {
+            if (this.isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitInsn(ICONST_1);
                 mv.visitFieldInsn(PUTFIELD, className, this.getFieldIsPresentFlagName(fieldName),
@@ -1015,12 +992,11 @@ class JvmValueGen {
         mv.visitVarInsn(ASTORE, entrySetVarIndex);
 
         for (BField optionalField : fields.values()) {
-            BField field = getRecordField(optionalField);
             Label ifNotPresent = new Label();
 
             // If its an optional field, generate if-condition to check the presense of the field.
-            String fieldName = field.name.value;
-            if (this.isOptionalRecordField(field)) {
+            String fieldName = optionalField.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitFieldInsn(GETFIELD, className, this.getFieldIsPresentFlagName(fieldName),
                         getTypeDesc(booleanType));
@@ -1037,8 +1013,8 @@ class JvmValueGen {
                     String.format("(L%s;)L%s;", STRING_VALUE, B_STRING_VALUE), false);
             // field value as the map-entry value
             mv.visitVarInsn(ALOAD, 0);
-            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(field.type));
-            addBoxInsn(mv, field.type);
+            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(optionalField.type));
+            JvmCastGen.addBoxInsn(mv, optionalField.type);
 
             mv.visitMethodInsn(INVOKESPECIAL, MAP_SIMPLE_ENTRY, JVM_INIT_METHOD,
                     String.format("(L%s;L%s;)V", OBJECT, OBJECT), false);
@@ -1088,12 +1064,11 @@ class JvmValueGen {
 
         int i = 0;
         for (BField optionalField : sortedFields) {
-            BField field = getObjectField(optionalField);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
 
-            String fieldName = field.name.value;
-            if (this.isOptionalRecordField(field)) {
+            String fieldName = optionalField.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
                 // if the field is optional, then return the value is the 'isPresent' flag.
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitFieldInsn(GETFIELD, className, this.getFieldIsPresentFlagName(fieldName),
@@ -1131,12 +1106,11 @@ class JvmValueGen {
         mv.visitVarInsn(ASTORE, valuesVarIndex);
 
         for (BField optionalField : fields.values()) {
-            BField field = getRecordField(optionalField);
             Label ifNotPresent = new Label();
 
             // If its an optional field, generate if-condition to check the presense of the field.
-            String fieldName = field.name.value;
-            if (this.isOptionalRecordField(field)) {
+            String fieldName = optionalField.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0); // this
                 mv.visitFieldInsn(GETFIELD, className, this.getFieldIsPresentFlagName(fieldName),
                                   getTypeDesc(booleanType));
@@ -1145,8 +1119,8 @@ class JvmValueGen {
 
             mv.visitVarInsn(ALOAD, valuesVarIndex);
             mv.visitVarInsn(ALOAD, 0); // this
-            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(field.type));
-            addBoxInsn(mv, field.type);
+            mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(optionalField.type));
+            JvmCastGen.addBoxInsn(mv, optionalField.type);
             mv.visitMethodInsn(INVOKEINTERFACE, LIST, "add", String.format("(L%s;)Z", OBJECT), true);
             mv.visitInsn(POP);
             mv.visitLabel(ifNotPresent);
@@ -1176,9 +1150,8 @@ class JvmValueGen {
 
         int requiredFieldsCount = 0;
         for (BField optionalField : fields.values()) {
-            BField field = getObjectField(optionalField);
-            String fieldName = field.name.value;
-            if (this.isOptionalRecordField(field)) {
+            String fieldName = optionalField.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitFieldInsn(GETFIELD, className, this.getFieldIsPresentFlagName(fieldName),
                                   getTypeDesc(booleanType));
@@ -1241,13 +1214,12 @@ class JvmValueGen {
 
         int i = 0;
         for (BField optionalField : sortedFields) {
-            BField field = getObjectField(optionalField);
             Label targetLabel = targetLabels.get(i);
             mv.visitLabel(targetLabel);
 
             //Setting isPresent as zero
-            if (this.isOptionalRecordField(field)) {
-                String fieldName = field.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
+                String fieldName = optionalField.name.value;
                 mv.visitVarInsn(ALOAD, 0);
                 mv.visitInsn(ICONST_0);
                 mv.visitFieldInsn(PUTFIELD, className, this.getFieldIsPresentFlagName(fieldName),
@@ -1255,14 +1227,14 @@ class JvmValueGen {
 
                 // load the existing value to return
                 mv.visitVarInsn(ALOAD, 0);
-                mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(field.type));
-                addBoxInsn(mv, field.type);
+                mv.visitFieldInsn(GETFIELD, className, fieldName, getTypeDesc(optionalField.type));
+                JvmCastGen.addBoxInsn(mv, optionalField.type);
 
                 // Set default value for reference types
-                if (checkIfValueIsJReferenceType(field.type)) {
+                if (checkIfValueIsJReferenceType(optionalField.type)) {
                     mv.visitVarInsn(ALOAD, 0);
                     mv.visitInsn(ACONST_NULL);
-                    mv.visitFieldInsn(PUTFIELD, className, fieldName, getTypeDesc(field.type));
+                    mv.visitFieldInsn(PUTFIELD, className, fieldName, getTypeDesc(optionalField.type));
                 }
 
                 mv.visitInsn(ARETURN);
@@ -1312,12 +1284,11 @@ class JvmValueGen {
         mv.visitVarInsn(ASTORE, keysVarIndex);
 
         for (BField optionalField : fields.values()) {
-            BField field = getRecordField(optionalField);
             Label ifNotPresent = new Label();
 
             // If its an optional field, generate if-condition to check the presense of the field.
-            String fieldName = field.name.value;
-            if (this.isOptionalRecordField(field)) {
+            String fieldName = optionalField.name.value;
+            if (this.isOptionalRecordField(optionalField)) {
                 mv.visitVarInsn(ALOAD, 0); // this
                 mv.visitFieldInsn(GETFIELD, className, this.getFieldIsPresentFlagName(fieldName),
                                   getTypeDesc(booleanType));
@@ -1369,27 +1340,26 @@ class JvmValueGen {
     void generateValueClasses(Map<String, byte[]> jarEntries) {
 
         module.typeDefs.parallelStream().forEach(optionalTypeDef -> {
-            BIRNode.BIRTypeDefinition typeDef = getTypeDef(optionalTypeDef);
-            BType bType = typeDef.type;
+            BType bType = optionalTypeDef.type;
             if (bType instanceof BServiceType) {
                 BServiceType serviceType = (BServiceType) bType;
-                String className = getTypeValueClassName(this.module, typeDef.name.value);
-                byte[] bytes = this.createObjectValueClass(serviceType, className, typeDef, true);
+                String className = getTypeValueClassName(this.module, optionalTypeDef.name.value);
+                byte[] bytes = this.createObjectValueClass(serviceType, className, optionalTypeDef, true);
                 jarEntries.put(className + ".class", bytes);
             } else if (bType.tag == TypeTags.OBJECT &&
                     !Symbols.isFlagOn(((BObjectType) bType).tsymbol.flags, Flags.ABSTRACT)) {
                 BObjectType objectType = (BObjectType) bType;
-                String className = getTypeValueClassName(this.module, typeDef.name.value);
-                byte[] bytes = this.createObjectValueClass(objectType, className, typeDef, false);
+                String className = getTypeValueClassName(this.module, optionalTypeDef.name.value);
+                byte[] bytes = this.createObjectValueClass(objectType, className, optionalTypeDef, false);
                 jarEntries.put(className + ".class", bytes);
             } else if (bType.tag == TypeTags.RECORD) {
                 BRecordType recordType = (BRecordType) bType;
-                String className = getTypeValueClassName(this.module, typeDef.name.value);
-                byte[] bytes = this.createRecordValueClass(recordType, className, typeDef);
+                String className = getTypeValueClassName(this.module, optionalTypeDef.name.value);
+                byte[] bytes = this.createRecordValueClass(recordType, className, optionalTypeDef);
                 jarEntries.put(className + ".class", bytes);
 
-                String typedescClass = getTypeDescClassName(this.module, typeDef.name.value);
-                bytes = this.createRecordTypeDescClass(recordType, typedescClass, typeDef);
+                String typedescClass = getTypeDescClassName(this.module, optionalTypeDef.name.value);
+                bytes = this.createRecordTypeDescClass(recordType, typedescClass, optionalTypeDef);
                 jarEntries.put(typedescClass + ".class", bytes);
             }
         });
@@ -1409,7 +1379,7 @@ class JvmValueGen {
 
         List<BIRNode.BIRFunction> attachedFuncs = typeDef.attachedFuncs;
         if (attachedFuncs != null) {
-            this.createObjectMethods(cw, attachedFuncs, className, typeDef.name.value, objectType,
+            this.createObjectMethods(cw, attachedFuncs, className, objectType,
                                      asyncDataCollector);
         }
 
@@ -1419,7 +1389,7 @@ class JvmValueGen {
         this.createObjectSetMethod(cw, fields, className);
         this.createObjectSetOnInitializationMethod(cw, fields, className);
         this.createLambdas(cw, asyncDataCollector);
-        visitStrandMetadataField(cw, asyncDataCollector);
+        JvmCodeGenUtil.visitStrandMetadataField(cw, asyncDataCollector);
         this.generateStaticInitializer(cw, className, module, asyncDataCollector);
 
         cw.visitEnd();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/BIRVarToJVMIndexMap.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/BIRVarToJVMIndexMap.java
@@ -34,7 +34,7 @@ import java.util.Map;
 public class BIRVarToJVMIndexMap {
 
     private int localVarIndex = 0;
-    private Map<String, Integer> jvmLocalVarIndexMap = new HashMap<>();
+    private final Map<String, Integer> jvmLocalVarIndexMap = new HashMap<>();
 
     private void add(BIRNode.BIRVariableDcl varDcl) {
 
@@ -62,7 +62,7 @@ public class BIRVarToJVMIndexMap {
         return varDcl.name.value;
     }
 
-    public int getIndex(BIRNode.BIRVariableDcl varDcl) {
+    public int addToMapIfNotFoundAndGetIndex(BIRNode.BIRVariableDcl varDcl) {
 
         String varRefName = this.getVarRefName(varDcl);
         if (!(this.jvmLocalVarIndexMap.containsKey(varRefName))) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -15,12 +15,15 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
+import org.wso2.ballerinalang.compiler.bir.codegen.JvmCastGen;
+import org.wso2.ballerinalang.compiler.bir.codegen.JvmCodeGenUtil;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmErrorGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen;
@@ -43,7 +46,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
-import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -110,11 +112,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WRAPPER_G
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.addDefaultableBooleanVarsToSignature;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.getNextDesugarBBId;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.insertAndGetNextBasicBlock;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmInstructionGen.addUnboxInsn;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getMethodDesc;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmMethodGen.getVariableDcl;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getFunctionWrapper;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPackageName;
 
 /**
  * Interop related method generation class for JVM byte code generation.
@@ -123,38 +121,33 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getPacka
  */
 public class InteropMethodGen {
 
-    private static final ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
-
     static void genJFieldForInteropField(JFieldFunctionWrapper jFieldFuncWrapper,
                                          ClassWriter classWriter,
                                          BIRPackage birModule,
                                          JvmPackageGen jvmPackageGen,
                                          JvmMethodGen jvmMethodGen,
                                          String moduleClassName,
-                                         String serviceName,
                                          AsyncDataCollector asyncDataCollector) {
-
-        String currentPackageName = getPackageName(birModule.org.value, birModule.name.value, birModule.version.value);
 
         // Create a local variable for the strand
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
         BIRVariableDcl strandVarDcl = new BIRVariableDcl(jvmPackageGen.symbolTable.stringType, new Name("$_strand_$"),
                 null, VarKind.ARG);
-        int strandParamIndex = indexMap.getIndex(strandVarDcl);
+        int strandParamIndex = indexMap.addToMapIfNotFoundAndGetIndex(strandVarDcl);
 
         // Generate method desc
         BIRFunction birFunc = jFieldFuncWrapper.func;
         BType retType = birFunc.type.retType;
 
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.build(birFunc.type.retType);
+            retType = JvmCodeGenUtil.TYPE_BUILDER.build(birFunc.type.retType);
         }
 
-        String desc = getMethodDesc(birFunc.type.paramTypes, retType, null, false);
+        String desc = JvmCodeGenUtil.getMethodDesc(birFunc.type.paramTypes, retType);
         int access = birFunc.receiver != null ? ACC_PUBLIC : ACC_PUBLIC + ACC_STATIC;
         MethodVisitor mv = classWriter.visitMethod(access, birFunc.name.value, desc, null, null);
         JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, birModule, jvmPackageGen);
-        JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, currentPackageName, instGen);
+        JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
         LabelGenerator labelGen = new LabelGenerator();
         JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, birModule, instGen,
                 jvmPackageGen);
@@ -173,7 +166,7 @@ public class InteropMethodGen {
             if (birLocalVarOptional instanceof BIRNode.BIRFunctionParameter) {
                 BIRNode.BIRFunctionParameter functionParameter = (BIRNode.BIRFunctionParameter) birLocalVarOptional;
                 birFuncParams.add(functionParameter);
-                indexMap.getIndex(functionParameter);
+                indexMap.addToMapIfNotFoundAndGetIndex(functionParameter);
             }
         }
 
@@ -191,16 +184,15 @@ public class InteropMethodGen {
 
             // The following boolean parameter indicates the existence of a default value
             BIRNode.BIRFunctionParameter isDefaultValueExist = birFuncParams.get(birFuncParamIndex + 1);
-            mv.visitVarInsn(ILOAD, indexMap.getIndex(isDefaultValueExist));
+            mv.visitVarInsn(ILOAD, indexMap.addToMapIfNotFoundAndGetIndex(isDefaultValueExist));
 
             // Gen the if not equal logic
             Label paramNextLabel = labelGen.getLabel(birFuncParam.name.value + "next");
             mv.visitJumpInsn(IFNE, paramNextLabel);
 
             List<BIRBasicBlock> basicBlocks = birFunc.parameters.get(birFuncParam);
-            jvmMethodGen.generateBasicBlocks(mv, basicBlocks, labelGen, errorGen, instGen, termGen, birFunc, -1, -1,
-                                             strandParamIndex, true, birModule, null, moduleClassName,
-                                             asyncDataCollector);
+            generateBasicBlocks(mv, basicBlocks, labelGen, errorGen, instGen, termGen, birFunc, moduleClassName,
+                                asyncDataCollector);
 
             mv.visitLabel(paramNextLabel);
 
@@ -212,7 +204,7 @@ public class InteropMethodGen {
 
         // Load receiver which is the 0th parameter in the birFunc
         if (!jField.isStatic()) {
-            int receiverLocalVarIndex = indexMap.getIndex(birFuncParams.get(0));
+            int receiverLocalVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(birFuncParams.get(0));
             mv.visitVarInsn(ALOAD, receiverLocalVarIndex);
             mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD, "()Ljava/lang/Object;", false);
             mv.visitTypeInsn(CHECKCAST, jField.getDeclaringClassName());
@@ -239,9 +231,9 @@ public class InteropMethodGen {
         birFuncParamIndex = jField.isStatic() ? 0 : 2;
         if (birFuncParamIndex < birFuncParams.size()) {
             BIRNode.BIRFunctionParameter birFuncParam = birFuncParams.get(birFuncParamIndex);
-            int paramLocalVarIndex = indexMap.getIndex(birFuncParam);
-            loadMethodParamToStackInInteropFunction(mv, birFuncParam, jFieldType, currentPackageName,
-                    paramLocalVarIndex, indexMap, false, instGen, jvmPackageGen.symbolTable);
+            int paramLocalVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(birFuncParam);
+            loadMethodParamToStackInInteropFunction(mv, birFuncParam, jFieldType,
+                                                    paramLocalVarIndex, instGen);
         }
 
         if (jField.isStatic()) {
@@ -260,7 +252,7 @@ public class InteropMethodGen {
 
         // Handle return type
         BIRVariableDcl retVarDcl = new BIRVariableDcl(retType, new Name("$_ret_var_$"), null, VarKind.LOCAL);
-        int returnVarRefIndex = indexMap.getIndex(retVarDcl);
+        int returnVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(retVarDcl);
 
         if (retType.tag == TypeTags.NIL) {
             mv.visitInsn(ACONST_NULL);
@@ -268,7 +260,7 @@ public class InteropMethodGen {
             // Here the corresponding Java method parameter type is 'jvm:RefType'. This has been verified before
             BIRVariableDcl retJObjectVarDcl = new BIRVariableDcl(jvmPackageGen.symbolTable.anyType,
                     new Name("$_ret_jobject_var_$"), null, VarKind.LOCAL);
-            int returnJObjectVarRefIndex = indexMap.getIndex(retJObjectVarDcl);
+            int returnJObjectVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(retJObjectVarDcl);
             mv.visitVarInsn(ASTORE, returnJObjectVarRefIndex);
             mv.visitTypeInsn(NEW, HANDLE_VALUE);
             mv.visitInsn(DUP);
@@ -279,18 +271,44 @@ public class InteropMethodGen {
             if (jField.getFieldType().isPrimitive() /*jFieldType instanceof JPrimitiveType*/) {
                 performWideningPrimitiveConversion(mv, retType, jFieldType);
             } else {
-                addUnboxInsn(mv, retType);
+                JvmCastGen.addUnboxInsn(mv, retType);
             }
         }
 
-        instGen.generateVarStore(mv, retVarDcl, currentPackageName, returnVarRefIndex);
+        instGen.generateVarStore(mv, retVarDcl, returnVarRefIndex);
 
         Label retLabel = labelGen.getLabel("return_lable");
         mv.visitLabel(retLabel);
         mv.visitLineNumber(birFunc.pos.sLine, retLabel);
-        termGen.genReturnTerm(new BIRTerminator.Return(birFunc.pos), returnVarRefIndex, birFunc);
+        termGen.genReturnTerm(returnVarRefIndex, birFunc);
         mv.visitMaxs(200, 400);
         mv.visitEnd();
+    }
+
+    private static void generateBasicBlocks(MethodVisitor mv, List<BIRBasicBlock> basicBlocks, LabelGenerator labelGen,
+                                            JvmErrorGen errorGen, JvmInstructionGen instGen, JvmTerminatorGen termGen,
+                                            BIRFunction func, String moduleClassName,
+                                            AsyncDataCollector asyncDataCollector) {
+        String funcName = JvmCodeGenUtil.cleanupFunctionName(func.name.value);
+        for (BIRBasicBlock basicBlock : basicBlocks) {
+            Label bbLabel = labelGen.getLabel(funcName + basicBlock.id.value);
+            mv.visitLabel(bbLabel);
+            JvmCodeGenUtil.generateBbInstructions(mv, labelGen, instGen, -1, asyncDataCollector, funcName, basicBlock);
+            Label bbEndLabel = labelGen.getLabel(funcName + basicBlock.id.value + "beforeTerm");
+            mv.visitLabel(bbEndLabel);
+            BIRTerminator terminator = basicBlock.terminator;
+            // process terminator
+            if (!(terminator instanceof BIRTerminator.Return)) {
+                JvmCodeGenUtil.generateDiagnosticPos(terminator.pos, mv);
+                termGen.genTerminator(terminator, moduleClassName, func, funcName, -1, -1, null, asyncDataCollector);
+            }
+            errorGen.generateTryCatch(func, funcName, basicBlock, termGen, labelGen);
+
+            BIRBasicBlock thenBB = terminator.thenBB;
+            if (thenBB != null) {
+                JvmCodeGenUtil.genYieldCheck(mv, termGen.getLabelGenerator(), thenBB, funcName, -1);
+            }
+        }
     }
 
     public static void desugarInteropFuncs(JMethodFunctionWrapper extFuncWrapper, BIRFunction birFunc,
@@ -298,7 +316,7 @@ public class InteropMethodGen {
         // resetting the variable generation index
         BType retType = birFunc.type.retType;
         if (Symbols.isFlagOn(retType.flags, Flags.PARAMETERIZED)) {
-            retType = typeBuilder.build(birFunc.type.retType);
+            retType = JvmCodeGenUtil.TYPE_BUILDER.build(birFunc.type.retType);
         }
         JMethod jMethod = extFuncWrapper.jMethod;
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();
@@ -379,9 +397,9 @@ public class InteropMethodGen {
         BIRBasicBlock thenBB = insertAndGetNextBasicBlock(birFunc.basicBlocks, bbPrefix, jvmMethodGen);
         thenBB.terminator = new BIRTerminator.GOTO(birFunc.pos, retBB);
 
-        if (!(retType.tag == TypeTags.NIL)) {
-            BIROperand retRef = new BIROperand(getVariableDcl(birFunc.localVars.get(0)));
-            if (!(JType.jVoid == jMethodRetType)) {
+        if (retType.tag != TypeTags.NIL) {
+            BIROperand retRef = new BIROperand(birFunc.localVars.get(0));
+            if (JType.jVoid != jMethodRetType) {
                 BIRVariableDcl retJObjectVarDcl = new BIRVariableDcl(jMethodRetType, new Name("$_ret_jobject_var_$"),
                         null, VarKind.LOCAL);
                 birFunc.localVars.add(retJObjectVarDcl);
@@ -451,9 +469,9 @@ public class InteropMethodGen {
     private static void performWideningPrimitiveConversion(MethodVisitor mv, BType bType, JType jType) {
 
         if (TypeTags.isIntegerTypeTag(bType.tag) && jType.jTag == JTypeTags.JLONG) {
-            return; // NOP
+            // NOP
         } else if (bType.tag == TypeTags.FLOAT && jType.jTag == JTypeTags.JDOUBLE) {
-            return; // NOP
+            // NOP
         } else if (TypeTags.isIntegerTypeTag(bType.tag)) {
             mv.visitInsn(I2L);
         } else if (bType.tag == TypeTags.FLOAT) {
@@ -467,24 +485,14 @@ public class InteropMethodGen {
         }
     }
 
-    private static void loadMethodParamToStackInInteropFunction(MethodVisitor mv,
-                                                                BIRNode.BIRFunctionParameter birFuncParam,
-                                                                JType jMethodParamType,
-                                                                String currentPackageName,
-                                                                int localVarIndex,
-                                                                BIRVarToJVMIndexMap indexMap,
-                                                                boolean isVarArg,
-                                                                JvmInstructionGen jvmInstructionGen,
-                                                                SymbolTable symbolTable) {
+    private static void loadMethodParamToStackInInteropFunction(
+            MethodVisitor mv, BIRNode.BIRFunctionParameter birFuncParam, JType jMethodParamType, int localVarIndex,
+            JvmInstructionGen jvmInstructionGen) {
 
         BType bFuncParamType = birFuncParam.type;
-        if (isVarArg) {
-            genVarArg(mv, indexMap, bFuncParamType, jMethodParamType, localVarIndex, symbolTable);
-        } else {
-            // Load the parameter value to the stack
-            jvmInstructionGen.generateVarLoad(mv, birFuncParam, currentPackageName, localVarIndex);
-            generateBToJCheckCast(mv, bFuncParamType, (JType) jMethodParamType);
-        }
+        // Load the parameter value to the stack
+        jvmInstructionGen.generateVarLoad(mv, birFuncParam, localVarIndex);
+        generateBToJCheckCast(mv, bFuncParamType, jMethodParamType);
     }
 
     public static String getJTypeSignature(JType jType) {
@@ -577,9 +585,9 @@ public class InteropMethodGen {
         BIRVariableDcl valueArray = new BIRVariableDcl(symbolTable.anyType, new Name("$valueArray"), null,
                 VarKind.TEMP);
 
-        int varArgsLenVarIndex = indexMap.getIndex(varArgsLen);
-        int indexVarIndex = indexMap.getIndex(index);
-        int valueArrayIndex = indexMap.getIndex(valueArray);
+        int varArgsLenVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(varArgsLen);
+        int indexVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(index);
+        int valueArrayIndex = indexMap.addToMapIfNotFoundAndGetIndex(valueArray);
 
         // get the number of var args provided
         mv.visitVarInsn(ALOAD, varArgIndex);
@@ -764,5 +772,8 @@ public class InteropMethodGen {
         JavaField jField = interopValidator.validateAndGetJField(
                 (InteropValidationRequest.FieldValidationRequest) jFieldValidationReq);
         return new JFieldFunctionWrapper(birFuncWrapper, jField);
+    }
+
+    private InteropMethodGen() {
     }
 }


### PR DESCRIPTION
## Purpose
> This is an attempt at refactoring runtime codegen classes. First attempt to refactor the genJMethodForBFunc method of JvmMethodGen. Other changes include moving static functions from the JvmMethodGen class to common utility classes.

Related issue https://github.com/ballerina-platform/ballerina-lang/issues/25252 and https://github.com/ballerina-platform/ballerina-lang/issues/24405

## Approach
> Break the genJMethodForBFunc method to smaller methods and remove static methods from JvmMethodGen class.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
