### PR TITLE
Add ballerina lang snapshot publish workflow

### DIFF
--- a/.github/workflows/CD_publish_snapshot.yml
+++ b/.github/workflows/CD_publish_snapshot.yml
@@ -1,0 +1,51 @@
+name: Publish Ballerina Snapshot
+
+on:
+    push:
+        paths-ignore:
+            - 'stdlib/release/**'
+            - '.github/workflows/**'
+        branchs:
+            - master
+    workflow_dispatch:
+
+jobs:
+    publish-ballerina-lang:
+        name: Build and Publish Ballerina Lang
+        runs-on: ubuntu-latest
+        if: github.repository_owner == 'ballerina-platform'
+        steps:
+            -   name: Checkout Repository
+                uses: actions/checkout@v2
+
+            -   name: Set up JDK 1.8
+                uses: actions/setup-java@v1
+                with:
+                    java-version: 1.8
+
+            -   name: Setup Node.js
+                uses: actions/setup-node@v1
+                with:
+                    node-version: '8.x'
+
+            -   name: Initialize Sub Modules
+                run: git submodule update --init
+
+            -   name: Build and Publish
+                env:
+                    NEXUS_USERNAME: ${{ github.actor }}
+                    NEXUS_PASSWORD: ${{ secrets.BAL_BOT_PAT }}
+                run: |
+                    ./gradlew build -x createJavadoc -x test -x check --max-workers=2 --no-daemon
+                    ./gradlew publish -PpublishToGithub
+
+            -   name: Trigger Standard Library Module Builds
+                run: |
+                    echo "Triggering stdlib module builds"
+                    curl --request POST 'https://api.github.com/repos/ballerina-platform/ballerina-lang/dispatches' \
+                    --header 'Accept: application/vnd.github.v3+json' \
+                    --header 'Authorization: Bearer ${{ secrets.BAL_BOT_PAT }}' \
+                    --header 'Content-Type: application/json' \
+                    --data-raw '{
+                        "event_type": "ballerina-lang-push"
+                    }'

--- a/.github/workflows/CI_push_build.yml
+++ b/.github/workflows/CI_push_build.yml
@@ -2,6 +2,8 @@ name: Build merged PR changes on Ubuntu
 
 on:
   push:
+    paths-ignore:
+      - 'stdlib/release/**'
     branches:
       - master
       - next-release

--- a/.github/workflows/CI_ubuntu.yml
+++ b/.github/workflows/CI_ubuntu.yml
@@ -2,6 +2,8 @@ name: CI Ubuntu
 
 on:
   pull_request:
+    paths-ignore:
+      - 'stdlib/release/**'
     branches:
       - master
       - next-release

--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -2,6 +2,8 @@ name: CI Windows
 
 on: 
   pull_request:
+    paths-ignore:
+      - 'stdlib/release/**'
     branches:
       - master
       - next-release

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,9 @@ subprojects {
         }
         repositories {
             maven {
-                if(project.version.endsWith('-SNAPSHOT')) {
+                if(project.version.endsWith('-SNAPSHOT') && project.hasProperty('publishToGithub')) {
+                    url = 'https://maven.pkg.github.com/ballerina-platform/ballerina-lang'
+                } else if(project.version.endsWith('-SNAPSHOT')) {
                     url "https://maven.wso2.org/nexus/content/repositories/snapshots/"
                 } else {
                     url "https://maven.wso2.org/nexus/service/local/staging/deploy/maven2/"


### PR DESCRIPTION
## Purpose
As a part of Ballerina Standard Library migration, the standard libraries need a `ballerina-lang` `SNAPSHOT` artifacts to be released. Current process is to publish them to the Nexus, using a periodical build job on Jenkins. With this PR, it is moved to Github and the build and publishing the `SNAPSHOT` whenever a push (PR merge) in the `master` branch.

After the publishing the artifacts, it will then trigger another workflow, which will trigger the stdlib module builds. (This is still in-progress). Once we finish this, the Jenkins job can be removed.

Additionally this ignores the ballerina standard library build pipeline changes when building the PRs and pushes, since it will not effect the ballerina-lang build in any way.

Related to #25789 