### PR TITLE
[Formatter] Add several node implementations

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
@@ -33,6 +33,7 @@ import io.ballerinalang.compiler.syntax.tree.CompoundAssignmentStatementNode;
 import io.ballerinalang.compiler.syntax.tree.ComputedNameFieldNode;
 import io.ballerinalang.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerinalang.compiler.syntax.tree.DoStatementNode;
+import io.ballerinalang.compiler.syntax.tree.DocumentationReferenceNode;
 import io.ballerinalang.compiler.syntax.tree.ElseBlockNode;
 import io.ballerinalang.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerinalang.compiler.syntax.tree.EnumMemberNode;
@@ -66,6 +67,9 @@ import io.ballerinalang.compiler.syntax.tree.ListConstructorExpressionNode;
 import io.ballerinalang.compiler.syntax.tree.LockStatementNode;
 import io.ballerinalang.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerinalang.compiler.syntax.tree.MappingFieldNode;
+import io.ballerinalang.compiler.syntax.tree.MarkdownDocumentationLineNode;
+import io.ballerinalang.compiler.syntax.tree.MarkdownDocumentationNode;
+import io.ballerinalang.compiler.syntax.tree.MarkdownParameterDocumentationLineNode;
 import io.ballerinalang.compiler.syntax.tree.MatchClauseNode;
 import io.ballerinalang.compiler.syntax.tree.MatchGuardNode;
 import io.ballerinalang.compiler.syntax.tree.MatchStatementNode;
@@ -1532,6 +1536,63 @@ public class NewFormattingTreeModifier extends FormattingTreeModifier {
                     .withIdentifier(identifier)
                     .apply();
         }
+    }
+
+    @Override
+    public MarkdownDocumentationNode transform(MarkdownDocumentationNode markdownDocumentationNode) {
+        NodeList<Node> documentationLines = formatNodeList(markdownDocumentationNode.documentationLines(), 0, 0, 0, 1);
+
+        return markdownDocumentationNode.modify()
+                .withDocumentationLines(documentationLines)
+                .apply();
+    }
+
+    @Override
+    public MarkdownDocumentationLineNode transform(MarkdownDocumentationLineNode markdownDocumentationLineNode) {
+        Token hashToken = formatToken(markdownDocumentationLineNode.hashToken(), 0, 0);
+        NodeList<Node> documentElements = formatNodeList(markdownDocumentationLineNode.documentElements(), 0, 0, 0, 1);
+
+        return markdownDocumentationLineNode.modify()
+                .withDocumentElements(documentElements)
+                .withHashToken(hashToken)
+                .apply();
+    }
+
+    @Override
+    public MarkdownParameterDocumentationLineNode transform(
+            MarkdownParameterDocumentationLineNode markdownParameterDocumentationLineNode) {
+        Token hashToken = formatToken(markdownParameterDocumentationLineNode.hashToken(), 1, 0);
+        Token plusToken = formatToken(markdownParameterDocumentationLineNode.plusToken(), 1, 0);
+        Token parameterName = formatToken(markdownParameterDocumentationLineNode.parameterName(), 1, 0);
+        Token minusToken = formatToken(markdownParameterDocumentationLineNode.minusToken(), 0, 0);
+        NodeList<Node> documentElements =
+                formatNodeList(markdownParameterDocumentationLineNode.documentElements(), 0, 0, 0, 1);
+
+        return markdownParameterDocumentationLineNode.modify()
+                .withHashToken(hashToken)
+                .withPlusToken(plusToken)
+                .withParameterName(parameterName)
+                .withMinusToken(minusToken)
+                .withDocumentElements(documentElements)
+                .apply();
+    }
+
+    @Override
+    public DocumentationReferenceNode transform(DocumentationReferenceNode documentationReferenceNode) {
+        if (documentationReferenceNode.referenceType().isPresent()) {
+            Token referenceType = formatToken(documentationReferenceNode.referenceType().get(), 1, 0);
+            documentationReferenceNode = documentationReferenceNode.modify().withReferenceType(referenceType).apply();
+        }
+
+        Token startBacktick = formatToken(documentationReferenceNode.startBacktick(), 0, 0);
+        Node backtickContent = formatNode(documentationReferenceNode.backtickContent(), 0, 0);
+        Token endBacktick = formatToken(documentationReferenceNode.endBacktick(), this.trailingWS, this.trailingNL);
+
+        return documentationReferenceNode.modify()
+                .withStartBacktick(startBacktick)
+                .withBacktickContent(backtickContent)
+                .withEndBacktick(endBacktick)
+                .apply();
     }
 
     @Override

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
@@ -30,6 +30,7 @@ import io.ballerinalang.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
 import io.ballerinalang.compiler.syntax.tree.CaptureBindingPatternNode;
 import io.ballerinalang.compiler.syntax.tree.CheckExpressionNode;
 import io.ballerinalang.compiler.syntax.tree.CompoundAssignmentStatementNode;
+import io.ballerinalang.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerinalang.compiler.syntax.tree.DoStatementNode;
 import io.ballerinalang.compiler.syntax.tree.ElseBlockNode;
 import io.ballerinalang.compiler.syntax.tree.ExplicitNewExpressionNode;
@@ -61,6 +62,7 @@ import io.ballerinalang.compiler.syntax.tree.NodeList;
 import io.ballerinalang.compiler.syntax.tree.OnFailClauseNode;
 import io.ballerinalang.compiler.syntax.tree.OptionalTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.ParameterNode;
+import io.ballerinalang.compiler.syntax.tree.ParameterizedTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.ParenthesizedArgList;
 import io.ballerinalang.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerinalang.compiler.syntax.tree.RecordFieldNode;
@@ -81,6 +83,7 @@ import io.ballerinalang.compiler.syntax.tree.SyntaxKind;
 import io.ballerinalang.compiler.syntax.tree.Token;
 import io.ballerinalang.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerinalang.compiler.syntax.tree.TypeDescriptorNode;
+import io.ballerinalang.compiler.syntax.tree.TypeParameterNode;
 import io.ballerinalang.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerinalang.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.VariableDeclarationNode;
@@ -917,6 +920,65 @@ public class NewFormattingTreeModifier extends FormattingTreeModifier {
         return nilTypeDescriptorNode.modify()
                 .withOpenParenToken(openParenToken)
                 .withCloseParenToken(closeParenToken)
+                .apply();
+    }
+
+    @Override
+    public ConstantDeclarationNode transform(ConstantDeclarationNode constantDeclarationNode) {
+        if (constantDeclarationNode.metadata().isPresent()) {
+            MetadataNode metadata = formatNode(constantDeclarationNode.metadata().get(), 1, 0);
+            constantDeclarationNode = constantDeclarationNode.modify()
+                    .withMetadata(metadata).apply();
+        }
+
+        if (constantDeclarationNode.visibilityQualifier().isPresent()) {
+            Token visibilityQualifier = formatToken(constantDeclarationNode.visibilityQualifier().get(), 1, 0);
+            constantDeclarationNode = constantDeclarationNode.modify()
+                    .withVisibilityQualifier(visibilityQualifier).apply();
+        }
+        Token constKeyword = formatToken(constantDeclarationNode.constKeyword(), 1, 0);
+
+        if (constantDeclarationNode.typeDescriptor().isPresent()) {
+            TypeDescriptorNode typeDescriptorNode = formatNode(constantDeclarationNode.typeDescriptor().get(), 1, 0);
+            constantDeclarationNode = constantDeclarationNode.modify().withTypeDescriptor(typeDescriptorNode).apply();
+        }
+
+        Token variableName = formatToken(constantDeclarationNode.variableName(), 1, 0);
+        Token equalsToken = formatToken(constantDeclarationNode.equalsToken(), 1, 0);
+        Node initializer = formatNode(constantDeclarationNode.initializer(), 0, 0);
+        Token semicolonToken = formatToken(constantDeclarationNode.semicolonToken(), this.trailingWS, this.trailingNL);
+
+        return constantDeclarationNode.modify()
+                .withConstKeyword(constKeyword)
+                .withEqualsToken(equalsToken)
+                .withInitializer(initializer)
+                .withSemicolonToken(semicolonToken)
+                .withVariableName(variableName)
+                .apply();
+    }
+
+    @Override
+    public ParameterizedTypeDescriptorNode transform(ParameterizedTypeDescriptorNode parameterizedTypeDescriptorNode) {
+        Token parameterizedType = formatToken(parameterizedTypeDescriptorNode.parameterizedType(), 0, 0);
+        TypeParameterNode typeParameter = formatNode(parameterizedTypeDescriptorNode.typeParameter(),
+                this.trailingWS, this.trailingNL);
+
+        return parameterizedTypeDescriptorNode.modify()
+                .withParameterizedType(parameterizedType)
+                .withTypeParameter(typeParameter)
+                .apply();
+    }
+
+    @Override
+    public TypeParameterNode transform(TypeParameterNode typeParameterNode) {
+        Token ltToken = formatToken(typeParameterNode.ltToken(), 0, 0);
+        TypeDescriptorNode typeNode = formatNode(typeParameterNode.typeNode(), 0, 0);
+        Token gtToken = formatToken(typeParameterNode.gtToken(), this.trailingWS, this.trailingNL);
+
+        return typeParameterNode.modify()
+                .withTypeNode(typeNode)
+                .withLtToken(ltToken)
+                .withGtToken(gtToken)
                 .apply();
     }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
@@ -43,6 +43,7 @@ import io.ballerinalang.compiler.syntax.tree.FunctionBodyNode;
 import io.ballerinalang.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerinalang.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerinalang.compiler.syntax.tree.FunctionSignatureNode;
+import io.ballerinalang.compiler.syntax.tree.FunctionTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.IdentifierToken;
 import io.ballerinalang.compiler.syntax.tree.IfElseStatementNode;
 import io.ballerinalang.compiler.syntax.tree.ImportDeclarationNode;
@@ -63,6 +64,7 @@ import io.ballerinalang.compiler.syntax.tree.OnFailClauseNode;
 import io.ballerinalang.compiler.syntax.tree.OptionalTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.ParameterNode;
 import io.ballerinalang.compiler.syntax.tree.ParameterizedTypeDescriptorNode;
+import io.ballerinalang.compiler.syntax.tree.ParenthesisedTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.ParenthesizedArgList;
 import io.ballerinalang.compiler.syntax.tree.QualifiedNameReferenceNode;
 import io.ballerinalang.compiler.syntax.tree.RecordFieldNode;
@@ -979,6 +981,34 @@ public class NewFormattingTreeModifier extends FormattingTreeModifier {
                 .withTypeNode(typeNode)
                 .withLtToken(ltToken)
                 .withGtToken(gtToken)
+                .apply();
+    }
+
+    @Override
+    public FunctionTypeDescriptorNode transform(FunctionTypeDescriptorNode functionTypeDescriptorNode) {
+        NodeList<Token> qualifierList = formatNodeList(functionTypeDescriptorNode.qualifierList(), 1, 0, 0, 1);
+        Token functionKeyword = formatToken(functionTypeDescriptorNode.functionKeyword(), 1, 0);
+        FunctionSignatureNode functionSignature = formatNode(functionTypeDescriptorNode.functionSignature(),
+                this.trailingWS, this.trailingNL);
+
+        return functionTypeDescriptorNode.modify()
+                .withQualifierList(qualifierList)
+                .withFunctionKeyword(functionKeyword)
+                .withFunctionSignature(functionSignature)
+                .apply();
+    }
+
+    @Override
+    public ParenthesisedTypeDescriptorNode transform(ParenthesisedTypeDescriptorNode parenthesisedTypeDescriptorNode) {
+        Token openParenToken = formatToken(parenthesisedTypeDescriptorNode.openParenToken(), 0, 0);
+        TypeDescriptorNode typedesc = formatNode(parenthesisedTypeDescriptorNode.typedesc(), 0, 0);
+        Token closeParenToken = formatToken(parenthesisedTypeDescriptorNode.closeParenToken(),
+                this.trailingWS, this.trailingNL);
+
+        return parenthesisedTypeDescriptorNode.modify()
+                .withOpenParenToken(openParenToken)
+                .withTypedesc(typedesc)
+                .withCloseParenToken(closeParenToken)
                 .apply();
     }
 

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
@@ -34,6 +34,8 @@ import io.ballerinalang.compiler.syntax.tree.ComputedNameFieldNode;
 import io.ballerinalang.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerinalang.compiler.syntax.tree.DoStatementNode;
 import io.ballerinalang.compiler.syntax.tree.ElseBlockNode;
+import io.ballerinalang.compiler.syntax.tree.EnumDeclarationNode;
+import io.ballerinalang.compiler.syntax.tree.EnumMemberNode;
 import io.ballerinalang.compiler.syntax.tree.ErrorTypeDescriptorNode;
 import io.ballerinalang.compiler.syntax.tree.ErrorTypeParamsNode;
 import io.ballerinalang.compiler.syntax.tree.ExplicitNewExpressionNode;
@@ -1474,6 +1476,62 @@ public class NewFormattingTreeModifier extends FormattingTreeModifier {
         return metadataNode.modify()
                 .withAnnotations(annotations)
                 .apply();
+    }
+
+    @Override
+    public EnumDeclarationNode transform(EnumDeclarationNode enumDeclarationNode) {
+        if (enumDeclarationNode.metadata().isPresent()) {
+            MetadataNode metadata = formatNode(enumDeclarationNode.metadata().get(), 0, 1);
+            enumDeclarationNode = enumDeclarationNode.modify()
+                    .withMetadata(metadata).apply();
+        }
+
+        Token qualifier = formatToken(enumDeclarationNode.qualifier(), 1, 0);
+        Token enumKeywordToken = formatToken(enumDeclarationNode.enumKeywordToken(), 1, 0);
+        IdentifierToken identifier = formatNode(enumDeclarationNode.identifier(), 1, 0);
+        Token openBraceToken = formatToken(enumDeclarationNode.openBraceToken(), 0, 1);
+        indent();
+        SeparatedNodeList<Node> enumMemberList = formatSeparatedNodeList(enumDeclarationNode.enumMemberList(),
+                0, 0, 0, 1, 0, 1);
+        unindent();
+        Token closeBraceToken = formatToken(enumDeclarationNode.closeBraceToken(), this.trailingWS, this.trailingNL);
+
+        return enumDeclarationNode.modify()
+                .withQualifier(qualifier)
+                .withEnumKeywordToken(enumKeywordToken)
+                .withIdentifier(identifier)
+                .withOpenBraceToken(openBraceToken)
+                .withEnumMemberList(enumMemberList)
+                .withCloseBraceToken(closeBraceToken)
+                .apply();
+    }
+
+    @Override
+    public EnumMemberNode transform(EnumMemberNode enumMemberNode) {
+        if (enumMemberNode.metadata().isPresent()) {
+            MetadataNode metadata = formatNode(enumMemberNode.metadata().get(), 0, 1);
+            enumMemberNode = enumMemberNode.modify().withMetadata(metadata).apply();
+        }
+        IdentifierToken identifier;
+
+        if (enumMemberNode.equalToken().isPresent()) {
+            identifier = formatNode(enumMemberNode.identifier(), 1, 0);
+            Token equalToken = formatToken(enumMemberNode.equalToken().get(), 1, 0);
+            ExpressionNode constExprNode = formatNode(enumMemberNode.constExprNode().get(),
+                    this.trailingWS, this.trailingNL);
+
+            return enumMemberNode.modify()
+                    .withIdentifier(identifier)
+                    .withEqualToken(equalToken)
+                    .withConstExprNode(constExprNode)
+                    .apply();
+        } else {
+            identifier = formatNode(enumMemberNode.identifier(), this.trailingWS, this.trailingNL);
+
+            return enumMemberNode.modify()
+                    .withIdentifier(identifier)
+                    .apply();
+        }
     }
 
     @Override


### PR DESCRIPTION
## Purpose
Adds the following node implementations:

* ConstantDeclarationNode
* ParameterizedTypeDescriptorNode
* TypeParameterNode
* FunctionTypeDescriptorNode
* ParenthesisedTypeDescriptorNode
* ExternalFunctionBodyNode
* AnnotationNode
* MappingConstructorExpressionNode
* SpecificFieldNode
* ListConstructorExpressionNode
* ErrorTypeDescriptorNode
* PanicStatementNode
* IntersectionTypeDescriptorNode
* ModuleVariableDeclarationNode
* ExpressionFunctionBodyNode
* TypeCastExpressionNode
* TypeCastParamNode
* IndexedExpressionNode
* ComputedNameFieldNode
* TupleTypeDescriptorNode
* ListBindingPatternNode
* RestBindingPatternNode
* TableTypeDescriptorNode
* KeyTypeConstraintNode
* MatchStatementNode
* MatchClauseNode
* MatchGuardNode
* LockStatementNode
* FieldAccessExpressionNode
* MetadataNode
* EnumDeclarationNode 
* EnumMemberNode
* MarkdownDocumentationNode
* MarkdownDocumentationLineNode
* MarkdownParameterDocumentationLineNode
* DocumentationReferenceNode

Partially Fixes #26052

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
