### PR TITLE
Increase kaitai build time and use global gradle cache directory to speedup build time

### DIFF
--- a/docs/bir-spec/build.gradle
+++ b/docs/bir-spec/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 
 kaitai {
     packageName = 'org.ballerinalang.build.kaitai'
+
+    cacheDir = new File("${project.gradle.gradleUserHomeDir}/kaitai-cache")
 }
 
 sourceSets.main.java.srcDirs += 'build/generated/kaitai/src'

--- a/docs/bir-spec/build.gradle
+++ b/docs/bir-spec/build.gradle
@@ -64,8 +64,8 @@ dependencies {
 
 kaitai {
     packageName = 'org.ballerinalang.build.kaitai'
-
     cacheDir = new File("${project.gradle.gradleUserHomeDir}/kaitai-cache")
+    executionTimeout = 10_000
 }
 
 sourceSets.main.java.srcDirs += 'build/generated/kaitai/src'


### PR DESCRIPTION
## Purpose
This PR will avoid timeout issues with kaitai build task. Currently this has the default value of 5 seconds and it can be configured using the property `executionTimeout `. 

Additionally, this PR also uses global gradle user home to be used with kaitai cache directory, which will speedup subsequent build time. 

Fixes #25852

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
