### PR TITLE
Undo renaming getDiagnostics to getErrorAndWarnDiagnostics

### DIFF
--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -51,7 +51,7 @@ public class LangLibValueTest {
 
         compileResult = BCompileUtil.compile("test-src/valuelib_test.bal");
         if (compileResult.getErrorCount() != 0) {
-            Arrays.stream(compileResult.getErrorAndWarnDiagnostics()).forEach(System.out::println);
+            Arrays.stream(compileResult.getDiagnostics()).forEach(System.out::println);
             Assert.fail("Compilation contains error");
         }
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/TypeParamTest.java
@@ -101,7 +101,7 @@ public class TypeParamTest {
 
         CompileResult result = BCompileUtil.compile("test-src/type-param/imported_type_param.bal");
         Assert.assertEquals(result.getErrorCount(), 0, "compilation contains error\n"
-                + Arrays.toString(result.getErrorAndWarnDiagnostics()));
+                + Arrays.toString(result.getDiagnostics()));
         BValue[] ret1 = BRunUtil.invoke(result, "testImportedModuleTypeParam1");
         Assert.assertEquals(ret1.length, 1);
         Assert.assertEquals(ret1[0].stringValue(), "[20, 40, 60, 80]");

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
@@ -41,7 +41,7 @@ public class SignatureTest {
                 "test-src/services/signature/no-request-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                 "resource signature parameter count should be >= 2");
     }
 
@@ -51,7 +51,7 @@ public class SignatureTest {
                 "test-src/services/signature/no-con-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                 "first parameter should be of type ballerina/http:1.0.0:Caller");
     }
 
@@ -61,7 +61,7 @@ public class SignatureTest {
                 "test-src/services/signature/with-res-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                 "second parameter should be of type ballerina/http:1.0.0:Request");
     }
 
@@ -71,7 +71,7 @@ public class SignatureTest {
                 "test-src/services/signature/int-param.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                 "second parameter should be of type ballerina/http:1.0.0:Request");
     }
 
@@ -93,7 +93,7 @@ public class SignatureTest {
     public void testSignatureWithMismatchedBodyParam() {
         CompileResult compileResult = BCompileUtil.compile(new File(getClass().getClassLoader().getResource(
                 "test-src/services/signature/mismatched-body-param.bal").getPath()).getAbsolutePath());
-        Diagnostic[] diag = compileResult.getErrorAndWarnDiagnostics();
+        Diagnostic[] diag = compileResult.getDiagnostics();
         Assert.assertEquals(diag.length, 2);
         Assert.assertEquals(diag[0].getMessage(), "invalid resource parameter(s): cannot specify > 2 parameters " +
                 "without specifying path config and/or body config in the resource annotation");
@@ -107,7 +107,7 @@ public class SignatureTest {
                 "test-src/services/signature/invalid-return.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(), "invalid resource " +
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(), "invalid resource " +
                 "function return type 'int', expected a subtype of 'error?' containing '()'");
     }
 

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/ResourceConfigPathTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/ResourceConfigPathTest.java
@@ -39,7 +39,7 @@ public class ResourceConfigPathTest {
     public void testResourceConfigPathAnnotationsNegativeCases() {
         CompileResult compileResult = BCompileUtil
                 .compile("test-src/services/configuration/resource-config-path-field.bal");
-        Diagnostic[] diag = compileResult.getErrorAndWarnDiagnostics();
+        Diagnostic[] diag = compileResult.getDiagnostics();
         Assert.assertEquals(diag.length, 12);
         assertResponse(diag[0], "Illegal closing brace detected in resource path config", 12);
         assertResponse(diag[1], "Illegal closing brace detected in resource path config", 19);
@@ -59,7 +59,7 @@ public class ResourceConfigPathTest {
     public void testPathParamAndSignatureParamMatch() {
         CompileResult compileResult = BCompileUtil
                 .compile("test-src/services/configuration/resource-arg--pathparam-match.bal");
-        Diagnostic[] diag = compileResult.getErrorAndWarnDiagnostics();
+        Diagnostic[] diag = compileResult.getDiagnostics();
         Assert.assertEquals(diag.length, 8);
         assertResponse(diag[0], INVALID_RESOURCE_PARAMETERS, 10);
         assertResponse(diag[1], INVALID_RESOURCE_PARAMETERS, 18);

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/ResourceConfigurationTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/ResourceConfigurationTest.java
@@ -35,7 +35,7 @@ public class ResourceConfigurationTest {
     public void testDuplicateResourceConfigAnnotations() {
         CompileResult compileResult = BCompileUtil
                 .compile("test-src/services/configuration/resource-config-annotation.bal");
-        Diagnostic[] diag = compileResult.getErrorAndWarnDiagnostics();
+        Diagnostic[] diag = compileResult.getDiagnostics();
         Assert.assertEquals(diag.length, 1);
         Assert.assertEquals(diag[0].getMessage(),
                             "cannot specify more than one annotation value for annotation 'ResourceConfig'");

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/ServiceConfigurationTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/ServiceConfigurationTest.java
@@ -43,7 +43,7 @@ public class ServiceConfigurationTest {
     public void testDuplicateServiceConfigAnnotations() {
         CompileResult compileResult = BCompileUtil.compile(
                 "test-src/services/configuration/service-config-annotation.bal");
-        Diagnostic[] diag = compileResult.getErrorAndWarnDiagnostics();
+        Diagnostic[] diag = compileResult.getDiagnostics();
         Assert.assertEquals(diag.length, 1);
         Assert.assertEquals(diag[0].getMessage(),
                             "cannot specify more than one annotation value for annotation 'ServiceConfig'");

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/compression/CompressionConfigNegativeTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/configuration/compression/CompressionConfigNegativeTest.java
@@ -38,7 +38,7 @@ public class CompressionConfigNegativeTest {
                                                                    .getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                             "incompatible types: expected '(AUTO|ALWAYS|NEVER)', found 'string'");
     }
 
@@ -49,7 +49,7 @@ public class CompressionConfigNegativeTest {
                                                                    .getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                 "Invalid multiple configurations for compression");
     }
 
@@ -59,7 +59,7 @@ public class CompressionConfigNegativeTest {
                 "test-src/services/configuration/compression/bogus-content-type.bal").getPath()).getAbsolutePath());
 
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().clone()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().clone()[0].getMessage(),
                             "Invalid Content-Type value for compression: 'hello=/#bal'");
     }
 

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/websocket/WebSocketCompilationTest.java
@@ -196,6 +196,6 @@ public class WebSocketCompilationTest {
     }
 
     private void assertExpectedDiagnosticsLength(CompileResult compileResult, int expectedLength) {
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, expectedLength);
+        Assert.assertEquals(compileResult.getDiagnostics().length, expectedLength);
     }
 }

--- a/stdlib/test-common/src/test/java/org/ballerinalang/stdlib/common/CommonTestUtils.java
+++ b/stdlib/test-common/src/test/java/org/ballerinalang/stdlib/common/CommonTestUtils.java
@@ -59,7 +59,7 @@ public class CommonTestUtils {
     }
 
     public static void printDiagnostics(CompileResult timerCompileResult, Log log) {
-        Arrays.asList(timerCompileResult.getErrorAndWarnDiagnostics()).
+        Arrays.asList(timerCompileResult.getDiagnostics()).
                 forEach(e -> log.info(e.getMessage() + " : " + e.getPosition()));
     }
 }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BAssertUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BAssertUtil.java
@@ -41,7 +41,7 @@ public class BAssertUtil {
      */
     public static void validateError(CompileResult result, int errorIndex, String expectedErrMsg, int expectedErrLine,
             int expectedErrCol) {
-        Diagnostic diag = result.getErrorAndWarnDiagnostics()[errorIndex];
+        Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.getKind(), Diagnostic.Kind.ERROR, "incorrect diagnostic type");
         Assert.assertEquals(diag.getMessage().replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING),
                 expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
@@ -51,7 +51,7 @@ public class BAssertUtil {
 
     public static void validateError(CompileResult result, int errorIndex, String expectedErrMsg, String fileName,
                                      int expectedErrLine, int expectedErrCol) {
-        Diagnostic diag = result.getErrorAndWarnDiagnostics()[errorIndex];
+        Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.getKind(), Diagnostic.Kind.ERROR, "incorrect diagnostic type");
         Assert.assertEquals(diag.getMessage().replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING),
                 expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
@@ -69,7 +69,7 @@ public class BAssertUtil {
      * @param expectedErrCol  Expected column number of the error
      */
     public static void validateError(CompileResult result, int errorIndex, int expectedErrLine, int expectedErrCol) {
-        Diagnostic diag = result.getErrorAndWarnDiagnostics()[errorIndex];
+        Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.getKind(), Diagnostic.Kind.ERROR, "incorrect diagnostic type");
         Assert.assertEquals(diag.getPosition().getStartLine(), expectedErrLine, "incorrect line number:");
         Assert.assertEquals(diag.getPosition().getStartColumn(), expectedErrCol, "incorrect column position:");
@@ -83,7 +83,7 @@ public class BAssertUtil {
      * @param expectedPartOfErrMsg Expected part of error message
      */
     public static void validateErrorMessageOnly(CompileResult result, int errorIndex, String expectedPartOfErrMsg) {
-        Diagnostic diag = result.getErrorAndWarnDiagnostics()[errorIndex];
+        Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.getKind(), Diagnostic.Kind.ERROR, "incorrect diagnostic type");
         Assert.assertTrue(diag.getMessage().contains(expectedPartOfErrMsg),
                 '\'' + expectedPartOfErrMsg + "' is not contained in error message '" + diag.getMessage() + '\'');
@@ -97,7 +97,7 @@ public class BAssertUtil {
      * @param expectedPartsOfErrMsg Array of expected parts of error message
      */
     public static void validateErrorMessageOnly(CompileResult result, int errorIndex, String[] expectedPartsOfErrMsg) {
-        Diagnostic diag = result.getErrorAndWarnDiagnostics()[errorIndex];
+        Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.getKind(), Diagnostic.Kind.ERROR, "incorrect diagnostic type");
         boolean contains = false;
         for (String part : expectedPartsOfErrMsg) {
@@ -121,7 +121,7 @@ public class BAssertUtil {
      */
     public static void validateWarning(CompileResult result, int warningIndex, String expectedWarnMsg,
             int expectedWarnLine, int expectedWarnCol) {
-        Diagnostic diag = result.getErrorAndWarnDiagnostics()[warningIndex];
+        Diagnostic diag = result.getDiagnostics()[warningIndex];
         Assert.assertEquals(diag.getKind(), Diagnostic.Kind.WARNING, "incorrect diagnostic type");
         Assert.assertEquals(diag.getMessage(), expectedWarnMsg, "incorrect warning message:");
         Assert.assertEquals(diag.getPosition().getStartLine(), expectedWarnLine, "incorrect line number:");

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/CompileResult.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/CompileResult.java
@@ -42,22 +42,11 @@ public class CompileResult {
         this.diagnosticListener = diagnosticListener;
     }
 
-    public Diagnostic[] getErrorAndWarnDiagnostics() {
-        List<Diagnostic> nonNoteDiagnostics = new ArrayList<>();
-
-        for (Diagnostic diagnostic : getDiagnostics()) {
-            if (diagnostic.getKind() != Diagnostic.Kind.NOTE) {
-                nonNoteDiagnostics.add(diagnostic);
-            }
-        }
-        return nonNoteDiagnostics.toArray(new Diagnostic[0]);
-    }
-
     public Diagnostic[] getDiagnostics() {
         List<Diagnostic> diagnostics = this.diagnosticListener.getDiagnostics();
         diagnostics.sort(Comparator.comparing((Diagnostic d) -> d.getSource().getCompilationUnitName()).
                 thenComparingInt(d -> d.getPosition().getStartLine()));
-        return diagnostics.toArray(new Diagnostic[diagnostics.size()]);
+        return diagnostics.toArray(new Diagnostic[0]);
     }
 
     public int getErrorCount() {
@@ -91,7 +80,7 @@ public class CompileResult {
             builder.append("Compilation Successful");
         } else {
             builder.append("Compilation Failed:\n");
-            for (Diagnostic diag : this.getErrorAndWarnDiagnostics()) {
+            for (Diagnostic diag : this.getDiagnostics()) {
                 builder.append(diag + "\n");
             }
         }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralPackageTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralPackageTest.java
@@ -42,7 +42,7 @@ public class IdentifierLiteralPackageTest {
 
         result = BCompileUtil.compile(this, "test-src/expressions/literals/identifierliteral/TestProject",
                 "pkg.main");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test(description = "Test accessing variable in other packages defined with identifier literal")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/TransactionLocalParticipantFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/TransactionLocalParticipantFunctionTest.java
@@ -46,7 +46,7 @@ public class TransactionLocalParticipantFunctionTest {
 
     @Test (enabled = false)
     public void testTransactionAnnotatedFunction() {
-        Diagnostic[] diagnostics = result.getErrorAndWarnDiagnostics();
+        Diagnostic[] diagnostics = result.getDiagnostics();
         Assert.assertTrue(diagnostics.length == 0, "Transaction annotation error");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeNegativeTests.java
@@ -39,7 +39,7 @@ public class RefTypeNegativeTests {
     public void testInvalidMethodSignaturesForRefTypes() {
         CompileResult compileResult =
                 BCompileUtil.compileInProc("test-src/javainterop/ballerina_ref_types_as_interop_negative.bal");
-        Diagnostic[] diagnostics = compileResult.getErrorAndWarnDiagnostics();
+        Diagnostic[] diagnostics = compileResult.getDiagnostics();
         Assert.assertNotNull(diagnostics);
         Assert.assertEquals(diagnostics.length, 6);
         BAssertUtil.validateError(compileResult, 0,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/NegativeValidationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/NegativeValidationTest.java
@@ -37,7 +37,7 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/ballerina_types_as_interop_types_negative.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 12);
+        Assert.assertEquals(compileResult.getDiagnostics().length, 12);
     }
 
     @Test
@@ -45,7 +45,7 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/negative/class_not_found.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}CLASS_NOT_FOUND 'org.ballerinalang.nativeimpl.jvm.tests.PublicStaticMethods'",
                 "class_not_found.bal", 25, 1);
@@ -56,8 +56,8 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/negative/method_not_found1.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_NOT_FOUND 'No such public method 'acceptStringOrErrorReturn' found in " +
                         "class 'class org.ballerinalang.nativeimpl.jvm.tests.StaticMethods''",
@@ -70,8 +70,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_not_found2.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_NOT_FOUND 'No such public method 'acceptObjectAndObjectReturn' with '3' " +
                         "parameter(s) found in class 'class org.ballerinalang.nativeimpl.jvm.tests.StaticMethods''",
@@ -84,8 +84,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_not_found3.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_NOT_FOUND 'No such public method 'acceptRecordAndRecordReturn' with '3' " +
                         "parameter(s) found in class 'class org.ballerinalang.nativeimpl.jvm.tests.StaticMethods''",
@@ -98,8 +98,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_not_found4.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_NOT_FOUND 'No such public method 'acceptIntAndUnionReturn' found in class " +
                         "'class org.ballerinalang.nativeimpl.jvm.tests.StaticMethods''",
@@ -112,8 +112,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_not_found5.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_NOT_FOUND 'No such public method 'acceptIntStringAndUnionReturn' found in " +
                         "class 'class org.ballerinalang.nativeimpl.jvm.tests.StaticMethods''",
@@ -127,7 +127,7 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/" + testFileName;
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(compileResult.getDiagnostics().length, 4);
 
         String message = "{ballerina/java}METHOD_NOT_FOUND 'No such public method '%s' that matches with " +
                 "parameter types '(%s)' found in class 'class org.ballerinalang.nativeimpl.jvm.tests.StaticMethods''";
@@ -156,8 +156,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match1.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'No such Java method " +
                         "'acceptIntReturnIntThrowsCheckedException' which throws checked exception found in class " +
@@ -171,8 +171,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match2.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'No such Java method " +
                         "'acceptRecordAndRecordReturnWhichThrowsCheckedException' which throws checked exception " +
@@ -186,8 +186,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match3.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'No such Java method " +
                         "'acceptIntUnionReturnWhichThrowsCheckedException' which throws checked exception found in " +
@@ -201,8 +201,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match4.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'No such Java method " +
                         "'acceptRefTypesAndReturnMapWhichThrowsCheckedException' which throws checked exception " +
@@ -216,8 +216,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match5.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'No such Java method " +
                         "'acceptStringErrorReturnWhichThrowsCheckedException' which throws checked exception found " +
@@ -231,8 +231,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match6.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'No such Java method " +
                         "'getArrayValueFromMapWhichThrowsCheckedException' which throws checked exception found in " +
@@ -246,8 +246,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match7.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible param type for method 'split' in " +
                         "class 'java.lang.String': Java type 'java.lang.String' will not be matched to ballerina " +
@@ -261,8 +261,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match8.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Parameter count does not match with Java method " +
                         "'split' found in class 'java.lang.String''",
@@ -275,8 +275,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match9.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible param type for method " +
                         "'decimalParamAsObjectAndReturn' in class " +
@@ -291,8 +291,8 @@ public class NegativeValidationTest {
         String path = "test-src/javainterop/negative/method_sig_not_match10.bal";
 
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible return type for method " +
                         "'decimalParamAndReturnAsObject' in class " +
@@ -306,8 +306,8 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/negative/method_sig_not_match11.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible return type for method " +
                         "'returnStringForBUnionFromJava' in class " +
@@ -321,8 +321,8 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/negative/method_sig_not_match12.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible param type for method " +
                         "'getIntFromJsonInt' in class 'org.ballerinalang.nativeimpl.jvm.tests.StaticMethods': " +
@@ -335,8 +335,8 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/negative/method_sig_not_match13.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible param type for method " +
                         "'getIntFromJsonInt' in class 'org.ballerinalang.nativeimpl.jvm.tests.StaticMethods': " +
@@ -349,8 +349,8 @@ public class NegativeValidationTest {
 
         String path = "test-src/javainterop/negative/method_sig_not_match14.bal";
         CompileResult compileResult = BCompileUtil.compileInProc(path);
-        compileResult.getErrorAndWarnDiagnostics();
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible param type for method " +
                         "'decimalParamAndWithBigDecimal' in class " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectDocumentationTest.java
@@ -92,7 +92,7 @@ public class ObjectDocumentationTest {
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/object/object_documentation_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0,
-                            getErrorString(compileResult.getErrorAndWarnDiagnostics()));
+                            getErrorString(compileResult.getDiagnostics()));
         Assert.assertEquals(compileResult.getWarnCount(), 21);
         int i = 0;
         BAssertUtil.validateWarning(compileResult, i++, "field 'a' already documented", 6, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/ExperimentalFeaturesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/ExperimentalFeaturesTest.java
@@ -39,7 +39,7 @@ public class ExperimentalFeaturesTest {
         int i = 0;
         BAssertUtil.validateError(result, i++, "using experimental feature 'transaction'. " +
                 "use '--experimental' flag to enable the experimental features", 4, 5);
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, i,
-                            "Error count mismatch" + Arrays.toString(result.getErrorAndWarnDiagnostics()));
+        Assert.assertEquals(result.getDiagnostics().length, i,
+                            "Error count mismatch" + Arrays.toString(result.getDiagnostics()));
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDocumentationTest.java
@@ -92,7 +92,7 @@ public class RecordDocumentationTest {
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/record_documentation_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0,
-                            getErrorString(compileResult.getErrorAndWarnDiagnostics()));
+                            getErrorString(compileResult.getDiagnostics()));
         Assert.assertEquals(compileResult.getWarnCount(), 20);
         int i = 0;
         BAssertUtil.validateWarning(compileResult, i++, "field 'a' already documented", 6, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/packageimport/PackageImportTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/packageimport/PackageImportTest.java
@@ -38,7 +38,7 @@ public class PackageImportTest {
     public void testDuplicatePackageImports() {
         CompileResult result =
                 BCompileUtil.compile("test-src/statements/package/imports/duplicate-import-negative.bal");
-        Assert.assertTrue(result.getErrorAndWarnDiagnostics().length > 0);
+        Assert.assertTrue(result.getDiagnostics().length > 0);
         BAssertUtil.validateError(result, 0, "redeclared import module 'ballerina/math'", 4, 1);
     }
 
@@ -46,7 +46,7 @@ public class PackageImportTest {
     public void testImportSamePkgWithDifferentAlias() {
         CompileResult result =
                 BCompileUtil.compile("test-src/statements/package/imports/import-same-pkg-with-different-alias.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ForwardReferencingGlobalDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ForwardReferencingGlobalDefinitionTest.java
@@ -40,7 +40,7 @@ public class ForwardReferencingGlobalDefinitionTest {
     public void globalDefinitionsWithCyclicReferences() {
         CompileResult resultNegativeCycleFound = BCompileUtil.compile("test-src/statements/variabledef/globalcycle/",
                 "simple");
-        Diagnostic[] diagnostics = resultNegativeCycleFound.getErrorAndWarnDiagnostics();
+        Diagnostic[] diagnostics = resultNegativeCycleFound.getDiagnostics();
         Assert.assertTrue(diagnostics.length > 0);
         BAssertUtil.validateError(resultNegativeCycleFound, 0, "illegal cyclic reference '[employee, person]'", 35, 1);
         BAssertUtil.validateError(resultNegativeCycleFound, 1, "illegal cyclic reference '[dep1, dep2]'", 54, 1);
@@ -51,7 +51,7 @@ public class ForwardReferencingGlobalDefinitionTest {
     public void globalDefinitionsReOrdering() {
         CompileResult resultReOrdered = BCompileUtil.compile(this, "test-src/statements/variabledef/TestProj/",
                 "multiFileReference");
-        Diagnostic[] diagnostics = resultReOrdered.getErrorAndWarnDiagnostics();
+        Diagnostic[] diagnostics = resultReOrdered.getDiagnostics();
         Assert.assertEquals(diagnostics.length, 0);
 
         BValue[] employee = BRunUtil.invoke(resultReOrdered, "getEmployee");
@@ -90,7 +90,7 @@ public class ForwardReferencingGlobalDefinitionTest {
         CompileResult cycle = BCompileUtil.compile("test-src/statements/variabledef/globalcycle/",
                                                    "viafunc");
 
-        Assert.assertTrue(cycle.getErrorAndWarnDiagnostics().length > 0);
+        Assert.assertTrue(cycle.getDiagnostics().length > 0);
         BAssertUtil.validateError(cycle, 0, "illegal cyclic reference '[fromFuncA, fromFunc, getPersonOuter, " +
                 "getPersonInner, getfromFuncA]'", 22, 1);
     }
@@ -100,7 +100,7 @@ public class ForwardReferencingGlobalDefinitionTest {
     public void globalDefinitionsListenerDef() {
         CompileResult resultNegativeCycleFound = BCompileUtil.compile(this,
                 "test-src/statements/variabledef/globalcycle/", "viaservice");
-        Assert.assertEquals(resultNegativeCycleFound.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(resultNegativeCycleFound.getDiagnostics().length, 1);
         BAssertUtil.validateError(resultNegativeCycleFound, 0, "illegal cyclic reference '[port, o, Obj]'", 22, 1);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
@@ -101,7 +101,7 @@ public class StructNegativeTest {
         CompileResult compileResult = BCompileUtil.compile(this, "test-src/structs/proj", "constants");
         Assert.assertEquals(compileResult.getWarnCount(), 0);
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "incompatible types: expected 'ballerina-test/constants:0.0.0:Person', found 'int'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/AnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/AnnotationTest.java
@@ -35,13 +35,13 @@ public class AnnotationTest {
     @Test
     public void testSensitive() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSensitiveNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 2, 39);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 3, 50);
     }
@@ -49,14 +49,14 @@ public class AnnotationTest {
     @Test
     public void testSensitiveDefaultArgs() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-default-args.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSensitiveDefaultArgsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-default-args-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 2, 56);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 3, 81);
     }
@@ -64,14 +64,14 @@ public class AnnotationTest {
     @Test
     public void testSensitiveRestArgs() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/sensitive-rest-args.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testSensitiveRestArgsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-rest-args-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 2, 30);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 3, 29);
     }
@@ -80,7 +80,7 @@ public class AnnotationTest {
     public void testSensitiveRestParamsWithVaryingInvocationArgs() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-rest-params-with-varying-invocation-args.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
@@ -88,7 +88,7 @@ public class AnnotationTest {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/" +
                         "sensitive-rest-params-with-varying-invocation-args-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'restParams'", 2, 46);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'restParams'", 3, 68);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'restParams'", 4, 87);
@@ -98,7 +98,7 @@ public class AnnotationTest {
     public void testSensitiveDefaultParamsWithUnorderedArgs() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/sensitive-default-params-with-unordered-args.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class AnnotationTest {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/annotations/" +
                         "sensitive-default-params-with-unordered-args-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'defaultableInput2'", 2, 43);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'defaultableInput2'", 3, 61);
     }
@@ -115,7 +115,7 @@ public class AnnotationTest {
     @Test
     public void testTainted() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/tainted.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 2, 20);
     }
 
@@ -124,6 +124,6 @@ public class AnnotationTest {
     @Test
     public void testUntainted() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/annotations/untainted.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ConflictTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ConflictTest.java
@@ -35,14 +35,14 @@ public class ConflictTest {
     @Test
     public void testRecursion() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/recursion.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testRecursionWithinAttachedExternalFunctions() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/recursions/recursion-within-attached-external-function.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     // Test cyclic function invocations.
@@ -50,19 +50,19 @@ public class ConflictTest {
     @Test
     public void testCyclicCall() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/cyclic-call.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMultipleCyclicCalls() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/multiple-cyclic-calls.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMultipleCyclicCallsComplex() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "multiple-cyclic-calls-complex.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/FunctionCallTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/FunctionCallTest.java
@@ -94,7 +94,7 @@ public class FunctionCallTest {
         BAssertUtil.validateError(negativeResult, i++, TAINTED_VALUE_FOR_I, 38, 9);
         BAssertUtil.validateError(negativeResult, i++, TAINTED_VALUE_FOR_S, 38, 9);
 
-        Assert.assertEquals(i, negativeResult.getErrorAndWarnDiagnostics().length);
+        Assert.assertEquals(i, negativeResult.getDiagnostics().length);
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ListenerServiceTaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ListenerServiceTaintedStatusPropagationTest.java
@@ -33,14 +33,14 @@ public class ListenerServiceTaintedStatusPropagationTest {
     public void testUntaintedListernBasedService() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/listener-taintedness-propagation-untainted-listener.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTaintednessPropagationFromTaintedListener() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/listener-taintedness-propagation-tainted-listener.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'p'", 26, 23);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'p'", 27, 23);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'p'", 40, 23);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/RecursionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/RecursionTest.java
@@ -34,14 +34,14 @@ public class RecursionTest {
     public void testRecursiveFunctionCallingSensitiveFunction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "recursive-function-calling-sensitive-function.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testRecursiveFunctionCallingSensitiveFunctionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "recursive-function-calling-sensitive-function-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'inputData'", 2, 21);
     }
 
@@ -49,7 +49,7 @@ public class RecursionTest {
     public void testRecursiveFunctionAlteringSensitiveStatusCallingSensitiveFunction1Negative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "cyclic-call-altering-sensitive-status-calling-sensitive-function-1-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 12, 20);
     }
 
@@ -57,14 +57,14 @@ public class RecursionTest {
     public void testRecursiveFunctionAlteringSensitiveStatusCallingSensitiveFunction2Negative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/" +
                 "cyclic-call-altering-sensitive-status-calling-sensitive-function-2-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 18, 20);
     }
 
     @Test
     public void testMultipleRecursionsNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/recursions/multiple-recursions.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 17, 20);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/TaintedStatusPropagationTest.java
@@ -32,26 +32,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testReturn() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/returns.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testReturnNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/returns-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 2, 20);
     }
 
     @Test
     public void testVariable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/variables.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testVariableNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/variables-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 6);
+        Assert.assertEquals(result.getDiagnostics().length, 6);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 10, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 14, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 19, 20);
@@ -63,26 +63,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testReceiver() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/receiver.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testReceiverNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/receiver-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 3, 20);
     }
 
     @Test
     public void testRecord() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/record.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testRecordNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/record-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 8);
+        Assert.assertEquals(result.getDiagnostics().length, 8);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 9, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 13, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 17, 20);
@@ -96,13 +96,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testArray() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/array.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testArrayNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/array-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 6);
+        Assert.assertEquals(result.getDiagnostics().length, 6);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 4, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 13, 20);
@@ -114,13 +114,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testJson() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/json.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testJsonNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/json-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 8);
+        Assert.assertEquals(result.getDiagnostics().length, 8);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 4, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 12, 20);
@@ -134,13 +134,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testMap() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/map.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMapNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/map-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 8);
+        Assert.assertEquals(result.getDiagnostics().length, 8);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 4, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 12, 20);
@@ -154,13 +154,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testXML() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/xml.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testXMLNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/xml-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 7, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 10, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 13, 20);
@@ -170,26 +170,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testBasicWorker() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/basic-worker.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testBasicWorkerNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/basic-worker-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 3, 24);
     }
 
     @Test
     public void testIfCondition() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/if-condition.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testIfConditionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/if-condition-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 8, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 16, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 24, 20);
@@ -199,13 +199,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testTernaryExpr() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/ternary.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTernaryExprNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/ternary-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 3, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 6, 20);
     }
@@ -213,26 +213,26 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testLambda() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/lambda.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testLambdaNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/lambda-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 28, 20);
     }
 
     @Test
     public void testTupleReturn() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/tuple-return.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTupleReturnNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/tuple-return-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 6, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 7, 20);
     }
@@ -240,53 +240,53 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testStringTemplate() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/string-template.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testStringTemplateNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/string-template-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 4, 20);
     }
 
     @Test
     public void testIterable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/iterable.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testIterableNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/iterable-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 3, 20);
     }
 
     @Test
     public void testIterableWitinIterable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/iterable-within-iterable.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testLambdaAsArgumentToIterableLanglibFunction() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/lambda-as-argument-to-iterable-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 6, 28);
     }
 
     @Test
     public void testForEach() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/foreach.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testForEachNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/foreach-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 5, 24);
     }
 
@@ -294,27 +294,27 @@ public class TaintedStatusPropagationTest {
     public void testMultipleInvocationLevels() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/multiple-invocation-levels.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMultipleInvocationLevelsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/multiple-invocation-levels-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'normalInput'", 2, 20);
     }
 
     @Test
     public void testCast() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/cast.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCastNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/cast-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 4, 20);
     }
 
@@ -322,14 +322,14 @@ public class TaintedStatusPropagationTest {
     public void testChainedInvocations() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/chained-invocations.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testChainedInvocationsNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/chained-invocations-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 2, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'rec'", 6, 22);
     }
@@ -338,14 +338,14 @@ public class TaintedStatusPropagationTest {
     public void testWithoutUserDataNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/without-user-data-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 7, 20);
     }
 
     @Test
     public void testGlobalVariables() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/global-variables.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
@@ -359,13 +359,13 @@ public class TaintedStatusPropagationTest {
         BAssertUtil.validateError(result, i++, "tainted value passed to global variable 'REC'", 13, 5);
         BAssertUtil.validateError(result, i++, "tainted value passed to global variable 'REC'", 14, 5);
         BAssertUtil.validateError(result, i++, "tainted value passed to global variable 'globalVariable'", 22, 5);
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, i);
+        Assert.assertEquals(result.getDiagnostics().length, i);
     }
 
     @Test
     public void testHttpService() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/http-service.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 14, 24);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 15, 24);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'payload'", 22, 37);
@@ -376,7 +376,7 @@ public class TaintedStatusPropagationTest {
     public void testHttpServiceInlineListenerDecl() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/http-service-in-line-listener.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 28, 24);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 29, 24);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'payload'", 36, 37);
@@ -385,14 +385,14 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testCompoundAssignment() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/compound-assignment.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCompoundAssignmentNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/compound-assignment-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 7, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 11, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 16, 24);
@@ -401,13 +401,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testMatch() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/is.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testMatchNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/is-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 6, 24);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 10, 24);
     }
@@ -415,27 +415,27 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testObjectFunction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/object-functions.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testObjectFunctionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/object-functions-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 14, 20);
     }
 
     @Test
     public void testGlobalObjectFunction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/global-object-functions.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testGlobalObjectFunctionNegative() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/global-object-functions-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "method invocation taint global object 'G'", 20, 5);
     }
 
@@ -443,7 +443,7 @@ public class TaintedStatusPropagationTest {
     public void testTaintedAssignmentToUntaintedObjReference() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/object-tainted-assigment-to-untainted-objref.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0,
                 "tainted value passed to untainted parameter 'secureIn' originating from object method " +
                         "'test2' invocation", 52, 15);
@@ -454,28 +454,28 @@ public class TaintedStatusPropagationTest {
     public void testObjectFunctionWithConstructor() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/object-functions-with-constructor.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testObjectFunctionWithConstructorNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/object-functions-with-constructor-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 21, 20);
     }
 
     @Test
     public void testSimpleWorkerInteraction() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/simple-worker-interaction.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test(enabled = false) // https://github.com/ballerina-platform/ballerina-lang/issues/17497
     public void testSimpleWorkerInteractionNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 6, 24);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 11, 24);
     }
@@ -484,7 +484,7 @@ public class TaintedStatusPropagationTest {
     public void testSimpleBlockedWorkerInteractionNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-blocked-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 5, 24);
     }
 
@@ -492,28 +492,28 @@ public class TaintedStatusPropagationTest {
     public void testSimpleWorkerInteractionWithTupleAssignment() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/simple-worker-interaction-with-tuple-assignment.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test (enabled = false)
     public void testSimpleWorkerInteractionWithTupleAssignmentNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "simple-worker-interaction-with-tuple-assignment-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 13, 24);
     }
 
     @Test
     public void testInOutParameters() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/in-out-param-basic.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testInOutParametersNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "in-out-param-basic-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 5);
+        Assert.assertEquals(result.getDiagnostics().length, 5);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 28, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 32, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 36, 20);
@@ -525,27 +525,27 @@ public class TaintedStatusPropagationTest {
     public void testParameterStatusWithNativeInvocations() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "param-status-with-native-invocations.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testParameterStatusWithNativeInvocationsNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "param-status-with-native-invocations-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'key'", 23, 33);
     }
 
     @Test
     public void testError() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/error.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testErrorNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/error-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 19, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 22, 20);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'secureIn'", 24, 21);
@@ -555,13 +555,13 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testCall() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/call.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCallNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/call-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 18, 20);
     }
 
@@ -569,14 +569,14 @@ public class TaintedStatusPropagationTest {
     public void testClosureVariableAssignment() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "closure-variable-assignment.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testClosureVariableAssignmentNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/" +
                 "closure-variable-assignment-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to closure variable 'test'", 22, 9);
     }
 
@@ -584,7 +584,7 @@ public class TaintedStatusPropagationTest {
     public void testLangLibFunctionTaintPropagationNegative() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/lang-lib-function-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'p'", 33, 16);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'p'", 34, 16);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'p'", 39, 16);
@@ -593,7 +593,7 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testTaintedStatusPropagationThroughListConstructor() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/list-ctor-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 't'", 20, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'a'", 21, 20);
     }
@@ -602,20 +602,20 @@ public class TaintedStatusPropagationTest {
     public void testGlobalFunctionPointerAsyncInvocation() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/global-func-pointer-async-invocation.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testTaintednessPropagationIntoTypeGuardNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/into-type-guard-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'arg'", 21, 13);
     }
 
     @Test
     public void testTaintednessPropagationCheckExpressionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/check-expression-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'arg'", 19, 9);
         BAssertUtil.validateError(result, 1,
                 "functions returning tainted value are required to annotate return signature @tainted: 'foo'", 22, 24);
@@ -624,13 +624,13 @@ public class TaintedStatusPropagationTest {
      @Test
      public void testTaintLetExpr() {
          CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/let.bal");
-         Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+         Assert.assertEquals(result.getDiagnostics().length, 0);
      }
 
      @Test
      public void testTaintLetExprNegative() {
          CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/let-negative.bal");
-         Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+         Assert.assertEquals(result.getDiagnostics().length, 2);
          BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 19, 20);
          BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 22, 20);
      }
@@ -638,14 +638,14 @@ public class TaintedStatusPropagationTest {
     @Test
     public void testNamedArgToNewExpr() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/named-arg-to-new.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'username'", 18, 16);
     }
 
     @Test
     public void testRestArgs() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/rest-args.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'rest'", 14, 18);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'arg'", 27, 18);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'argv'", 28, 23);
@@ -655,7 +655,7 @@ public class TaintedStatusPropagationTest {
     public void testClassMemberWithConstructorNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/propagation/class-member-with-constructor-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 30, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 31, 20);
     }
@@ -663,7 +663,7 @@ public class TaintedStatusPropagationTest {
 //    @Test () Disabled on #21823
 //    public void testLambdaFunctionBlockedAnalysis() {
 //        CompileResult result = BCompileUtil.compile("test-src/taintchecking/propagation/lambda-func.bal");
-//        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+//        Assert.assertEquals(result.getDiagnostics().length, 1);
 //        BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureParameter'", 5, 36);
 //    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/UntaintAndTaintAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/UntaintAndTaintAnnotationTest.java
@@ -50,14 +50,14 @@ public class UntaintAndTaintAnnotationTest {
     @Test
     public void testTaint() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/expressions/taint.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(result.getDiagnostics().length, 1);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'sensitiveInput'", 19, 20);
     }
 
     @Test
     public void testUntaintVariable() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/expressions/untaint-variable-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'secureIn'", 5, 20);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 8, 20);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/HttpClientTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/HttpClientTest.java
@@ -33,13 +33,13 @@ public class HttpClientTest {
     @Test
     public void testHttpClient() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/httpclient.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testHttpClientNegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/httpclient-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'path'", 12, 42);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'secureIn'", 16, 28);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/IOTest.java
@@ -32,13 +32,13 @@ public class IOTest {
     @Test
     public void testCharacterIO() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/character-io.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
     @Test
     public void testCharacterIONegative() {
         CompileResult result = BCompileUtil.compile("test-src/taintchecking/connectors/character-io-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'path'", 10, 69);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'path'", 13, 69);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'numberOfChars'", 17, 35);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/SQLTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/connectors/SQLTest.java
@@ -36,14 +36,14 @@ public class SQLTest {
     public void testSelectWithUntaintedQuery() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-untainted-query.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(result.getDiagnostics().length, 3);
     }
 
     @Test (enabled = false)
     public void testSelectWithTaintedQueryNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-tainted-query-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'args'", 4, 40);
     }
 
@@ -52,14 +52,14 @@ public class SQLTest {
     public void testSelectWithUntaintedQueryProducingTaintedReturn() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 2);
+        Assert.assertEquals(result.getDiagnostics().length, 2);
     }
 
     @Test (enabled = false)
     public void testSelectWithUntaintedQueryProducingTaintedReturnNegative() {
         CompileResult result = BCompileUtil
                 .compile("test-src/taintchecking/connectors/sql-select-untainted-query-tainted-return-negative.bal");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(result.getDiagnostics().length, 4);
         BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'anyValue'", 25, 26);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
@@ -181,24 +181,24 @@ public class BMapValueTest {
     @Test(description = "Testing map value access in variableDefStmt")
     void testInvalidGrammar1() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/map/map-value-validator-1-negative.bal");
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
+        Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "incompatible types: expected 'string', found 'any'");
     }
 
     @Test(description = "Testing map value access in assignStmt")
     void testInvalidGrammar2() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/map/map-value-validator-2-negative.bal");
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
+        Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "incompatible types: expected 'string', found 'any'");
     }
 
     @Test(description = "Testing map value access in binary expression")
     void testInvalidGrammar3() {
         CompileResult compileResult = BCompileUtil.compile("test-src/types/map/map-value-validator-3-negative.bal");
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics().length, 1);
-        Assert.assertEquals(compileResult.getErrorAndWarnDiagnostics()[0].getMessage(),
+        Assert.assertEquals(compileResult.getDiagnostics().length, 1);
+        Assert.assertEquals(compileResult.getDiagnostics()[0].getMessage(),
                             "operator '+' not defined for 'any' and 'int'");
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
@@ -92,7 +92,7 @@ public class MapAccessExprTest {
     @Test(description = "Test nested map access")
     public void testNestedMapAccess() {
         CompileResult incorrectCompileResult = BCompileUtil.compile("test-src/types/map/nested-map-access.bal");
-        Assert.assertEquals(incorrectCompileResult.getErrorAndWarnDiagnostics().length, 1);
+        Assert.assertEquals(incorrectCompileResult.getDiagnostics().length, 1);
         BAssertUtil.validateError(incorrectCompileResult, 0, "invalid operation: type 'any' does not support " +
                 "indexing", 4, 12);
     }
@@ -155,7 +155,7 @@ public class MapAccessExprTest {
 
     @Test(description = "Map access negative scenarios", groups = { "disableOnOldParser" })
     public void testNegativeSemantics() {
-        Assert.assertEquals(resultSemanticsNegative.getErrorAndWarnDiagnostics().length, 4);
+        Assert.assertEquals(resultSemanticsNegative.getDiagnostics().length, 4);
         int index = 0;
         BAssertUtil.validateError(resultSemanticsNegative, index++,
                 "incompatible types: expected 'string', found " + "'int'", 4, 20);
@@ -167,7 +167,7 @@ public class MapAccessExprTest {
 
     @Test(description = "Map access negative scenarios")
     public void negativeTest() {
-        Assert.assertEquals(resultNegative.getErrorAndWarnDiagnostics().length, 3);
+        Assert.assertEquals(resultNegative.getDiagnostics().length, 3);
         int index = 0;
 
         // uninitialized map access

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLIterationTest.java
@@ -149,7 +149,7 @@ public class XMLIterationTest {
             description = "Test iterating over xml elements where some elements are characters")
     public void testXMLCompoundCharacterSequenceIteration() {
         BValue[] results = BRunUtil.invoke(result, "xmlSequenceIter");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
         String str = results[0].stringValue();
         Assert.assertEquals(str, "<book>the book</book>\nbit of text\\u2702\\u2705\n");
     }
@@ -158,7 +158,7 @@ public class XMLIterationTest {
             description = "Test iterating over xml sequence where all elements are character items")
     public void testXMLCharacterSequenceIteration() {
         BValue[] results = BRunUtil.invoke(result, "xmlCharItemIter");
-        Assert.assertEquals(result.getErrorAndWarnDiagnostics().length, 0);
+        Assert.assertEquals(result.getDiagnostics().length, 0);
         String str = results[0].stringValue();
         Assert.assertEquals(str, "bit of text\\u2702\\u2705\n");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkTest.java
@@ -42,7 +42,7 @@ public class BasicForkTest {
     @BeforeClass
     public void setup() {
         this.result = BCompileUtil.compile("test-src/workers/basic-fork.bal");
-        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getErrorAndWarnDiagnostics()).toString());
+        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getDiagnostics()).toString());
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerTest.java
@@ -38,7 +38,7 @@ public class BasicWorkerTest {
     @BeforeClass
     public void setup() {
         this.result = BCompileUtil.compile("test-src/workers/basic-worker-actions.bal");
-        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getErrorAndWarnDiagnostics()).toString());
+        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getDiagnostics()).toString());
     }
     
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/ForkInFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/ForkInFunctionTest.java
@@ -60,7 +60,7 @@ public class ForkInFunctionTest {
     @Test(description = "Test Fork With Workers in same function")
     public void testForkWithWorkersInSameFunction() {
         CompileResult result = BCompileUtil.compile("test-src/workers/fork-workers-under-same-funtion.bal");
-        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getErrorAndWarnDiagnostics()).toString());
+        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getDiagnostics()).toString());
         BValue[] args = {};
         BValue[] returns = BRunUtil.invoke(result, "forkWithWorkers", args);
         Assert.assertEquals(returns.length, 1);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/VarMutabilityWithWorkersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/VarMutabilityWithWorkersTest.java
@@ -41,7 +41,7 @@ public class VarMutabilityWithWorkersTest {
     public void setup() {
         compileResult = BCompileUtil.compile("test-src/workers/var-mutability-with-workers.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0,
-                            Arrays.asList(compileResult.getErrorAndWarnDiagnostics()).toString());
+                            Arrays.asList(compileResult.getDiagnostics()).toString());
     }
 
     @Test(description = "Test variable mutability with basic types")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllWorkersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllWorkersTest.java
@@ -40,7 +40,7 @@ public class WaitForAllWorkersTest {
     @BeforeClass
     public void setup() {
         this.result = BCompileUtil.compile("test-src/workers/wait_for_all_workers.bal");
-        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getErrorAndWarnDiagnostics()).toString());
+        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getDiagnostics()).toString());
     }
 
     @Test(description = "Test to see if worker continues to run even when default worker has finished")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerCancelledTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerCancelledTest.java
@@ -37,7 +37,7 @@ public class WorkerCancelledTest {
     @BeforeClass
     public void setup() {
         this.result = BCompileUtil.compile("test-src/workers/worker-cancelled.bal");
-        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getErrorAndWarnDiagnostics()).toString());
+        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getDiagnostics()).toString());
     }
 
     @Test()

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFailTest.java
@@ -33,7 +33,7 @@ public class WorkerFailTest {
     @Test
     public void invalidWorkerSendReceive() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-worker-send-receive.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1);
         Assert.assertTrue(message.contains(" interactions are invalid"), message);
     }
@@ -48,7 +48,7 @@ public class WorkerFailTest {
     @Test
     public void invalidWorkReceiveWithoutWorker() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-workreceive-without-worker.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("undefined worker"), message);
     }
@@ -70,7 +70,7 @@ public class WorkerFailTest {
     @Test
     public void invalidSendInLambda() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-send-in-lambda.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("undefined worker"), message);
     }
@@ -79,7 +79,7 @@ public class WorkerFailTest {
     public void invalidSendWithReturnTest() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-send-with-return.bal");
         Assert.assertEquals(result.getErrorCount(), 1);
-        String message = result.getErrorAndWarnDiagnostics()[0].getMessage();
+        String message = result.getDiagnostics()[0].getMessage();
         Assert.assertTrue(message.contains("can not be used after a non-error return"), message);
     }
 
@@ -87,7 +87,7 @@ public class WorkerFailTest {
     public void invalidSendWithErrorReturnTest() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-send-with-error-return.bal");
         Assert.assertEquals(result.getErrorCount(), 1);
-        String message = result.getErrorAndWarnDiagnostics()[0].getMessage();
+        String message = result.getDiagnostics()[0].getMessage();
         Assert.assertTrue(message.contains("expected 'int', found '(error|int)'"), message);
     }
 
@@ -95,7 +95,7 @@ public class WorkerFailTest {
     public void invalidReceiveWithErrorReturnTest() {
         CompileResult result =
                 BCompileUtil.compile("test-src/workers/invalid-receive-with-error-return.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("incompatible types"), message);
     }
@@ -131,14 +131,14 @@ public class WorkerFailTest {
     public void invalidSendWithErrorCheckTest() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-send-with-error-check.bal");
         Assert.assertEquals(result.getErrorCount(), 1);
-        String message = result.getErrorAndWarnDiagnostics()[0].getMessage();
+        String message = result.getDiagnostics()[0].getMessage();
         Assert.assertTrue(message.contains("can not be used after a non-error return"), message);
     }
 
     @Test
     public void invalidSendInIf() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-send-in-if.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker send statement position, must be a top level statement in " +
                                                    "a worker"), message);
@@ -147,7 +147,7 @@ public class WorkerFailTest {
     @Test
     public void invalidSyncSendInIf() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-sync-send-in-if.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker send statement position, must be a top level statement in " +
                                                    "a worker"), message);
@@ -156,7 +156,7 @@ public class WorkerFailTest {
     @Test
     public void invalidReceiveInIf() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-receive-in-if.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker receive statement position, must be a top level statement " +
                                                    "in a worker"), message);
@@ -201,7 +201,7 @@ public class WorkerFailTest {
     @Test
     public void invalidReceiveInForEach() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-receive-in-foreach.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker receive statement position, must be a top level statement " +
                                                    "in a worker"), message);
@@ -210,7 +210,7 @@ public class WorkerFailTest {
     @Test
     public void invalidAsycnSendInForEach() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-async-send-in-foreach.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker send statement position, must be a top level statement in " +
                                                    "a worker"), message);
@@ -219,7 +219,7 @@ public class WorkerFailTest {
     @Test
     public void invalidSycnSendInForEach() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-sync-send-in-foreach.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker send statement position, must be a top level statement in " +
                                                    "a worker"), message);
@@ -228,7 +228,7 @@ public class WorkerFailTest {
     @Test
     public void invalidAsyncSendInFork() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-async-send-in-fork.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker send statement position, must be a top level statement " +
                                                    "in a worker"), message);
@@ -237,7 +237,7 @@ public class WorkerFailTest {
     @Test
     public void invalidSyncSendInFork() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-sync-send-in-fork.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker send statement position, must be a top level statement " +
                                                    "in a worker"), message);
@@ -246,7 +246,7 @@ public class WorkerFailTest {
     @Test
     public void invalidReceiveInFork() {
         CompileResult result = BCompileUtil.compile("test-src/workers/invalid-receive-in-fork.bal");
-        String message = Arrays.toString(result.getErrorAndWarnDiagnostics());
+        String message = Arrays.toString(result.getDiagnostics());
         Assert.assertEquals(result.getErrorCount(), 1, message);
         Assert.assertTrue(message.contains("invalid worker receive statement position, must be a top level statement " +
                                                    "in a worker"), message);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -43,7 +43,7 @@ public class WorkerTest {
     @BeforeClass
     public void setup() {
         this.result = BCompileUtil.compile("test-src/workers/workers.bal");
-        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getErrorAndWarnDiagnostics()).toString());
+        Assert.assertEquals(result.getErrorCount(), 0, Arrays.asList(result.getDiagnostics()).toString());
     }
 
     @Test


### PR DESCRIPTION
## Purpose
$title.

This is no longer required since isolation analysis doesn't log note logs now.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
