### PR TITLE
Capture dependencies of global variables

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -396,7 +396,7 @@ public class Desugar extends BLangNodeVisitor {
         // Initialize the annotation map
         annotationDesugar.initializeAnnotationMap(pkgNode);
         SymbolEnv env = this.symTable.pkgEnvMap.get(pkgNode.symbol);
-        this.globalVariablesDependsOn = pkgNode.globalVariableDependsOn;
+        this.globalVariablesDependsOn = env.enclPkg.globalVariableDependencies;
         return rewrite(pkgNode, env);
     }
 
@@ -3667,7 +3667,7 @@ public class Desugar extends BLangNodeVisitor {
                 BVarSymbol symbol = (BVarSymbol) varRefExpr.symbol;
                 BLangLockStmt lockStmt = enclLocks.peek();
                 lockStmt.addLockVariable(symbol);
-                lockStmt.addAllLockVariable(this.globalVariablesDependsOn.getOrDefault(symbol, new HashSet<>()));
+                lockStmt.addLockVariable(this.globalVariablesDependsOn.getOrDefault(symbol, new HashSet<>()));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -303,6 +303,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage));
         this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
         this.globalVariableRefAnalyzer.populateFunctionDependencies(this.functionToDependency);
+        pkgNode.globalVariableDependsOn = globalVariableRefAnalyzer.getGlobalVariablesDependsOn();
         checkUnusedImports(pkgNode.imports);
         pkgNode.completedPhases.add(CompilerPhase.DATAFLOW_ANALYZE);
     }
@@ -1202,7 +1203,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
     }
 
     private void addFunctionToGlobalVarDependency(BSymbol dependent, BSymbol provider) {
-        if (dependent.kind != SymbolKind.FUNCTION) {
+        if (dependent.kind != SymbolKind.FUNCTION && !isGlobalVarSymbol(dependent)) {
             return;
         }
         if (isVariableOrConstant(provider) && !isGlobalVarSymbol(provider)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/DataflowAnalyzer.java
@@ -303,7 +303,7 @@ public class DataflowAnalyzer extends BLangNodeVisitor {
         pkgNode.getTestablePkgs().forEach(testablePackage -> visit((BLangPackage) testablePackage));
         this.globalVariableRefAnalyzer.analyzeAndReOrder(pkgNode, this.globalNodeDependsOn);
         this.globalVariableRefAnalyzer.populateFunctionDependencies(this.functionToDependency);
-        pkgNode.globalVariableDependsOn = globalVariableRefAnalyzer.getGlobalVariablesDependsOn();
+        pkgNode.globalVariableDependencies = globalVariableRefAnalyzer.getGlobalVariablesDependsOn();
         checkUnusedImports(pkgNode.imports);
         pkgNode.completedPhases.add(CompilerPhase.DATAFLOW_ANALYZE);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/cyclefind/GlobalVariableRefAnalyzer.java
@@ -40,7 +40,6 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Deque;
@@ -63,6 +62,7 @@ public class GlobalVariableRefAnalyzer {
     private final BLangDiagnosticLog dlog;
     private BLangPackage pkgNode;
     private Map<BSymbol, Set<BSymbol>> globalNodeDependsOn;
+    private Map<BSymbol, Set<BVarSymbol>> globalVariablesDependsOn;
     private final Map<BSymbol, NodeInfo> dependencyNodes;
     private final Deque<NodeInfo> nodeInfoStack;
     private final List<List<NodeInfo>> cycles;
@@ -85,6 +85,7 @@ public class GlobalVariableRefAnalyzer {
         this.cycles = new ArrayList<>();
         this.nodeInfoStack = new ArrayDeque<>();
         this.dependencyOrder = new ArrayList<>();
+        this.globalVariablesDependsOn = new HashMap<>();
     }
 
     /**
@@ -103,6 +104,14 @@ public class GlobalVariableRefAnalyzer {
 
             analyzeDependenciesRecursively(dependent);
         }
+    }
+
+    /**
+     * Get the global variable dependency map.
+     * @return global variable dependency map.
+     */
+    public Map<BSymbol, Set<BVarSymbol>> getGlobalVariablesDependsOn() {
+        return this.globalVariablesDependsOn;
     }
 
     private void analyzeDependenciesRecursively(BSymbol dependent) {
@@ -125,28 +134,38 @@ public class GlobalVariableRefAnalyzer {
 
         node.visited = true;
 
-        if (isGlobalVarSymbol(node.symbol)) {
-            return new HashSet<>(Arrays.asList((BVarSymbol) node.symbol));
-        }
-
         node.onStack = true;
 
         Set<BSymbol> providers = this.globalNodeDependsOn.getOrDefault(node.symbol, new LinkedHashSet<>());
-        // No providers means either not a function or function does not have dependents.
+
+        // Means no dependencies for this node.
         if (providers.isEmpty()) {
             return new HashSet<>();
         }
 
-        // Means the current node is a function and has dependencies. Lets analyze its dependencies further.
+        // Means the current node has dependencies. Lets analyze its dependencies further.
+        Set<BVarSymbol> dependentGlobalVars = new HashSet<>();
         for (BSymbol providerSym : providers) {
             NodeInfo providerNode =
                     this.dependencyNodes.computeIfAbsent(providerSym, s -> new NodeInfo(curNodeId++, providerSym));
-            ((BInvokableSymbol) node.symbol).dependentGlobalVars
-                    .addAll(analyzeDependenciesRecursively(providerNode));
+            if (isGlobalVarSymbol(providerSym)) {
+                dependentGlobalVars.add((BVarSymbol) providerSym);
+            }
+            dependentGlobalVars.addAll(analyzeDependenciesRecursively(providerNode));
         }
 
         node.onStack = false;
-        return ((BInvokableSymbol) node.symbol).dependentGlobalVars;
+
+        if (node.symbol.kind == SymbolKind.FUNCTION) {
+            Set<BVarSymbol> depGlobalVarsOfFunction = ((BInvokableSymbol) node.symbol).dependentGlobalVars;
+            depGlobalVarsOfFunction.addAll(dependentGlobalVars);
+            return dependentGlobalVars;
+        } else {
+            Set<BVarSymbol> dependenciesOfGlobalVars = this.globalVariablesDependsOn
+                    .computeIfAbsent(node.symbol, s -> new HashSet<>());
+            dependenciesOfGlobalVars.addAll(dependentGlobalVars);
+            return dependenciesOfGlobalVars;
+        }
     }
 
     private Set<BVarSymbol> getGlobalVarFromCurrentNode(NodeInfo node) {
@@ -166,9 +185,7 @@ public class GlobalVariableRefAnalyzer {
         if (isFunction(symbol)) {
             return ((BInvokableSymbol) symbol).dependentGlobalVars;
         } else if (isGlobalVarSymbol(symbol)) {
-            Set<BVarSymbol> dependentSet = new HashSet<>();
-            dependentSet.add((BVarSymbol) symbol);
-            return dependentSet;
+            return this.globalVariablesDependsOn.getOrDefault(symbol, new HashSet<>());
         }
 
         return new HashSet<>();
@@ -271,6 +288,7 @@ public class GlobalVariableRefAnalyzer {
         this.nodeInfoStack.clear();
         this.dependencyOrder.clear();
         this.curNodeId = 0;
+        this.globalVariablesDependsOn = new HashMap<>();
     }
 
     private void pruneDependencyRelations() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -36,7 +36,6 @@ public class BVarSymbol extends BSymbol implements VariableSymbol {
     // Only used for type-narrowing. Cache of the original symbol.
     public BVarSymbol originalSymbol;
 
-
     /**
      * This indicate the indicated (by programmer) taintedness of a variable.
      */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
@@ -74,8 +74,8 @@ public class BLangPackage extends BLangNode implements PackageNode {
     public Queue<BLangLambdaFunction> lambdaFunctions = new ArrayDeque<>();
     public List<BLangClassDefinition> classDefinitions;
 
-    // Hold global variable dependencies identified from DataflowAnalyzer
-    public Map<BSymbol, Set<BVarSymbol>> globalVariableDependsOn;
+    // Hold global variable dependencies identified in DataflowAnalyzer.
+    public Map<BSymbol, Set<BVarSymbol>> globalVariableDependencies;
 
     public PackageID packageID;
     public BPackageSymbol symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
@@ -38,6 +38,7 @@ import org.wso2.ballerinalang.compiler.diagnostic.DiagnosticComparator;
 import org.wso2.ballerinalang.compiler.packaging.RepoHierarchy;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 
@@ -45,6 +46,7 @@ import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import java.util.Set;
 import java.util.TreeSet;
@@ -71,6 +73,9 @@ public class BLangPackage extends BLangNode implements PackageNode {
     // Queue to maintain lambda functions so that we can visit all lambdas at the end of the semantic phase
     public Queue<BLangLambdaFunction> lambdaFunctions = new ArrayDeque<>();
     public List<BLangClassDefinition> classDefinitions;
+
+    // Hold global variable dependencies identified from DataflowAnalyzer
+    public Map<BSymbol, Set<BVarSymbol>> globalVariableDependsOn;
 
     public PackageID packageID;
     public BPackageSymbol symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
@@ -109,7 +109,7 @@ public class BLangLock extends BLangStatement implements LockNode {
             return lockVariables.add(variable);
         }
 
-        public boolean addAllLockVariable(Set<BVarSymbol> variables) {
+        public boolean addLockVariable(Set<BVarSymbol> variables) {
             return lockVariables.addAll(variables);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangLock.java
@@ -108,6 +108,10 @@ public class BLangLock extends BLangStatement implements LockNode {
         public boolean addLockVariable(BVarSymbol variable) {
             return lockVariables.add(variable);
         }
+
+        public boolean addAllLockVariable(Set<BVarSymbol> variables) {
+            return lockVariables.addAll(variables);
+        }
     }
 
     /**

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -43,7 +43,7 @@ import static org.testng.Assert.assertTrue;
  */
 public class LocksInMainTest {
 
-    private  CompileResult parallelCompileResult;
+    private CompileResult parallelCompileResult;
 
     @BeforeClass
     public void setup() {
@@ -100,7 +100,7 @@ public class LocksInMainTest {
 
     }
 
-//    TODO:https://github.com/ballerina-platform/ballerina-lang/issues/11305
+    //    TODO:https://github.com/ballerina-platform/ballerina-lang/issues/11305
     @Test(description = "Tests throwing and error inside lock", enabled = false)
     public void testThrowErrorInsideLock() {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/locks-in-functions.bal");
@@ -251,9 +251,9 @@ public class LocksInMainTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/lock/locks-in-functions-negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 2);
         BAssertUtil.validateError(compileResult, 0, "undefined symbol 'val'",
-                8, 5);
+                                  8, 5);
         BAssertUtil.validateError(compileResult, 1, "undefined symbol 'val1'",
-                18, 9);
+                                  18, 9);
     }
 
     @Test(description = "Test for parallel run using locks", enabled = false)
@@ -279,8 +279,23 @@ public class LocksInMainTest {
     @Test(description = "Test for parallel run when invocations are imported and contains global var dependencies")
     public void testParallelRunWithImportInvocationDependencies() {
         CompileResult importInvocationDependencies = BCompileUtil.compile("test-src/lock/locks-in-imports-test",
-                "mod1", true);
+                                                                          "mod1", true);
 
         BRunUtil.invoke(importInvocationDependencies, "testLockWIthInvokableChainsAccessingGlobal");
+    }
+
+    @Test(description = "Test for locks on global references")
+    public void testLocksWhenGlobalVariablesReferToSameValue() {
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLocksWhenGlobalVariablesReferToSameValue");
+    }
+
+    @Test(description = "Test for global reference update inside a worker")
+    public void testForGlobalRefUpdateInsideWorker() {
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideWorker");
+    }
+
+    @Test(description = "Test for global reference updated inside conditional statment")
+    public void testForGlobalRefUpdateInsideConditional() {
+        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideConditional");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -286,16 +286,16 @@ public class LocksInMainTest {
 
     @Test(description = "Test for locks on global references")
     public void testLocksWhenGlobalVariablesReferToSameValue() {
-        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testLocksWhenGlobalVariablesReferToSameValue");
+        BRunUtil.invoke(parallelCompileResult, "testLocksWhenGlobalVariablesReferToSameValue");
     }
 
     @Test(description = "Test for global reference update inside a worker")
     public void testForGlobalRefUpdateInsideWorker() {
-        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideWorker");
+        BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideWorker");
     }
 
     @Test(description = "Test for global reference updated inside conditional statment")
     public void testForGlobalRefUpdateInsideConditional() {
-        BValue[] returns = BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideConditional");
+        BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideConditional");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
@@ -203,7 +203,7 @@ function testLocksWhenGlobalVariablesReferToSameValue() {
     worker w1 {
         foreach var i in 1 ... 1000 {
             lock {
-		        values[values.length()] = 1;
+                values[values.length()] = 1;
             }
         }
     }
@@ -212,7 +212,7 @@ function testLocksWhenGlobalVariablesReferToSameValue() {
     worker w2 {
         foreach var i in 1 ... 1000 {
             lock {
-		        values[values.length()] = 1;
+                values[values.length()] = 1;
             }
         }
     }
@@ -221,7 +221,7 @@ function testLocksWhenGlobalVariablesReferToSameValue() {
     worker w3 {
         foreach var i in 1 ... 1000 {
             lock {
-		        values[values.length()] = 1;
+                values[values.length()] = 1;
             }
         }
     }
@@ -230,7 +230,7 @@ function testLocksWhenGlobalVariablesReferToSameValue() {
     worker w4 {
         foreach var i in 1 ... 1000 {
             lock {
-		        numbers[numbers.length()] = 1;
+                numbers[numbers.length()] = 1;
             }
         }
     }
@@ -326,6 +326,6 @@ function testForGlobalRefUpdateInsideConditional() {
 
     runtime:sleep(250);
     if (toBeUpdateRefConditional.length() == 100 && refConditional.length() == 200) {
-        panic error("Invalid value 1000 recieved in \"testForGlobalRefUpdateInsideConditional\"");
+        panic error("Invalid value 100 recieved in \"testForGlobalRefUpdateInsideConditional\"");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/lock/parallel-run-lock.bal
@@ -194,3 +194,138 @@ function testLockWIthInvokableRecursiveAccessGlobal() {
         panic error("Invalid Value");
     }
 }
+
+int[] values = [];
+int[] numbers = values;
+
+function testLocksWhenGlobalVariablesReferToSameValue() {
+    @strand {thread: "any"}
+    worker w1 {
+        foreach var i in 1 ... 1000 {
+            lock {
+		        values[values.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w2 {
+        foreach var i in 1 ... 1000 {
+            lock {
+		        values[values.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w3 {
+        foreach var i in 1 ... 1000 {
+            lock {
+		        values[values.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w4 {
+        foreach var i in 1 ... 1000 {
+            lock {
+		        numbers[numbers.length()] = 1;
+            }
+        }
+    }
+    var result = wait {w1, w2, w3, w4};
+
+    int length = numbers.length();
+    if ( length != 4000) {
+        panic error("Expected 4000, but found " + length.toString());
+    }
+
+}
+
+int[] ref = [];
+int[] toBeUpdateRef = ref;
+function testForGlobalRefUpdateInsideWorker() {
+    ref.removeAll();
+    toBeUpdateRef.removeAll();
+
+    @strand {thread: "any"}
+    worker w1 {
+        foreach var i in 1 ... 100 {
+            lock {
+                runtime:sleep(1);
+                ref[ref.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w2 {
+        foreach var i in 1 ... 100 {
+            lock {
+                runtime:sleep(1);
+                ref[ref.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w3 {
+        toBeUpdateRef = [];
+        foreach var i in 1 ... 100 {
+            lock {
+                runtime:sleep(1);
+                toBeUpdateRef[toBeUpdateRef.length()] = 1;
+            }
+        }
+    }
+
+    runtime:sleep(250);
+    if (toBeUpdateRef.length() == 100 && ref.length() == 200) {
+        panic error("Invalid value 1000 recieved in \"testForGlobalRefUpdateInsideWorker\"");
+    }
+}
+
+int[] refConditional = [];
+int[] toBeUpdateRefConditional = refConditional;
+function testForGlobalRefUpdateInsideConditional() {
+    boolean updateRef = true;
+
+    @strand {thread: "any"}
+    worker w1 {
+        foreach var i in 1 ... 100 {
+            lock {
+                runtime:sleep(1);
+                refConditional[refConditional.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w2 {
+        foreach var i in 1 ... 100 {
+            lock {
+                runtime:sleep(1);
+                refConditional[refConditional.length()] = 1;
+            }
+        }
+    }
+
+    @strand {thread: "any"}
+    worker w3 {
+        if (updateRef) {
+            toBeUpdateRefConditional = [];
+        }
+        foreach var i in 1 ... 100 {
+            lock {
+                runtime:sleep(1);
+                toBeUpdateRefConditional[toBeUpdateRefConditional.length()] = 1;
+            }
+        }
+    }
+
+    runtime:sleep(250);
+    if (toBeUpdateRefConditional.length() == 100 && refConditional.length() == 200) {
+        panic error("Invalid value 1000 recieved in \"testForGlobalRefUpdateInsideConditional\"");
+    }
+}


### PR DESCRIPTION
## Purpose
> ATM we lock the reference only when we use a ballerina lock statement. Hence, when we optimize ballerina locks, we miss the information regarding shared references to a single value.
> This PR will fix the bug

Fixes #25216

## Approach
> In the Dataflow analysis phase, capture the dependencies of global variables. 
> If any dependencies found, irrespective of whether a code branch will use or modify the reference, we use that info in the optimisation phase.

## Samples

```import ballerina/io;
int[] values = [];
int[] numbers = values;

public function main() {
    process();
    io:println("final array size - ", values.length());
}

function process() {
    @strand {thread: "any"}
    worker w1 {
        foreach var i in 1 ... 1000 {
            lock {
		        values[values.length()] = 1;
            }
        }
    }

    @strand {thread: "any"}
    worker w2 {
        foreach var i in 1 ... 1000 {
            lock {
		        values[values.length()] = 1;
            }
        }
    }
    var result = wait {w1, w2, w3, w4};
}
```

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
