### PR TITLE
Add an API for retrieving the workspace symbols

### DIFF
--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/api/SemanticModel.java
@@ -51,6 +51,13 @@ public interface SemanticModel {
     Optional<Symbol> symbol(String srcFile, LinePosition position);
 
     /**
+     * Retrieves the symbols of module-scoped constructs in the semantic model.
+     *
+     * @return A list of module-scoped symbols
+     */
+    List<Symbol> moduleLevelSymbols();
+
+    /**
      * Get the diagnostics within the given text Span.
      *
      * @param textRange Text range to filter the diagnostics

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/BallerinaSemanticModel.java
@@ -124,6 +124,25 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
+    public List<Symbol> moduleLevelSymbols() {
+        List<Symbol> compiledSymbols = new ArrayList<>();
+
+        for (Map.Entry<Name, Scope.ScopeEntry> e : bLangPackage.symbol.scope.entries.entrySet()) {
+            Name key = e.getKey();
+            Scope.ScopeEntry value = e.getValue();
+
+            if (value.symbol.origin == SOURCE) {
+                compiledSymbols.add(SymbolFactory.getBCompiledSymbol(value.symbol, key.value));
+            }
+        }
+
+        return compiledSymbols;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<Diagnostic> diagnostics(TextRange range) {
         return new ArrayList<>();
     }

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/WorkspaceSymbolLookupTest.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/WorkspaceSymbolLookupTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import org.ballerina.compiler.api.symbols.Symbol;
+import org.ballerina.compiler.impl.BallerinaSemanticModel;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertList;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getSymbolNames;
+import static org.ballerinalang.model.symbols.SymbolOrigin.SOURCE;
+
+/**
+ * Test cases for the API for getting the workspace symbols. i.e., all module-level symbols.
+ *
+ * @since 2.0.0
+ */
+public class WorkspaceSymbolLookupTest {
+
+    private final Path resourceDir = Paths.get("src/test/resources").toAbsolutePath();
+
+    @Test
+    public void testWSSymbolLookup() {
+        CompilerContext context = new CompilerContext();
+        CompileResult result = compile("test-src/test-project/", "foo", context);
+        BLangPackage pkg = (BLangPackage) result.getAST();
+        BallerinaSemanticModel model = new BallerinaSemanticModel(pkg, context);
+
+        List<Symbol> symbols = model.moduleLevelSymbols();
+
+        List<String> allSymbols = getSymbolNames(pkg.symbol, 0, SOURCE);
+        assertList(symbols, allSymbols);
+    }
+
+    private CompileResult compile(String sourceRoot, String module, CompilerContext context) {
+        String sourceRootAbsolute = BCompileUtil.concatFileName(sourceRoot, resourceDir.toAbsolutePath());
+        return BCompileUtil.compileOnJBallerina(context, sourceRootAbsolute, module, false, true, false);
+    }
+}

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -21,6 +21,7 @@ import io.ballerina.tools.text.LinePosition;
 import org.ballerina.compiler.api.ModuleID;
 import org.ballerina.compiler.api.symbols.Symbol;
 import org.ballerina.compiler.impl.BallerinaSemanticModel;
+import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -83,6 +84,19 @@ public class SemanticAPITestUtils {
 
             if (value.symbol != null && (value.symbol.tag & symTag) == symTag
                     && Symbols.isFlagOn(value.symbol.flags, Flags.PUBLIC) && value.symbol.origin == COMPILED_SOURCE) {
+                symbolNames.add(name.value);
+            }
+        }
+        return symbolNames;
+    }
+
+    public static List<String> getSymbolNames(BPackageSymbol pkgSymbol, int symTag, SymbolOrigin origin) {
+        List<String> symbolNames = new ArrayList<>();
+        for (Map.Entry<Name, Scope.ScopeEntry> entry : pkgSymbol.scope.entries.entrySet()) {
+            Name name = entry.getKey();
+            Scope.ScopeEntry value = entry.getValue();
+
+            if (value.symbol != null && (value.symbol.tag & symTag) == symTag && value.symbol.origin == origin) {
                 symbolNames.add(name.value);
             }
         }

--- a/compiler/ballerina-compiler-api/src/test/resources/testng.xml
+++ b/compiler/ballerina-compiler-api/src/test/resources/testng.xml
@@ -23,6 +23,8 @@
         <classes>
             <class name="io.ballerina.semantic.api.test.SymbolLookupTest" />
             <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest" />
+            <class name="io.ballerina.semantic.api.test.SymbolBIRTest" />
+            <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR adds an API to the semantic model to get the list of symbols of the module level constructs in the model.


## Approach
- Get the scope entries from the module symbol.
- Iterate through the scope entries and create API symbol wrappers for symbols whose origin is `SOURCE`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
