### PR TITLE
Add Error Constructor and Error Type Definition Snippets

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetGenerator.java
@@ -1094,17 +1094,6 @@ public class SnippetGenerator {
                                 SnippetType.SNIPPET);
     }
 
-    /**
-     * Get Error Definition Snippet Block.
-     *
-     * @return {@link SnippetBlock}     Generated Snippet Block
-     */
-    public static SnippetBlock getErrorDefinitionSnippet() {
-        String snippet = "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");";
-        return new SnippetBlock(ItemResolverConstants.ERROR, snippet, ItemResolverConstants.SNIPPET_TYPE,
-                                SnippetType.SNIPPET);
-    }
-
     // Iterable Operations Snippets
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/SnippetGenerator.java
@@ -402,16 +402,6 @@ public class SnippetGenerator {
     }
 
     /**
-     * Get Lengthof Keyword Snippet Block.
-     *
-     * @return {@link SnippetBlock}     Generated Snippet Block
-     */
-    public static SnippetBlock getLengthofKeywordSnippet() {
-        return new SnippetBlock(ItemResolverConstants.LENGTHOF, "lengthof ", ItemResolverConstants.KEYWORD_TYPE,
-                                SnippetType.KEYWORD);
-    }
-
-    /**
      * Get Lock Statement Snippet Block.
      *
      * @return {@link SnippetBlock}     Generated Snippet Block
@@ -563,6 +553,18 @@ public class SnippetGenerator {
                 + CommonUtil.LINE_SEPARATOR + "};";
 
         return new SnippetBlock(ItemResolverConstants.RECORD_TYPE, snippet, ItemResolverConstants.SNIPPET_TYPE,
+                                SnippetType.SNIPPET);
+    }
+
+    /**
+     * Get Error Type Definition Snippet Block.
+     *
+     * @return {@link SnippetBlock}     Generated Snippet Block
+     */
+    public static SnippetBlock getErrorTypeDefinitionSnippet() {
+        String snippet = "type ${1:ErrorName} error<${2:map<anydata>}>;";
+
+        return new SnippetBlock(ItemResolverConstants.ERROR_TYPE, snippet, ItemResolverConstants.SNIPPET_TYPE,
                                 SnippetType.SNIPPET);
     }
 
@@ -952,6 +954,17 @@ public class SnippetGenerator {
                 CommonUtil.LINE_SEPARATOR + "}";
         return new SnippetBlock(ItemResolverConstants.SERVICE_GRPC, snippet, ItemResolverConstants.SNIPPET_TYPE,
                                 SnippetType.SNIPPET, grpcImport);
+    }
+
+    /**
+     * Get Error Constructor expression Snippet Block.
+     *
+     * @return {@link SnippetBlock}     Generated Snippet Block
+     */
+    public static SnippetBlock getErrorConstructorSnippet() {
+        String snippet = "error(\"${1}\")";
+        return new SnippetBlock("error constructor", snippet, ItemResolverConstants.SNIPPET_TYPE,
+                SnippetType.SNIPPET);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -279,7 +279,6 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Comp
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_ENUM.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_XMLNS.get()));
 
-        completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_ERROR.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_FUNCTION.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_MAIN_FUNCTION.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_SERVICE.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -291,6 +291,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Comp
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_OBJECT_SNIPPET.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_RECORD.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_CLOSED_RECORD.get()));
+        completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_ERROR_TYPE_DESC.get()));
         return completionItems;
     }
 
@@ -591,6 +592,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Comp
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_TYPEOF.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_TRAP.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_ERROR.get()));
+        completionItems.add(new SnippetCompletionItem(context, Snippet.EXPR_ERROR_CONSTRUCTOR.get()));
 
         List<Scope.ScopeEntry> filteredList = visibleSymbols.stream()
                 .filter(scopeEntry -> scopeEntry.symbol instanceof BVarSymbol

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -117,8 +117,6 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FLUSH.get()));
         // Add the function keyword
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FUNCTION.get()));
-        // Add the error type CompletionItem
-        completionItems.add(CommonUtil.getErrorTypeCompletionItem(context));
         // Add the checkpanic keyword
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_CHECK_PANIC.get()));
         // Add the check keyword

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -117,8 +117,6 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FLUSH.get()));
         // Add the function keyword
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_FUNCTION.get()));
-        // Add the error snippet
-        completionItems.add(new SnippetCompletionItem(context, Snippet.DEF_ERROR.get()));
         // Add the error type CompletionItem
         completionItems.add(CommonUtil.getErrorTypeCompletionItem(context));
         // Add the checkpanic keyword

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeDefinitionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeDefinitionNodeContext.java
@@ -15,8 +15,8 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
+import io.ballerina.tools.text.TextRange;
 import io.ballerinalang.compiler.syntax.tree.TypeDefinitionNode;
-import io.ballerinalang.compiler.text.TextRange;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.LSContext;
 import org.ballerinalang.langserver.commons.completion.CompletionKeys;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeDefinitionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/TypeDefinitionNodeContext.java
@@ -50,6 +50,7 @@ public class TypeDefinitionNodeContext extends AbstractCompletionProvider<TypeDe
         // Add the type names
         List<LSCompletionItem> typeItems = this.getTypeItems(context);
         // Add the special snippets
+        typeItems.add(new SnippetCompletionItem(context, Snippet.DEF_ERROR_TYPE_DESC.get()));
         typeItems.add(new SnippetCompletionItem(context, Snippet.DEF_RECORD_TYPE_DESC.get()));
         typeItems.add(new SnippetCompletionItem(context, Snippet.DEF_CLOSED_RECORD_TYPE_DESC.get()));
         typeItems.add(new SnippetCompletionItem(context, Snippet.DEF_OBJECT_TYPE_DESC_SNIPPET.get()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ItemResolverConstants.java
@@ -95,6 +95,7 @@ public class ItemResolverConstants {
     public static final String BOOLEAN_TYPE = "boolean";
     public static final String OBJECT_TYPE = "type <ObjectName> object";
     public static final String RECORD_TYPE = "type <RecordName> record";
+    public static final String ERROR_TYPE = "type <ErrorName> error<?>";
     public static final String CLOSED_RECORD_TYPE = "type <RecordName> closed record";
     public static final String TYPE_TYPE = "type";
     public static final String REMOTE_FUNCTION_TYPE = "remote function";

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -100,8 +100,6 @@ public enum Snippet {
 
     DEF_WORKER(SnippetGenerator.getWorkerDeclarationSnippet()),
 
-    DEF_ERROR(SnippetGenerator.getErrorDefinitionSnippet()),
-
     DEF_REMOTE_FUNCTION(SnippetGenerator.getRemoteFunctionSnippet()),
 
     DEF_INIT_FUNCTION(SnippetGenerator.getInitFunctionSnippet()),

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/Snippet.java
@@ -46,6 +46,8 @@ public enum Snippet {
 
     DEF_CLOSED_RECORD_TYPE_DESC(SnippetGenerator.getClosedRecordTypeDescSnippet()),
 
+    DEF_ERROR_TYPE_DESC(SnippetGenerator.getErrorTypeDefinitionSnippet()),
+
     DEF_RESOURCE_HTTP(SnippetGenerator.getResourceDefinitionSnippet()),
 
     DEF_RESOURCE_COMMON(SnippetGenerator.getCommonResourceDefinitionSnippet()),
@@ -114,10 +116,13 @@ public enum Snippet {
 
     DEF_DETACH_FUNCTION(SnippetGenerator.getDetachFunctionSnippet()),
 
+    
     // Expressions Snippets
     EXPR_MATCH(SnippetGenerator.getMatchExpressionSnippet()),
-    
-    
+
+    EXPR_ERROR_CONSTRUCTOR(SnippetGenerator.getErrorConstructorSnippet()),
+
+
     // Keyword Snippets
     KW_ON(SnippetGenerator.getOnSnippet()),
 
@@ -289,7 +294,7 @@ public enum Snippet {
     BUILTIN_DETAIL(SnippetGenerator.getBuiltinDetailSnippet()),
 
     BUILTIN_REASON(SnippetGenerator.getBuiltinReasonSnippet()),
-    
+
     // Iterable operators' lambda function parameters
     ITR_ON_MAP_PARAMS(SnippetGenerator.getIterableOnMapParamSnippet()),
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionAfterIf2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeIfElse.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeIfElse.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeIfElse.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeIfElse.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeWhile.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeWhile.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeWhile.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionBeforeWhile.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElse.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElse.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElse.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElse.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElseIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElseIf.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElseIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinElseIf.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinIf.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinIf.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWhile.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWhile.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWhile.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/completionWithinWhile.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/emptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/emptyLineCompletion.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/emptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/emptyLineCompletion.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion4.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/forkJoinCompletion4.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/functionPointerAsParameter.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/functionPointerAsParameter.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/functionPointerAsParameter.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/functionPointerAsParameter.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion1.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "res",
       "kind": "Variable",
       "detail": "ObjectName",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion2.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "res",
       "kind": "Variable",
       "detail": "ObjectName",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/newObjectCompletion3.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "cl",
       "kind": "Variable",
       "detail": "http:RedirectClient",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/nonEmptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/nonEmptyLineCompletion.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/nonEmptyLineCompletion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/nonEmptyLineCompletion.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/suggestionsInWorkersWithinFunction.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/suggestionsInWorkersWithinFunction.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/suggestionsInWorkersWithinFunction.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/suggestionsInWorkersWithinFunction.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions5.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeGuardSuggestions5.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeguardDestruct1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeguardDestruct1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeguardDestruct1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeguardDestruct1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeofKWSuggestion.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeofKWSuggestion.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testVal",
       "kind": "Variable",
       "detail": "typedesc<string>",

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/typeofKWSuggestion2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/typeofKWSuggestion2.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testTypeOfKW()",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config1.json
@@ -1144,6 +1144,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "value2",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config2.json
@@ -1144,6 +1144,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "value2",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config3.json
@@ -1144,6 +1144,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "value2",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config1.json
@@ -1129,6 +1129,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "value2",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config2.json
@@ -1129,6 +1129,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "value2",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config1.json
@@ -1129,6 +1129,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "myList",
       "kind": "Variable",
       "detail": "int[]",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config2.json
@@ -1129,6 +1129,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "myList",
       "kind": "Variable",
       "detail": "int[]",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config1.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "obj1",
       "kind": "Variable",
       "detail": "TestObject1",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config2.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "obj2",
       "kind": "Variable",
       "detail": "TestObject2",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config3.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "obj2",
       "kind": "Variable",
       "detail": "TestObject2",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config4.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "obj1",
       "kind": "Variable",
       "detail": "TestObject1",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config5.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "obj1",
       "kind": "Variable",
       "detail": "module1:TestObject1",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/new_expr_ctx_config6.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "obj1",
       "kind": "Variable",
       "detail": "module1:TestObject1",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config1.json
@@ -1129,6 +1129,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testVar",
       "kind": "Variable",
       "detail": "other",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config2.json
@@ -1129,6 +1129,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testVar",
       "kind": "Variable",
       "detail": "other",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config1.json
@@ -234,6 +234,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "type <ErrorName> error<?>",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "type ${1:ErrorName} error<${2:map<anydata>}>;",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "float",
       "kind": "Unit",
       "detail": "Float",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config1.json
@@ -86,14 +86,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "function",
       "kind": "Snippet",
       "detail": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config2.json
@@ -234,6 +234,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "type <ErrorName> error<?>",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "type ${1:ErrorName} error<${2:map<anydata>}>;",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "float",
       "kind": "Unit",
       "detail": "Float",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config2.json
@@ -86,14 +86,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "function",
       "kind": "Snippet",
       "detail": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config3.json
@@ -234,6 +234,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "type <ErrorName> error<?>",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "type ${1:ErrorName} error<${2:map<anydata>}>;",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "float",
       "kind": "Unit",
       "detail": "Float",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_part_context/config/config3.json
@@ -86,14 +86,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "function",
       "kind": "Snippet",
       "detail": "Snippet",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config1.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "new(string url)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config2.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "new(string url)",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config3.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "test",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/module_var_context/config/config4.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "test",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config5.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
       "detail": "string",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config6.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
       "detail": "string",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config7.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
       "detail": "string",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config8.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
       "detail": "string",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config1.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "l1",
       "kind": "Variable",
       "detail": "module1:Listener",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config2.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "l1",
       "kind": "Variable",
       "detail": "module1:Listener",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config3.json
@@ -1177,6 +1177,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "l1",
       "kind": "Variable",
       "detail": "module1:Listener",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/checking_call_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/checking_call_stmt_ctx_config1.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "doSomeTask()",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/checking_call_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/checking_call_stmt_ctx_config2.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "doSomeTask()",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config5.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "numberList",
       "kind": "Variable",
       "detail": "int[]",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config6.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "numberList",
       "kind": "Variable",
       "detail": "int[]",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config7.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config7.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config8.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config8.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/lock_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/lock_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/lock_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/lock_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/match_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/match_stmt_ctx_config1.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "bar((string|int|boolean) i)((string|int|boolean))",
       "kind": "Function",
       "detail": "Function",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/wait_action_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/wait_action_ctx_config1.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testVar",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/wait_action_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/wait_action_ctx_config2.json
@@ -1192,6 +1192,14 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "error constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "testVar",
       "kind": "Variable",
       "detail": "int",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config1.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config1.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config2.json
@@ -63,14 +63,6 @@
     },
     {
       "label": "error",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "sortText": "240",
-      "insertText": "error ${1:name} = error(\"${2:errorCode}\", message = \"${3}\");",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "error",
       "kind": "Event",
       "detail": "error",
       "sortText": "200",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config2.json
@@ -62,14 +62,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "error",
-      "kind": "Event",
-      "detail": "error",
-      "sortText": "200",
-      "insertText": "error",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/type_def/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/type_def/config/config1.json
@@ -9,7 +9,7 @@
       "label": "float",
       "kind": "Unit",
       "detail": "Float",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "float",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "readonly",
       "kind": "Unit",
       "detail": "Readonly",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "readonly",
       "insertTextFormat": "Snippet"
     },
@@ -25,7 +25,7 @@
       "label": "xml",
       "kind": "Unit",
       "detail": "Xml",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
@@ -33,7 +33,7 @@
       "label": "byte",
       "kind": "Unit",
       "detail": "Byte",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "byte",
       "insertTextFormat": "Snippet"
     },
@@ -41,7 +41,7 @@
       "label": "handle",
       "kind": "Unit",
       "detail": "Handle",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "handle",
       "insertTextFormat": "Snippet"
     },
@@ -52,7 +52,7 @@
       "documentation": {
         "left": "Defaultable argument names. This is for internal use.\n"
       },
-      "sortText": "140",
+      "sortText": "180",
       "insertText": "ArgsData",
       "insertTextFormat": "Snippet"
     },
@@ -60,7 +60,7 @@
       "label": "never",
       "kind": "Unit",
       "detail": "Never",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "never",
       "insertTextFormat": "Snippet"
     },
@@ -68,7 +68,7 @@
       "label": "null",
       "kind": "Unit",
       "detail": "Nil",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "null",
       "insertTextFormat": "Snippet"
     },
@@ -76,7 +76,7 @@
       "label": "decimal",
       "kind": "Unit",
       "detail": "Decimal",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "decimal",
       "insertTextFormat": "Snippet"
     },
@@ -84,7 +84,7 @@
       "label": "TEST_TYPE",
       "kind": "Unit",
       "detail": "Other",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "TEST_TYPE",
       "insertTextFormat": "Snippet"
     },
@@ -92,7 +92,7 @@
       "label": "string",
       "kind": "Unit",
       "detail": "String",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "string",
       "insertTextFormat": "Snippet"
     },
@@ -100,7 +100,7 @@
       "label": "stream",
       "kind": "Unit",
       "detail": "Stream",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "stream",
       "insertTextFormat": "Snippet"
     },
@@ -108,7 +108,7 @@
       "label": "json",
       "kind": "Unit",
       "detail": "Json",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "json",
       "insertTextFormat": "Snippet"
     },
@@ -119,7 +119,7 @@
       "documentation": {
         "left": "Describes Strand execution details for the runtime.\n"
       },
-      "sortText": "140",
+      "sortText": "180",
       "insertText": "StrandData",
       "insertTextFormat": "Snippet"
     },
@@ -127,7 +127,7 @@
       "label": "map",
       "kind": "Unit",
       "detail": "Map",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "map",
       "insertTextFormat": "Snippet"
     },
@@ -135,7 +135,7 @@
       "label": "table",
       "kind": "Unit",
       "detail": "Table",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
@@ -143,7 +143,7 @@
       "label": "anydata",
       "kind": "Unit",
       "detail": "Anydata",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "anydata",
       "insertTextFormat": "Snippet"
     },
@@ -151,7 +151,7 @@
       "label": "any",
       "kind": "Unit",
       "detail": "Any",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "any",
       "insertTextFormat": "Snippet"
     },
@@ -159,7 +159,7 @@
       "label": "int",
       "kind": "Unit",
       "detail": "Int",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "int",
       "insertTextFormat": "Snippet"
     },
@@ -167,7 +167,7 @@
       "label": "Thread",
       "kind": "TypeParameter",
       "detail": "Finite",
-      "sortText": "140",
+      "sortText": "170",
       "insertText": "Thread",
       "insertTextFormat": "Snippet"
     },
@@ -175,7 +175,7 @@
       "label": "boolean",
       "kind": "Unit",
       "detail": "Boolean",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "boolean",
       "insertTextFormat": "Snippet"
     },
@@ -183,7 +183,7 @@
       "label": "future",
       "kind": "Unit",
       "detail": "Future",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "future",
       "insertTextFormat": "Snippet"
     },
@@ -191,7 +191,7 @@
       "label": "service",
       "kind": "Unit",
       "detail": "Service",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
@@ -199,7 +199,7 @@
       "label": "typedesc",
       "kind": "Unit",
       "detail": "Typedesc",
-      "sortText": "140",
+      "sortText": "230",
       "insertText": "typedesc",
       "insertTextFormat": "Snippet"
     },
@@ -207,15 +207,23 @@
       "label": "error",
       "kind": "Event",
       "detail": "error",
-      "sortText": "150",
+      "sortText": "200",
       "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "type <ErrorName> error<?>",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "sortText": "240",
+      "insertText": "type ${1:ErrorName} error<${2:map<anydata>}>;",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "type <RecordName> record",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "110",
+      "sortText": "240",
       "insertText": "record {\n\t${1}\n};",
       "insertTextFormat": "Snippet"
     },
@@ -223,7 +231,7 @@
       "label": "type <RecordName> closed record",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "110",
+      "sortText": "240",
       "insertText": "record {|\n\t${1}\n|};",
       "insertTextFormat": "Snippet"
     },
@@ -231,7 +239,7 @@
       "label": "type <ObjectName> object",
       "kind": "Snippet",
       "detail": "Snippet",
-      "sortText": "110",
+      "sortText": "240",
       "insertText": "object {\n\t${1}\n};",
       "insertTextFormat": "Snippet"
     }


### PR DESCRIPTION
## Purpose
> With this
- Add the error constructor and type definition snippets
- Remove deprecated error snippets
- Fix compilation failure

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
