### PR TITLE
Fix position issue in empty package alias for function calls

### DIFF
--- a/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/compiler/ballerina-compiler-api/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -92,6 +92,8 @@ public class SymbolAtCursorTest {
                 {60, 12, "self"},
                 {64, 24, "fname"},
                 {64, 42, "lname"},
+                {73, 5, "test"},
+                {73, 8, "test"},
         };
     }
 

--- a/compiler/ballerina-compiler-api/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
+++ b/compiler/ballerina-compiler-api/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
@@ -68,3 +68,7 @@ class PersonObj {
 enum Colour {
     RED, GREEN, BLUE
 }
+
+function testFunctionCall() {
+    test();
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -4645,7 +4645,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         }
 
         Token iToken = (Token) node;
-        BLangIdentifier pkgAlias = this.createIdentifier(getPosition(iToken), "");
+        BLangIdentifier pkgAlias = this.createIdentifier(symTable.builtinPos, "");
         BLangIdentifier name = this.createIdentifier(iToken);
         return new BLangNameReference(getPosition(node), null, pkgAlias, name);
     }


### PR DESCRIPTION
## Purpose
For function calls without a qualifier, an empty module alias is added with the same position as the invocation. This causes the Node Resolver to incorrectly decide that the cursor is within the empty module alias. This PR addresses this by adding a virtual position to the empty module alias.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
