### PR TITLE
Refactor BRuntime to have only public apis

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BRuntime.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/BRuntime.java
@@ -20,25 +20,14 @@ import org.ballerinalang.jvm.observability.ObservabilityConstants;
 import org.ballerinalang.jvm.observability.ObserveUtils;
 import org.ballerinalang.jvm.observability.ObserverContext;
 import org.ballerinalang.jvm.scheduling.Scheduler;
-import org.ballerinalang.jvm.scheduling.State;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
-import org.ballerinalang.jvm.types.BFunctionType;
 import org.ballerinalang.jvm.types.BTypes;
-import org.ballerinalang.jvm.values.ErrorValue;
-import org.ballerinalang.jvm.values.FPValue;
-import org.ballerinalang.jvm.values.FutureValue;
 import org.ballerinalang.jvm.values.ObjectValue;
 import org.ballerinalang.jvm.values.connector.CallableUnitCallback;
 
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 /**
  * External API to be used by the interop users to control Ballerina runtime behavior.
@@ -63,111 +52,23 @@ public class BRuntime {
         return new BRuntime(strand.scheduler);
     }
 
-    /**
-     * Block the current strand to execute asynchronously.
-     *
-     * @return Future object to unblock the strand.
-     */
-    public static CompletableFuture<Object> markAsync() {
-        Strand strand = Scheduler.getStrand();
-        strand.blockedOnExtern = true;
-        strand.setState(State.BLOCK_AND_YIELD);
-        CompletableFuture<Object> future = new CompletableFuture<>();
-        future.whenComplete(new Unblocker(strand));
-        return future;
-    }
-
-    /**
-     * Invoke Function Pointer asynchronously. This will schedule the function and block the strand.
-     *
-     * @param func                 Function Pointer to be invoked.
-     * @param strandName           Name for newly creating strand which is used to execute the function pointer.
-     *                             This is optional and can be null.
-     * @param metadata             Meta data of new strand.
-     * @param args                 Ballerina function arguments.
-     * @param resultHandleFunction Function used to process the result received after execution of function.
-     * @return Future Value
-     */
-    public FutureValue invokeFunctionPointerAsync(FPValue<?, ?> func, String strandName, StrandMetadata metadata,
-                                                  Object[] args, Function<Object, Object> resultHandleFunction) {
-        AsyncFunctionCallback callback = new AsyncFunctionCallback() {
-            @Override
-            public void notifySuccess() {
-                setReturnValues(resultHandleFunction.apply(getFutureResult()));
-            }
-
-            @Override
-            public void notifyFailure(ErrorValue error) {
-                handleRuntimeErrors(error);
-            }
-        };
-        return invokeFunctionPointerAsync(func, strandName, metadata, args, callback);
-    }
-
-    /**
-     * Invoke Function Pointer asynchronously. This will schedule the function and block the strand.
-     *
-     * @param func       Function Pointer to be invoked.
-     * @param strandName Name for newly creating strand which is used to execute the function pointer. This is
-     *                   optional and can be null.
-     * @param metadata   Meta data of new strand.
-     * @param args       Ballerina function arguments.
-     * @param callback   Asynchronous call back.
-     * @return Future value
-     */
-    public FutureValue invokeFunctionPointerAsync(FPValue<?, ?> func, String strandName, StrandMetadata metadata,
-                                                  Object[] args, AsyncFunctionCallback callback) {
-
-        Strand strand = Scheduler.getStrand();
-        return invokeFunctionPointerAsync(func, strand, strandName, metadata, args, callback);
-    }
-
-    /**
-     * Invoke Function Pointer asynchronously given number of times. This will schedule the function and block the
-     * strand. This method can be used with collection of data where we need to invoke the function pointer for each
-     * item of the collection.
-     *
-     * @param func                 Function Pointer to be invoked.
-     * @param strandName           Name for newly creating strand which is used to execute the function pointer. This is
-     *                             optional and can be null.
-     * @param metadata             Meta data of new strand.
-     * @param noOfIterations       Number of iterations need to call the function pointer.
-     * @param argsSupplier         Supplier provides dynamic arguments to function pointer execution in each iteration.
-     * @param futureResultConsumer Consumer used to process the future value received after execution of function.
-     *                             Future value result will have the return object of the function pointer.
-     * @param returnValueSupplier  Suppler used to set the final return value for the parent function invocation.
-     */
-    public void invokeFunctionPointerAsyncIteratively(FPValue<?, ?> func, String strandName,
-                                                      StrandMetadata metadata, int noOfIterations,
-                                                      Supplier<Object[]> argsSupplier,
-                                                      Consumer<Object> futureResultConsumer,
-                                                      Supplier<Object> returnValueSupplier) {
-        if (noOfIterations <= 0) {
-            return;
-        }
-        Strand strand = Scheduler.getStrand();
-        blockStrand(strand);
-        AtomicInteger callCount = new AtomicInteger(0);
-        scheduleNextFunction(func, strand, strandName, metadata, noOfIterations, callCount, argsSupplier,
-                             futureResultConsumer, returnValueSupplier);
-    }
-
-    /**
-     * Invoke Object method asynchronously. This will schedule the function and block the strand.
-     *
-     * @param object     Object Value.
-     * @param methodName Name of the method.
-     * @param strandName Name for newly creating strand which is used to execute the function pointer. This is
-     *                   optional and can be null.
-     * @param metadata   Meta data of new strand.
-     * @param callback   Callback which will get notify once method execution done.
-     * @param args       Ballerina function arguments.
-     */
-    public void invokeMethodAsync(ObjectValue object, String methodName, String strandName, StrandMetadata metadata,
-                                  CallableUnitCallback callback, Object... args) {
-        Function<?, ?> func = o -> object.call((Strand) (((Object[]) o)[0]), methodName, args);
-        scheduler.schedule(new Object[1], func, null, callback, strandName, metadata);
-    }
+     /**
+      * Invoke Object method asynchronously. This will schedule the function and block the strand.
+      *
+      * @param object     Object Value.
+      * @param methodName Name of the method.
+      * @param strandName Name for newly creating strand which is used to execute the function pointer. This is optional
+      *                   and can be null.
+      * @param metadata   Meta data of new strand.
+      * @param callback   Callback which will get notify once method execution done.
+      * @param args       Ballerina function arguments.
+      * @return the result of the function invocation
+      */
+     public Object invokeMethodAsync(ObjectValue object, String methodName, String strandName, StrandMetadata metadata,
+                                     CallableUnitCallback callback, Object... args) {
+         Function<?, ?> func = o -> object.call((Strand) (((Object[]) o)[0]), methodName, args);
+         return scheduler.schedule(new Object[1], func, null, callback, strandName, metadata).result;
+     }
 
     /**
      * Invoke Object method asynchronously. This will schedule the function and block the strand.
@@ -193,148 +94,5 @@ public class BRuntime {
             return object.call(strand, methodName, args);
         };
         scheduler.schedule(new Object[1], func, null, callback, properties, BTypes.typeNull, strandName, metadata);
-    }
-
-    /**
-     * Invoke Object method synchronously. This will block the thread.
-     *
-     * @param object     Object Value.
-     * @param methodName Name of the method.
-     * @param strandName Name for newly creating strand which is used to execute the function pointer. This is
-     *                   optional and can be null.
-     * @param metadata   Meta data of new strand.
-     * @param args       Ballerina function arguments.
-     */
-    public void invokeMethodSync(ObjectValue object, String methodName, String strandName,
-                                 StrandMetadata metadata, Object... args) {
-        Function<?, ?> func = o -> object.call((Strand) (((Object[]) o)[0]), methodName, args);
-        Semaphore semaphore = new Semaphore(0);
-        final ErrorValue[] errorValue = new ErrorValue[1];
-        scheduler.schedule(new Object[1], func, null, new CallableUnitCallback() {
-            @Override
-            public void notifySuccess() {
-                semaphore.release();
-            }
-
-            @Override
-            public void notifyFailure(ErrorValue error) {
-                errorValue[0] = error;
-                semaphore.release();
-            }
-        }, strandName, metadata);
-        try {
-            semaphore.acquire();
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        if (errorValue[0] != null) {
-            throw errorValue[0];
-        }
-    }
-
-    /**
-     * Invoke Ballerina function and get the result.
-     *
-     * @param object     Ballerina object in which the function is defined.
-     * @param methodName Ballerina function name, to invoke.
-     * @param strandName Name for newly creating strand which is used to execute the function pointer. This is
-     *                   optional and can be null.
-     * @param metadata   Meta data of new strand.
-     * @param timeout    Timeout in milliseconds to wait until acquiring the semaphore.
-     * @param args       Ballerina function arguments.
-     * @return Ballerina function invoke result.
-     */
-    public Object getSyncMethodInvokeResult(ObjectValue object, String methodName, String strandName,
-                                            StrandMetadata metadata, int timeout, Object... args) {
-        Function<?, ?> func = o -> object.call((Strand) (((Object[]) o)[0]), methodName, args);
-        Semaphore semaphore = new Semaphore(0);
-        final ErrorValue[] errorValue = new ErrorValue[1];
-        // Add 1 more element to keep null for add the strand later.
-        Object[] params = new Object[]{null, args};
-        FutureValue futureValue = scheduler.schedule(params, func, null, new CallableUnitCallback() {
-            @Override
-            public void notifySuccess() {
-                semaphore.release();
-            }
-
-            @Override
-            public void notifyFailure(ErrorValue error) {
-                errorValue[0] = error;
-                semaphore.release();
-            }
-        }, strandName, metadata);
-        try {
-            semaphore.tryAcquire(timeout, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            // Ignore
-        }
-        if (errorValue[0] != null) {
-            throw errorValue[0];
-        }
-        return futureValue.result;
-    }
-
-
-    private void scheduleNextFunction(FPValue<?, ?> func, Strand strand, String strandName,
-                                      StrandMetadata metadata, int noOfIterations,
-                                      AtomicInteger callCount, Supplier<Object[]> argsSupplier,
-                                      Consumer<Object> futureResultConsumer,
-                                      Supplier<Object> returnValueSupplier) {
-        AsyncFunctionCallback callback = new AsyncFunctionCallback() {
-            @Override
-            public void notifySuccess() {
-                futureResultConsumer.accept(getFutureResult());
-                if (callCount.incrementAndGet() != noOfIterations) {
-                    scheduleNextFunction(func, strand, strandName, metadata, noOfIterations, callCount, argsSupplier,
-                                         futureResultConsumer, returnValueSupplier);
-                } else {
-                    setReturnValues(returnValueSupplier.get());
-                }
-            }
-
-            @Override
-            public void notifyFailure(ErrorValue error) {
-                handleRuntimeErrors(error);
-            }
-        };
-        invokeFunctionPointerAsync(func, strand, strandName, metadata, argsSupplier.get(), callback);
-    }
-
-    private FutureValue invokeFunctionPointerAsync(FPValue<?, ?> func, Strand parent, String name,
-                                                   StrandMetadata metadata, Object[] args,
-                                                   AsyncFunctionCallback callback) {
-
-        blockStrand(parent);
-        final FutureValue future = scheduler.createFuture(parent, null, null,
-                                                          ((BFunctionType) func.getType()).retType, name, metadata);
-        future.callback = callback;
-        callback.setFuture(future);
-        callback.setStrand(parent);
-        return scheduler.scheduleLocal(args, func, parent, future);
-    }
-
-    private void blockStrand(Strand strand) {
-        if (!strand.blockedOnExtern) {
-            strand.blockedOnExtern = true;
-            strand.setState(State.BLOCK_AND_YIELD);
-            strand.returnValue = null;
-        }
-    }
-
-    private static class Unblocker implements java.util.function.BiConsumer<Object, Throwable> {
-
-        private Strand strand;
-
-        public Unblocker(Strand strand) {
-            this.strand = strand;
-        }
-
-        @Override
-        public void accept(Object returnValue, Throwable throwable) {
-            if (throwable == null) {
-                this.strand.returnValue = returnValue;
-                this.strand.scheduler.unblockStrand(strand);
-            }
-        }
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/runtime/AsyncFunctionCallback.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/runtime/AsyncFunctionCallback.java
@@ -16,7 +16,7 @@
  *  under the License.
  */
 
-package org.ballerinalang.jvm;
+package org.ballerinalang.jvm.runtime;
 
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.values.FutureValue;

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/runtime/AsyncUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/runtime/AsyncUtils.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.jvm.runtime;
+
+import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.State;
+import org.ballerinalang.jvm.scheduling.Strand;
+import org.ballerinalang.jvm.scheduling.StrandMetadata;
+import org.ballerinalang.jvm.types.BFunctionType;
+import org.ballerinalang.jvm.values.ErrorValue;
+import org.ballerinalang.jvm.values.FPValue;
+import org.ballerinalang.jvm.values.FutureValue;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Util functions for async invocations.
+ */
+public class AsyncUtils {
+
+    /**
+     * Block the current strand to execute asynchronously.
+     *
+     * @return Future object to unblock the strand.
+     */
+    public static CompletableFuture<Object> markAsync() {
+        Strand strand = Scheduler.getStrand();
+        strand.blockedOnExtern = true;
+        strand.setState(State.BLOCK_AND_YIELD);
+        CompletableFuture<Object> future = new CompletableFuture<>();
+        future.whenComplete(new Unblocker(strand));
+        return future;
+    }
+
+    /**
+     * Invoke Function Pointer asynchronously. This will schedule the function and block the strand.
+     *
+     * @param func                 Function Pointer to be invoked.
+     * @param strandName           Name for newly creating strand which is used to execute the function pointer. This is
+     *                             optional and can be null.
+     * @param metadata             Meta data of new strand.
+     * @param args                 Ballerina function arguments.
+     * @param resultHandleFunction Function used to process the result received after execution of function.
+     * @param scheduler            The scheduler for invoking functions
+     * @return Future Value
+     */
+    public static FutureValue invokeFunctionPointerAsync(FPValue<?, ?> func, String strandName, StrandMetadata metadata,
+                                                         Object[] args, Function<Object, Object> resultHandleFunction,
+                                                         Scheduler scheduler) {
+        AsyncFunctionCallback callback = new AsyncFunctionCallback() {
+            @Override
+            public void notifySuccess() {
+                setReturnValues(resultHandleFunction.apply(getFutureResult()));
+            }
+
+            @Override
+            public void notifyFailure(ErrorValue error) {
+                handleRuntimeErrors(error);
+            }
+        };
+        return invokeFunctionPointerAsync(func, Scheduler.getStrand(), strandName, metadata, args, callback, scheduler);
+    }
+
+    public static FutureValue invokeFunctionPointerAsync(FPValue<?, ?> func, Strand parent, String name,
+                                                         StrandMetadata metadata, Object[] args,
+                                                         AsyncFunctionCallback callback, Scheduler scheduler) {
+
+        blockStrand(parent);
+        final FutureValue future = scheduler.createFuture(parent, null, null,
+                                                          ((BFunctionType) func.getType()).retType, name, metadata);
+        future.callback = callback;
+        callback.setFuture(future);
+        callback.setStrand(parent);
+        return scheduler.scheduleLocal(args, func, parent, future);
+    }
+
+    public static void blockStrand(Strand strand) {
+        if (!strand.blockedOnExtern) {
+            strand.blockedOnExtern = true;
+            strand.setState(State.BLOCK_AND_YIELD);
+            strand.returnValue = null;
+        }
+    }
+
+    /**
+     * Invoke Function Pointer asynchronously given number of times. This will schedule the function and block the
+     * strand. This method can be used with collection of data where we need to invoke the function pointer for each
+     * item of the collection.
+     *
+     * @param func                 Function Pointer to be invoked.
+     * @param strandName           Name for newly creating strand which is used to execute the function pointer. This is
+     *                             optional and can be null.
+     * @param metadata             Meta data of new strand.
+     * @param noOfIterations       Number of iterations need to call the function pointer.
+     * @param argsSupplier         Supplier provides dynamic arguments to function pointer execution in each iteration.
+     * @param futureResultConsumer Consumer used to process the future value received after execution of function.
+     *                             Future value result will have the return object of the function pointer.
+     * @param returnValueSupplier  Suppler used to set the final return value for the parent function invocation.
+     * @param scheduler            The scheduler for invoking functions
+     */
+    public static void invokeFunctionPointerAsyncIteratively(FPValue<?, ?> func, String strandName,
+                                                             StrandMetadata metadata, int noOfIterations,
+                                                             Supplier<Object[]> argsSupplier,
+                                                             Consumer<Object> futureResultConsumer,
+                                                             Supplier<Object> returnValueSupplier,
+                                                             Scheduler scheduler) {
+
+        if (noOfIterations <= 0) {
+            return;
+        }
+        Strand strand = Scheduler.getStrand();
+        blockStrand(strand);
+        AtomicInteger callCount = new AtomicInteger(0);
+        scheduleNextFunction(func, strand, strandName, metadata, noOfIterations, callCount, argsSupplier,
+                             futureResultConsumer, returnValueSupplier, scheduler);
+    }
+
+    private static void scheduleNextFunction(FPValue<?, ?> func, Strand strand, String strandName,
+                                             StrandMetadata metadata, int noOfIterations,
+                                             AtomicInteger callCount, Supplier<Object[]> argsSupplier,
+                                             Consumer<Object> futureResultConsumer,
+                                             Supplier<Object> returnValueSupplier, Scheduler scheduler) {
+        AsyncFunctionCallback callback = new AsyncFunctionCallback() {
+            @Override
+            public void notifySuccess() {
+                futureResultConsumer.accept(getFutureResult());
+                if (callCount.incrementAndGet() != noOfIterations) {
+                    scheduleNextFunction(func, strand, strandName, metadata, noOfIterations, callCount, argsSupplier,
+                                         futureResultConsumer, returnValueSupplier, scheduler);
+                } else {
+                    setReturnValues(returnValueSupplier.get());
+                }
+            }
+
+            @Override
+            public void notifyFailure(ErrorValue error) {
+                handleRuntimeErrors(error);
+            }
+        };
+        invokeFunctionPointerAsync(func, strand, strandName, metadata, argsSupplier.get(), callback, scheduler);
+    }
+
+    private static class Unblocker implements java.util.function.BiConsumer<Object, Throwable> {
+
+        private Strand strand;
+
+        public Unblocker(Strand strand) {
+            this.strand = strand;
+        }
+
+        @Override
+        public void accept(Object returnValue, Throwable throwable) {
+            if (throwable == null) {
+                this.strand.returnValue = returnValue;
+                this.strand.scheduler.unblockStrand(strand);
+            }
+        }
+    }
+}

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/FPValue.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/FPValue.java
@@ -17,7 +17,8 @@
  */
 package org.ballerinalang.jvm.values;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BType;
 import org.ballerinalang.jvm.util.BLangConstants;
@@ -66,8 +67,8 @@ public class FPValue<T, R> implements BFunctionPointer<T, R>, RefValue {
 
     public FutureValue asyncCall(Object[] args, Function<Object, Object> resultHandleFunction,
                                  StrandMetadata metaData) {
-        return BRuntime.getCurrentRuntime().invokeFunctionPointerAsync(this, this.strandName, metaData,
-                                                                       args, resultHandleFunction);
+        return AsyncUtils.invokeFunctionPointerAsync(this, this.strandName, metaData,
+                                                     args, resultHandleFunction, Scheduler.getStrand().scheduler);
     }
 
     public Function<T, R> getFunction() {

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Filter.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.array;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BArrayType;
@@ -57,16 +58,15 @@ public class Filter {
         int size = arr.size();
         AtomicInteger newArraySize = new AtomicInteger(-1);
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
-                .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                                                       () -> new Object[]{strand, arr.get(index.incrementAndGet()),
+        AsyncUtils.invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
+                                                         () -> new Object[]{strand, arr.get(index.incrementAndGet()),
                                                                true},
                                                        result -> {
                                                            if ((Boolean) result) {
                                                                newArr.add(newArraySize.incrementAndGet(),
                                                                           arr.get(index.get()));
                                                            }
-                                                       }, () -> newArr);
+                                                       }, () -> newArr, Scheduler.getStrand().scheduler);
         return newArr;
     }
 }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/ForEach.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.array;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BType;
@@ -56,11 +57,11 @@ public class ForEach {
         BType arrType = arr.getType();
         GetFunction getFn = getElementAccessFunction(arrType, "forEach()");
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand,
                                                                getFn.get(arr, index.incrementAndGet()), true},
                                                        result -> {
-                                                       }, () -> null);
+                                                       }, () -> null, Scheduler.getStrand().scheduler);
     }
 }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Map.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.array;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BArrayType;
@@ -76,12 +77,12 @@ public class Map {
                 throw createOpNotSupportedError(arrType, "map()");
         }
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand,
                                                                getFn.get(arr, index.incrementAndGet()), true},
                                                        result -> retArr.add(index.get(), result),
-                                                       () -> retArr);
+                                                       () -> retArr, Scheduler.getStrand().scheduler);
 
         return retArr;
     }

--- a/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reduce.java
+++ b/langlib/lang.array/src/main/java/org/ballerinalang/langlib/array/Reduce.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.array;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BType;
@@ -61,11 +62,11 @@ public class Reduce {
         GetFunction getFn = getElementAccessFunction(arrType, "reduce()");
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand, accum.get(), true,
                                                                getFn.get(arr, index.incrementAndGet()), true},
-                                                       accum::set, accum::get);
+                                                       accum::set, accum::get, Scheduler.getStrand().scheduler);
         return accum.get();
 
         

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Filter.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.map;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BMapType;
@@ -74,7 +75,7 @@ public class Filter {
         MapValue<Object, Object> newMap = new MapValueImpl<>(newMapType);
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
@@ -84,7 +85,7 @@ public class Filter {
                                                                Object value = m.get(key);
                                                                newMap.put(key, value);
                                                            }
-                                                       }, () -> newMap);
+                                                       }, () -> newMap, Scheduler.getStrand().scheduler);
         return newMap;
     }
 }

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/ForEach.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.map;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -51,11 +52,11 @@ public class ForEach {
     public static void forEach(Strand strand, MapValue<?, ?> m, FPValue<Object, Object> func) {
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
                                                        result -> {
-                                                       }, () -> null);
+                                                       }, () -> null, Scheduler.getStrand().scheduler);
     }
 }

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Map.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.map;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BFunctionType;
@@ -58,13 +59,13 @@ public class Map {
         MapValue<Object, Object> newMap = new MapValueImpl<>(newMapType);
         int size = m.size();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
                                                        result -> newMap
                                                                .put(m.getKeys()[index.get()], result),
-                                                       () -> newMap);
+                                                       () -> newMap, Scheduler.getStrand().scheduler);
         return newMap;
     }
 }

--- a/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Reduce.java
+++ b/langlib/lang.map/src/main/java/org/ballerinalang/langlib/map/Reduce.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.map;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -56,11 +57,11 @@ public class Reduce {
         int size = m.values().size();
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand, accum.get(), true,
                                                                m.get(m.getKeys()[index.incrementAndGet()]), true},
-                                                       accum::set, accum::get);
+                                                       accum::set, accum::get, Scheduler.getStrand().scheduler);
         return accum.get();
     }
 }

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Filter.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.table;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BTableType;
@@ -58,9 +59,9 @@ public class Filter {
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
 
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{strand,
+                                                       () -> new Object[]{strand,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         result -> {
                             if ((Boolean) result) {
@@ -68,7 +69,7 @@ public class Filter {
                                 Object value = tbl.get(key);
                                 newTable.put(key, value);
                             }
-                        }, () -> newTable);
+                        }, () -> newTable, Scheduler.getStrand().scheduler);
         return newTable;
     }
 

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Foreach.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.table;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -51,12 +52,12 @@ public class Foreach {
     public static void forEach(Strand strand, TableValueImpl tbl, FPValue<Object, Object> func) {
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{strand,
+                                                       () -> new Object[]{strand,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         result -> {
-                        }, () -> null);
+                        }, () -> null, Scheduler.getStrand().scheduler);
     }
 
     public static void forEach_bstring(Strand strand, TableValueImpl tbl, FPValue<Object, Object> func) {

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Map.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.table;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.types.BFunctionType;
@@ -62,13 +63,13 @@ public class Map {
         TableValueImpl newTable = new TableValueImpl(newTableType);
         int size = tbl.size();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{strand,
+                                                       () -> new Object[]{strand,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
                         result -> newTable
                                 .put(tbl.getKeys()[index.get()], result),
-                        () -> newTable);
+                                                       () -> newTable, Scheduler.getStrand().scheduler);
         return newTable;
     }
 

--- a/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
+++ b/langlib/lang.table/src/main/java/org/ballerinalang/langlib/table/Reduce.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.table;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -56,11 +57,11 @@ public class Reduce {
         int size = tbl.values().size();
         AtomicReference<Object> accum = new AtomicReference<>(initial);
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
-                        () -> new Object[]{strand, accum.get(), true,
+                                                       () -> new Object[]{strand, accum.get(), true,
                                 tbl.get(tbl.getKeys()[index.incrementAndGet()]), true},
-                        accum::set, accum::get);
+                                                       accum::set, accum::get, Scheduler.getStrand().scheduler);
         return accum.get();
     }
 

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Filter.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.xml;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -72,7 +73,7 @@ public class Filter {
         List<BXML> elements = new ArrayList<>();
         int size = x.size();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, size,
                                                        () -> new Object[]{strand,
                                                                x.getItem(index.incrementAndGet()), true},
@@ -80,7 +81,8 @@ public class Filter {
                                                            if ((Boolean) result) {
                                                                elements.add(x.getItem(index.get()));
                                                            }
-                                                       }, () -> new XMLSequence(elements));
+                                                       }, () -> new XMLSequence(elements),
+                                                       Scheduler.getStrand().scheduler);
 
         return new XMLSequence(elements);
     }

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/ForEach.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.xml;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -56,11 +57,11 @@ public class ForEach {
             return;
         }
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, x.size(),
                                                        () -> new Object[]{strand, x.getItem(index.incrementAndGet()),
                                                                true},
                                                        result -> {
-                                                       }, () -> null);
+                                                       }, () -> null, Scheduler.getStrand().scheduler);
     }
 }

--- a/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
+++ b/langlib/lang.xml/src/main/java/org/ballerinalang/langlib/xml/Map.java
@@ -18,7 +18,8 @@
 
 package org.ballerinalang.langlib.xml;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
+import org.ballerinalang.jvm.scheduling.Scheduler;
 import org.ballerinalang.jvm.scheduling.Strand;
 import org.ballerinalang.jvm.scheduling.StrandMetadata;
 import org.ballerinalang.jvm.values.FPValue;
@@ -63,12 +64,13 @@ public class Map {
         }
         List<BXML> elements = new ArrayList<>();
         AtomicInteger index = new AtomicInteger(-1);
-        BRuntime.getCurrentRuntime()
+        AsyncUtils
                 .invokeFunctionPointerAsyncIteratively(func, null, METADATA, x.size(),
                                                        () -> new Object[]{strand, x.getItem(index.incrementAndGet()),
                                                                true},
                                                        result -> elements.add((XMLValue) result),
-                                                       () -> new XMLSequence(elements));
+                                                       () -> new XMLSequence(elements),
+                                                       Scheduler.getStrand().scheduler);
         return new XMLSequence(elements);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/AsyncInterop.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/AsyncInterop.java
@@ -16,7 +16,7 @@
  */
 package org.ballerinalang.nativeimpl.jvm.tests;
 
-import org.ballerinalang.jvm.BRuntime;
+import org.ballerinalang.jvm.runtime.AsyncUtils;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -30,7 +30,7 @@ import java.util.concurrent.CompletableFuture;
 public class AsyncInterop {
 
     public static int countSlowly() {
-        CompletableFuture<Object> future = BRuntime.markAsync();
+        CompletableFuture<Object> future = AsyncUtils.markAsync();
 
         new Thread(() -> {
             sleep();


### PR DESCRIPTION
## Purpose
> Let BRuntime have only public apis

## Approach
> The BRuntime api is refactored to have only public apis used on other projects like stdlibs. AsyncUtils have methods used only in the langlib  projects.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
