### PR TITLE
Fix Zero Match clauses not registering a diagnostic

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParser.java
@@ -11355,6 +11355,7 @@ public class BallerinaParser extends AbstractParser {
      */
     private STNode parseMatchClauses() {
         List<STNode> matchClauses = new ArrayList<>();
+        matchClauses.add(parseMatchClause());
         while (!isEndOfMatchClauses(peek().kind)) {
             STNode clause = parseMatchClause();
             matchClauses.add(clause);

--- a/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerinalang/compiler/internal/parser/BallerinaParserErrorHandler.java
@@ -554,9 +554,6 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
     private static final ParserRuleContext[] LIST_MATCH_PATTERN_MEMBER_RHS =
             { ParserRuleContext.COMMA, ParserRuleContext.CLOSE_BRACKET };
 
-    private static final ParserRuleContext[] FIELD_MATCH_PATTERNS_START =
-            { ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER, ParserRuleContext.CLOSE_BRACE };
-
     private static final ParserRuleContext[] FIELD_MATCH_PATTERN_MEMBER =
             { ParserRuleContext.VARIABLE_NAME, ParserRuleContext.REST_MATCH_PATTERN };
 
@@ -702,7 +699,6 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
             case LIST_MATCH_PATTERNS_START:
             case LIST_MATCH_PATTERN_MEMBER:
             case LIST_MATCH_PATTERN_MEMBER_RHS:
-            case FIELD_MATCH_PATTERNS_START:
             case FIELD_MATCH_PATTERN_MEMBER:
             case FIELD_MATCH_PATTERN_MEMBER_RHS:
             case FUNC_MATCH_PATTERN_OR_CONST_PATTERN:
@@ -1310,7 +1306,6 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
             case ARG_BINDING_PATTERN:
             case ARG_BINDING_PATTERN_END:
             case ARG_BINDING_PATTERN_START_IDENT:
-            case FIELD_MATCH_PATTERNS_START:
             case FIELD_MATCH_PATTERN_MEMBER:
             case FIELD_MATCH_PATTERN_MEMBER_RHS:
             case FUNC_MATCH_PATTERN_OR_CONST_PATTERN:
@@ -1706,9 +1701,6 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
                 break;
             case LIST_MATCH_PATTERN_MEMBER_RHS:
                 alternativeRules = LIST_MATCH_PATTERN_MEMBER_RHS;
-                break;
-            case FIELD_MATCH_PATTERNS_START:
-                alternativeRules = FIELD_MATCH_PATTERNS_START;
                 break;
             case FIELD_MATCH_PATTERN_MEMBER:
                 alternativeRules = FIELD_MATCH_PATTERN_MEMBER;
@@ -3187,7 +3179,7 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
             case MAPPING_BINDING_PATTERN:
                 return ParserRuleContext.MAPPING_BINDING_PATTERN_MEMBER;
             case MAPPING_MATCH_PATTERN:
-                return ParserRuleContext.FIELD_MATCH_PATTERNS_START;
+                return ParserRuleContext.FIELD_MATCH_PATTERN_MEMBER;
             default:
                 return ParserRuleContext.STATEMENT;
         }

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/MatchStatementTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/statements/MatchStatementTest.java
@@ -94,4 +94,9 @@ public class MatchStatementTest extends AbstractStatementTest {
     public void testMatchStmtRecoveryInvalidFunctionalMatchPatterns() {
         testFile("match-stmt/match_stmt_source_13.bal", "match-stmt/match_stmt_assert_13.json");
     }
+
+    @Test
+    public void testMatchStmtRecoveryZeroMatchCluases() {
+        testFile("match-stmt/match_stmt_source_14.bal", "match-stmt/match_stmt_assert_14.json");
+    }
 }

--- a/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_assert_11.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_assert_11.json
@@ -1929,23 +1929,16 @@
                                                           "hasDiagnostics": true,
                                                           "children": [
                                                             {
-                                                              "kind": "MAPPING_MATCH_PATTERN",
+                                                              "kind": "SIMPLE_NAME_REFERENCE",
                                                               "hasDiagnostics": true,
                                                               "children": [
                                                                 {
-                                                                  "kind": "OPEN_BRACE_TOKEN",
+                                                                  "kind": "IDENTIFIER_TOKEN",
                                                                   "isMissing": true,
                                                                   "hasDiagnostics": true,
                                                                   "diagnostics": [
-                                                                    "ERROR_MISSING_OPEN_BRACE_TOKEN"
+                                                                    "ERROR_MISSING_IDENTIFIER"
                                                                   ]
-                                                                },
-                                                                {
-                                                                  "kind": "LIST",
-                                                                  "children": []
-                                                                },
-                                                                {
-                                                                  "kind": "CLOSE_BRACE_TOKEN"
                                                                 }
                                                               ]
                                                             }
@@ -1955,9 +1948,21 @@
                                                           "kind": "CLOSE_BRACKET_TOKEN",
                                                           "hasDiagnostics": true,
                                                           "diagnostics": [
+                                                            "ERROR_INVALID_TOKEN",
                                                             "ERROR_INVALID_TOKEN"
                                                           ],
                                                           "leadingMinutiae": [
+                                                            {
+                                                              "kind": "INVALID_NODE_MINUTIAE",
+                                                              "invalidNode": {
+                                                                "kind": "INVALID_TOKEN_MINUTIAE_NODE",
+                                                                "children": [
+                                                                  {
+                                                                    "kind": "CLOSE_BRACE_TOKEN"
+                                                                  }
+                                                                ]
+                                                              }
+                                                            },
                                                             {
                                                               "kind": "INVALID_NODE_MINUTIAE",
                                                               "invalidNode": {

--- a/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_assert_14.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_assert_14.json
@@ -1,0 +1,222 @@
+{
+  "kind": "FUNCTION_DEFINITION",
+  "hasDiagnostics": true,
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "FUNCTION_KEYWORD",
+      "trailingMinutiae": [
+        {
+          "kind": "WHITESPACE_MINUTIAE",
+          "value": " "
+        }
+      ]
+    },
+    {
+      "kind": "IDENTIFIER_TOKEN",
+      "value": "func"
+    },
+    {
+      "kind": "FUNCTION_SIGNATURE",
+      "children": [
+        {
+          "kind": "OPEN_PAREN_TOKEN"
+        },
+        {
+          "kind": "LIST",
+          "children": [
+            {
+              "kind": "REQUIRED_PARAM",
+              "children": [
+                {
+                  "kind": "LIST",
+                  "children": []
+                },
+                {
+                  "kind": "ANY_TYPE_DESC",
+                  "children": [
+                    {
+                      "kind": "ANY_KEYWORD",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "IDENTIFIER_TOKEN",
+                  "value": "v"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_PAREN_TOKEN"
+        }
+      ]
+    },
+    {
+      "kind": "FUNCTION_BODY_BLOCK",
+      "hasDiagnostics": true,
+      "children": [
+        {
+          "kind": "OPEN_BRACE_TOKEN",
+          "trailingMinutiae": [
+            {
+              "kind": "END_OF_LINE_MINUTIAE",
+              "value": "\n"
+            }
+          ]
+        },
+        {
+          "kind": "LIST",
+          "hasDiagnostics": true,
+          "children": [
+            {
+              "kind": "MATCH_STATEMENT",
+              "hasDiagnostics": true,
+              "children": [
+                {
+                  "kind": "MATCH_KEYWORD",
+                  "leadingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": "    "
+                    }
+                  ],
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                },
+                {
+                  "kind": "SIMPLE_NAME_REFERENCE",
+                  "children": [
+                    {
+                      "kind": "IDENTIFIER_TOKEN",
+                      "value": "v",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "OPEN_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                },
+                {
+                  "kind": "LIST",
+                  "hasDiagnostics": true,
+                  "children": [
+                    {
+                      "kind": "MATCH_CLAUSE",
+                      "hasDiagnostics": true,
+                      "children": [
+                        {
+                          "kind": "LIST",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "SIMPLE_NAME_REFERENCE",
+                              "hasDiagnostics": true,
+                              "children": [
+                                {
+                                  "kind": "IDENTIFIER_TOKEN",
+                                  "isMissing": true,
+                                  "hasDiagnostics": true,
+                                  "diagnostics": [
+                                    "ERROR_MISSING_IDENTIFIER"
+                                  ]
+                                }
+                              ]
+                            }
+                          ]
+                        },
+                        {
+                          "kind": "RIGHT_DOUBLE_ARROW_TOKEN",
+                          "isMissing": true,
+                          "hasDiagnostics": true,
+                          "diagnostics": [
+                            "ERROR_MISSING_RIGHT_DOUBLE_ARROW_TOKEN"
+                          ]
+                        },
+                        {
+                          "kind": "BLOCK_STATEMENT",
+                          "hasDiagnostics": true,
+                          "children": [
+                            {
+                              "kind": "OPEN_BRACE_TOKEN",
+                              "isMissing": true,
+                              "hasDiagnostics": true,
+                              "diagnostics": [
+                                "ERROR_MISSING_OPEN_BRACE_TOKEN"
+                              ]
+                            },
+                            {
+                              "kind": "LIST",
+                              "children": []
+                            },
+                            {
+                              "kind": "CLOSE_BRACE_TOKEN",
+                              "leadingMinutiae": [
+                                {
+                                  "kind": "WHITESPACE_MINUTIAE",
+                                  "value": "    "
+                                }
+                              ],
+                              "trailingMinutiae": [
+                                {
+                                  "kind": "END_OF_LINE_MINUTIAE",
+                                  "value": "\n"
+                                }
+                              ]
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "kind": "CLOSE_BRACE_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "CLOSE_BRACE_TOKEN",
+          "isMissing": true,
+          "hasDiagnostics": true,
+          "diagnostics": [
+            "ERROR_MISSING_CLOSE_BRACE_TOKEN"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_source_14.bal
+++ b/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_source_14.bal
@@ -1,0 +1,8 @@
+function func(any v){
+    match v {
+    }
+}
+
+public function main() {
+    func(2);
+}


### PR DESCRIPTION
## Purpose
To make the parser give a diagnostic message when there are 0 match clauses in a match statement.

Fixes #25296

## Approach
Add a mandatory addition of match clause to the list of match clauses even before checking end of match clauses. Update error handler to reflect that at least one match clause should be present.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
