### PR TITLE
Fix ballerina test issue with interop functions using rest args

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodRequest.java
@@ -64,16 +64,15 @@ class JMethodRequest {
                 JInterop.buildParamTypeConstraints(methodValidationRequest.paramTypeConstraints, classLoader);
 
         BInvokableType bFuncType = methodValidationRequest.bFuncType;
-        List<BType> currentParamTypes = bFuncType.paramTypes;
         List<BType> paramTypes = new ArrayList<>();
         if (!isEntryModuleValidation) {
             int i = 0;
-            while (i < currentParamTypes.size()) {
-                paramTypes.add(currentParamTypes.get(i));
+            while (i < bFuncType.paramTypes.size()) {
+                paramTypes.add(bFuncType.paramTypes.get(i));
                 i = i + 2;
             }
         } else {
-            paramTypes = currentParamTypes;
+            paramTypes.addAll(bFuncType.paramTypes);
         }
 
         BType restType = bFuncType.restType;

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
@@ -47,6 +47,15 @@ public class BasicCasesTest extends BaseTestCase {
     }
 
     @Test(dependsOnMethods = "testAssertTrue")
+    public void testJavaInterops() throws BallerinaTestException {
+        String msg = "1 passing";
+        LogLeecher clientLeecher = new LogLeecher(msg);
+        balClient.runMain("test", new String[]{"interops"}, null, new String[]{}, new LogLeecher[]{clientLeecher},
+                          projectPath);
+        clientLeecher.waitForText(20000);
+    }
+
+    @Test(dependsOnMethods = "testAssertTrue")
     public void testAllExceptAssertTrue() throws BallerinaTestException {
         String msg1 = "15 passing";
         String msg2 = "1 passing";

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/interops/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/interops/main.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/java;
+
+public function formatFruits() returns string {
+   handle result = format( java:fromString("%s and %s"), java:fromString("mango"), java:fromString("banana"));
+   return <string>java:toString(result);
+}
+
+function format(handle a, handle... args) returns handle = @java:Method {
+    class: "java.lang.String"
+} external;

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/interops/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/interops/tests/main_test.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {
+}
+function testInteropWithRestArgs() {
+    string formattedString = formatFruits();
+    test:assertEquals(formattedString, "mango and banana");
+}


### PR DESCRIPTION
## Purpose
This was due to changing original ballerina function type when generating wrappers for interop functions with rest args.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/25301

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
