### PR TITLE
Add Testerina code-coverage error message when source not present

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -29,6 +29,7 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.jacoco.core.tools.ExecFileLoader;
 
 import java.io.IOException;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
@@ -75,7 +76,12 @@ public class CoverageReport {
      * @throws IOException when file operations are failed
      */
     public void generateReport() throws IOException {
-        CodeCoverageUtils.unzipCompiledSource(sourceJarPath, projectDir, orgName, moduleName, version);
+        try {
+            CodeCoverageUtils.unzipCompiledSource(sourceJarPath, projectDir, orgName, moduleName, version);
+        } catch (NoSuchFileException e) {
+            return;
+        }
+
         execFileLoader.load(executionDataFile.toFile());
 
         final IBundleCoverage bundleCoverage = analyzeStructure();

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -22,7 +22,9 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.PrintStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
@@ -40,6 +42,8 @@ import java.util.zip.ZipInputStream;
  */
 public class CodeCoverageUtils {
 
+    private static final PrintStream errStream = System.err;
+
     /**
      * Util method to extract required class files for code coverage analysis.
      *
@@ -48,9 +52,10 @@ public class CodeCoverageUtils {
      * @param orgName org name of the project being executed
      * @param moduleName name of the module being executed
      * @param version version of the module being executed
+     * @throws NoSuchFileException if source file doesnt exist
      */
     public static void unzipCompiledSource(Path source, Path destination, String orgName, String moduleName,
-                                           String version) {
+                                           String version) throws NoSuchFileException {
         String destJarDir = destination.resolve(source.getFileName()).toString();
 
         try (JarFile jarFile = new JarFile(source.toFile())) {
@@ -70,8 +75,13 @@ public class CodeCoverageUtils {
                 }
 
             }
+
             copyClassFilesToBinPath(destination, destJarDir, orgName, moduleName, version);
             deleteDirectory(new File(destJarDir));
+        } catch (NoSuchFileException e) {
+            String msg = "Source file for " + moduleName + " doesnt exist. Cannot generate Code coverage";
+            errStream.println(msg);
+            throw new NoSuchFileException(msg);
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -79,7 +79,8 @@ public class CodeCoverageUtils {
             copyClassFilesToBinPath(destination, destJarDir, orgName, moduleName, version);
             deleteDirectory(new File(destJarDir));
         } catch (NoSuchFileException e) {
-            String msg = "Source file for " + moduleName + " doesnt exist. Cannot generate Code coverage";
+            String msg = "Unable to generate code coverage for the module " + moduleName + ". Source file does not " +
+                    "exist";
             errStream.println(msg);
             throw new NoSuchFileException(msg);
         } catch (IOException e) {


### PR DESCRIPTION
## Purpose
Change the error message to highlight when the source file is not present in the module when passing the --code-coverage flag

Fixes #25399

## Approach
Error message generated now look like this

```
 mohamedaquibzulfikar/Module2:0.1.0

        [pass] testSubtract
        [pass] testAdd

        2 passing
        0 failing
        0 skipped

Source file for Module2 doesnt exist. Cannot generate Code coverage
        mohamedaquibzulfikar/Module1:0.1.0

        [pass] test1

        1 passing
        0 failing
        0 skipped


Generating Test Report
        target/test_results.json

```

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
