### PR TITLE
Fix runtime crash when using XML element literals with query expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -264,9 +264,9 @@ public class QueryDesugar extends BLangNodeVisitor {
             onConflictExpr = null;
         } else {
             BLangVariableReference result;
-            if (queryExpr.type.tag == TypeTags.XML) {
+            if (TypeTags.isXMLTypeTag(queryExpr.type.tag)) {
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_XML_FUNCTION, Lists.of(streamRef), pos);
-            } else if (queryExpr.type.tag == TypeTags.STRING) {
+            } else if (TypeTags.isStringTypeTag(queryExpr.type.tag)) {
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_STRING_FUNCTION, Lists.of(streamRef), pos);
             } else {
                 BType arrayType = queryExpr.type;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
@@ -184,4 +184,11 @@ public class XMLQueryExpressionTest {
         Assert.assertEquals(returnValues[0].stringValue(), "<name>Sherlock Holmes</name>");
         Assert.assertEquals(returnValues[1].stringValue(), "<name>The Da Vinci Code</name>");
     }
+
+    @Test(description = "Test simple query expression with a XML Element Literal")
+    public void testSimpleQueryExprWithXMLElementLiteral() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testSimpleQueryExprWithXMLElementLiteral");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<entry>Value</entry>");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
@@ -373,3 +373,23 @@ function testSimpleQueryExprWithUnionTypeForXML2() returns xml[]|error {
 
     return  books;
 }
+
+public function testSimpleQueryExprWithXMLElementLiteral() returns xml {
+    xml payload = xml `<Root>
+                            <data>
+                                <record>
+                                    <field name="Country or Area" key="ABW">Aruba</field>
+                                    <field name="Item" key="EN.ATM.CO2E.KT">CO2 emissions (kt)</field>
+                                    <field name="Year">1960</field>
+                                    <field name="Value">11092.675</field>
+                                </record>
+                            </data>
+                       </Root>`;
+
+    xml res = from var x in payload/<data>/<*>
+             let var year = <xml> x/<'field>[2]
+             let var value = <xml> x/<'field>[3].name
+             select xml `<entry>${<string> value}</entry>`;
+
+    return res;
+}


### PR DESCRIPTION
## Purpose
$title, and improve `isXML` and `isString` checking at query desugar level.

Fixes #25948

## Approach
n/a

## Samples
- refer to the added test.

## Remarks
n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
