### PR TITLE
Add ImportUtils class to extract imported modules from SyntaxTree

### DIFF
--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/importresolver/Import.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/importresolver/Import.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.projects.importresolver;
+
+/**
+ * The {@code SyntaxTree} represents a model for import in a ballerina source.
+ *
+ * @since 2.0.0
+ */
+public class Import {
+
+    private String orgName;
+    private String moduleName;
+    private String version;
+
+    Import(String orgName, String moduleName, String version) {
+        this.orgName = orgName;
+        this.moduleName = moduleName;
+        this.version = version;
+    }
+
+    public String getOrgName() {
+        return orgName;
+    }
+
+    public void setOrgName(String orgName) {
+        this.orgName = orgName;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+}

--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/importresolver/ImportUtil.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/importresolver/ImportUtil.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.projects.importresolver;
+
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Module;
+import io.ballerinalang.compiler.syntax.tree.ImportDeclarationNode;
+import io.ballerinalang.compiler.syntax.tree.ImportOrgNameNode;
+import io.ballerinalang.compiler.syntax.tree.ModulePartNode;
+import io.ballerinalang.compiler.syntax.tree.NodeList;
+import io.ballerinalang.compiler.syntax.tree.SyntaxTree;
+import io.ballerinalang.compiler.syntax.tree.TreeModifier;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * The {@code SyntaxTree} util functions for import resolver.
+ *
+ * @since 2.0.0
+ */
+public class ImportUtil extends TreeModifier {
+
+    private List<Import> getImportsFromSyntaxTree(SyntaxTree syntaxTree) {
+        List<Import> imports = new ArrayList<>();
+        ModulePartNode modulePartNode = syntaxTree.rootNode();
+        NodeList<ImportDeclarationNode> importNodes = modifyNodeList(modulePartNode.imports());
+
+        for (ImportDeclarationNode importDeclarationNode : importNodes) {
+            String orgName = null;
+            Optional<ImportOrgNameNode> importOrgNameNode = importDeclarationNode.orgName();
+            if (importOrgNameNode.isPresent()) {
+                orgName = importOrgNameNode.get().orgName().text();
+            }
+            String moduleName = importDeclarationNode.moduleName().toString();
+            String version = importDeclarationNode.version().toString();
+            imports.add(new Import(orgName, moduleName, version));
+        }
+        return imports;
+    }
+
+    private List<Import> getImportsFromModule(Module module) {
+        List<Import> imports = new ArrayList<>();
+        Iterable<Document> documents = module.documents();
+
+        for (Document document : documents) {
+            imports.addAll(getImportsFromSyntaxTree(document.syntaxTree()));
+        }
+        return imports;
+    }
+}


### PR DESCRIPTION
## Purpose
> Add `ImportUtils` class to extract imported modules from SyntaxTree

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/25461

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
