### PR TITLE
Add an API to retrieve position info from the public symbol API

### DIFF
--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/api/symbols/Symbol.java
@@ -63,7 +63,7 @@ public interface Symbol {
      *
      * @return The position information of the symbol
      */
-    Location position();
+    Location location();
 
     // TODO: Add the annotation attachment API
 }

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/api/symbols/Symbol.java
@@ -17,6 +17,7 @@
  */
 package org.ballerina.compiler.api.symbols;
 
+import io.ballerina.tools.diagnostics.Location;
 import org.ballerina.compiler.api.ModuleID;
 
 import java.util.Optional;
@@ -44,17 +45,25 @@ public interface Symbol {
 
     /**
      * Get the Symbol Kind.
-     * 
+     *
      * @return {@link SymbolKind} of the symbol
      */
     SymbolKind kind();
 
     /**
      * Get the Documentation attachment bound to the symbol.
-     * 
+     *
      * @return {@link Optional} doc attachment
      */
     Optional<Documentation> docAttachment();
+
+    /**
+     * This retrieves position information of the symbol in the source code. The position given here is the location of
+     * the definition of the symbol.
+     *
+     * @return The position information of the symbol
+     */
+    Location position();
 
     // TODO: Add the annotation attachment API
 }

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaMethodSymbol.java
@@ -17,6 +17,7 @@
  */
 package org.ballerina.compiler.impl.symbols;
 
+import io.ballerina.tools.diagnostics.Location;
 import org.ballerina.compiler.api.ModuleID;
 import org.ballerina.compiler.api.symbols.Documentation;
 import org.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -69,5 +70,10 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     @Override
     public List<Qualifier> qualifiers() {
         return this.functionSymbol.qualifiers();
+    }
+
+    @Override
+    public Location position() {
+        return this.functionSymbol.position();
     }
 }

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaMethodSymbol.java
@@ -73,7 +73,7 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     }
 
     @Override
-    public Location position() {
-        return this.functionSymbol.position();
+    public Location location() {
+        return this.functionSymbol.location();
     }
 }

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaSymbol.java
@@ -17,12 +17,14 @@
  */
 package org.ballerina.compiler.impl.symbols;
 
+import io.ballerina.tools.diagnostics.Location;
 import org.ballerina.compiler.api.ModuleID;
 import org.ballerina.compiler.api.symbols.Documentation;
 import org.ballerina.compiler.api.symbols.Symbol;
 import org.ballerina.compiler.api.symbols.SymbolKind;
 import org.ballerina.compiler.impl.BallerinaModuleID;
 import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -40,16 +42,16 @@ public class BallerinaSymbol implements Symbol {
     private final SymbolKind symbolKind;
     private final Documentation docAttachment;
     private final boolean isLangLib;
+    private final Location position;
 
-    protected BallerinaSymbol(String name,
-                                  PackageID moduleID,
-                                  SymbolKind symbolKind,
-                                  BSymbol symbol) {
+    protected BallerinaSymbol(String name, PackageID moduleID, SymbolKind symbolKind, BSymbol symbol) {
         this.name = name;
         this.moduleID = moduleID;
         this.symbolKind = symbolKind;
         this.docAttachment = getDocAttachment(symbol);
         this.isLangLib = symbol != null && ((symbol.flags & Flags.LANG_LIB) == Flags.LANG_LIB);
+        this.position = new BLangDiagnosticLocation(symbol.pos.src.getCompilationUnitName(), symbol.pos.sLine,
+                                                    symbol.pos.eLine, symbol.pos.sCol, symbol.pos.eCol);
     }
 
     /**
@@ -84,6 +86,11 @@ public class BallerinaSymbol implements Symbol {
         return Optional.ofNullable(this.docAttachment);
     }
 
+    @Override
+    public Location position() {
+        return this.position;
+    }
+
     /**
      * Whether the symbol is a langlib symbol.
      *
@@ -103,7 +110,7 @@ public class BallerinaSymbol implements Symbol {
      * @param <T> Symbol Type
      */
     protected abstract static class SymbolBuilder<T extends SymbolBuilder<T>> {
-        
+
         protected String name;
         protected PackageID moduleID;
         protected SymbolKind ballerinaSymbolKind;

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaSymbol.java
@@ -49,7 +49,12 @@ public class BallerinaSymbol implements Symbol {
         this.moduleID = moduleID;
         this.symbolKind = symbolKind;
         this.docAttachment = getDocAttachment(symbol);
-        this.isLangLib = symbol != null && ((symbol.flags & Flags.LANG_LIB) == Flags.LANG_LIB);
+
+        if (symbol == null) {
+            throw new IllegalArgumentException("'symbol' cannot be null");
+        }
+
+        this.isLangLib = (symbol.flags & Flags.LANG_LIB) == Flags.LANG_LIB;
         this.position = new BLangDiagnosticLocation(symbol.pos.src.getCompilationUnitName(), symbol.pos.sLine,
                                                     symbol.pos.eLine, symbol.pos.sCol, symbol.pos.eCol);
     }

--- a/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-compiler-api/src/main/java/org/ballerina/compiler/impl/symbols/BallerinaSymbol.java
@@ -92,7 +92,7 @@ public class BallerinaSymbol implements Symbol {
     }
 
     @Override
-    public Location position() {
+    public Location location() {
         return this.position;
     }
 

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerina.compiler.api.symbols.Symbol;
+import org.ballerina.compiler.impl.BallerinaSemanticModel;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.compile;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Test cases for the positions of symbols.
+ *
+ * @since 2.0.0
+ */
+public class SymbolPositionTest {
+
+    private BallerinaSemanticModel model;
+
+    @BeforeClass
+    public void setup() {
+        CompilerContext context = new CompilerContext();
+        CompileResult result = compile("test-src/symbol_position_test.bal", context);
+        BLangPackage pkg = (BLangPackage) result.getAST();
+        model = new BallerinaSemanticModel(pkg, context);
+    }
+
+    @Test(dataProvider = "PositionProvider")
+    public void testSymbolPositions(int sLine, int sCol, int eLine, int eCol, String expSymbolName) {
+        Optional<Symbol> symbol = model.symbol("symbol_position_test.bal", LinePosition.from(sLine, sCol));
+
+        if (!symbol.isPresent()) {
+            assertNull(expSymbolName);
+        }
+
+        assertEquals(symbol.get().name(), expSymbolName);
+
+        Location pos = symbol.get().position();
+        assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
+        assertEquals(pos.lineRange().startLine().line(), sLine);
+        assertEquals(pos.lineRange().startLine().offset(), sCol);
+        assertEquals(pos.lineRange().endLine().line(), eLine);
+        assertEquals(pos.lineRange().endLine().offset(), eCol);
+    }
+
+    @DataProvider(name = "PositionProvider")
+    public Object[][] getPositions() {
+        return new Object[][]{
+                {17, 8, 17, 15, "aString"},
+                {20, 10, 20, 14, "test"},
+                {21, 12, 21, 17, "greet"},
+                {26, 7, 26, 12, "HELLO"},
+                {28, 6, 28, 12, "Person"},
+                {32, 6, 32, 15, "PersonObj"},
+                {33, 12, 33, 16, "name"},
+                {35, 14, 35, 21, "PersonObj.getName"},
+                {38, 7, 38, 18, "PersonClass"},
+                {41, 14, 41, 18, "PersonClass.init"},
+                {45, 14, 45, 21, "PersonClass.getName"},
+                {52, 6, 52, 12, "Colour"},
+                {55, 12, 55, 14, "w1"},
+        };
+    }
+}

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -61,7 +61,7 @@ public class SymbolPositionTest {
 
         assertEquals(symbol.get().name(), expSymbolName);
 
-        Location pos = symbol.get().position();
+        Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
         assertEquals(pos.lineRange().startLine().line(), sLine);
         assertEquals(pos.lineRange().startLine().offset(), sCol);
@@ -94,7 +94,7 @@ public class SymbolPositionTest {
 
         assertEquals(symbol.get().name(), "val");
 
-        Location pos = symbol.get().position();
+        Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
         assertEquals(pos.lineRange().startLine().line(), 61);
         assertEquals(pos.lineRange().startLine().offset(), 22);

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -87,4 +87,28 @@ public class SymbolPositionTest {
                 {55, 12, 55, 14, "w1"},
         };
     }
+
+    @Test(dataProvider = "PositionProvider2")
+    public void testTypeNarrowedSymbolPositions(int line, int col) {
+        Optional<Symbol> symbol = model.symbol("symbol_position_test.bal", LinePosition.from(line, col));
+
+        assertEquals(symbol.get().name(), "val");
+
+        Location pos = symbol.get().position();
+        assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
+        assertEquals(pos.lineRange().startLine().line(), 61);
+        assertEquals(pos.lineRange().startLine().offset(), 22);
+        assertEquals(pos.lineRange().endLine().line(), 61);
+        assertEquals(pos.lineRange().endLine().offset(), 25);
+    }
+
+    @DataProvider(name = "PositionProvider2")
+    public Object[][] getTypeNarrowedPositions() {
+        return new Object[][]{
+                {65, 14},
+                {68, 22},
+                {70, 24},
+                {73, 21},
+        };
+    }
 }

--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -22,12 +22,17 @@ import org.ballerina.compiler.api.ModuleID;
 import org.ballerina.compiler.api.symbols.Symbol;
 import org.ballerina.compiler.impl.BallerinaSemanticModel;
 import org.ballerinalang.model.symbols.SymbolOrigin;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.CompileResult;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -46,6 +51,15 @@ import static org.testng.Assert.assertTrue;
  * @since 2.0.0
  */
 public class SemanticAPITestUtils {
+
+    private static final Path resourceDir = Paths.get("src/test/resources").toAbsolutePath();
+
+    public static CompileResult compile(String path, CompilerContext context) {
+        Path sourcePath = Paths.get(path);
+        String packageName = sourcePath.getFileName().toString();
+        Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
+        return BCompileUtil.compileOnJBallerina(context, sourceRoot.toString(), packageName, false, true, false);
+    }
 
     public static void assertList(List<? extends Symbol> actualValues, List<String> expectedValues) {
         Map<String, Symbol> symbols = actualValues.stream().collect(Collectors.toMap(Symbol::name, s -> s));

--- a/compiler/ballerina-compiler-api/src/test/resources/test-src/symbol_position_test.bal
+++ b/compiler/ballerina-compiler-api/src/test/resources/test-src/symbol_position_test.bal
@@ -56,3 +56,20 @@ function workers() {
         int x = 10;
     }
 }
+
+function typeNarrowing() {
+    int|float|string val = 10;
+    typedesc<anydata> td;
+
+    if (val is int|float) {
+        _ = val;
+
+        if (val is int) {
+            int x = val;
+        } else {
+            float f = val;
+        }
+    } else {
+        string s = val;
+    }
+}

--- a/compiler/ballerina-compiler-api/src/test/resources/test-src/symbol_position_test.bal
+++ b/compiler/ballerina-compiler-api/src/test/resources/test-src/symbol_position_test.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+string aString = "foo";
+int anInt = 10;
+
+function test() {
+    string greet = "Hello " + aString;
+
+    var greetFn = function (string name) returns string => HELLO + " " + name;
+}
+
+const HELLO = "Hello";
+
+type Person record {|
+    string name;
+|};
+
+type PersonObj object {
+    string name;
+
+    function getName() returns string;
+};
+
+class PersonClass {
+    string name;
+
+    function init(string name) {
+        self.name = name;
+    }
+
+    function getName() returns string => self.name;
+}
+
+const RED = "red";
+const GREEN = "green";
+const BLUE = "blue";
+
+type Colour RED|GREEN|BLUE;
+
+function workers() {
+    worker w1 {
+        int x = 10;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2539,7 +2539,6 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     public BLangNode transform(IfElseStatementNode ifElseStmtNode) {
         BLangIf bLIf = (BLangIf) TreeBuilder.createIfElseStatementNode();
         bLIf.pos = getPosition(ifElseStmtNode);
-        trimRight(bLIf.pos, getPosition(ifElseStmtNode.ifBody()));
         bLIf.setCondition(createExpression(ifElseStmtNode.condition()));
         bLIf.setBody((BLangBlockStmt) ifElseStmtNode.ifBody().apply(this));
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -597,8 +597,9 @@ public class SymbolEnter extends BLangNodeVisitor {
         boolean isPublicType = flags.contains(Flag.PUBLIC);
 
         BTypeSymbol tSymbol = Symbols.createClassSymbol(Flags.asMask(flags),
-                names.fromIdNode(classDefinition.name),
-                env.enclPkg.symbol.pkgID, null, env.scope.owner, classDefinition.pos, SOURCE);
+                                                        names.fromIdNode(classDefinition.name),
+                                                        env.enclPkg.symbol.pkgID, null, env.scope.owner,
+                                                        classDefinition.name.pos, SOURCE);
         tSymbol.scope = new Scope(tSymbol);
         tSymbol.markdownDocumentation = getMarkdownDocAttachment(classDefinition.markdownDocumentationAttachment);
 
@@ -1350,10 +1351,11 @@ public class SymbolEnter extends BLangNodeVisitor {
             funcNode.flagSet.add(Flag.LANG_LIB);
         }
 
+        DiagnosticPos symbolPos = funcNode.flagSet.contains(Flag.LAMBDA) ? symTable.builtinPos : funcNode.name.pos;
         BInvokableSymbol funcSymbol = Symbols.createFunctionSymbol(Flags.asMask(funcNode.flagSet),
                                                                    getFuncSymbolName(funcNode),
                                                                    env.enclPkg.symbol.pkgID, null, env.scope.owner,
-                                                                   funcNode.hasBody(), funcNode.pos, SOURCE);
+                                                                   funcNode.hasBody(), symbolPos, SOURCE);
         funcSymbol.source = funcNode.pos.src.cUnitName;
         funcSymbol.markdownDocumentation = getMarkdownDocAttachment(funcNode.markdownDocumentationAttachment);
         SymbolEnv invokableEnv = SymbolEnv.createFunctionEnv(funcNode, funcSymbol.scope, env);
@@ -1461,7 +1463,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         Name name = names.fromIdNode(constant.name);
         PackageID pkgID = env.enclPkg.symbol.pkgID;
         return new BConstantSymbol(Flags.asMask(constant.flagSet), name, pkgID,
-                                   symTable.semanticError, symTable.noType, env.scope.owner, constant.pos, SOURCE);
+                                   symTable.semanticError, symTable.noType, env.scope.owner, constant.name.pos, SOURCE);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2397,7 +2397,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             return;
         }
 
-        BVarSymbol varSymbol = createVarSymbol(symbol.flags, type, symbol.name, targetEnv, pos, isInternal);
+        BVarSymbol varSymbol = createVarSymbol(symbol.flags, type, symbol.name, targetEnv, symbol.pos, isInternal);
         if (type.tag == TypeTags.INVOKABLE && type.tsymbol != null) {
             BInvokableTypeSymbol tsymbol = (BInvokableTypeSymbol) type.tsymbol;
             BInvokableSymbol invokableSymbol = (BInvokableSymbol) varSymbol;


### PR DESCRIPTION
## Purpose
> This PR adds a new method to access the position info of the symbols. The position returned by this API is the position of the identifier of that particular construct.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
