### PR TITLE
Add BalEnv special parameter support for interop functions

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BalEnv.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BalEnv.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.jvm.api;
+
+import org.ballerinalang.jvm.scheduling.Scheduler;
+import org.ballerinalang.jvm.scheduling.State;
+import org.ballerinalang.jvm.scheduling.Strand;
+
+/**
+ * When this class is used as the first argument of an interop method, Ballerina
+ * will inject an instance of the class when calling. That instance can be used to
+ * communicate with currently executing Ballerina runtime.
+ *
+ * @since 2.0.0
+ */
+public class BalEnv {
+    private Strand strand;
+
+    public BalEnv(Strand strand) {
+        this.strand = strand;
+    }
+
+    /**
+     * Mark the current executing strand as async. Execution of Ballerina code after the current
+     * interop will stop until given BalFuture is completed. However the java thread will not be blocked
+     * and will be reused for running other Ballerina code in the meantime. Therefor callee of this method
+     * must return as soon as possible to avoid starvation of ballerina code execution.
+     *
+     * @return BalFuture which will resume the current strand when completed.
+     */
+    public BalFuture markAsync() {
+        Strand strand = Scheduler.getStrand();
+        strand.blockedOnExtern = true;
+        strand.setState(State.BLOCK_AND_YIELD);
+        return new BalFuture(this.strand);
+    }
+}

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BalFuture.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BalFuture.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.jvm.api;
+
+import org.ballerinalang.jvm.scheduling.Strand;
+
+/**
+ * A future that will resume the underling strand when completed.
+ *
+ * @since 2.0.0
+ */
+public class BalFuture {
+    private final Strand strand;
+
+    public BalFuture(Strand strand) {
+        this.strand = strand;
+    }
+
+    public void complete(Object returnValue) {
+        strand.returnValue = returnValue;
+        strand.scheduler.unblockStrand(strand);
+    }
+}

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/connector/NonBlockingCallback.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/values/connector/NonBlockingCallback.java
@@ -33,6 +33,7 @@ public class NonBlockingCallback {
     private final Strand strand;
     private final Scheduler scheduler;
 
+    @Deprecated // replace with org.ballerinalang.jvm.api.BalEnv#markAsync
     public NonBlockingCallback(Strand strand) {
         strand.blockedOnExtern = true;
         strand.setState(State.BLOCK_AND_YIELD);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -297,6 +297,8 @@ public class JvmCastGen {
             case TypeTags.HANDLE:
                 mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD,
                         String.format("()L%s;", OBJECT), false);
+                mv.visitTypeInsn(CHECKCAST, LONG_VALUE);
+                mv.visitMethodInsn(INVOKEVIRTUAL, LONG_VALUE, "longValue", "()J", false);
                 break;
             case TypeTags.FINITE:
                 mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_INT_METHOD, String.format("(L%s;)J", OBJECT),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -107,6 +107,8 @@ public class JvmConstants {
     public static final String JSON_UTILS = "org/ballerinalang/jvm/JSONUtils";
     public static final String STRAND_CLASS = "org/ballerinalang/jvm/scheduling/Strand";
     public static final String STRAND_METADATA = "org/ballerinalang/jvm/scheduling/StrandMetadata";
+    public static final String BAL_ENV = "org/ballerinalang/jvm/api/BalEnv";
+    public static final String BAL_FUTURE = "org/ballerinalang/jvm/api/BalFuture";
     public static final String TYPE_CONVERTER = "org/ballerinalang/jvm/TypeConverter";
     public static final String STRAND_STATE = "org/ballerinalang/jvm/scheduling/State";
     public static final String VALUE_CREATOR = "org/ballerinalang/jvm/values/ValueCreator";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -322,6 +322,10 @@ public class InteropMethodGen {
         Class<?>[] jMethodParamTypes = jMethod.getParamTypes();
         JType jMethodRetType = JInterop.getJType(jMethod.getReturnType());
 
+        if (jMethodRetType == JType.jVoid && jMethod.isBalEnvAcceptingMethod()) {
+            jMethodRetType = JType.getPrimitiveJTypeForBType(birFunc.returnVariable.type);
+        }
+
         jvmMethodGen.resetIds();
         String bbPrefix = WRAPPER_GEN_BB_ID_NAME;
 
@@ -346,6 +350,11 @@ public class InteropMethodGen {
             jMethodParamIndex++;
             args.add(new BIROperand(birFunc.receiver));
         }
+
+        if (jMethod.isBalEnvAcceptingMethod()) {
+            jMethodParamIndex++;
+        }
+
         int paramCount = birFuncParams.size();
         while (birFuncParamIndex < paramCount) {
             BIRNode.BIRFunctionParameter birFuncParam = birFuncParams.get(birFuncParamIndex);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethod.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethod.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.types.BArrayType;
 import org.ballerinalang.jvm.types.BTypes;
 import org.ballerinalang.jvm.values.ArrayValue;
@@ -41,6 +42,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_
 class JMethod {
 
     static final JMethod NO_SUCH_METHOD = new JMethod(null, null, null);
+    public static final String BAL_ENV_CANONICAL_NAME = BalEnv.class.getCanonicalName();
 
     JMethodKind kind;
     private Executable method;
@@ -108,7 +110,6 @@ class JMethod {
     }
 
     Class<?>[] getParamTypes() {
-
         return method.getParameterTypes();
     }
 
@@ -166,5 +167,10 @@ class JMethod {
             throw new JInteropException(CLASS_NOT_FOUND, e.getMessage(), e);
         }
         return checkedExceptions.toArray(new Class[0]);
+    }
+
+    public boolean isBalEnvAcceptingMethod() {
+        Class<?>[] paramTypes = getParamTypes();
+        return paramTypes.length > 0 && paramTypes[0].getCanonicalName().equals(BAL_ENV_CANONICAL_NAME);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
@@ -138,19 +138,25 @@ class JMethodResolver {
                 .collect(Collectors.toList());
     }
 
-    private List<JMethod> resolveByParamCount(List<JMethod> jMethods, int paramCount, BType receiverType) {
-
-        return jMethods.stream()
-                .filter(jMethod -> {
-                    if (jMethod.getParamTypes().length == paramCount) {
-                        return true;
-                    } else if (receiverType != null && jMethod.getParamTypes().length == paramCount + 1) {
+    private List<JMethod> resolveByParamCount(List<JMethod> jMethods, int expectedCount, BType receiverType) {
+        return jMethods.stream().filter(jMethod -> {
+            int count = jMethod.getParamTypes().length;
+            if (count == expectedCount) {
+                return true;
+            } else {
+                boolean hasOneExtraParam = count == expectedCount + 1;
+                if (hasOneExtraParam) {
+                    boolean hasReceiver = receiverType != null;
+                    if (hasReceiver) {
                         jMethod.setReceiverType(receiverType);
                         return true;
+                    } else if (jMethod.isBalEnvAcceptingMethod()) {
+                        return true;
                     }
-                    return false;
-                })
-                .collect(Collectors.toList());
+                }
+            }
+            return false;
+        }).collect(Collectors.toList());
     }
 
     private JMethod resolve(JMethodRequest jMethodRequest, List<JMethod> jMethods) {
@@ -262,9 +268,11 @@ class JMethodResolver {
             BType receiverType = bParamTypes[0];
             if (!isValidParamBType(jMethodRequest.declaringClass, receiverType, jMethodRequest)) {
                 throw getNoSuchMethodError(jMethodRequest.methodName, jParamTypes[0], receiverType,
-                        jMethodRequest.declaringClass);
+                                           jMethodRequest.declaringClass);
             }
             i++;
+        } else if (jMethod.isBalEnvAcceptingMethod()) {
+            j++;
         } else if (bParamCount != jParamTypes.length) {
             throw getParamCountMismatchError(jMethodRequest);
         }
@@ -283,7 +291,9 @@ class JMethodResolver {
 
         Class<?> jReturnType = jMethod.getReturnType();
         BType bReturnType = jMethodRequest.bReturnType;
-        if (!isValidReturnBType(jReturnType, bReturnType, jMethodRequest)) {
+        //!(jMethod.isBalEnvAcceptingMethod() && )
+        if (!isValidReturnBType(jReturnType, bReturnType, jMethodRequest) &&
+            !(jMethod.isBalEnvAcceptingMethod() && jReturnType.equals(void.class))) {
             throw new JInteropException(DiagnosticCode.METHOD_SIGNATURE_DOES_NOT_MATCH,
                     "Incompatible return type for method '" + jMethodRequest.methodName + "' in class '" +
                             jMethodRequest.declaringClass.getName() + "': Java type '" + jReturnType.getName() +

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
+import org.ballerinalang.jvm.types.TypeTags;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags.JARRAY;
@@ -153,6 +154,21 @@ public class JType extends BType {
         }
 
         return arrayType;
+    }
+
+    static JType getPrimitiveJTypeForBType(BType type) {
+        switch (type.tag) {
+            case TypeTags.INT_TAG:
+                return jLong;
+            case TypeTags.BYTE_TAG:
+                return jInt;
+            case TypeTags.BOOLEAN_TAG:
+                return jBoolean;
+            case TypeTags.FLOAT_TAG:
+                return jFloat;
+            default:
+                return new JType(JREF);
+        }
     }
 
     /**

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -21,6 +21,8 @@ import org.ballerinalang.jvm.BallerinaErrors;
 import org.ballerinalang.jvm.BallerinaValues;
 import org.ballerinalang.jvm.StringUtils;
 import org.ballerinalang.jvm.TypeChecker;
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.BalFuture;
 import org.ballerinalang.jvm.types.BArrayType;
 import org.ballerinalang.jvm.types.BPackage;
 import org.ballerinalang.jvm.types.BTupleType;
@@ -437,6 +439,50 @@ public class StaticMethods {
 
     public static boolean echoImmutableRecordField(MapValue value, BString key) {
         return value.getBooleanValue(key);
+    }
+
+    public static void addTwoNumbersSlowAsyncVoidSig(BalEnv env, long a, long b) {
+        BalFuture balFuture = env.markAsync();
+        new Thread(() -> {
+            sleep();
+            balFuture.complete(a + b);
+        }).start();
+    }
+
+    public static void addTwoNumbersFastAsyncVoidSig(BalEnv env, long a, long b) {
+        BalFuture balFuture = env.markAsync();
+        balFuture.complete(a + b);
+    }
+
+
+    public static long addTwoNumbersSlowAsync(BalEnv env, long a, long b) {
+        BalFuture balFuture = env.markAsync();
+        new Thread(() -> {
+            sleep();
+            balFuture.complete(a + b);
+        }).start();
+
+        return -38263;
+    }
+
+    public static long addTwoNumbersFastAsync(BalEnv env, long a, long b) {
+        BalFuture balFuture = env.markAsync();
+        balFuture.complete(a + b);
+
+        return -282619;
+    }
+
+    public static void addTwoNumbersBuggy(BalEnv env, long a, long b) {
+        // Buggy because env.markAsync() is not called
+        // TODO: see if we can verify this
+    }
+
+    private static void sleep() {
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            assert false;
+        }
     }
 
     public static Object acceptAndReturnReadOnly(Object value) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
@@ -171,4 +171,24 @@ public class StaticMethodTest {
         Assert.assertTrue(returns[0] instanceof BDecimal);
         Assert.assertEquals(returns[0].stringValue(), "199.7");
     }
+
+    @Test
+    public void testBalEnvSlowAsyncVoidSig() {
+        BRunUtil.invoke(result, "testBalEnvSlowAsyncVoidSig");
+    }
+
+    @Test
+    public void testBalEnvFastAsyncVoidSig() {
+        BRunUtil.invoke(result, "testBalEnvFastAsyncVoidSig");
+    }
+
+    @Test
+    public void testBalEnvSlowAsync() {
+        BRunUtil.invoke(result, "testBalEnvSlowAsync");
+    }
+
+    @Test
+    public void testBalEnvFastAsync() {
+        BRunUtil.invoke(result, "testBalEnvFastAsync");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -187,3 +187,51 @@ function decimalParamAndReturn(decimal a1) returns decimal = @java:Method {
     class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
 } external;
 
+ public function addTwoNumbersSlowAsyncVoidSig(int a, int b) returns int = @java:Method {
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+} external;
+
+ public function addTwoNumbersFastAsyncVoidSig(int a, int b) returns int = @java:Method {
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+} external;
+
+ public function addTwoNumbersSlowAsync(int a, int b) returns int = @java:Method {
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+} external;
+
+ public function addTwoNumbersFastAsync(int a, int b) returns int = @java:Method {
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+} external;
+
+public function testBalEnvSlowAsyncVoidSig() {
+    int added = addTwoNumbersSlowAsyncVoidSig(1, 2);
+    assertEquality(3, added);
+}
+
+public function testBalEnvFastAsyncVoidSig() {
+    int added = addTwoNumbersFastAsyncVoidSig(1, 2);
+    assertEquality(3, added);
+}
+
+public function testBalEnvSlowAsync() {
+    int added = addTwoNumbersSlowAsync(1, 2);
+    assertEquality(3, added);
+}
+
+public function testBalEnvFastAsync() {
+    int added = addTwoNumbersFastAsync(1, 2);
+    assertEquality(3, added);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+    if expected === actual {
+        return;
+    }
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}


### PR DESCRIPTION
## Purpose
BalEnv will provide a way to create async interop methods without direct access to Strand (which will become an internal API).

## Approach
BalEnv wapping Strand is created for each interop call that asks for it. users can use `markAsync` to convert method to async.

## Samples
```java
    public static void addTwoNumbersSlowAsyncVoidSig(BalEnv env, long a, long b) {
        BalFuture balFuture = env.markAsync();
        new Thread(() -> {
            sleep();
            balFuture.complete(a + b);
        }).start();
    }
```