### PR TITLE
Filter out anonymous user defined types in node resolver

### DIFF
--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/NodeResolver.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/NodeResolver.java
@@ -176,6 +176,8 @@ import org.wso2.ballerinalang.compiler.util.diagnotic.DiagnosticPos;
 
 import java.util.List;
 
+import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
+
 /**
  * Finds the enclosing AST node for the given position.
  *
@@ -950,8 +952,8 @@ class NodeResolver extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangUserDefinedType userDefinedType) {
-        this.enclosingNode = userDefinedType;
-        if (setEnclosingNode(userDefinedType, userDefinedType.typeName.pos)) {
+        if (userDefinedType.type.tsymbol.origin == VIRTUAL
+                || setEnclosingNode(userDefinedType, userDefinedType.typeName.pos)) {
             return;
         }
 

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -95,7 +95,7 @@ public class SymbolAtCursorTest {
         };
     }
 
-    @Test(dataProvider = "EnumPosProvider", enabled = false)
+    @Test(dataProvider = "EnumPosProvider")
     public void testEnum(int line, int column, String expSymbolName) {
         CompilerContext context = new CompilerContext();
         CompileResult result = compile("test-src/symbol_at_cursor_enum_test.bal", context);
@@ -113,13 +113,12 @@ public class SymbolAtCursorTest {
     @DataProvider(name = "EnumPosProvider")
     public Object[][] getEnumPos() {
         return new Object[][]{
-                {69, 7, "RED"},
-                {73, 19, "RED"},
-                {74, 9, "Colour"},
-                {78, 46, "Colour"},
-                {78, 46, "Colour"},
-                {82, 18, "GREEN"},
-                {83, 29, "BLUE"},
+                {18, 7, "RED"},
+//                {22, 19, "RED"}, // TODO: issue #25841
+                {23, 9, "Colour"},
+                {27, 46, "Colour"},
+//                {31, 18, "GREEN"}, // TODO: issue #25841
+//                {32, 29, "BLUE"}, // TODO: issue #25841
         };
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangConstant.java
@@ -18,6 +18,7 @@
 package org.wso2.ballerinalang.compiler.tree.expressions;
 
 import org.ballerinalang.model.elements.Flag;
+import org.ballerinalang.model.symbols.Symbol;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.MarkdownDocumentationNode;
@@ -131,5 +132,15 @@ public class BLangConstant extends BLangVariable implements ConstantNode, TypeDe
     @Override
     public void setPrecedence(int precedence) {
         // Ignore
+    }
+
+    @Override
+    public Symbol getSymbol() {
+        return this.symbol;
+    }
+
+    @Override
+    public void setSymbol(Symbol symbol) {
+        this.symbol = (BConstantSymbol) symbol;
     }
 }


### PR DESCRIPTION
## Purpose
> This PR is to filter out compiler generated user defined types in the node resolver. This allows exposing constants as just constant symbols from the semantic API.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
