### PR TITLE
Fix Testerina AfterGroups not running on disabling tests

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -247,8 +247,8 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                             continue;
                         }
 
-                        // check if groups attribute is present in the annotation
-                        if (GROUP_ANNOTATION_NAME.equals(name)) {
+                        // check if groups attribute is present in the annotation and it is not disabled
+                        if (GROUP_ANNOTATION_NAME.equals(name) && !shouldSkip.get()) {
                             if (valueExpr instanceof BLangListConstructorExpr) {
                                 BLangListConstructorExpr values = (BLangListConstructorExpr) valueExpr;
                                 test.setGroups(values.exprs.stream().map(node -> node.toString())

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -516,7 +516,6 @@ public class BTestRunner {
                     String errorMsg;
                     for (String afterGroupFunc : suite.getGroups().get(groupName).getAfterGroupsFunctions()) {
                         try {
-
                             invokeTestFunction(suite, afterGroupFunc, classLoader, scheduler);
                         } catch (Throwable e) {
                             shouldSkip.set(true);


### PR DESCRIPTION
## Purpose
After groups doesnt run if one of the tests in the groups are disabled. 

In the TestAnnotation processor, disabled tests are added to the groups.

When it comes to executing the `AfterGroups` function, the implementation checks if all the tests in the group have been executed. However, this condition is never met since the disabled tests in the group are never executed. 

Fixes #25526

## Approach
Dont add tests with the disabled flag to the groups

## Sample
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
