### PR TITLE
Fix explicit paramTypes passing for BalEnv accepting functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodResolver.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
+import org.ballerinalang.jvm.api.BalEnv;
 import org.ballerinalang.jvm.api.values.BArray;
 import org.ballerinalang.jvm.api.values.BDecimal;
 import org.ballerinalang.jvm.api.values.BError;
@@ -625,11 +626,21 @@ class JMethodResolver {
 
         Executable executable = (kind == JMethodKind.CONSTRUCTOR) ? resolveConstructor(clazz, paramTypes) :
                 resolveMethod(clazz, name, paramTypes);
+        if (executable == null) {
+            executable = tryResolveExactWithBalEnv(paramTypes, clazz, name);
+        }
         if (executable != null) {
             return JMethod.build(kind, executable, receiverType);
         } else {
             return JMethod.NO_SUCH_METHOD;
         }
+    }
+
+    private Executable tryResolveExactWithBalEnv(Class<?>[] paramTypes, Class<?> clazz, String name) {
+        Class<?>[] paramTypesWithBalEnv = new Class<?>[paramTypes.length + 1];
+        System.arraycopy(paramTypes, 0, paramTypesWithBalEnv, 1, paramTypes.length);
+        paramTypesWithBalEnv[0] = BalEnv.class;
+        return resolveMethod(clazz, name, paramTypesWithBalEnv);
     }
 
     private JMethod resolveMatchingMethod(JMethodRequest jMethodRequest, List<JMethod> jMethods) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -218,7 +218,8 @@ function decimalParamAndReturn(decimal a1) returns decimal = @java:Method {
 } external;
 
  public function addTwoNumbersSlowAsync(int a, int b) returns int = @java:Method {
-    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods",
+    paramTypes: ["long" ,"long"]
 } external;
 
  public function addTwoNumbersFastAsync(int a, int b) returns int = @java:Method {


### PR DESCRIPTION
## Purpose
Fixes #26027

## Approach
If normal exact match fails we re-match with `BalEnv` as the first param.