### PR TITLE
Save global var dependencies in BIRFunction

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -141,6 +141,8 @@ public class BIRPackageSymbolEnter {
     private static final CompilerContext.Key<BIRPackageSymbolEnter> COMPILED_PACKAGE_SYMBOL_ENTER_KEY =
             new CompilerContext.Key<>();
 
+    private Map<String, BVarSymbol> globalVarMap = new HashMap<>();
+
     public static BIRPackageSymbolEnter getInstance(CompilerContext context) {
         BIRPackageSymbolEnter packageReader = context.get(COMPILED_PACKAGE_SYMBOL_ENTER_KEY);
         if (packageReader == null) {
@@ -404,9 +406,21 @@ public class BIRPackageSymbolEnter {
 
         defineMarkDownDocAttachment(invokableSymbol, readDocBytes(dataInStream));
 
+        defineGlobalVarDependencies(invokableSymbol, dataInStream);
+
         dataInStream.skip(dataInStream.readLong()); // read and skip method body
 
         scopeToDefine.define(invokableSymbol.name, invokableSymbol);
+    }
+
+    private void defineGlobalVarDependencies(BInvokableSymbol invokableSymbol, DataInputStream dataInStream)
+            throws IOException {
+
+        long length = dataInStream.readLong();
+        for (int i = 0; i < length; i++) {
+            String globalVarName = getStringCPEntryValue(dataInStream.readInt());
+            invokableSymbol.dependentGlobalVars.add(this.globalVarMap.get(globalVarName));
+        }
     }
 
     private void defineTypeDef(DataInputStream dataInStream) throws IOException {
@@ -676,6 +690,8 @@ public class BIRPackageSymbolEnter {
                 varSymbol.tag = SymTag.ENDPOINT;
             }
         }
+
+        this.globalVarMap.put(varName, varSymbol);
 
         defineMarkDownDocAttachment(varSymbol, docBytes);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -416,7 +416,7 @@ public class BIRPackageSymbolEnter {
     private void defineGlobalVarDependencies(BInvokableSymbol invokableSymbol, DataInputStream dataInStream)
             throws IOException {
 
-        long length = dataInStream.readLong();
+        long length = dataInStream.readInt();
         for (int i = 0; i < length; i++) {
             String globalVarName = getStringCPEntryValue(dataInStream.readInt());
             invokableSymbol.dependentGlobalVars.add(this.globalVarMap.get(globalVarName));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -581,6 +581,8 @@ public class BIRGen extends BLangNodeVisitor {
         birFunc.basicBlocks.forEach(bb -> bb.id = this.env.nextBBId(names));
         // Rearrange error entries.
         birFunc.errorTable.sort(Comparator.comparingInt(o -> Integer.parseInt(o.trapBB.id.value.replace("bb", ""))));
+        birFunc.dependentGlobalVars = astFunc.symbol.dependentGlobalVars.stream()
+                .map(varSymbol -> this.globalVarMap.get(varSymbol)).collect(Collectors.toSet());
         this.env.clear();
     }
 
@@ -2160,7 +2162,7 @@ public class BIRGen extends BLangNodeVisitor {
 
     private void populateBirLockWithGlobalVars(BLangLockStmt lockStmt) {
         for (BVarSymbol globalVar : lockStmt.lockVariables) {
-            BIRGlobalVariableDcl birGlobalVar = globalVarMap.get(globalVar);
+            BIRGlobalVariableDcl birGlobalVar = this.globalVarMap.get(globalVar);
 
             // If null query the dummy map for dummy variables.
             if (birGlobalVar == null) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -28,11 +28,11 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 /**
  * Root class of Ballerina intermediate representation-BIR.
@@ -333,7 +333,7 @@ public abstract class BIRNode {
 
         public List<BIRAnnotationAttachment> annotAttachments;
 
-        public Set<BIRGlobalVariableDcl> dependentGlobalVars = new HashSet<>();
+        public Set<BIRGlobalVariableDcl> dependentGlobalVars = new TreeSet<>();
 
         public BIRFunction(DiagnosticPos pos, Name name, int flags, BInvokableType type, Name workerName,
                            int sendInsCount, TaintTable taintTable, SymbolOrigin origin) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -28,6 +28,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -331,6 +332,8 @@ public abstract class BIRNode {
         public TaintTable taintTable;
 
         public List<BIRAnnotationAttachment> annotAttachments;
+
+        public Set<BIRGlobalVariableDcl> dependentGlobalVars = new HashSet<>();
 
         public BIRFunction(DiagnosticPos pos, Name name, int flags, BInvokableType type, Name workerName,
                            int sendInsCount, TaintTable taintTable, SymbolOrigin origin) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/optimizer/BIRLockOptimizer.java
@@ -54,21 +54,21 @@ public class BIRLockOptimizer extends BIRVisitor {
         propagateLocks();
     }
 
-    private void propagateLocks() {
-        for (Map.Entry<Integer, List<BIRTerminator.Lock>> entry : setToLockMap.entrySet()) {
-            Integer lockId = entry.getKey();
-            for (BIRTerminator.Lock lock : entry.getValue()) {
-                lock.lockId = lockId;
-            }
-        }
-    }
-
     private void analyzeLocks() {
         for (int lockListIndex = 0; lockListIndex < lockList.size(); lockListIndex++) {
             if (!lockToSetMap.containsKey(lockList.get(lockListIndex))) {
                 analyzeUnvisitedLock(lockListIndex);
             } else {
                 analyzeVisitedLock(lockListIndex);
+            }
+        }
+    }
+
+    private void propagateLocks() {
+        for (Map.Entry<Integer, List<BIRTerminator.Lock>> entry : setToLockMap.entrySet()) {
+            Integer lockId = entry.getKey();
+            for (BIRTerminator.Lock lock : entry.getValue()) {
+                lock.lockId = lockId;
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -45,7 +45,6 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -306,14 +305,11 @@ public class BIRBinaryWriter {
     }
 
     private void writeFunctionsGlobalVarDependency(ByteBuf buf, BIRNode.BIRFunction birFunction) {
-        List<Integer> globalVarBuf = new LinkedList<>();
+        buf.writeInt(birFunction.dependentGlobalVars.size());
 
         for (BIRNode.BIRVariableDcl var : birFunction.dependentGlobalVars) {
-            globalVarBuf.add(addStringCPEntry(var.name.value));
+            buf.writeInt(addStringCPEntry(var.name.value));
         }
-
-        buf.writeInt(globalVarBuf.size());
-        globalVarBuf.forEach(buf::writeInt);
     }
 
     private void writeTaintTable(ByteBuf buf, TaintTable taintTable) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -315,7 +315,7 @@ public class BIRBinaryWriter {
             globalVarBuf.add(addStringCPEntry(var.name.value));
         }
 
-        buf.writeLong(globalVarBuf.size());
+        buf.writeInt(globalVarBuf.size());
         globalVarBuf.forEach(buf::writeInt);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -309,9 +309,6 @@ public class BIRBinaryWriter {
         List<Integer> globalVarBuf = new LinkedList<>();
 
         for (BIRNode.BIRVariableDcl var : birFunction.dependentGlobalVars) {
-            if (var == null) {
-                continue;
-            }
             globalVarBuf.add(addStringCPEntry(var.name.value));
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ASTBuilderUtil.java
@@ -804,6 +804,7 @@ public class ASTBuilderUtil {
         BInvokableType prevFuncType = (BInvokableType) invokableSymbol.type;
         dupFuncSymbol.type = new BInvokableType(new ArrayList<>(prevFuncType.paramTypes),
                                                 prevFuncType.restType, prevFuncType.retType, prevFuncType.tsymbol);
+        dupFuncSymbol.dependentGlobalVars = invokableSymbol.dependentGlobalVars;
         return dupFuncSymbol;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -1741,7 +1741,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
 
         // So global variable assignments happen in functions.
         if (varRef.getKind() == NodeKind.SIMPLE_VARIABLE_REF) {
-            BSymbol owner = this.env.scope.owner;
+            BSymbol owner = this.currDependentSymbol.peek();
             addFunctionToGlobalVarDependency(owner, ((BLangSimpleVarRef) varRef).symbol);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -192,9 +192,7 @@ public class GlobalVariableRefAnalyzer {
             return false;
         }
 
-        return ((symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE) ||
-                ((symbol.tag & SymTag.CONSTANT) == SymTag.CONSTANT);
-
+        return ((symbol.tag & SymTag.VARIABLE) == SymTag.VARIABLE);
     }
 
     /**

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -630,6 +630,12 @@ types:
         type: taint_table
       - id: doc
         type: markdown
+      - id: dependent_global_var_length
+        type: s4
+      - id: dependent_global_var_cp_entry
+        type: s4
+        repeat: expr
+        repeat-expr: dependent_global_var_length
       - id: function_body_length
         type: s8
       - id: function_body

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -144,9 +144,27 @@ class BIRTestUtils {
             Assert.assertEquals(actualFunctionBody.argsCount(), expectedFunction.argsCount);
             Assert.assertEquals(actualFunctionBody.defaultParameterCount(), expectedFunction.parameters.size());
 
+            // assert dependent global variables
+            assertDepGlobalVar(actualFunction, expectedFunction.dependentGlobalVars.toArray(), constantPoolEntries);
+
             // assert basic blocks
             assertBasicBlocks(actualFunctionBody.functionBasicBlocksInfo(), expectedFunction.basicBlocks,
                     constantPoolEntries);
+        }
+    }
+
+    private static void assertDepGlobalVar(Bir.Function actualFunction,
+            Object[] dependentGlobalVars,
+            ArrayList<Bir.ConstantPoolEntry> constantPoolEntries) {
+
+        ArrayList<Integer> dependentGlobalVarsCPEntries = actualFunction.dependentGlobalVarCpEntry();
+        Assert.assertEquals(dependentGlobalVarsCPEntries.size(), dependentGlobalVars.length);
+
+
+        for (int i = 0; i < dependentGlobalVarsCPEntries.size(); i++) {
+            Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(dependentGlobalVarsCPEntries.get(i));
+            String expectedName = ((BIRNode.BIRGlobalVariableDcl) dependentGlobalVars[i]).name.value;
+            assertConstantPoolEntry(constantPoolEntry, expectedName);
         }
     }
 

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -153,13 +153,11 @@ class BIRTestUtils {
         }
     }
 
-    private static void assertDepGlobalVar(Bir.Function actualFunction,
-            Object[] dependentGlobalVars,
+    private static void assertDepGlobalVar(Bir.Function actualFunction, Object[] dependentGlobalVars,
             ArrayList<Bir.ConstantPoolEntry> constantPoolEntries) {
 
         ArrayList<Integer> dependentGlobalVarsCPEntries = actualFunction.dependentGlobalVarCpEntry();
         Assert.assertEquals(dependentGlobalVarsCPEntries.size(), dependentGlobalVars.length);
-
 
         for (int i = 0; i < dependentGlobalVarsCPEntries.size(); i++) {
             Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(dependentGlobalVarsCPEntries.get(i));

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -153,15 +153,15 @@ class BIRTestUtils {
         }
     }
 
-    private static void assertDepGlobalVar(Bir.Function actualFunction, Object[] dependentGlobalVars,
+    private static void assertDepGlobalVar(Bir.Function actualFunction, Object[] expectedGlobalVars,
             ArrayList<Bir.ConstantPoolEntry> constantPoolEntries) {
 
-        ArrayList<Integer> dependentGlobalVarsCPEntries = actualFunction.dependentGlobalVarCpEntry();
-        Assert.assertEquals(dependentGlobalVarsCPEntries.size(), dependentGlobalVars.length);
+        ArrayList<Integer> actualGlobalVarCpEntries = actualFunction.dependentGlobalVarCpEntry();
+        Assert.assertEquals(actualGlobalVarCpEntries.size(), expectedGlobalVars.length);
 
-        for (int i = 0; i < dependentGlobalVarsCPEntries.size(); i++) {
-            Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(dependentGlobalVarsCPEntries.get(i));
-            String expectedName = ((BIRNode.BIRGlobalVariableDcl) dependentGlobalVars[i]).name.value;
+        for (int i = 0; i < actualGlobalVarCpEntries.size(); i++) {
+            Bir.ConstantPoolEntry constantPoolEntry = constantPoolEntries.get(actualGlobalVarCpEntries.get(i));
+            String expectedName = ((BIRNode.BIRGlobalVariableDcl) expectedGlobalVars[i]).name.value;
             assertConstantPoolEntry(constantPoolEntry, expectedName);
         }
     }


### PR DESCRIPTION
## Purpose
> $title
Global vars accessed inside functions are saved in the invokable symbol to be used in the Lock optimisation. Even though the dependencies are present in the symbol, BIR does not have it. Hence in case we are reading a module from a BIR, we loose this info leading to incorrect optimisation of locks.

This PR fixes that issue.

Fixes #24973

## Check List 
- [ x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
