### PR TITLE
Add debugger expression evaluation support for bitwise operators

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BinaryExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BinaryExpressionEvaluator.java
@@ -246,32 +246,44 @@ public class BinaryExpressionEvaluator extends Evaluator {
         }
     }
 
+    /**
+     * Performs bitwise AND operation on the given ballerina variable values and returns the result.
+     */
     private BExpressionValue bitwiseAND(BVariable lVar, BVariable rVar) throws EvaluationException {
         if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
             // int + int
             long result = Long.parseLong(lVar.computeValue()) & Long.parseLong(rVar.computeValue());
             return EvaluationUtils.make(context, result);
         } else {
+            // Todo - Add support for signed and unsigned integers
             throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.BITWISE_AND_TOKEN);
         }
     }
 
+    /**
+     * Performs bitwise OR operation on the given ballerina variable values and returns the result.
+     */
     private BExpressionValue bitwiseOR(BVariable lVar, BVariable rVar) throws EvaluationException {
         if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
             // int + int
             long result = Long.parseLong(lVar.computeValue()) | Long.parseLong(rVar.computeValue());
             return EvaluationUtils.make(context, result);
         } else {
+            // Todo - Add support for signed and unsigned integers
             throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.PIPE_TOKEN);
         }
     }
 
+    /**
+     * Performs bitwise XOR operation on the given ballerina variable values and returns the result.
+     */
     private BExpressionValue bitwiseXOR(BVariable lVar, BVariable rVar) throws EvaluationException {
         if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
             // int + int
             long result = Long.parseLong(lVar.computeValue()) ^ Long.parseLong(rVar.computeValue());
             return EvaluationUtils.make(context, result);
         } else {
+            // Todo - Add support for signed and unsigned integers
             throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.BITWISE_XOR_TOKEN);
         }
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BinaryExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BinaryExpressionEvaluator.java
@@ -87,6 +87,12 @@ public class BinaryExpressionEvaluator extends Evaluator {
                 return div(lVar, rVar);
             case PERCENT_TOKEN:
                 return mod(lVar, rVar);
+            case BITWISE_AND_TOKEN:
+                return bitwiseAND(lVar, rVar);
+            case PIPE_TOKEN:
+                return bitwiseOR(lVar, rVar);
+            case BITWISE_XOR_TOKEN:
+                return bitwiseXOR(lVar, rVar);
             default:
                 throw createUnsupportedOperationException(lVar, rVar, operatorType);
         }
@@ -237,6 +243,36 @@ public class BinaryExpressionEvaluator extends Evaluator {
             throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.PERCENT_TOKEN);
         } else {
             throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.PERCENT_TOKEN);
+        }
+    }
+
+    private BExpressionValue bitwiseAND(BVariable lVar, BVariable rVar) throws EvaluationException {
+        if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
+            // int + int
+            long result = Long.parseLong(lVar.computeValue()) & Long.parseLong(rVar.computeValue());
+            return EvaluationUtils.make(context, result);
+        } else {
+            throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.BITWISE_AND_TOKEN);
+        }
+    }
+
+    private BExpressionValue bitwiseOR(BVariable lVar, BVariable rVar) throws EvaluationException {
+        if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
+            // int + int
+            long result = Long.parseLong(lVar.computeValue()) | Long.parseLong(rVar.computeValue());
+            return EvaluationUtils.make(context, result);
+        } else {
+            throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.PIPE_TOKEN);
+        }
+    }
+
+    private BExpressionValue bitwiseXOR(BVariable lVar, BVariable rVar) throws EvaluationException {
+        if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
+            // int + int
+            long result = Long.parseLong(lVar.computeValue()) ^ Long.parseLong(rVar.computeValue());
+            return EvaluationUtils.make(context, result);
+        } else {
+            throw createUnsupportedOperationException(lVar, rVar, SyntaxKind.BITWISE_XOR_TOKEN);
         }
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BinaryExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BinaryExpressionEvaluator.java
@@ -252,6 +252,7 @@ public class BinaryExpressionEvaluator extends Evaluator {
     private BExpressionValue bitwiseAND(BVariable lVar, BVariable rVar) throws EvaluationException {
         if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
             // int + int
+            // Todo - filter unsigned integers and signed integers with 8, 16 and 32 bits
             long result = Long.parseLong(lVar.computeValue()) & Long.parseLong(rVar.computeValue());
             return EvaluationUtils.make(context, result);
         } else {
@@ -266,6 +267,7 @@ public class BinaryExpressionEvaluator extends Evaluator {
     private BExpressionValue bitwiseOR(BVariable lVar, BVariable rVar) throws EvaluationException {
         if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
             // int + int
+            // Todo - filter unsigned integers and signed integers with 8, 16 and 32 bits
             long result = Long.parseLong(lVar.computeValue()) | Long.parseLong(rVar.computeValue());
             return EvaluationUtils.make(context, result);
         } else {
@@ -280,6 +282,7 @@ public class BinaryExpressionEvaluator extends Evaluator {
     private BExpressionValue bitwiseXOR(BVariable lVar, BVariable rVar) throws EvaluationException {
         if (lVar.getBType() == BVariableType.INT && rVar.getBType() == BVariableType.INT) {
             // int + int
+            // Todo - filter unsigned integers and signed integers with 8, 16 and 32 bits
             long result = Long.parseLong(lVar.computeValue()) ^ Long.parseLong(rVar.computeValue());
             return EvaluationUtils.make(context, result);
         } else {


### PR DESCRIPTION
## Purpose
This PR will add debugger expression evaluation support for the below bitwise operators. 

- [x]  AND - x & y
- [x]  OR   - x | y
- [x]  XOR - x ^ y

Related issue: https://github.com/ballerina-platform/ballerina-lang/issues/25369