### PR TITLE
[Debugger] Fix stepping over at the last statement inside a function [1.2.x]

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/EventBus.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/EventBus.java
@@ -253,12 +253,15 @@ public class EventBus {
             Optional<Location> firstLocation =
                     allLineLocations.stream().min(Comparator.comparingInt(Location::lineNumber));
             // We are going to add breakpoints for each and every line and continue the debugger.
-
             if (!firstLocation.isPresent()) {
                 return;
             }
-            int nextStepPoint = firstLocation.get().lineNumber();
+            if (currentLocation.lineNumber() == lastLocation.get().lineNumber()) {
+                createStepRequest(threadId, StepRequest.STEP_OUT);
+                return;
+            }
 
+            int nextStepPoint = currentLocation.lineNumber();
             while (true) {
                 List<Location> locations = referenceType.locationsOfLine(nextStepPoint);
                 if (locations.size() > 0) {
@@ -339,5 +342,4 @@ public class EventBus {
             return relativePath.toString();
         }
     }
-
 }


### PR DESCRIPTION
## Purpose
This PR fixes stepping over at the last line of an nested function block, so that now it will return back to its invocation, as expected.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/25775.

## Remarks 
Related PR - https://github.com/ballerina-platform/ballerina-lang/pull/25880

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
