### PR TITLE
Deprecate BExecutor.submit() method.

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BExecutor.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BExecutor.java
@@ -65,6 +65,9 @@ public class BExecutor {
      * This method will execute Ballerina resource in non-blocking manner. It will use Ballerina worker-pool for the
      * execution and will return the connector thread immediately.
      *
+     * @deprecated use {@link BRuntime#invokeMethodAsync(BObject, String, String,
+     *                                                   StrandMetadata, CallableUnitCallback, Map, Object...)} instead.
+     *
      * @param scheduler    available scheduler.
      * @param service      to be executed.
      * @param resourceName to be executed.
@@ -74,6 +77,7 @@ public class BExecutor {
      * @param properties   to be passed to context.
      * @param args         required for the resource.
      */
+    @Deprecated
     public static void submit(Scheduler scheduler, BObject service, String resourceName, String strandName,
                               StrandMetadata metaData, CallableUnitCallback callback,
                               Map<String, Object> properties, Object... args) {

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BRuntime.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BRuntime.java
@@ -38,15 +38,17 @@ public class BRuntime {
 
     private Scheduler scheduler;
 
-    private BRuntime(Scheduler scheduler) {
+    BRuntime(Scheduler scheduler) {
         this.scheduler = scheduler;
     }
 
     /**
      * Gets the instance of ballerina runtime.
      *
+     * @deprecated use {@link BalEnv#getRuntime()} instead.
      * @return Ballerina runtime instance.
      */
+    @Deprecated
     public static BRuntime getCurrentRuntime() {
         Strand strand = Scheduler.getStrand();
         return new BRuntime(strand.scheduler);

--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BalEnv.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/api/BalEnv.java
@@ -49,4 +49,8 @@ public class BalEnv {
         strand.setState(State.BLOCK_AND_YIELD);
         return new BalFuture(this.strand);
     }
+
+    public BRuntime getRuntime() {
+        return new BRuntime(strand.scheduler);
+    }
 }


### PR DESCRIPTION
## Purpose
Deprecate BExecutor.submit() method. BExecutor will be removed completely in the future as part of the runtime API clean up.

Part of #26060
