### PR TITLE
Revert "Unset JAVA_TOOL_OPTIONS in GitHub action builds"

### DIFF
--- a/.github/workflows/CI_push_build.yml
+++ b/.github/workflows/CI_push_build.yml
@@ -40,7 +40,6 @@ jobs:
 
       - name: Build without integration test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew build -x createJavadoc -x :jballerina-integration-test:test --max-workers=2 --scan
@@ -49,7 +48,6 @@ jobs:
 
       - name: Run integration test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew :jballerina-integration-test:test -x createJavadoc --no-parallel --scan

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -76,7 +76,6 @@ jobs:
 
       - name: Run integration test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew :jballerina-integration-test:test --fail-fast -x createJavadoc --max-workers=1 --scan --no-daemon
@@ -112,7 +111,6 @@ jobs:
 
       - name: Run jballerina unit test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew :jballerina-unit-test:test :ballerina-http:test :ballerina-kafka:test :ballerina-mysql:test :testerina-integration-test:test --fail-fast -x createJavadoc --max-workers=1 --scan --no-daemon
@@ -148,7 +146,6 @@ jobs:
 
       - name: Run all the other unit test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew build -x createJavadoc -x :ballerina-http:test -x :ballerina-kafka:test -x :ballerina-mysql:test -x :jballerina-unit-test:test -x :jballerina-integration-test:test -x :testerina-integration-test:test --max-workers=1 --scan --no-daemon

--- a/.github/workflows/daily_build.yml
+++ b/.github/workflows/daily_build.yml
@@ -35,7 +35,6 @@ jobs:
 
       - name: Build with Gradle
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew build -x createJavadoc -x test --max-workers=2 --scan --no-daemon
@@ -72,7 +71,6 @@ jobs:
 
       - name: Run integration test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew :jballerina-integration-test:test --fail-fast -x createJavadoc --max-workers=1 --scan --no-daemon
@@ -108,7 +106,6 @@ jobs:
 
       - name: Run jballerina unit test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew :jballerina-unit-test:test :ballerina-http:test :ballerina-kafka:test :ballerina-mysql:test :testerina-integration-test:test --fail-fast -x createJavadoc --max-workers=1 --scan --no-daemon
@@ -144,7 +141,6 @@ jobs:
 
       - name: Run all the other unit test
         run: |
-          unset JAVA_TOOL_OPTIONS
           export DISPLAY=':99.0'
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           ./gradlew build -x createJavadoc -x :ballerina-http:test -x :ballerina-kafka:test -x :ballerina-mysql:test -x :jballerina-unit-test:test -x :jballerina-integration-test:test -x :testerina-integration-test:test --max-workers=1 --scan --no-daemon


### PR DESCRIPTION
## Purpose
Revert "Unset JAVA_TOOL_OPTIONS in GitHub action builds" since the original issue is being fixed by GitHub actions.
This reverts commit 60e12e3dfbfdde60074c8864df4a2d44bd06e141.

We had to previously explicitly unset this due to an issue with the GitHub action build. See https://github.com/ballerina-platform/ballerina-lang/issues/25353 for details.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/25353

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
