### PR TITLE
Change the formatter API to return an exception

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -23,6 +23,7 @@ import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
 import io.ballerinalang.compiler.syntax.tree.SyntaxTree;
 import io.ballerinalang.compiler.syntax.tree.Token;
 import org.ballerinalang.formatter.core.Formatter;
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.langserver.codeaction.CodeActionRouter;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.codelenses.CodeLensUtil;
@@ -544,7 +545,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 Range range = new Range(new Position(0, 0), new Position(originalPos.line(), originalPos.offset()));
                 textEdit = new TextEdit(range, formattedSource);
                 return Collections.singletonList(textEdit);
-            } catch (UserErrorException e) {
+            } catch (UserErrorException | FormatterException e) {
                 notifyUser("Formatting", e);
                 return Collections.singletonList(textEdit);
             } catch (Throwable e) {

--- a/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatCmd.java
+++ b/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatCmd.java
@@ -15,9 +15,11 @@
  */
 package org.ballerinalang.formatter.cli;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.tool.BLauncherCmd;
 import picocli.CommandLine;
 
+import java.io.PrintStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
@@ -29,6 +31,7 @@ import java.util.List;
 @CommandLine.Command(name = "format", description = "format given Ballerina source file")
 public class FormatCmd implements BLauncherCmd {
     private static final String USER_DIR = "user.dir";
+    private static final PrintStream outStream = System.err;
 
     @CommandLine.Parameters
     private List<String> argList;
@@ -43,7 +46,11 @@ public class FormatCmd implements BLauncherCmd {
     public void execute() {
         // Get source root path.
         Path sourceRootPath = Paths.get(System.getProperty(USER_DIR));
-        FormatUtil.execute(argList, helpFlag, dryRun, sourceRootPath);
+        try {
+            FormatUtil.execute(argList, helpFlag, dryRun, sourceRootPath);
+        } catch (FormatterException e) {
+            outStream.println(e.getMessage());
+        }
     }
 
     @Override

--- a/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatUtil.java
+++ b/misc/formatter/modules/formatter-cli/src/main/java/org/ballerinalang/formatter/cli/FormatUtil.java
@@ -17,6 +17,7 @@ package org.ballerinalang.formatter.cli;
 
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.formatter.core.Formatter;
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.tool.BLauncherCmd;
 import org.ballerinalang.tool.LauncherUtils;
 import org.wso2.ballerinalang.compiler.Compiler;
@@ -66,7 +67,8 @@ class FormatUtil {
      * @param dryRun         run the whole formatting
      * @param sourceRootPath execution path
      */
-    static void execute(List<String> argList, boolean helpFlag, boolean dryRun, Path sourceRootPath) {
+    static void execute(List<String> argList, boolean helpFlag, boolean dryRun, Path sourceRootPath)
+            throws FormatterException {
         if (helpFlag) {
             String commandUsageInfo = BLauncherCmd.getCommandUsageInfo(CMD_NAME);
             outStream.println(commandUsageInfo);
@@ -213,7 +215,7 @@ class FormatUtil {
     }
 
     private static void formatAndWrite(BLangCompilationUnit compilationUnit, Path sourceRootPath,
-                                       List<String> formattedFiles, boolean dryRun) throws IOException {
+                               List<String> formattedFiles, boolean dryRun) throws IOException, FormatterException {
         String fileName = Paths.get(sourceRootPath.toString()).resolve("src")
                 .resolve(compilationUnit.getPosition().getSource().getPackageName())
                 .resolve(compilationUnit.getPosition().getSource().getCompilationUnitName()).toString();
@@ -232,7 +234,7 @@ class FormatUtil {
     }
 
     private static List<String> iterateAndFormat(BLangPackage bLangPackage, Path sourceRootPath, boolean dryRun)
-            throws IOException {
+            throws IOException, FormatterException {
         List<String> formattedFiles = new ArrayList<>();
 
         // Iterate compilation units and format.

--- a/misc/formatter/modules/formatter-cli/src/test/java/org/ballerinalang/formatter/cli/FormatCmdTest.java
+++ b/misc/formatter/modules/formatter-cli/src/test/java/org/ballerinalang/formatter/cli/FormatCmdTest.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.formatter.cli;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.tool.BLauncherException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -34,7 +35,7 @@ public class FormatCmdTest {
     private static final String NOT_A_PROJECT = "notAProject";
 
     @Test(description = "Test to check the exception for too many argument provided.")
-    public void formatCLITooManyArgumentsTest() {
+    public void formatCLITooManyArgumentsTest() throws FormatterException {
         Path sourceRoot = RES_DIR.resolve(NOT_A_PROJECT);
         List<String> argList = new ArrayList<>();
         argList.add("pkg2");
@@ -54,7 +55,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for not a ballerina project.")
-    public void formatCLINotAProjectTest() {
+    public void formatCLINotAProjectTest() throws FormatterException {
         Path sourceRoot = RES_DIR.resolve(NOT_A_PROJECT);
         try {
             FormatUtil.execute(null, false, false, sourceRoot);
@@ -71,7 +72,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for not a ballerina project when given a module name.")
-    public void formatCLINotAProjectInModuleTest() {
+    public void formatCLINotAProjectInModuleTest() throws FormatterException {
         Path sourceRoot = RES_DIR.resolve(NOT_A_PROJECT);
         List<String> argList = new ArrayList<>();
         argList.add("pkg1");
@@ -90,7 +91,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for no ballerina module found for a given module name.")
-    public void formatCLINotAModuleTest() {
+    public void formatCLINotAModuleTest() throws FormatterException {
         Path sourceRoot = RES_DIR.resolve("project");
         List<String> argList = new ArrayList<>();
         argList.add("pkg2");
@@ -109,7 +110,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for file that is not a ballerina file.")
-    public void formatCLINotABalFileTest() {
+    public void formatCLINotABalFileTest() throws FormatterException {
         List<String> argList = new ArrayList<>();
         argList.add(RES_DIR.resolve("invalidFile.txt").toString());
         try {
@@ -128,7 +129,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for no existing ballerina file.")
-    public void formatCLINoBallerinaFileTest() {
+    public void formatCLINoBallerinaFileTest() throws FormatterException {
         List<String> argList = new ArrayList<>();
         argList.add(RES_DIR.resolve("invalidFile.bal").toString());
         try {
@@ -147,7 +148,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for no existing ballerina file or module.")
-    public void formatCLINotABallerinaFileOrModuleTest() {
+    public void formatCLINotABallerinaFileOrModuleTest() throws FormatterException {
         List<String> argList = new ArrayList<>();
         argList.add("invalid.pkg2");
         try {
@@ -166,7 +167,7 @@ public class FormatCmdTest {
     }
 
     @Test(description = "Test to check the exception for general error in File IO or a argument.")
-    public void formatCLIGeneralExceptionTest() {
+    public void formatCLIGeneralExceptionTest() throws FormatterException {
         try {
             FormatUtil.execute(null, false, false, null);
         } catch (BLauncherException e) {

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/Formatter.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/Formatter.java
@@ -20,23 +20,20 @@ import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextDocuments;
 import io.ballerinalang.compiler.syntax.tree.ModulePartNode;
 import io.ballerinalang.compiler.syntax.tree.SyntaxTree;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class that exposes the formatting APIs.
  */
 public class Formatter {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(Formatter.class);
-
     /**
      * Formats the provided source string and returns back the formatted source string.
      *
      * @param source A Ballerina source in string form
      * @return A modified source string after formatting changes
+     * @throws FormatterException Exception caught while formatting
      */
-    public static String format(String source) {
+    public static String format(String source) throws FormatterException {
         return format(source, new FormattingOptions());
     }
 
@@ -47,8 +44,9 @@ public class Formatter {
      * @param syntaxTree The complete SyntaxTree, of which a part is to be formatted
      * @param range LineRange which specifies the range to be formatted
      * @return The modified SyntaxTree after formatting changes
+     * @throws FormatterException Exception caught while formatting
      */
-    public static SyntaxTree format(SyntaxTree syntaxTree, LineRange range) {
+    public static SyntaxTree format(SyntaxTree syntaxTree, LineRange range) throws FormatterException {
         return format(syntaxTree, range, new FormattingOptions());
     }
 
@@ -57,8 +55,9 @@ public class Formatter {
      *
      * @param syntaxTree The SyntaxTree which is to be formatted
      * @return The modified SyntaxTree after formatting changes
+     * @throws FormatterException Exception caught while formatting
      */
-    public static SyntaxTree format(SyntaxTree syntaxTree) {
+    public static SyntaxTree format(SyntaxTree syntaxTree) throws FormatterException {
         return format(syntaxTree, new FormattingOptions());
     }
 
@@ -68,8 +67,9 @@ public class Formatter {
      * @param source A Ballerina source in string form
      * @param options Formatting options that are to be used when formatting
      * @return A modified source string after formatting changes
+     * @throws FormatterException Exception caught while formatting
      */
-    public static String format(String source, FormattingOptions options) {
+    public static String format(String source, FormattingOptions options) throws FormatterException {
         TextDocument textDocument = TextDocuments.from(source);
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
         return modifyTree(syntaxTree, options, null).toSourceCode();
@@ -83,8 +83,10 @@ public class Formatter {
      * @param range LineRange which needs to be formatted
      * @param options Formatting options that are to be used when formatting
      * @return The modified SyntaxTree after formatting changes
+     * @throws FormatterException Exception caught while formatting
      */
-    public static SyntaxTree format(SyntaxTree syntaxTree, LineRange range, FormattingOptions options) {
+    public static SyntaxTree format(SyntaxTree syntaxTree, LineRange range, FormattingOptions options)
+            throws FormatterException {
         return modifyTree(syntaxTree, options, range);
     }
 
@@ -94,20 +96,21 @@ public class Formatter {
      * @param syntaxTree The SyntaxTree which is to be formatted
      * @param options Formatting options that are to be used when formatting
      * @return The modified SyntaxTree after formatting changes
+     * @throws FormatterException Exception caught while formatting
      */
-    public static SyntaxTree format(SyntaxTree syntaxTree, FormattingOptions options) {
+    public static SyntaxTree format(SyntaxTree syntaxTree, FormattingOptions options) throws FormatterException {
         return modifyTree(syntaxTree, options, null);
     }
 
-    private static SyntaxTree modifyTree(SyntaxTree syntaxTree, FormattingOptions options, LineRange range) {
+    private static SyntaxTree modifyTree(SyntaxTree syntaxTree, FormattingOptions options, LineRange range)
+            throws FormatterException {
         FormattingTreeModifier treeModifier = new FormattingTreeModifier(options, range);
         ModulePartNode modulePartNode = syntaxTree.rootNode();
         try {
             SyntaxTree newSyntaxTree = syntaxTree.modifyWith(treeModifier.transform(modulePartNode));
             return newSyntaxTree.modifyWith(treeModifier.transform((ModulePartNode) newSyntaxTree.rootNode()));
         } catch (Exception e) {
-            LOGGER.error(String.format("Error while formatting the source: %s", e.getMessage()));
-            return syntaxTree;
+            throw new FormatterException("Error while formatting the source: " + e.getMessage(), e.getCause());
         }
     }
 }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterException.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterException.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.formatter.core;
+
+/**
+ * Indicate the errors thrown by the formatter core.
+ *
+ */
+public class FormatterException extends Exception {
+
+    /**
+     * Constructs an FormatterException with the specified detail message.
+     *
+     * @param message the detail message
+     */
+    public FormatterException(String message) {
+        super(message);
+    }
+
+    /**
+     * Constructs a new exception with the specified detail message and cause.
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     */
+    public FormatterException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterException.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormatterException.java
@@ -19,7 +19,6 @@ package org.ballerinalang.formatter.core;
 
 /**
  * Indicate the errors thrown by the formatter core.
- *
  */
 public class FormatterException extends Exception {
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
@@ -53,7 +53,7 @@ public abstract class FormatterTest {
      * @param sourcePath Resources directory for the test type
      */
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         Path assertFilePath = Paths.get(resourceDirectory.toString(), sourcePath, ASSERT_DIR, source);
         Path sourceFilePath = Paths.get(resourceDirectory.toString(), sourcePath, SOURCE_DIR, source);
         String content = getSourceText(sourceFilePath);

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/CheckingActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/CheckingActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class CheckingActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/FlushActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/FlushActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class FlushActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/QueryActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/QueryActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class QueryActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/SendReceiveActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/SendReceiveActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class SendReceiveActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/StartActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/StartActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class StartActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/TrapActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/TrapActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class TrapActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/TypeCastActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/TypeCastActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class TypeCastActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/WaitActionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/actions/WaitActionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.actions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class WaitActionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/FunctionDefinitionDeclarationsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/FunctionDefinitionDeclarationsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.declarations;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class FunctionDefinitionDeclarationsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ImportDeclarationsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ImportDeclarationsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.declarations;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ImportDeclarationsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ModuleEnumDeclarationsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ModuleEnumDeclarationsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.declarations;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class ModuleEnumDeclarationsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ModuleTypeDefinitionDeclarationsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ModuleTypeDefinitionDeclarationsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.declarations;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ModuleTypeDefinitionDeclarationsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ModuleVariableDeclarationsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ModuleVariableDeclarationsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.declarations;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ModuleVariableDeclarationsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ServiceListenerDeclarationsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/declarations/ServiceListenerDeclarationsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.declarations;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ServiceListenerDeclarationsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/AdditiveExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/AdditiveExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class AdditiveExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/BinaryBitwiseExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/BinaryBitwiseExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class BinaryBitwiseExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ConditionalExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ConditionalExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ConditionalExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ConstantExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ConstantExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ConstantExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/EqualityExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/EqualityExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class EqualityExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/LetExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/LetExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class LetExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/LiteralExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/LiteralExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class LiteralExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/LogicalExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/LogicalExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class LogicalExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/MultiplicativeExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/MultiplicativeExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class MultiplicativeExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/NewExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/NewExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class NewExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ObjectConstructorExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ObjectConstructorExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ObjectConstructorExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/OptionalFieldAccessExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/OptionalFieldAccessExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class OptionalFieldAccessExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/QueryExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/QueryExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class QueryExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/RangeExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/RangeExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class RangeExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/RawTemplateExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/RawTemplateExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class RawTemplateExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/RelationalExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/RelationalExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class RelationalExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ShiftExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/ShiftExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ShiftExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/StringTemplateExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/StringTemplateExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class StringTemplateExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/TypeTestExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/TypeTestExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class TypeTestExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/UnaryExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/UnaryExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class UnaryExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/XMLTemplateExpressionsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/expressions/XMLTemplateExpressionsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.expressions;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class XMLTemplateExpressionsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/AssignmentStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/AssignmentStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class AssignmentStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/BlockStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/BlockStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class BlockStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/BreakStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/BreakStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class BreakStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/CallStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/CallStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class CallStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/CompoundAssignmentStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/CompoundAssignmentStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class CompoundAssignmentStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ContinueStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ContinueStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class ContinueStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ForEachStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ForEachStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class ForEachStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ForkStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ForkStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class ForkStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/IfElseStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/IfElseStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class IfElseStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/LocalTypeDefinitionStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/LocalTypeDefinitionStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class LocalTypeDefinitionStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/LockStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/LockStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class LockStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/MatchStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/MatchStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class MatchStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/PanicStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/PanicStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class PanicStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ReturnStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/ReturnStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class ReturnStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/WhileStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/WhileStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class WhileStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/XMLNSDeclarationStatementsTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/statements/XMLNSDeclarationStatementsTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.statements;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class XMLNSDeclarationStatementsTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/BehaviouralTypesTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/BehaviouralTypesTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.types;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class BehaviouralTypesTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/OtherTypesTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/OtherTypesTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.types;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class OtherTypesTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/SequenceTypesTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/SequenceTypesTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.types;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class SequenceTypesTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String config, String configPath) throws IOException {
+    public void test(String config, String configPath) throws IOException, FormatterException {
         super.test(config, configPath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/SimpleTypesTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/SimpleTypesTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.types;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -30,7 +31,7 @@ import java.nio.file.Paths;
 public class SimpleTypesTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/StructuredTypesTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/types/StructuredTypesTest.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.formatter.core.types;
 
+import org.ballerinalang.formatter.core.FormatterException;
 import org.ballerinalang.formatter.core.FormatterTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -32,7 +33,7 @@ import java.util.List;
 public class StructuredTypesTest extends FormatterTest {
 
     @Test(dataProvider = "test-file-provider")
-    public void test(String source, String sourcePath) throws IOException {
+    public void test(String source, String sourcePath) throws IOException, FormatterException {
         super.test(source, sourcePath);
     }
 


### PR DESCRIPTION
## Purpose
When an exception occurs, the current implementation logs the exception and returns back an unaltered syntax tree. This PR changes this behavior to return an exception instead so that the module using the formatter core can handle it accordingly.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
