### PR TITLE
Fix identifying module level arrow expression with closure vars

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4773,7 +4773,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
     private void markAndRegisterClosureVariable(BSymbol symbol, DiagnosticPos pos) {
         BLangInvokableNode encInvokable = env.enclInvokable;
-        if (symbol.owner instanceof BPackageSymbol) {
+        if (symbol.owner instanceof BPackageSymbol && env.node.getKind() != NodeKind.ARROW_EXPR) {
             return;
         }
         if (encInvokable != null && encInvokable.flagSet.contains(Flag.LAMBDA)

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -265,6 +265,11 @@ public class ArrowExprTest {
         BRunUtil.invoke(basic, "testNestedArrowExpressionWithOneParameter");
     }
 
+    @Test(description = "Test global arrow expression with closures")
+    public void testGlobalArrowExpressionsWithClosure() {
+        BRunUtil.invoke(basic, "testGlobalArrowExpressionsWithClosure");
+    }
+
     @Test(description = "Test type narrowing in arrow expression")
     public void testTypeNarrowingInArrowExpression() {
         BRunUtil.invoke(basic, "testTypeNarrowingInArrowExpression");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
@@ -191,6 +191,11 @@ public class FunctionPointersTest {
         Assert.assertEquals(returns[0].stringValue(), "truetest6");
     }
 
+    @Test(description = "Test global function type defs with closures")
+    public void testGlobalFunctionTypeDefWithClosures() {
+        BRunUtil.invoke(globalProgram, "testGlobalFunctionTypeDefWithClosures");
+    }
+
     @Test
     public void testStructFP() {
         BValue[] returns = BRunUtil.invoke(structProgram, "test1");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -14,6 +14,12 @@
 // specific language governing permissions and limitations
 // under the License.
 
+type F1 function (int) returns function (int) returns int;
+F1 f1 = a => b => a + b;
+
+type F2 function (int) returns function (int) returns function (int) returns int;
+F2 f2 = a => b => c => a + b + c;
+
 function testArrowExprWithOneParam() returns int {
     function (int) returns int lambda = param1 => param1*2;
     return lambda(12);
@@ -231,6 +237,21 @@ function testTypeNarrowingInArrowExpression() {
         result = arrowFun();
     }
 
+    assertEquality(expected, result);
+}
+
+function testGlobalArrowExpressionsWithClosure() {
+    var expected = 5;
+
+    var a = f1(2);
+    var result = a(3);
+    assertEquality(expected, result);
+
+    expected = 18;
+
+    var b = f2(5);
+    var c = b(6);
+    result = c(7);
     assertEquality(expected, result);
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/global-function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/global-function-pointers.bal
@@ -3,6 +3,23 @@ function (string a, int b) returns (string) glf1 = foo;
 function (string a, boolean b) returns (string) glf2 = function (string a, boolean b) returns (string) {
                                                                return a + b.toString();
                                                            };
+type F1 function (int) returns function (int) returns int;
+F1 f1 = function (int a) returns function (int) returns int  {
+    return function (int b) returns int {
+        return a + b;
+    };
+};
+
+
+type F2 function (int) returns function (int) returns function (int) returns int;
+F2 f2 = function (int a) returns function (int) returns function (int) returns int {
+    return function (int b) returns function (int) returns int {
+        return function (int c) returns int {
+                return a + b + c;
+        };
+    };
+};
+
 
 function (string, int) returns (string) glf3 = function (string a, int b) returns (string) {
     return "llll";
@@ -48,4 +65,32 @@ function test6() returns (string) {
     function (string a, boolean b) returns (string) glf4 = bar;
     glf2 = glf4;
     return glf2("test6", true);
+}
+
+function testGlobalFunctionTypeDefWithClosures() {
+    var expected = 5;
+
+    var a = f1(2);
+    var result = a(3);
+    assertEquality(expected, result);
+
+    expected = 18;
+
+    var b = f2(5);
+    var c = b(6);
+    result = c(7);
+    assertEquality(expected, result);
+}
+
+const ASSERTION_ERR_REASON = "AssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+    if expected === actual {
+        return;
+    }
+    panic error(ASSERTION_ERR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }


### PR DESCRIPTION
## Purpose
This PR fixes the issue where module level arrow expressions with closure vars are failing to compile.

Fixes #25288

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
