### PR TITLE
Allow `new` as a valid constructor for `stream`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -4255,11 +4255,12 @@ public class Desugar extends BLangNodeVisitor {
         BLangTypedescExpr typedescExpr = new BLangTypedescExpr();
         typedescExpr.resolvedType = targetType;
         typedescExpr.type = typedescType;
-        BLangExpression iteratorObj = typeInitExpr.argsExpr.get(0);
-
+        List<BLangExpression> args = new ArrayList<>(Lists.of(typedescExpr));
+        if (!typeInitExpr.argsExpr.isEmpty()) {
+            args.add(typeInitExpr.argsExpr.get(0));
+        }
         BLangInvocation streamConstructInvocation = ASTBuilderUtil.createInvocationExprForMethod(
-                typeInitExpr.pos, symbol, new ArrayList<>(Lists.of(typedescExpr, iteratorObj)),
-                symResolver);
+                typeInitExpr.pos, symbol, args, symResolver);
         streamConstructInvocation.type = new BStreamType(TypeTags.STREAM, targetType, errorType, null);
         return streamConstructInvocation;
     }

--- a/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/stream-utils.bal
+++ b/langlib/lang.__internal/src/main/ballerina/src/lang.__internal/stream-utils.bal
@@ -30,6 +30,12 @@ public type Type any|error;
 @typeParam
 public type Type1 any|error;
 
+# An `EmptyIterator` which returns nil on next() method invocation.
+class EmptyIterator {
+    public isolated function next() returns record {|Type value;|}|ErrorType? {
+        return ();
+    }
+};
 
 # Sets the narrowed type of the `value`.
 #
@@ -47,7 +53,8 @@ public function setNarrowType(typedesc<Type> td, record {|Type value;|} val) ret
 # + iteratorObj - An iterator object.
 # + return - New stream containing results of `iteratorObj` object's next function invocations.
 public function construct(typedesc<Type> td, object { public function next() returns
-        record {|Type value;|}|ErrorType?;} iteratorObj) returns stream<Type, ErrorType> = @java:Method {
+        record {|Type value;|}|ErrorType?;} iteratorObj = new EmptyIterator())
+        returns stream<Type, ErrorType> = @java:Method {
             'class: "org.ballerinalang.langlib.internal.Construct",
             name: "construct"
         } external;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -107,6 +107,12 @@ public class BStreamValueTest {
         Assert.assertTrue(((BBoolean) values[0]).booleanValue());
     }
 
+    @Test(description = "Test empty stream constructs")
+    public void testEmptyStreamConstructs() {
+        BValue[] values = BRunUtil.invoke(result, "testEmptyStreamConstructs", new BValue[]{});
+        Assert.assertTrue(((BBoolean) values[0]).booleanValue());
+    }
+
     @Test(description = "Test negative test scenarios of stream type")
     public void testStreamTypeNegative() {
         int i = 0;
@@ -180,8 +186,26 @@ public class BStreamValueTest {
                 "|}|CustomError1)?', found '(record {| int value; |}|CustomError)?'", 228, 48);
         BAssertUtil.validateError(negativeResult, i++, "invalid expected stream type. 'itr' does not " +
                 "return an error", 239, 48);
-        BAssertUtil.validateError(negativeResult, i, "invalid expected stream type. 'itr' does not " +
+        BAssertUtil.validateError(negativeResult, i++, "invalid expected stream type. 'itr' does not " +
                 "return an error", 240, 44);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                246, 27);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                247, 27);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                248, 34);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                249, 34);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                250, 34);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                251, 34);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                252, 19);
+        BAssertUtil.validateError(negativeResult, i++, "'new(itr, itr)' is not a valid constructor for streams type",
+                253, 19);
+        BAssertUtil.validateError(negativeResult, i, "'new(itr, itr)' is not a valid constructor for streams type",
+                254, 19);
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
@@ -239,3 +239,17 @@ function testInvalidStreamConstructor() {
     var streamC = new stream<int, CustomError>(itr);
     stream<int, CustomError> streamD = new(itr);
 }
+
+
+function testInvalidStreamConstructs() returns boolean {
+    IteratorWithOutError itr = new();
+    stream<int> stream1 = new(itr, itr);
+    stream<int> stream2 = new stream<int>(itr, itr);
+    stream<int, never> stream3 = new(itr, itr);
+    stream<int, error> stream4 = new(itr, itr);
+    stream<int, never> stream5 = new stream<int, never>(itr, itr);
+    stream<int, error> stream6 = new stream<int, error>(itr, itr);
+    var stream7 = new stream<int>(itr, itr);
+    var stream8 = new stream<int, never>(itr, itr);
+    var stream9 = new stream<int, error>(itr, itr);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
@@ -382,3 +382,27 @@ function testStreamOfStreams() returns boolean {
     }
     return testPassed;
 }
+
+function testEmptyStreamConstructs() returns boolean {
+    boolean testPassed = true;
+    stream<int> emptyStream1 = new;
+    stream<int> emptyStream2 = new stream<int>();
+    stream<int, never> emptyStream3 = new;
+    stream<int, error> emptyStream4 = new;
+    stream<int, never> emptyStream5 = new stream<int, never>();
+    stream<int, error> emptyStream6 = new stream<int, error>();
+    var emptyStream7 = new stream<int>();
+    var emptyStream8 = new stream<int, never>();
+    var emptyStream9 = new stream<int, error>();
+
+    testPassed = testPassed && (emptyStream1.next() == ());
+    testPassed = testPassed && (emptyStream2.next() == ());
+    testPassed = testPassed && (emptyStream3.next() == ());
+    testPassed = testPassed && (emptyStream4.next() == ());
+    testPassed = testPassed && (emptyStream5.next() == ());
+    testPassed = testPassed && (emptyStream6.next() == ());
+    testPassed = testPassed && (emptyStream7.next() == ());
+    testPassed = testPassed && (emptyStream8.next() == ());
+    testPassed = testPassed && (emptyStream9.next() == ());
+    return testPassed;
+}


### PR DESCRIPTION
## Purpose
$title and partially #fixes https://github.com/ballerina-platform/ballerina-lang/issues/26272. Please note,`@typeParam { scope: "object" }` and `streamx is object{...}` implementations are not included in this PR.

## Approach
n/a

## Samples
following are now valid empty constructors for streams.
```ballerina
    stream<int> emptyStream1 = new;
    stream<int> emptyStream2 = new stream<int>();
    stream<int, never> emptyStream3 = new;
    stream<int, error> emptyStream4 = new;
    stream<int, never> emptyStream5 = new stream<int, never>();
    stream<int, error> emptyStream6 = new stream<int, error>();
    var emptyStream7 = new stream<int>();
    var emptyStream8 = new stream<int, never>();
    var emptyStream9 = new stream<int, error>();
```
## Remarks
- https://github.com/ballerina-platform/ballerina-spec/issues/434

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
