### PR TITLE
Improve logging of Testerina Runtime exceptions

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaUtils.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.test.runtime.util;
 
+import org.ballerinalang.jvm.util.BLangConstants;
 import org.ballerinalang.jvm.util.RuntimeUtils;
 import org.ballerinalang.jvm.util.exceptions.BallerinaException;
 import org.ballerinalang.test.runtime.BTestRunner;
@@ -77,6 +78,8 @@ public class TesterinaUtils {
             }
         } catch (BallerinaException e) {
             errStream.println("error: " + e.getMessage());
+            errStream.println(BLangConstants.INTERNAL_ERROR_MESSAGE);
+            RuntimeUtils.silentlyLogBadSad(e);
             throw e;
         } catch (Throwable e) {
             RuntimeUtils.silentlyLogBadSad(e);


### PR DESCRIPTION
## Purpose

The following code in the `TesterinaUtils` class prints a vague message with no stack trace or logs. 

```
catch (BallerinaException e) {
            errStream.println("error: " + e.getMessage());
```

The PR improves this by printing a BAD-SAD and logging the error

Fixes #23588

## Approach
With the changes, the console output shows up as

```
Compiling source
        ballerinax/cassandra:0.99.0

Creating balos
        target/balo/cassandra-2020r2-java8-0.99.0.balo

Running Tests
        ballerinax/cassandra:0.99.0
error: java.lang.NullPointerException
ballerina: Oh no, something really went wrong.

The `ballerina-internal.log` file located in the current directory
will indicate what the problem is.
We really appreciate it if you can share with us, the code
that broke Ballerina, together with this log file by creating a
bug report in https://github.com/ballerina-platform/ballerina-lang/issues.

error: there are test failures
```
and the relevant stack trace is logged.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
