### PR TITLE
Fix issue in recognizing overloaded instance method

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JInterop.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JInterop.java
@@ -134,7 +134,9 @@ class JInterop {
     static ParamTypeConstraint[] buildParamTypeConstraints(List<JType> javaTypeConstraints, ClassLoader classLoader) {
 
         if (javaTypeConstraints == null) {
-            return new ParamTypeConstraint[0];
+            // Returning null because empty array signifies that the parameterTypes field is set but is empty
+            // Null signifies that parameterTypes field has not been set
+            return null;
         }
 
         List<ParamTypeConstraint> constraintList = new ArrayList<>();
@@ -291,5 +293,8 @@ class JInterop {
     static boolean isMethodAnnotationTag(String annotTag) {
 
         return CONSTRUCTOR_ANNOT_TAG.equals(annotTag) || METHOD_ANNOT_TAG.equals(annotTag);
+    }
+
+    private JInterop() {
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
@@ -111,13 +111,12 @@ class JMethodResolver {
 
         // 3) Filter out the constructors or methods that have the same number of
         //      parameters as the number of constraints
-        int paramCount = getBFuncParamCount(jMethodRequest, jMethods);
-        jMethods = resolveByParamCount(jMethods, paramCount, jMethodRequest.receiverType);
+        jMethods = resolveByParamCount(jMethods, jMethodRequest);
 
         // 4) If the above list is zero then throw an error
         if (jMethods.isEmpty()) {
             throw getMethodNotFoundError(jMethodRequest.kind, jMethodRequest.declaringClass,
-                    jMethodRequest.methodName, paramCount);
+                                         jMethodRequest.methodName, jMethodRequest.bFuncParamCount);
         }
 
         // 5) Now resolve the most specific method using the constraints.
@@ -138,29 +137,30 @@ class JMethodResolver {
                 .collect(Collectors.toList());
     }
 
-    private List<JMethod> resolveByParamCount(List<JMethod> jMethods, int expectedCount, BType receiverType) {
-        return jMethods.stream().filter(jMethod -> {
-            int count = jMethod.getParamTypes().length;
-            if (count == expectedCount) {
+    private List<JMethod> resolveByParamCount(List<JMethod> jMethods, JMethodRequest jMethodRequest) {
+        return jMethods.stream()
+                .filter(jMethod -> hasEqualParamCounts(jMethodRequest, jMethod))
+                .collect(Collectors.toList());
+    }
+
+    private boolean hasEqualParamCounts(JMethodRequest jMethodRequest, JMethod jMethod) {
+        int expectedCount = getBFuncParamCount(jMethodRequest, jMethod);
+        int count = jMethod.getParamTypes().length;
+        if (count == expectedCount) {
+            return true;
+        } else if (count == expectedCount + 1) {
+            // This is for object interop functions when self is passed as a parameter
+            if (jMethodRequest.receiverType != null) {
+                jMethod.setReceiverType(jMethodRequest.receiverType);
                 return true;
-            } else {
-                boolean hasOneExtraParam = count == expectedCount + 1;
-                if (hasOneExtraParam) {
-                    boolean hasReceiver = receiverType != null;
-                    if (hasReceiver) {
-                        jMethod.setReceiverType(receiverType);
-                        return true;
-                    } else if (jMethod.isBalEnvAcceptingMethod()) {
-                        return true;
-                    }
-                }
+            } else if (jMethod.isStatic()) {
+                return jMethod.isBalEnvAcceptingMethod();
             }
-            return false;
-        }).collect(Collectors.toList());
+        }
+        return false;
     }
 
     private JMethod resolve(JMethodRequest jMethodRequest, List<JMethod> jMethods) {
-
         boolean noConstraints = noConstraintsSpecified(jMethodRequest.paramTypeConstraints);
         if (jMethods.size() == 1 && noConstraints) {
             return jMethods.get(0);
@@ -184,18 +184,22 @@ class JMethodResolver {
     }
 
     private Optional<JMethod> findCovariantReturnTypeMethod(List<JMethod> jMethods) {
-
         for (int i = 0; i < jMethods.size(); i++) {
-            for (int k = i; k < jMethods.size(); k++) {
-                if (i == k) {
-                    continue;
-                }
-
+            for (int k = i + 1; k < jMethods.size(); k++) {
                 JMethod ithMethod = jMethods.get(i);
                 JMethod kthMethod = jMethods.get(k);
 
                 if (ithMethod.getReturnType().isAssignableFrom(kthMethod.getReturnType()) ||
                         kthMethod.getReturnType().isAssignableFrom(ithMethod.getReturnType())) {
+                    if (ithMethod.getParamTypes().length != kthMethod.getParamTypes().length) {
+                        // This occurs when there are static methods and instance methods and the static method
+                        // has one more parameter than the instance method. Also this occurs when an interop
+                        // method in an object maps to instance methods of which one accepting self and another
+                        // that doesn't.
+                        throw new JInteropException(
+                                OVERLOADED_METHODS, "Overloaded methods cannot be differentiated. Please specify the " +
+                                "parameterTypes for each parameter in 'paramTypes' field in the annotation");
+                    }
                     return Optional.of(ithMethod);
                 }
             }
@@ -291,14 +295,16 @@ class JMethodResolver {
 
         Class<?> jReturnType = jMethod.getReturnType();
         BType bReturnType = jMethodRequest.bReturnType;
-        //!(jMethod.isBalEnvAcceptingMethod() && )
         if (!isValidReturnBType(jReturnType, bReturnType, jMethodRequest) &&
-            !(jMethod.isBalEnvAcceptingMethod() && jReturnType.equals(void.class))) {
+                !(jMethod.isBalEnvAcceptingMethod() && jReturnType.equals(void.class))) {
             throw new JInteropException(DiagnosticCode.METHOD_SIGNATURE_DOES_NOT_MATCH,
-                    "Incompatible return type for method '" + jMethodRequest.methodName + "' in class '" +
-                            jMethodRequest.declaringClass.getName() + "': Java type '" + jReturnType.getName() +
-                            "' will not be matched to ballerina type '" +
-                            (bReturnType.tag == TypeTags.FINITE ? bReturnType.tsymbol.name.value : bReturnType) + "'");
+                                        "Incompatible return type for method '" + jMethodRequest.methodName +
+                                                "' in class '" +
+                                                jMethodRequest.declaringClass.getName() + "': Java type '" +
+                                                jReturnType.getName() +
+                                                "' will not be matched to ballerina type '" +
+                                                (bReturnType.tag == TypeTags.FINITE ? bReturnType.tsymbol.name.value :
+                                                        bReturnType) + "'");
         }
     }
 
@@ -629,7 +635,8 @@ class JMethodResolver {
     private JMethod resolveMatchingMethod(JMethodRequest jMethodRequest, List<JMethod> jMethods) {
 
         ParamTypeConstraint[] constraints = jMethodRequest.paramTypeConstraints;
-        int constraintsSize, paramTypesInitialIndex;
+        int constraintsSize;
+        int paramTypesInitialIndex;
         if (jMethodRequest.receiverType != null) {
             constraintsSize = constraints.length + 1;
             paramTypesInitialIndex = 1;
@@ -701,7 +708,12 @@ class JMethodResolver {
     }
 
     private boolean noConstraintsSpecified(ParamTypeConstraint[] constraints) {
-
+        if (constraints == null) {
+            return true;
+        }
+        if (constraints.length == 0) {
+            return false;
+        }
         for (ParamTypeConstraint constraint : constraints) {
             if (constraint != ParamTypeConstraint.NO_CONSTRAINT) {
                 return false;
@@ -710,27 +722,26 @@ class JMethodResolver {
         return true;
     }
 
-    private int getBFuncParamCount(JMethodRequest jMethodRequest, List<JMethod> jMethods) {
+    private int getBFuncParamCount(JMethodRequest jMethodRequest, JMethod jMethod) {
 
         int bFuncParamCount = jMethodRequest.bFuncParamCount;
         if (jMethodRequest.kind == JMethodKind.METHOD) {
-            boolean isStaticMethod = jMethods.get(0).isStatic();
+            boolean isStaticMethod = jMethod.isStatic();
             // Remove the receiver parameter in instance methods.
             bFuncParamCount = isStaticMethod ? bFuncParamCount : bFuncParamCount - 1;
         }
         return bFuncParamCount;
     }
 
-    private JInteropException getMethodNotFoundError(JMethodKind kind,
-                                                     Class<?> declaringClass,
-                                                     String methodName) {
+    private JInteropException getMethodNotFoundError(JMethodKind kind, Class<?> declaringClass, String methodName) {
 
         if (kind == JMethodKind.CONSTRUCTOR) {
             return new JInteropException(DiagnosticCode.CONSTRUCTOR_NOT_FOUND,
-                    "No such public constructor found in class '" + declaringClass + "'");
+                                         "No such public constructor found in class '" + declaringClass + "'");
         } else {
             return new JInteropException(DiagnosticCode.METHOD_NOT_FOUND,
-                    "No such public method '" + methodName + "' found in class '" + declaringClass + "'");
+                                         "No such public method '" + methodName + "' found in class '" +
+                                                 declaringClass + "'");
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLog.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/diagnostic/BLangDiagnosticLog.java
@@ -164,7 +164,7 @@ public class BLangDiagnosticLog implements DiagnosticLog {
      * Report a diagnostic for a given package.
      * 
      * @param pkgId Package ID of the diagnostic associated with
-     * @param diagnostic
+     * @param diagnostic the diagnostic to be logged
      */
     public void logDiagnostic(PackageID pkgId, Diagnostic diagnostic) {
         if (diagnostic.diagnosticInfo().severity() == DiagnosticSeverity.ERROR) {

--- a/stdlib/time/src/main/ballerina/src/time/timelib.bal
+++ b/stdlib/time/src/main/ballerina/src/time/timelib.bal
@@ -51,7 +51,8 @@ public type Time record {|
 # + return - The ISO 8601-formatted string of the given time
 public function toString(Time time) returns string = @java:Method {
     name: "toString",
-    'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods"
+    'class: "org.ballerinalang.stdlib.time.nativeimpl.ExternMethods",
+    paramTypes: ["org.ballerinalang.jvm.values.MapValue"]
 } external;
 
 # Returns the formatted string representation of the given time.

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
@@ -15,6 +15,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.ballerinalang.test.javainterop.basic;
 
 import org.ballerinalang.model.types.BErrorType;
@@ -246,8 +247,13 @@ public class InstanceMethodTest {
             Assert.assertTrue(e.getMessage().contains("error: java.lang.RuntimeException"));
             Assert.assertTrue(e.getMessage().contains("{\"message\":\"Unchecked Exception"));
             Assert.assertTrue(e.getMessage().contains("\"cause\":error(\"java.lang.Throwable\"," +
-                    "message=\"Unchecked cause\""));
+                                                              "message=\"Unchecked cause\""));
         }
     }
 
+    @Test(description = "When instance and static methods have the same name resolve instance method based on the " +
+            "parameter type")
+    public void testInstanceResolve() {
+        BRunUtil.invoke(result, "testInstanceResolve");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/NegativeValidationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/NegativeValidationTest.java
@@ -351,11 +351,28 @@ public class NegativeValidationTest {
         CompileResult compileResult = BCompileUtil.compileInProc(path);
         compileResult.getDiagnostics();
         Assert.assertEquals(compileResult.getDiagnostics().length, 1);
-        BAssertUtil.validateError(compileResult, 0,
+        BAssertUtil.validateError(
+                compileResult, 0,
                 "{ballerina/java}METHOD_SIGNATURE_DOES_NOT_MATCH 'Incompatible param type for method " +
-                        "'decimalParamAndWithBigDecimal' in class " +
-                        "'org.ballerinalang.nativeimpl.jvm.tests.StaticMethods': Java type 'java.math.BigDecimal' " +
-                        "will not be matched to ballerina type 'decimal''",
-                "method_sig_not_match14.bal", 3, 1);
+                        "'decimalParamAndWithBigDecimal' in class 'org.ballerinalang.nativeimpl.jvm.tests" +
+                        ".StaticMethods': Java type 'java.math.BigDecimal' will not be matched to ballerina type " +
+                        "'decimal''", "method_sig_not_match14.bal", 3, 1);
+    }
+
+    @Test(description = "When there are instance and static methods with same name and parameters that differ by one")
+    public void testResolveWithInstanceAndStatic() {
+        String path = "test-src/javainterop/negative/method_resolve_error.bal";
+        CompileResult compileResult = BCompileUtil.compileInProc(path);
+        compileResult.getDiagnostics();
+        Assert.assertEquals(compileResult.getDiagnostics().length, 2);
+        BAssertUtil.validateError(compileResult, 0,
+                                  "{ballerina/java}OVERLOADED_METHODS 'Overloaded methods cannot be differentiated. " +
+                                          "Please specify the parameterTypes for each parameter in 'paramTypes' field" +
+                                          " in the annotation'", "method_resolve_error.bal", 19, 1);
+        BAssertUtil.validateError(compileResult, 1,
+                                  "{ballerina/java}OVERLOADED_METHODS 'Overloaded methods cannot be differentiated. " +
+                                          "Please specify the parameterTypes for each parameter in 'paramTypes' field" +
+                                          " in the annotation'", "method_resolve_error.bal", 24, 1);
+
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
@@ -194,4 +194,10 @@ public class StaticMethodTest {
     public void testBalEnvFastAsync() {
         BRunUtil.invoke(result, "testBalEnvFastAsync");
     }
+
+    @Test(description = "When instance and static methods have the same name resolve static method based on the " +
+            "parameter type")
+    public void testStaticResolve() {
+        BRunUtil.invoke(result, "testStaticResolve");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
@@ -1,4 +1,21 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/java;
+import ballerina/test;
 
 function testAcceptNothingAndReturnNothing(handle receiver) {
     increaseCounterByOne(receiver);
@@ -62,6 +79,11 @@ function testUnionWithErrorReturnThrows(handle receiver) returns error|int|boole
 
 function testUnionWithErrorReturnHandle(handle receiver) returns error|int|boolean|byte|handle {
      return unionWithErrorReturnHandle(receiver);
+}
+
+function testInstanceResolve() {
+    int val = hashCode(newByte(2));
+    test:assertEquals(val, 2);
 }
 
 // Interop functions
@@ -157,5 +179,15 @@ public function errorDetail(handle receiver) returns error? = @java:Method{
 
 public function uncheckedErrorDetail(handle receiver) returns int = @java:Method{
     'class:"org/ballerinalang/nativeimpl/jvm/tests/InstanceMethods"
+} external;
+
+function hashCode(handle receiver) returns int = @java:Method {
+    name: "hashCode",
+    'class: "java.lang.Byte",
+    paramTypes: []
+} external;
+
+function newByte(int val) returns handle = @java:Constructor {
+   'class: "java.lang.Byte"
 } external;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -1,6 +1,23 @@
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 import ballerina/runtime;
 import ballerina/java;
 import ballerina/lang.'value;
+import ballerina/test;
 
 function testAcceptNothingAndReturnNothing() {
     acceptNothingAndReturnNothing();
@@ -55,6 +72,11 @@ function testUsingParamValues() returns int {
 
 function testDecimalParamAndReturn(decimal a1) returns decimal {
     return decimalParamAndReturn(a1);
+}
+
+function testStaticResolve() {
+    int val = hashCode(2);
+    test:assertEquals(val, 2);
 }
 
 // Interop functions
@@ -222,6 +244,12 @@ public function testBalEnvFastAsync() {
     int added = addTwoNumbersFastAsync(1, 2);
     assertEquality(3, added);
 }
+
+function hashCode(int receiver) returns int = @java:Method {
+    name: "hashCode",
+    'class: "java.lang.Byte",
+    paramTypes: ["byte"]
+} external;
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/negative/method_resolve_error.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/negative/method_resolve_error.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/java;
+
+function hashCodeInstance(handle receiver) returns int = @java:Method {
+    name: "hashCode",
+    'class: "java.lang.Byte"
+} external;
+
+function hashCodeStatic(int receiver) returns int = @java:Method {
+    name: "hashCode",
+    'class: "java.lang.Byte"
+} external;
+


### PR DESCRIPTION
## Purpose
> Failure is when there's an overloaded instance and static methods with parameters differing by one.
Resolve https://github.com/ballerina-platform/ballerina-lang/issues/22858

## Approach
> Mandates having `paramTypes` specified in such cases and allows having an empty array for `paramTypes` to indicate no parameters.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
