### PR TITLE
Fix Testerina grouping tests

### DIFF
--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-afterGroups-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-afterGroups-fails.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/test;
+
 # Test file to test the test execution behavior when a @AfterGroups function
 # fails. The expected behavior is that none other function should be exectuted
 # subsequently other than the @AfterSuite function.
-
-import ballerina/test;
 
 string a = "";
 

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeGroups-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeGroups-fails.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/test;
+
 # Test file to test the test execution behavior when a @BeforeGroups function
 # fails. The expected behavior is that none other function should be exectuted
-# subsequently other than the @AfterSuite function.
-
-import ballerina/test;
+# subsequently other than the @AfterSuite function
 
 string a = "";
 


### PR DESCRIPTION
## Purpose
Move the comments to prevent the `invalid metadata` issue.

```

Sep 17, 2020 5:07:23 AM org.ballerinalang.test.context.ServerLogReader feedAndPrint |  
-- | --
  | INFO: Compiling source |  
  | Sep 17, 2020 5:07:23 AM org.ballerinalang.test.context.ServerLogReader feedAndPrint |  
  | INFO: 	skip-when-afterGroups-fails.bal |  
  | Sep 17, 2020 5:07:23 AM org.ballerinalang.test.context.ServerLogReader feedAndPrint |  
  | SEVERE: error: .::skip-when-afterGroups-fails.bal:21:1: invalid metadata
```

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
