### PR TITLE
Add APIs for getting the defaultable params and param kinds

### DIFF
--- a/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/api/types/FunctionTypeDescriptor.java
+++ b/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/api/types/FunctionTypeDescriptor.java
@@ -35,6 +35,13 @@ public interface FunctionTypeDescriptor extends BallerinaTypeDescriptor {
     List<Parameter> requiredParams();
 
     /**
+     * Get the defaultable parameters.
+     *
+     * @return {@link List} of defaultable parameters
+     */
+    List<Parameter> defaultableParams();
+
+    /**
      * Get the rest parameter.
      *
      * @return {@link Optional} rest parameter

--- a/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/api/types/Parameter.java
+++ b/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/api/types/Parameter.java
@@ -58,9 +58,9 @@ public interface Parameter {
     public String signature();
 
     /**
-     * Whether the parameter is defaultable or not.
+     * Get the kind of the parameter.
      *
-     * @return {@link Boolean} defaultable status
+     * @return {@link ParameterKind} of the param
      */
-    public boolean isDefaultable();
+    ParameterKind kind();
 }

--- a/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/api/types/ParameterKind.java
+++ b/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/api/types/ParameterKind.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.types;
+
+/**
+ * Represents the different types of function/method parameters.
+ *
+ * @since 2.0.0
+ */
+public enum ParameterKind {
+    REQUIRED, DEFAULTABLE, REST
+}

--- a/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/impl/symbols/SymbolFactory.java
+++ b/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/impl/symbols/SymbolFactory.java
@@ -20,7 +20,9 @@ package io.ballerina.compiler.impl.symbols;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.types.BallerinaTypeDescriptor;
+import io.ballerina.compiler.api.types.FunctionTypeDescriptor;
 import io.ballerina.compiler.api.types.Parameter;
+import io.ballerina.compiler.api.types.ParameterKind;
 import io.ballerina.compiler.api.types.TypeDescKind;
 import io.ballerina.compiler.impl.TypesFactory;
 import io.ballerina.compiler.impl.types.BallerinaParameter;
@@ -103,7 +105,8 @@ public class SymbolFactory {
             builder.withQualifier(Qualifier.PRIVATE);
         }
 
-        return builder.build();
+        return builder.withTypeDescriptor((FunctionTypeDescriptor) TypesFactory.getTypeDescriptor(invokableSymbol.type))
+                .build();
     }
 
     /**
@@ -150,9 +153,10 @@ public class SymbolFactory {
      * Create a ballerina parameter.
      *
      * @param symbol Variable symbol for the parameter
+     * @param kind   The kind of the parameter
      * @return {@link Parameter} generated parameter
      */
-    public static Parameter createBallerinaParameter(BVarSymbol symbol) {
+    public static Parameter createBallerinaParameter(BVarSymbol symbol, ParameterKind kind) {
         if (symbol == null) {
             return null;
         }
@@ -162,7 +166,7 @@ public class SymbolFactory {
         if ((symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             qualifiers.add(Qualifier.PUBLIC);
         }
-        return new BallerinaParameter(name, typeDescriptor, qualifiers, symbol.defaultableParam);
+        return new BallerinaParameter(name, typeDescriptor, qualifiers, kind);
     }
 
     /**

--- a/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/impl/types/BallerinaParameter.java
+++ b/compiler/ballerina-compiler-api/src/main/java/io/ballerina/compiler/impl/types/BallerinaParameter.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.impl.types;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.types.BallerinaTypeDescriptor;
 import io.ballerina.compiler.api.types.Parameter;
+import io.ballerina.compiler.api.types.ParameterKind;
 
 import java.util.Collections;
 import java.util.List;
@@ -37,15 +38,15 @@ public class BallerinaParameter implements Parameter {
     private List<Qualifier> qualifiers;
     private String parameterName;
     private BallerinaTypeDescriptor typeDescriptor;
-    private boolean defaultable;
+    private ParameterKind kind;
 
     public BallerinaParameter(String parameterName, BallerinaTypeDescriptor typeDescriptor, List<Qualifier> qualifiers,
-            boolean defaultable) {
+                              ParameterKind kind) {
         // TODO: Add the metadata
         this.parameterName = parameterName;
         this.typeDescriptor = typeDescriptor;
         this.qualifiers = Collections.unmodifiableList(qualifiers);
-        this.defaultable = defaultable;
+        this.kind = kind;
     }
 
     /**
@@ -95,13 +96,8 @@ public class BallerinaParameter implements Parameter {
         return joiner.toString();
     }
 
-    /**
-     * Whether the parameter is defaultable or not.
-     *
-     * @return {@link Boolean} defaultable status
-     */
     @Override
-    public boolean isDefaultable() {
-        return defaultable;
+    public ParameterKind kind() {
+        return this.kind;
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds a separate API to the function typedesc to retrieve the defaultable params. This also gets rid of the isDefaultable() method in the parameter and introduces kind() instead, which tells what type of parameter it is.

## Remarks
Will add the tests for this with the rest of the tests for typedescs. Wanted to get the API change merged asap.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
