### PR TITLE
Fix failing language server test cases with new class syntax

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/LSNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/LSNodeVisitor.java
@@ -1,25 +1,26 @@
 /*
-*  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*  WSO2 Inc. licenses this file to you under the Apache License,
-*  Version 2.0 (the "License"); you may not use this file except
-*  in compliance with the License.
-*  You may obtain a copy of the License at
-*
-*    http://www.apache.org/licenses/LICENSE-2.0
-*
-*  Unless required by applicable law or agreed to in writing,
-*  software distributed under the License is distributed on an
-*  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*  KIND, either express or implied.  See the License for the
-*  specific language governing permissions and limitations
-*  under the License.
-*/
+ *  Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
 package org.ballerinalang.langserver.common;
 
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotation;
 import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
+import org.wso2.ballerinalang.compiler.tree.BLangClassDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangErrorVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangExprFunctionBody;
@@ -66,6 +67,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangElvisExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangFailExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess.BLangStructFunctionVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
@@ -98,6 +100,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchExpression.BLangMatchExprPatternClause;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangObjectConstructorExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRawTemplateLiteral;
@@ -1127,5 +1130,17 @@ public class LSNodeVisitor extends BLangNodeVisitor {
     @Override
     public void visit(BLangTableTypeNode tableType) {
         // no implementation
+    }
+
+    @Override
+    public void visit(BLangFailExpr failExpr) {
+    }
+
+    @Override
+    public void visit(BLangObjectConstructorExpression bLangObjectConstructorExpression) {
+    }
+
+    @Override
+    public void visit(BLangClassDefinition classDefinition) {
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source1.bal
@@ -3,7 +3,7 @@ import ballerina/lang.'object as lang;
 
 public listener 
 
-public type Listener object {
+public class Listener {
 
     *lang:Listener;
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source2.bal
@@ -3,7 +3,7 @@ import ballerina/lang.'object as lang;
 
 public listener m
 
-public type Listener object {
+public class Listener {
 
     *lang:Listener;
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source3.bal
@@ -3,7 +3,7 @@ import ballerina/lang.'object as lang;
 
 public listener module1:
 
-public type Listener object {
+public class Listener {
 
     *lang:Listener;
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source4.bal
@@ -3,7 +3,7 @@ import ballerina/lang.'object as lang;
 
 public listener mod:Listener test = 
 
-public type Listener object {
+public class Listener {
 
     *lang:Listener;
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/listener_decl/source/source5.bal
@@ -3,7 +3,7 @@ import ballerina/lang.'object as lang;
 
 public listener mod:Listener test = n
 
-public type Listener object {
+public class Listener {
 
     *lang:Listener;
 


### PR DESCRIPTION
## Purpose
> With this, we fix the failing language server test due to the latest class syntax change.

## Approach
> Service scope resolver revamped to use the new class definition context for position resolving, instead of the earlier object based implementation.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
