### PR TITLE
Force cast return statement within wrapped lambda

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
@@ -248,6 +248,7 @@ public class TransactionDesugar extends BLangNodeVisitor {
                 transactionLambdaVariable);
         BLangSimpleVarRef transactionLambdaVarRef = new BLangSimpleVarRef.
                 BLangLocalVarRef(transactionLambdaVariable.symbol);
+        transactionLambdaVarRef.type = transactionLambdaVariable.symbol.type;
         transactionBlockStmt.stmts.add(transactionLambdaVariableDef);
 
         // Add lambda function call

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/TransactionStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/transaction/TransactionStmtTest.java
@@ -222,4 +222,11 @@ public class TransactionStmtTest {
     public void testInvokeRemoteTransactionalMethodInTransactionalScope() {
         BRunUtil.invoke(programFile, "testInvokeRemoteTransactionalMethodInTransactionalScope");
     }
+
+    @Test
+    public void testAsyncReturn() {
+        BValue[] result = BRunUtil.invoke(programFile, "testAsyncReturn");
+        Assert.assertTrue(result[0] instanceof BInteger);
+        Assert.assertEquals(((BInteger) result[0]).intValue(), 10);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/transaction/transaction_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/transaction/transaction_stmt.bal
@@ -386,3 +386,16 @@ function testInvokeRemoteTransactionalMethodInTransactionalScope() {
     Bank bank = new;
     assertEquality("trx started -> deposit trx func", bank.doTransaction());
 }
+
+function testAsyncReturn() returns int {
+    transaction {
+        var x = start getInt();
+        int f = wait x;
+        var y = commit;
+        return f;
+    }
+}
+
+transactional function getInt() returns int {
+    return 10;
+}


### PR DESCRIPTION
## Purpose
> $subject

Fixes #25998

## Approach
> While wrapping transaction content within lambda function; the return type is set to any|error to support returns generically. Hence, return statements needs to be casted to any|error forcefully.

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
