### PR TITLE
Change error cause type in BLangErrorVariableNode to BLangVariable

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -282,6 +282,7 @@ import javax.xml.XMLConstants;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.ballerinalang.util.BLangCompilerConstants.RETRY_MANAGER_OBJECT_SHOULD_RETRY_FUNC;
 import static org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil.createBlockStmt;
+import static org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil.createErrorVariableDef;
 import static org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil.createExpressionStmt;
 import static org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil.createLiteral;
 import static org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil.createStatementExpression;
@@ -1506,9 +1507,16 @@ public class Desugar extends BLangNodeVisitor {
         }
 
         if (parentErrorVariable.cause != null) {
-            BLangSimpleVariableDef causeVariableDef =
-                    ASTBuilderUtil.createVariableDefStmt(parentErrorVariable.cause.pos, parentBlockStmt);
-            causeVariableDef.var = parentErrorVariable.cause;
+            BLangVariable errorCause = parentErrorVariable.cause;
+            if (errorCause.getKind() == NodeKind.ERROR_VARIABLE) {
+                BLangErrorVariableDef errorVarDef = createErrorVariableDef(errorCause.pos,
+                        (BLangErrorVariable) errorCause);
+                parentBlockStmt.addStatement(errorVarDef);
+            } else {
+                BLangSimpleVariableDef causeVariableDef =
+                        ASTBuilderUtil.createVariableDefStmt(parentErrorVariable.cause.pos, parentBlockStmt);
+                causeVariableDef.var = (BLangSimpleVariable) parentErrorVariable.cause;
+            }
             parentErrorVariable.cause.expr = generateErrorCauseLanglibFunction(parentErrorVariable.cause.pos,
                     parentErrorVariable.cause.type, convertedErrorVarSymbol, null);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -4024,7 +4024,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                             }
                             // Fall through.
                         case ERROR_BINDING_PATTERN:
-                            bLangErrorVariable.cause = (BLangSimpleVariable) getBLangVariableNode(bindingPatternNode);
+                            bLangErrorVariable.cause = getBLangVariableNode(bindingPatternNode);
                             break;
                         case NAMED_ARG_BINDING_PATTERN:
                             NamedArgBindingPatternNode namedArgBindingPatternNode =

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangErrorVariable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangErrorVariable.java
@@ -45,7 +45,7 @@ public class BLangErrorVariable extends BLangVariable implements ErrorVariableNo
     public boolean reasonVarPrefixAvailable;
     public BLangLiteral reasonMatchConst; // todo: no longer needed remove
     public boolean isInMatchStmt;
-    public BLangSimpleVariable cause;
+    public BLangVariable cause;
 
     public BLangErrorVariable() {
         this.annAttachments = new ArrayList<>();

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
@@ -34,7 +34,8 @@ public class ErrorDestructureNegetiveTest {
     public void testErrorDestructuring() {
         CompileResult destructuringResult = BCompileUtil.
                 compile("test-src/error/error_destructure_binding_pattern_error_cause.bal");
-        BAssertUtil.validateError(destructuringResult, 0, "incompatible types: expected 'error?', found 'error'", 4, 21);
+        BAssertUtil.validateError(destructuringResult, 0,
+                "incompatible types: expected 'error?', found 'error'", 4, 21);
         Assert.assertEquals(1, destructuringResult.getErrorCount());
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
@@ -17,10 +17,8 @@
  */
 package org.ballerinalang.test.error;
 
-import org.ballerinalang.model.values.BValue;
 import org.ballerinalang.test.util.BAssertUtil;
 import org.ballerinalang.test.util.BCompileUtil;
-import org.ballerinalang.test.util.BRunUtil;
 import org.ballerinalang.test.util.CompileResult;
 import org.testng.Assert;
 import org.testng.annotations.Test;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.test.error;
+
+import org.ballerinalang.model.values.BValue;
+import org.ballerinalang.test.util.BAssertUtil;
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Test cases for Invalid error destructure binding pattern.
+ *
+ * @since 2.0 Swan Lake
+ */
+public class ErrorDestructureNegetiveTest {
+
+    @Test(description = "Test error destruturing binding pattern with error cause error binding pattern")
+    public void testErrorDestructuring() {
+        CompileResult destructuringResult = BCompileUtil.
+                compile("test-src/error/error_destructure_binding_pattern_error_cause.bal");
+        BAssertUtil.validateError(destructuringResult, 0, "incompatible types: expected 'error?', found 'error'", 4, 21);
+        Assert.assertEquals(1, destructuringResult.getErrorCount());
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 /**
  * Test cases for Invalid error destructure binding pattern.
  *
- * @since 2.0 Swan Lake
+ * @since Swan Lake
  */
 public class ErrorDestructureNegetiveTest {
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorDestructureNegetiveTest.java
@@ -35,7 +35,7 @@ public class ErrorDestructureNegetiveTest {
         CompileResult destructuringResult = BCompileUtil.
                 compile("test-src/error/error_destructure_binding_pattern_error_cause.bal");
         BAssertUtil.validateError(destructuringResult, 0,
-                "incompatible types: expected 'error?', found 'error'", 4, 21);
+                "incompatible types: expected 'error?', found 'error'", 20, 21);
         Assert.assertEquals(1, destructuringResult.getErrorCount());
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_destructure_binding_pattern_error_cause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_destructure_binding_pattern_error_cause.bal
@@ -1,4 +1,20 @@
-public function main() {
+//  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+//  WSO2 Inc. licenses this file to you under the Apache License,
+//  Version 2.0 (the "License"); you may not use this file except
+//  in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+ public function main() {
     string errorMsg;
     string errorCause;
     error(errorMsg, error(errorCause)) = error("msg", error("Error cause"));

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_destructure_binding_pattern_error_cause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_destructure_binding_pattern_error_cause.bal
@@ -1,0 +1,5 @@
+public function main() {
+    string errorMsg;
+    string errorCause;
+    error(errorMsg, error(errorCause)) = error("msg", error("Error cause"));
+}


### PR DESCRIPTION
## Purpose
Change the type of error cause in `BLangErrorVariableNode` from `BLangSimpleVariable` to `BLangVariable.`

Fixes #25313

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
