### PR TITLE
Cleanup generated names

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/IdentifierUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/org/ballerinalang/jvm/IdentifierUtils.java
@@ -36,7 +36,6 @@ public class IdentifierUtils {
     private static final String CHAR_PREFIX = "$";
     private static final String ESCAPE_PREFIX = "\\";
     private static final String ENCODABLE_CHAR_SET = "\\.:;[]/<>$";
-    private static final Pattern ENCODING_PATTERN = Pattern.compile("\\$(\\d{4})");
     private static final Pattern UNESCAPED_SPECIAL_CHAR_SET =
             Pattern.compile("(?<!\\\\)(?:\\\\\\\\)*([$&+,:;=\\?@#|/' \\[\\}\\]<\\>.\"^*{}~`()%!-])");
 
@@ -76,8 +75,6 @@ public class IdentifierUtils {
         }
         if (identifier.contains(ESCAPE_PREFIX)) {
             identifier = encodeSpecialCharacters(identifier);
-        } else {
-            identifier = ENCODING_PATTERN.matcher(identifier).replaceAll("\\$#$1");
         }
         return StringEscapeUtils.unescapeJava(identifier);
     }
@@ -96,10 +93,7 @@ public class IdentifierUtils {
         int index = 0;
         while (index < encodedIdentifier.length()) {
             if (encodedIdentifier.charAt(index) == '$' && index + 4 < encodedIdentifier.length()) {
-                if (isDollarHashPattern(encodedIdentifier, index)) {
-                    sb.append("$").append(encodedIdentifier, index + 2, index + 6);
-                    index += 6;
-                } else if (isUnicodePoint(encodedIdentifier, index)) {
+                if (isUnicodePoint(encodedIdentifier, index)) {
                     sb.append((char) Integer.parseInt(encodedIdentifier.substring(index + 1, index + 5)));
                     index += 5;
                 } else {
@@ -127,11 +121,6 @@ public class IdentifierUtils {
 
     private static boolean isUnicodePoint(String encodedName, int index) {
         return (containsOnlyDigits(encodedName.substring(index + 1, index + 5)));
-    }
-
-    private static boolean isDollarHashPattern(String encodedName, int index) {
-        return encodedName.charAt(index + 1) == '#' && index + 5 < encodedName.length() &&
-                containsOnlyDigits(encodedName.substring(index + 2, index + 6));
     }
 
     private static boolean containsOnlyDigits(String digitString) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -310,8 +310,9 @@ public class BIRGen extends BLangNodeVisitor {
             String builtinFuncName = funcName.substring(funcName.indexOf("<") + 1, funcName.indexOf(">"));
             String modifiedFuncName = funcName.replace(builtinFuncName, "test" + builtinFuncName);
             function.name.setValue(modifiedFuncName);
-            function.originalFuncSymbol.name.value = modifiedFuncName;
-            function.symbol.name.value = modifiedFuncName;
+            Name functionName = names.fromString(modifiedFuncName);
+            function.originalFuncSymbol.name = functionName;
+            function.symbol.name = functionName;
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.CompilerOptions;
+import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -152,7 +153,7 @@ public class CodeGenerator {
         InteropValidator interopValidator = new InteropValidator(interopValidationClassLoader, symbolTable);
 
         //Rewrite identiifier names with encoding special characters
-        encodeModuleIdentifiers(packageSymbol.bir);
+        encodeModuleIdentifiers(packageSymbol.bir, Names.getInstance(this.compilerContext));
 
         packageSymbol.compiledJarFile = jvmPackageGen.generate(packageSymbol.bir, interopValidator, true);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -60,7 +60,10 @@ import static org.objectweb.asm.Opcodes.L2D;
 import static org.objectweb.asm.Opcodes.L2F;
 import static org.objectweb.asm.Opcodes.L2I;
 import static org.objectweb.asm.Opcodes.NEW;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANY_TO_BOOLEAN_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANY_TO_BYTE_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANY_TO_DECIMAL_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANY_TO_FLOAT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ANY_TO_INT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ARRAY_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BHANDLE;
@@ -330,7 +333,7 @@ public class JvmCastGen {
                         String.format("()L%s;", OBJECT), false);
                 break;
             case TypeTags.FINITE:
-                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_FLOAT_METHOD, String.format("(L%s;)D", OBJECT),
                         false);
                 mv.visitInsn(D2F);
                 break;
@@ -359,7 +362,7 @@ public class JvmCastGen {
                         String.format("()L%s;", OBJECT), false);
                 break;
             case TypeTags.FINITE:
-                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_FLOAT_METHOD, String.format("(L%s;)D", OBJECT),
                         false);
                 break;
             default:
@@ -570,7 +573,8 @@ public class JvmCastGen {
         }
 
         if (sourceType.jTag == JTypeTags.JREF) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToBoolean", String.format("(L%s;)Z", OBJECT), false);
+            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_BOOLEAN_METHOD, String.format("(L%s;)Z", OBJECT),
+                    false);
         } else {
             throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'boolean'",
                     sourceType));
@@ -1081,7 +1085,7 @@ public class JvmCastGen {
             case TypeTags.JSON:
             case TypeTags.READONLY:
             case TypeTags.FINITE:
-                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT),
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_FLOAT_METHOD, String.format("(L%s;)D", OBJECT),
                         false);
                 break;
             default:
@@ -1108,7 +1112,7 @@ public class JvmCastGen {
             case TypeTags.JSON:
             case TypeTags.READONLY:
             case TypeTags.FINITE:
-                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_DECIMAL_METHOD,
                         String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
                 break;
             case TypeTags.FLOAT:
@@ -1214,7 +1218,8 @@ public class JvmCastGen {
                 sourceType.tag == TypeTags.JSON ||
                 sourceType.tag == TypeTags.READONLY ||
                 sourceType.tag == TypeTags.FINITE) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToBoolean", String.format("(L%s;)Z", OBJECT), false);
+            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_BOOLEAN_METHOD, String.format("(L%s;)Z", OBJECT),
+                    false);
         } else {
             throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'boolean'",
                     sourceType));
@@ -1233,12 +1238,6 @@ public class JvmCastGen {
                 mv.visitMethodInsn(INVOKESTATIC, TYPE_CONVERTER, "floatToByte", "(D)I", false);
                 break;
             case TypeTags.DECIMAL:
-                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_BYTE_METHOD, String.format("(L%s;)I", OBJECT),
-                        false);
-                break;
-            case TypeTags.BYTE:
-                // do nothing
-                break;
             case TypeTags.ANY:
             case TypeTags.ANYDATA:
             case TypeTags.UNION:
@@ -1247,6 +1246,9 @@ public class JvmCastGen {
             case TypeTags.READONLY:
                 mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_BYTE_METHOD, String.format("(L%s;)I", OBJECT),
                         false);
+                break;
+            case TypeTags.BYTE:
+                // do nothing
                 break;
             default:
                 throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'byte'",
@@ -1451,7 +1453,8 @@ public class JvmCastGen {
                 sourceType.tag == TypeTags.UNION ||
                 sourceType.tag == TypeTags.JSON ||
                 sourceType.tag == TypeTags.READONLY) {
-            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToFloat", String.format("(L%s;)D", OBJECT), false);
+            mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_FLOAT_METHOD, String.format("(L%s;)D", OBJECT),
+                    false);
         } else {
             throw new BLangCompilerException(String.format("Casting is not supported from '%s' to 'float'",
                     sourceType));
@@ -1510,7 +1513,7 @@ public class JvmCastGen {
             case TypeTags.UNION:
             case TypeTags.JSON:
             case TypeTags.READONLY:
-                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, "anyToDecimal",
+                mv.visitMethodInsn(INVOKESTATIC, TYPE_CHECKER, ANY_TO_DECIMAL_METHOD,
                         String.format("(L%s;)L%s;", OBJECT, DECIMAL_VALUE), false);
                 break;
             default:

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -67,7 +67,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_EXTEN
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BTYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHANNEL_DETAILS;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONSTRUCTOR_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FILE_NAME_PERIOD_SEPERATOR;
@@ -247,7 +246,7 @@ public class JvmCodeGenUtil {
         }
         mv.visitLdcInsn(metaData.parentFunctionName);
         mv.visitMethodInsn(Opcodes.INVOKESPECIAL, STRAND_METADATA,
-                           CONSTRUCTOR_INIT_METHOD, String.format("(L%s;L%s;L%s;L%s;L%s;)V", STRING_VALUE, STRING_VALUE,
+                           JVM_INIT_METHOD, String.format("(L%s;L%s;L%s;L%s;L%s;)V", STRING_VALUE, STRING_VALUE,
                                                                   STRING_VALUE, STRING_VALUE, STRING_VALUE), false);
         mv.visitFieldInsn(Opcodes.PUTSTATIC, moduleClass, varName, String.format("L%s;", STRAND_METADATA));
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -206,6 +206,9 @@ public class JvmConstants {
     public static final String GET_VALUE_METHOD = "getValue";
     public static final String ANY_TO_BYTE_METHOD = "anyToByte";
     public static final String ANY_TO_INT_METHOD = "anyToInt";
+    public static final String ANY_TO_FLOAT_METHOD = "anyToFloat";
+    public static final String ANY_TO_DECIMAL_METHOD = "anyToDecimal";
+    public static final String ANY_TO_BOOLEAN_METHOD = "anyToBoolean";
     public static final String DECIMAL_VALUE_OF_J_METHOD = "valueOfJ";
     public static final String VALUE_OF_METHOD = "valueOf";
     public static final String POPULATE_INITIAL_VALUES_METHOD = "populateInitialValues";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -183,7 +183,6 @@ public class JvmConstants {
 
     // code generation related constants.
     public static final String MODULE_INIT_CLASS_NAME = "$_init";
-    public static final String CONSTRUCTOR_INIT_METHOD = "<init>";
     public static final String CURRENT_MODULE_INIT = "$currentModuleInit";
     public static final String MODULE_INIT = "$moduleInit";
     public static final String MODULE_START = "$moduleStart";
@@ -215,6 +214,8 @@ public class JvmConstants {
     public static final String GLOBAL_LOCK_NAME = "lock";
     public static final String SERVICE_EP_AVAILABLE = "serviceEPAvailable";
     public static final String LOCK_STORE_VAR_NAME = "LOCK_STORE";
+    public static final String RECORD_INIT_WRAPPER_NAME = "$init";
+
 
     // scheduler related constants
     public static final String SCHEDULE_FUNCTION_METHOD = "scheduleFunction";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -212,8 +212,8 @@ public class JvmConstants {
     public static final String CREATE_TYPES_METHOD = "$createTypes";
     public static final String CREATE_TYPE_INSTANCES_METHOD = "$createTypeInstances";
     public static final String GLOBAL_LOCK_NAME = "lock";
-    public static final String SERVICE_EP_AVAILABLE = "serviceEPAvailable";
-    public static final String LOCK_STORE_VAR_NAME = "LOCK_STORE";
+    public static final String SERVICE_EP_AVAILABLE = "$serviceEPAvailable";
+    public static final String LOCK_STORE_VAR_NAME = "$LOCK_STORE";
     public static final String RECORD_INIT_WRAPPER_NAME = "$init";
 
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmMethodGen.java
@@ -194,6 +194,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.XML_VALUE
  */
 public class JvmMethodGen {
 
+    private static final String INIT_FUNCTION_SUFFIX = "<init>";
     private static final String START_FUNCTION_SUFFIX = "<start>";
     private static final String STOP_FUNCTION_SUFFIX = "<stop>";
 
@@ -1000,7 +1001,7 @@ public class JvmMethodGen {
     }
 
     private String calculateModuleInitFuncName(PackageID id) {
-        return calculateModuleSpecialFuncName(id, JVM_INIT_METHOD);
+        return calculateModuleSpecialFuncName(id, INIT_FUNCTION_SUFFIX);
     }
 
     private String calculateModuleSpecialFuncName(PackageID id, String funcSuffix) {
@@ -1628,7 +1629,7 @@ public class JvmMethodGen {
 
         if (hasInitFunction(pkg)) {
             generateMethodCall(initClass, asyncDataCollector, mv, indexMap, schedulerVarIndex, MODULE_INIT,
-                               "<init>", "initdummy");
+                               INIT_FUNCTION_SUFFIX, "initdummy");
         }
 
         if (userMainFunc != null) {
@@ -1907,7 +1908,7 @@ public class JvmMethodGen {
                                    BIRPackage pkg, List<PackageID> moduleImports) {
 
         JavaClass javaClass = jvmClassMap.get(typeOwnerClass);
-        BIRFunction initFunc = generateDepModInit(moduleImports, pkg, MODULE_INIT, JVM_INIT_METHOD);
+        BIRFunction initFunc = generateDepModInit(moduleImports, pkg, MODULE_INIT, INIT_FUNCTION_SUFFIX);
         javaClass.functions.add(initFunc);
         pkg.functions.add(initFunc);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -585,7 +585,7 @@ public class JvmPackageGen {
             }
         }
 
-        globalVarClassMap.put(pkgName + "LOCK_STORE", initClass);
+        globalVarClassMap.put(pkgName + LOCK_STORE_VAR_NAME, initClass);
     }
 
     private void linkTypeDefinitions(BIRPackage module, String pkgName,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -102,7 +102,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BTYPE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BUILT_IN_PACKAGE_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_ERROR;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHANNEL_DETAILS;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONSTRUCTOR_INIT_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DEFAULT_STRAND_DISPATCHER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
@@ -542,7 +541,7 @@ public class JvmTerminatorGen {
             mv.visitTypeInsn(NEW, BAL_ENV);
             mv.visitInsn(DUP);
             this.mv.visitVarInsn(ALOAD, localVarOffset); // load the strand
-            mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, CONSTRUCTOR_INIT_METHOD, String.format("(L%s;)V", STRAND_CLASS),
+            mv.visitMethodInsn(INVOKESPECIAL, BAL_ENV, JVM_INIT_METHOD, String.format("(L%s;)V", STRAND_CLASS),
                                false);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -474,8 +474,8 @@ class JvmTypeGen {
                                String.format("(L%s;L%s;L%s;L%s;L%s;)V", STRING_VALUE, STRAND_METADATA, SCHEDULER,
                                              STRAND_CLASS, MAP), false);
             mv.visitInsn(SWAP);
-            mv.visitMethodInsn(INVOKESTATIC, className, "$init", String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE),
-                               false);
+            mv.visitMethodInsn(INVOKESTATIC, className, JvmConstants.RECORD_INIT_WRAPPER_NAME,
+                    String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), false);
 
             mv.visitInsn(ARETURN);
             i += 1;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -591,7 +591,7 @@ class JvmValueGen {
             if (typeRef.tag == TypeTags.RECORD) {
                 String refTypeClassName = getTypeValueClassName(typeRef.tsymbol.pkgID, toNameString(typeRef));
                 mv.visitInsn(DUP2);
-                mv.visitMethodInsn(INVOKESTATIC, refTypeClassName, "$init",
+                mv.visitMethodInsn(INVOKESTATIC, refTypeClassName, JvmConstants.RECORD_INIT_WRAPPER_NAME,
                                    String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), false);
             }
         }
@@ -765,7 +765,7 @@ class JvmValueGen {
     // TODO: remove this method, logic moved to createInstantiateMethod, see #23012
     private void createRecordInitWrapper(ClassWriter cw, String className, BIRNode.BIRTypeDefinition typeDef) {
 
-        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "$init",
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, JvmConstants.RECORD_INIT_WRAPPER_NAME,
                                           String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), null, null);
         mv.visitCode();
         // load strand
@@ -783,7 +783,7 @@ class JvmValueGen {
             String refTypeClassName = getTypeValueClassName(typeRef.tsymbol.pkgID,
                                                             toNameString(typeRef));
             mv.visitInsn(DUP2);
-            mv.visitMethodInsn(INVOKESTATIC, refTypeClassName, "$init",
+            mv.visitMethodInsn(INVOKESTATIC, refTypeClassName, JvmConstants.RECORD_INIT_WRAPPER_NAME,
                                String.format("(L%s;L%s;)V", STRAND_CLASS, MAP_VALUE), false);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/AnnotationDesugar.java
@@ -91,6 +91,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 
 /**
@@ -537,7 +538,7 @@ public class AnnotationDesugar {
     }
 
     private BLangFunction defineFunction(DiagnosticPos pos, PackageID pkgID, BSymbol owner) {
-        String funcName = ANNOT_FUNC + annotFuncCount++;
+        String funcName = ANNOT_FUNC + UNDERSCORE + annotFuncCount++;
         BLangFunction function = ASTBuilderUtil.createFunction(pos, funcName);
         function.type = new BInvokableType(Collections.emptyList(), symTable.mapType, null);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -171,6 +171,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
     private static final String BLOCK_MAP_SYM_NAME = "$map$block$";
     private static final String FUNCTION_MAP_SYM_NAME = "$map$func$";
+    private static final String PARAMETER_MAP_NAME = "$paramMap$";
     private static final BVarSymbol CLOSURE_MAP_NOT_FOUND;
 
     private SymbolTable symTable;
@@ -1055,7 +1056,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
             // It is resolved from a parameter map.
             // Add parameter map symbol if one is not added.
             ((BLangFunction) env.enclInvokable).paramClosureMap.putIfAbsent(absoluteLevel, createMapSymbol(
-                    "$paramMap$" + absoluteLevel, env));
+                    PARAMETER_MAP_NAME + UNDERSCORE + absoluteLevel, env));
 
             // Update the closure vars.
             updateClosureVars(localVarRef, ((BLangFunction) env.enclInvokable).paramClosureMap.get(absoluteLevel));
@@ -1118,8 +1119,8 @@ public class ClosureDesugar extends BLangNodeVisitor {
             if (bLangFunction.paramClosureMap.containsKey(resolvedLevel)) {
                 return;
             }
-            bLangFunction.paramClosureMap.put(resolvedLevel, createMapSymbol("$paramMap$" + resolvedLevel,
-                    symbolEnv));
+            bLangFunction.paramClosureMap
+                    .put(resolvedLevel, createMapSymbol(PARAMETER_MAP_NAME + UNDERSCORE + resolvedLevel, symbolEnv));
 
             symbolEnv = symbolEnv.enclEnv;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ClosureDesugar.java
@@ -157,6 +157,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.TreeMap;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.wso2.ballerinalang.compiler.semantics.model.Scope.NOT_FOUND_ENTRY;
 
@@ -300,7 +301,7 @@ public class ClosureDesugar extends BLangNodeVisitor {
      * @param funcEnv  function environment
      */
     private void createFunctionMap(BLangFunction funcNode, SymbolEnv funcEnv) {
-        funcNode.mapSymbol = createMapSymbol(FUNCTION_MAP_SYM_NAME + funClosureMapCount, funcEnv);
+        funcNode.mapSymbol = createMapSymbol(FUNCTION_MAP_SYM_NAME + UNDERSCORE + funClosureMapCount, funcEnv);
         BLangRecordLiteral emptyRecord = ASTBuilderUtil.createEmptyRecordLiteral(funcNode.pos, symTable.mapType);
         BLangSimpleVariable mapVar = ASTBuilderUtil.createVariable(funcNode.pos, funcNode.mapSymbol.name.value,
                                                                    funcNode.mapSymbol.type, emptyRecord,
@@ -455,21 +456,21 @@ public class ClosureDesugar extends BLangNodeVisitor {
 
     private BVarSymbol createMapSymbolIfAbsent(BLangBlockFunctionBody body, int closureMapCount) {
         if (body.mapSymbol == null) {
-            body.mapSymbol = createMapSymbol(BLOCK_MAP_SYM_NAME + closureMapCount, env);
+            body.mapSymbol = createMapSymbol(BLOCK_MAP_SYM_NAME + UNDERSCORE + closureMapCount, env);
         }
         return body.mapSymbol;
     }
 
     private BVarSymbol createMapSymbolIfAbsent(BLangBlockStmt blockStmt, int closureMapCount) {
         if (blockStmt.mapSymbol == null) {
-            blockStmt.mapSymbol = createMapSymbol(BLOCK_MAP_SYM_NAME + closureMapCount, env);
+            blockStmt.mapSymbol = createMapSymbol(BLOCK_MAP_SYM_NAME + UNDERSCORE + closureMapCount, env);
         }
         return blockStmt.mapSymbol;
     }
 
     private BVarSymbol createMapSymbolIfAbsent(BLangFunction function, int closureMapCount) {
         if (function.mapSymbol == null) {
-            function.mapSymbol = createMapSymbol(FUNCTION_MAP_SYM_NAME + closureMapCount, env);
+            function.mapSymbol = createMapSymbol(FUNCTION_MAP_SYM_NAME + UNDERSCORE + closureMapCount, env);
         }
         return function.mapSymbol;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -1182,8 +1182,8 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangRecordVariable varNode) {
         final BLangBlockStmt blockStmt = ASTBuilderUtil.createBlockStmt(varNode.pos);
         final BLangSimpleVariable mapVariable =
-                ASTBuilderUtil.createVariable(varNode.pos, "$map$0", symTable.mapAllType, null,
-                                              new BVarSymbol(0, names.fromString("$map$0"), this.env.scope.owner.pkgID,
+                ASTBuilderUtil.createVariable(varNode.pos, "$map$_0", symTable.mapAllType, null,
+                                              new BVarSymbol(0, names.fromString("$map$_0"), this.env.scope.owner.pkgID,
                                                              symTable.mapAllType, this.env.scope.owner, varNode.pos,
                                                              VIRTUAL));
         mapVariable.expr = varNode.expr;
@@ -1434,7 +1434,7 @@ public class Desugar extends BLangNodeVisitor {
         if (parentRecordVariable.restParam != null) {
             // The restParam is desugared to a filter iterable operation that filters out the fields provided in the
             // record variable
-            // map<any> restParam = $map$0.filter($lambdaArg$0);
+            // map<any> restParam = $map$_0.filter($lambdaArg$_0);
 
             DiagnosticPos pos = parentBlockStmt.pos;
             BMapType restParamType = (BMapType) ((BLangVariable) parentRecordVariable.restParam).type;
@@ -1442,9 +1442,9 @@ public class Desugar extends BLangNodeVisitor {
 
             if (parentIndexAccessExpr != null) {
                 BLangSimpleVariable mapVariable =
-                        ASTBuilderUtil.createVariable(pos, "$map$1",
+                        ASTBuilderUtil.createVariable(pos, "$map$_1",
                                                       parentIndexAccessExpr.type, null,
-                                                      new BVarSymbol(0, names.fromString("$map$1"),
+                                                      new BVarSymbol(0, names.fromString("$map$_1"),
                                                                      this.env.scope.owner.pkgID,
                                                                      parentIndexAccessExpr.type, this.env.scope.owner,
                                                                      pos, VIRTUAL));
@@ -1671,7 +1671,7 @@ public class Desugar extends BLangNodeVisitor {
         String anonfuncName = "$anonGetValFunc$" + UNDERSCORE + lambdaFunctionCount++;
         BLangFunction function = ASTBuilderUtil.createFunction(pos, anonfuncName);
 
-        BVarSymbol keyValSymbol = new BVarSymbol(0, names.fromString("$lambdaArg$0"), this.env.scope.owner.pkgID,
+        BVarSymbol keyValSymbol = new BVarSymbol(0, names.fromString("$lambdaArg$_0"), this.env.scope.owner.pkgID,
                                                  getStringAnyTupleType(), this.env.scope.owner, pos, VIRTUAL);
 
         BLangSimpleVariable inputParameter = ASTBuilderUtil.createVariable(pos, null, getStringAnyTupleType(),
@@ -1878,12 +1878,12 @@ public class Desugar extends BLangNodeVisitor {
 
         // Creates following anonymous function
         //
-        // function ((string, any) $lambdaArg$0) returns boolean {
+        // function ((string, any) $lambdaArg$_0) returns boolean {
         //     Following if block is generated for all parameters given in the record variable
-        //     if ($lambdaArg$0[0] == "name") {
+        //     if ($lambdaArg$_0[0] == "name") {
         //         return false;
         //     }
-        //     if ($lambdaArg$0[0] == "age") {
+        //     if ($lambdaArg$_0[0] == "age") {
         //         return false;
         //     }
         //      return true;
@@ -1892,7 +1892,7 @@ public class Desugar extends BLangNodeVisitor {
         String anonfuncName = "$anonRestParamFilterFunc$" + UNDERSCORE + lambdaFunctionCount++;
         BLangFunction function = ASTBuilderUtil.createFunction(pos, anonfuncName);
 
-        BVarSymbol keyValSymbol = new BVarSymbol(0, names.fromString("$lambdaArg$0"), this.env.scope.owner.pkgID,
+        BVarSymbol keyValSymbol = new BVarSymbol(0, names.fromString("$lambdaArg$_0"), this.env.scope.owner.pkgID,
                                                  getStringAnyTupleType(), this.env.scope.owner, pos, VIRTUAL);
         BLangBlockFunctionBody functionBlock = createAnonymousFunctionBlock(pos, function, keyValSymbol);
 
@@ -2301,7 +2301,7 @@ public class Desugar extends BLangNodeVisitor {
 
         BType runTimeType = new BMapType(TypeTags.MAP, symTable.anyType, null);
 
-        String name = "$map$0";
+        String name = "$map$_0";
         final BLangSimpleVariable mapVariable =
                 ASTBuilderUtil.createVariable(recordDestructure.pos, name, runTimeType, null,
                                               new BVarSymbol(0, names.fromString(name), this.env.scope.owner.pkgID,
@@ -2388,7 +2388,7 @@ public class Desugar extends BLangNodeVisitor {
         if (parentRecordVarRef.restParam != null) {
             // The restParam is desugared to a filter iterable operation that filters out the fields provided in the
             // record variable
-            // map<any> restParam = $map$0.filter($lambdaArg$0);
+            // map<any> restParam = $map$_0.filter($lambdaArg$_0);
 
             DiagnosticPos pos = parentBlockStmt.pos;
             BMapType restParamType = (BMapType) ((BLangSimpleVarRef) parentRecordVarRef.restParam).type;
@@ -2396,8 +2396,8 @@ public class Desugar extends BLangNodeVisitor {
 
             if (parentIndexAccessExpr != null) {
                 BLangSimpleVariable mapVariable =
-                        ASTBuilderUtil.createVariable(pos, "$map$1", restParamType, null,
-                                                      new BVarSymbol(0, names.fromString("$map$1"),
+                        ASTBuilderUtil.createVariable(pos, "$map$_1", restParamType, null,
+                                                      new BVarSymbol(0, names.fromString("$map$_1"),
                                                                      this.env.scope.owner.pkgID, restParamType,
                                                                      this.env.scope.owner, pos, VIRTUAL));
                 mapVariable.expr = parentIndexAccessExpr;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -179,6 +179,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 
 /**
@@ -899,7 +900,7 @@ public class QueryDesugar extends BLangNodeVisitor {
      * @return new variable name.
      */
     private String getNewVarName() {
-        return "$streamElement$" + streamElementCount++;
+        return "$streamElement$" + UNDERSCORE + streamElementCount++;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -49,6 +49,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
+
 /**
  * Service De-sugar.
  *
@@ -147,7 +149,8 @@ public class ServiceDesugar {
             } else {
                 // Define anonymous listener variable.
                 BLangSimpleVariable listenerVar = ASTBuilderUtil
-                        .createVariable(pos, LISTENER + service.name.value + count++, attachExpr.type, attachExpr,
+                        .createVariable(pos, LISTENER + service.name.value + UNDERSCORE + count++, attachExpr.type,
+                                attachExpr,
                                 null);
                 ASTBuilderUtil.defineVariable(listenerVar, env.enclPkg.symbol, names);
                 listenerVar.symbol.flags |= Flags.LISTENER;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/TransactionDesugar.java
@@ -66,6 +66,7 @@ import org.wso2.ballerinalang.util.Lists;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.wso2.ballerinalang.compiler.util.Names.CLEAN_UP_TRANSACTION;
 import static org.wso2.ballerinalang.compiler.util.Names.CURRENT_TRANSACTION_INFO;
@@ -83,6 +84,7 @@ import static org.wso2.ballerinalang.compiler.util.Names.TRANSACTION_INFO_RECORD
 public class TransactionDesugar extends BLangNodeVisitor {
 
     private static final CompilerContext.Key<TransactionDesugar> TRANSACTION_DESUGAR_KEY = new CompilerContext.Key<>();
+    private static final String SHOULD_CLEANUP_SYMBOL = "$shouldCleanUp$";
     private final Desugar desugar;
     private final SymbolTable symTable;
     private final SymbolResolver symResolver;
@@ -177,11 +179,11 @@ public class TransactionDesugar extends BLangNodeVisitor {
         transactionBlockStmt.stmts.add(transactionBlockIDVariableDef);
 
         //boolean $shouldCleanUp$ = false;
-        BVarSymbol shouldCleanUpSymbol = new BVarSymbol(0, new Name("$shouldCleanUp$" + uniqueId),
+        BVarSymbol shouldCleanUpSymbol = new BVarSymbol(0, new Name(SHOULD_CLEANUP_SYMBOL + UNDERSCORE + uniqueId),
                 env.scope.owner.pkgID, symTable.booleanType, env.scope.owner, pos, VIRTUAL);
-        BLangSimpleVariable shouldCleanUpVariable = ASTBuilderUtil.createVariable(pos, "$shouldCleanUp$"
-                        + uniqueId, symTable.booleanType,
-                ASTBuilderUtil.createLiteral(pos, symTable.booleanType, false), shouldCleanUpSymbol);
+        BLangSimpleVariable shouldCleanUpVariable =
+                ASTBuilderUtil.createVariable(pos, SHOULD_CLEANUP_SYMBOL + UNDERSCORE + uniqueId, symTable.booleanType,
+                        ASTBuilderUtil.createLiteral(pos, symTable.booleanType, false), shouldCleanUpSymbol);
         shouldCleanUpVariable.symbol.closure = true;
         BLangSimpleVariableDef shouldCleanUpVariableDef = ASTBuilderUtil.createVariableDef(pos,
                 shouldCleanUpVariable);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangAnonymousModelHelper.java
@@ -25,6 +25,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
+
 /**
  * {@link BLangAnonymousModelHelper} is a util for holding the number of anonymous constructs found so far in the
  * current package.
@@ -75,33 +77,33 @@ public class BLangAnonymousModelHelper {
         Integer nextValue = Optional.ofNullable(anonTypeCount.get(packageID)).orElse(0);
         anonTypeCount.put(packageID, nextValue + 1);
         if (PackageID.ANNOTATIONS.equals(packageID)) {
-            return BUILTIN_ANON_TYPE + nextValue;
+            return BUILTIN_ANON_TYPE + UNDERSCORE + nextValue;
         }
-        return ANON_TYPE + nextValue;
+        return ANON_TYPE + UNDERSCORE + nextValue;
     }
 
     String getNextAnonymousServiceTypeKey(PackageID packageID, String serviceName) {
         Integer nextValue = Optional.ofNullable(anonServiceCount.get(packageID)).orElse(0);
         anonServiceCount.put(packageID, nextValue + 1);
-        return serviceName + SERVICE + nextValue;
+        return serviceName + SERVICE + UNDERSCORE + nextValue;
     }
 
     String getNextAnonymousServiceVarKey(PackageID packageID) {
         Integer nextValue = Optional.ofNullable(anonServiceCount.get(packageID)).orElse(0);
         anonServiceCount.put(packageID, nextValue + 1);
-        return ANON_SERVICE + nextValue;
+        return ANON_SERVICE + UNDERSCORE + nextValue;
     }
 
     public String getNextAnonymousFunctionKey(PackageID packageID) {
         Integer nextValue = Optional.ofNullable(anonFunctionCount.get(packageID)).orElse(0);
         anonFunctionCount.put(packageID, nextValue + 1);
-        return LAMBDA + nextValue;
+        return LAMBDA + UNDERSCORE + nextValue;
     }
 
     public String getNextAnonymousForkKey(PackageID packageID) {
         Integer nextValue = Optional.ofNullable(anonFunctionCount.get(packageID)).orElse(0);
         anonFunctionCount.put(packageID, nextValue + 1);
-        return FORK + nextValue;
+        return FORK + UNDERSCORE + nextValue;
     }
 
     public String getNextDistinctErrorId(PackageID packageID) {
@@ -113,7 +115,7 @@ public class BLangAnonymousModelHelper {
     public String getNextRawTemplateTypeKey(PackageID packageID, Name rawTemplateTypeName) {
         Integer nextValue = rawTemplateTypeCount.getOrDefault(packageID, 0);
         rawTemplateTypeCount.put(packageID, nextValue + 1);
-        return RAW_TEMPLATE_TYPE + rawTemplateTypeName.value + "$" + nextValue;
+        return RAW_TEMPLATE_TYPE + rawTemplateTypeName.value + "$" + UNDERSCORE + nextValue;
     }
 
     public boolean isAnonymousType(BSymbol symbol) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangMissingNodesHelper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangMissingNodesHelper.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
+
 /**
  * {@link BLangMissingNodesHelper} contains utility methods to handle missing nodes
  * in the syntax tree.
@@ -55,7 +57,7 @@ public class BLangMissingNodesHelper {
     public String getNextMissingNodeName(PackageID packageID) {
         Integer nextValue = Optional.ofNullable(missingIdentifierCount.get(packageID)).orElse(0);
         missingIdentifierCount.put(packageID, nextValue + 1);
-        return MISSING_NODE_PREFIX + nextValue;
+        return MISSING_NODE_PREFIX + UNDERSCORE + nextValue;
     }
     
     public boolean isMissingNode(Name nodeName) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -95,6 +95,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import static org.ballerinalang.jvm.util.BLangConstants.UNDERSCORE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MAX_VALUE;
 import static org.wso2.ballerinalang.compiler.semantics.model.SymbolTable.BBYTE_MIN_VALUE;
@@ -2654,10 +2655,10 @@ public class Types {
 
         // Create a new finite type representing the assignable values.
         BTypeSymbol finiteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, finiteType.tsymbol.flags,
-                                                                names.fromString("$anonType$" + finiteTypeCount++),
-                                                                finiteType.tsymbol.pkgID, null,
-                                                                finiteType.tsymbol.owner, finiteType.tsymbol.pos,
-                                                                VIRTUAL);
+                names.fromString("$anonType$" + UNDERSCORE + finiteTypeCount++),
+                finiteType.tsymbol.pkgID, null,
+                finiteType.tsymbol.owner, finiteType.tsymbol.pos,
+                VIRTUAL);
         BFiniteType intersectingFiniteType = new BFiniteType(finiteTypeSymbol, matchingValues);
         finiteTypeSymbol.type = intersectingFiniteType;
         return intersectingFiniteType;
@@ -3131,10 +3132,10 @@ public class Types {
         }
 
         BTypeSymbol finiteTypeSymbol = Symbols.createTypeSymbol(SymTag.FINITE_TYPE, originalType.tsymbol.flags,
-                                                                names.fromString("$anonType$" + finiteTypeCount++),
-                                                                originalType.tsymbol.pkgID, null,
-                                                                originalType.tsymbol.owner, originalType.tsymbol.pos,
-                                                                VIRTUAL);
+                names.fromString("$anonType$" + UNDERSCORE + finiteTypeCount++),
+                originalType.tsymbol.pkgID, null,
+                originalType.tsymbol.owner, originalType.tsymbol.pos,
+                VIRTUAL);
         BFiniteType intersectingFiniteType = new BFiniteType(finiteTypeSymbol, remainingValueSpace);
         finiteTypeSymbol.type = intersectingFiniteType;
         return intersectingFiniteType;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Name.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Name.java
@@ -23,7 +23,7 @@ package org.wso2.ballerinalang.compiler.util;
 public class Name implements org.ballerinalang.model.Name {
 
     //TODO: Make this field private.
-    public String value;
+    public final String value;
 
     public Name(String value) {
         this.value = value;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
@@ -52,7 +52,7 @@ public class ForeachErrorHandlingTests {
     @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
             "error: \\{ballerina\\}TypeCastError \\{\"message\":\"incompatible types: 'error' cannot be cast to " +
                     "'int'\"\\}\n" +
-                    "\tat foreach_error_handling:\\$lambda\\$0\\(foreach_error_handling.bal:41\\)")
+                    "\tat foreach_error_handling:\\$lambda\\$_0\\(foreach_error_handling.bal:41\\)")
     public void testArrayForeachAndPanic() {
         BValue[] returns = BRunUtil.invoke(program, "testArrayForeachAndPanic");
     }

--- a/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
+++ b/stdlib/http/src/test/java/org/ballerinalang/stdlib/services/basics/SignatureTest.java
@@ -116,6 +116,6 @@ public class SignatureTest {
         CompileResult compileResult = BCompileUtil.compile(new File(getClass().getClassLoader()
                 .getResource("test-src/services/resources/duplicate_resource_test.bal").getPath()).getAbsolutePath());
         Assert.assertEquals(compileResult.getErrorCount(), 1);
-        BAssertUtil.validateError(compileResult, 0, "redeclared symbol 'dataservice$$service$0.employee'", 8, 23);
+        BAssertUtil.validateError(compileResult, 0, "redeclared symbol 'dataservice$$service$_0.employee'", 8, 23);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/annotations/AnnotationAttachmentTest.java
@@ -148,7 +148,7 @@ public class AnnotationAttachmentTest {
 
     @Test
     public void testAnnotOnResourceOne() {
-        BLangFunction function = getFunction("ser$$service$0.res");
+        BLangFunction function = getFunction("ser$$service$_0.res");
         List<BLangAnnotationAttachment> attachments = function.annAttachments;
         Assert.assertEquals(attachments.size(), 2);
         assertAnnotationNameAndKeyValuePair(attachments.get(0), "v3", "val", "v34");
@@ -169,7 +169,7 @@ public class AnnotationAttachmentTest {
     public void testAnnotOnServiceTwo() {
         List<BLangAnnotationAttachment> attachments = (List<BLangAnnotationAttachment>)
                 compileResult.getAST().getServices().stream()
-                        .filter(serviceNode -> serviceNode.getName().getValue().equals("$anonService$1"))
+                        .filter(serviceNode -> serviceNode.getName().getValue().equals("$anonService$_1"))
                         .findFirst()
                         .get().getAnnotationAttachments();
         Assert.assertEquals(attachments.size(), 1);
@@ -178,7 +178,7 @@ public class AnnotationAttachmentTest {
 
     @Test
     public void testAnnotOnResourceTwo() {
-        BLangFunction function = getFunction("$anonService$1$$service$2.res");
+        BLangFunction function = getFunction("$anonService$_1$$service$_2.res");
         List<BLangAnnotationAttachment> attachments = function.annAttachments;
         Assert.assertEquals(attachments.size(), 1);
         assertAnnotationNameAndKeyValuePair(attachments.get(0), "v5", "val", "542");
@@ -292,7 +292,7 @@ public class AnnotationAttachmentTest {
         CompileResult result = BCompileUtil.compile("test-src/annotations/annots_with_list_consts.bal");
         List<BLangAnnotationAttachment> attachments = (List<BLangAnnotationAttachment>)
                 result.getAST().getServices().stream()
-                        .filter(serviceNode -> serviceNode.getName().getValue().equals("$anonService$0"))
+                        .filter(serviceNode -> serviceNode.getName().getValue().equals("$anonService$_0"))
                         .findFirst()
                         .get().getAnnotationAttachments();
         Assert.assertEquals(attachments.size(), 1);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
@@ -167,7 +167,7 @@ public class IdentifierLiteralTest {
                 BCompileUtil.compile("test-src/expressions/literals/identifierliteral/invalid_IL_special_char.bal");
         Assert.assertEquals(resultNeg.getErrorCount(), 12);
         BAssertUtil.validateError(resultNeg, 0, "no new variables on left side", 18, 5);
-        BAssertUtil.validateError(resultNeg, 1, "invalid intersection type '$missingNode$0 & *%_var = ': no " +
+        BAssertUtil.validateError(resultNeg, 1, "invalid intersection type '$missingNode$_0 & *%_var = ': no " +
                 "intersection", 18, 14);
         BAssertUtil.validateError(resultNeg, 2, "missing semicolon token", 18, 14);
         BAssertUtil.validateError(resultNeg, 3, "missing type desc", 18, 14);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AbstractObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AbstractObjectTest.java
@@ -74,15 +74,15 @@ public class AbstractObjectTest {
         CompileResult compileResult = BCompileUtil.compile("test-src/object/abstract_anon_object_negative.bal");
         int index = 0;
         BAssertUtil.validateError(compileResult, index++,
-                                  "abstract object '$anonType$1' cannot have a constructor method", 2, 45);
+                "abstract object '$anonType$_1' cannot have a constructor method", 2, 45);
         BAssertUtil.validateError(compileResult, index++, "missing object keyword", 2, 81);
         BAssertUtil.validateError(compileResult, index++, "missing semicolon token", 2, 81);
         BAssertUtil.validateError(compileResult, index++, "missing identifier", 2, 83);
         BAssertUtil.validateError(compileResult, index++, "missing semicolon token", 2, 83);
-        BAssertUtil.validateError(compileResult, index++, "cannot initialize abstract object '$anonType$1'", 2, 90);
-        BAssertUtil.validateError(compileResult, index++, "cannot initialize abstract object '$anonType$2'", 3, 68);
+        BAssertUtil.validateError(compileResult, index++, "cannot initialize abstract object '$anonType$_1'", 2, 90);
+        BAssertUtil.validateError(compileResult, index++, "cannot initialize abstract object '$anonType$_2'", 3, 68);
         BAssertUtil.validateError(compileResult, index++,
-                "abstract object '$anonType$6' cannot have a constructor method", 6, 49);
+                "abstract object '$anonType$_6' cannot have a constructor method", 6, 49);
         BAssertUtil.validateError(compileResult, index++, "missing object keyword", 6, 85);
         BAssertUtil.validateError(compileResult, index++, "missing semicolon token", 6, 85);
         BAssertUtil.validateError(compileResult, index++, "invalid token '}'", 6, 89);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/ResilientParserTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/parser/ResilientParserTest.java
@@ -68,7 +68,7 @@ public class ResilientParserTest {
         BAssertUtil.validateError(result, 28, "missing semicolon token", 52, 1);
         BAssertUtil.validateError(result, 29, "missing at token", 53, 1);
         BAssertUtil.validateError(result, 30, "missing type keyword", 53, 1);
-        BAssertUtil.validateError(result, 31, "undefined annotation '$missingNode$12'", 53, 1);
+        BAssertUtil.validateError(result, 31, "undefined annotation '$missingNode$_12'", 53, 1);
         BAssertUtil.validateError(result, 32, "invalid token '}'", 55, 2);
         BAssertUtil.validateError(result, 33, "redeclared symbol 'Foo1'", 55, 2);
         BAssertUtil.validateError(result, 34, "redeclared symbol 'Foo1'", 59, 6);
@@ -141,11 +141,11 @@ public class ResilientParserTest {
 
         BAssertUtil.validateError(result, 0, "redeclared symbol ''", 2, 1);
         BAssertUtil.validateError(result, 1, "missing identifier", 2, 12);
-        BAssertUtil.validateError(result, 2, "cannot resolve module '$missingNode$0/bar'", 3, 1);
+        BAssertUtil.validateError(result, 2, "cannot resolve module '$missingNode$_0/bar'", 3, 1);
         BAssertUtil.validateError(result, 3, "missing identifier", 3, 8);
-        BAssertUtil.validateError(result, 4, "cannot resolve module 'foo/bar version 1.0.0 as $missingNode$1'", 4, 1);
+        BAssertUtil.validateError(result, 4, "cannot resolve module 'foo/bar version 1.0.0 as $missingNode$_1'", 4, 1);
         BAssertUtil.validateError(result, 5, "missing identifier", 4, 32);
-        BAssertUtil.validateError(result, 6, "cannot resolve module 'foo/bar version 1.0.0 as $missingNode$2'", 5, 1);
+        BAssertUtil.validateError(result, 6, "cannot resolve module 'foo/bar version 1.0.0 as $missingNode$_2'", 5, 1);
         BAssertUtil.validateError(result, 7, "cannot resolve module 'foo/bar as foobar'", 6, 1);
         BAssertUtil.validateError(result, 8, "missing identifier", 6, 1);
         BAssertUtil.validateError(result, 9, "missing semicolon token", 6, 1);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/MapToRecordAssignabilityTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/MapToRecordAssignabilityTest.java
@@ -94,7 +94,7 @@ public class MapToRecordAssignabilityTest {
 
     @Test(expectedExceptions = BLangRuntimeException.class,
           expectedExceptionsMessageRegExp = ".*InherentTypeViolation \\{\"message\":\"invalid map insertion: " +
-                  "expected value of type 'Bar', found '\\$anonType\\$30'.*")
+                  "expected value of type 'Bar', found '\\$anonType\\$_30'.*")
     public void testComplexSubtyping2() {
         BRunUtil.invoke(compileResult, "testComplexSubtyping2");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/VarDeclrSemanticTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/vardeclr/VarDeclrSemanticTest.java
@@ -45,7 +45,8 @@ public class VarDeclrSemanticTest {
     public void testIncompleteListenerDecl() {
         CompileResult result = BCompileUtil.compile("test-src/statements/vardeclr/incomplete_listener_decl.bal");
         int indx = 0;
-        validateError(result, indx++, "listener variable incompatible types: '$missingNode$0' is not a Listener object",
+        validateError(result, indx++, "listener variable incompatible types: '$missingNode$_0' is not a Listener " +
+                        "object",
                       17, 1);
         validateError(result, indx++, "missing open paren token", 19, 10);
         validateError(result, indx++, "required parameter after the defaultable parameter", 19, 10);
@@ -63,7 +64,8 @@ public class VarDeclrSemanticTest {
     public void testIncompleteListenerDecl2() {
         CompileResult result = BCompileUtil.compile("test-src/statements/vardeclr/incomplete_listener_decl_2.bal");
         int indx = 0;
-        validateError(result, indx++, "listener variable incompatible types: '$missingNode$0' is not a Listener object",
+        validateError(result, indx++, "listener variable incompatible types: '$missingNode$_0' is not a Listener " +
+                        "object",
                       17, 1);
         validateError(result, indx++, "missing object keyword", 18, 1);
         validateError(result, indx++, "missing open brace token", 18, 1);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/variable/shadowing/ShadowingTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/variable/shadowing/ShadowingTest.java
@@ -135,4 +135,9 @@ public class ShadowingTest {
     public void testTypeNameAsVariable5() {
         BRunUtil.invoke(result, "testTypeNameAsVariable5");
     }
+
+    @Test(description = "test shadowing with ballerina generated names")
+    public void testGeneratedNames() {
+        BRunUtil.invoke(result, "testGeneratedNames");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFlushTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFlushTest.java
@@ -81,7 +81,7 @@ public class WorkerFlushTest {
         }
         Assert.assertNotNull(expectedException);
         String result =
-                "error: error3 {\"message\":\"msg3\"}\n" + "\tat flush-workers:$lambda$12(flush-workers.bal:187)";
+                "error: error3 {\"message\":\"msg3\"}\n" + "\tat flush-workers:$lambda$_12(flush-workers.bal:187)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
@@ -96,7 +96,7 @@ public class WorkerSyncSendTest {
             expectedException = e;
         }
         Assert.assertNotNull(expectedException);
-        String result = "error: error3 {\"message\":\"msg3\"}\n" + "\tat sync-send:$lambda$14(sync-send.bal:291)";
+        String result = "error: error3 {\"message\":\"msg3\"}\n" + "\tat sync-send:$lambda$_14(sync-send.bal:291)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -115,7 +115,7 @@ public class WorkerSyncSendTest {
             expectedException = e;
         }
         Assert.assertNotNull(expectedException);
-        String result = "error: err from panic from w2\n\tat sync-send:$lambda$18(sync-send.bal:344)";
+        String result = "error: err from panic from w2\n\tat sync-send:$lambda$_18(sync-send.bal:344)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -128,7 +128,7 @@ public class WorkerSyncSendTest {
             expectedException = e;
         }
         Assert.assertNotNull(expectedException);
-        String result = "error: err from panic from w1 w1\n\tat sync-send:$lambda$19(sync-send.bal:360)";
+        String result = "error: err from panic from w1 w1\n\tat sync-send:$lambda$_19(sync-send.bal:360)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -141,7 +141,7 @@ public class WorkerSyncSendTest {
             expectedException = e;
         }
         Assert.assertNotNull(expectedException);
-        String result = "error: err from panic from w2\n\tat sync-send:$lambda$22(sync-send.bal:392)";
+        String result = "error: err from panic from w2\n\tat sync-send:$lambda$_22(sync-send.bal:392)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 
@@ -154,7 +154,7 @@ public class WorkerSyncSendTest {
             expectedException = e;
         }
         Assert.assertNotNull(expectedException);
-        String result = "error: err from panic from w3w3\n\tat sync-send:$lambda$25(sync-send.bal:432)";
+        String result = "error: err from panic from w3w3\n\tat sync-send:$lambda$_25(sync-send.bal:432)";
         Assert.assertEquals(expectedException.getMessage().trim(), result.trim());
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/$lambda$_0
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/$lambda$_0
@@ -1,4 +1,4 @@
-$lambda$0 function(map<any | error{map<anydata | readonly>}>, int) -> int {
+$lambda$_0 function(map<any | error{map<anydata | readonly>}>, int) -> int {
     %0(RETURN) int;
     %1(ARG) map<any | error>;
     %2(ARG) int;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/globalVarsAndAnonFunctions
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/globalVarsAndAnonFunctions
@@ -19,7 +19,7 @@ public globalVarsAndAnonFunctions function() -> () {
         %4 = <any | error> %7;
         %7 = ConstLoad l;
         %1[%7] = %4;
-        %12 = fp $anon/.:0.0.0::$lambda$0(%1);
+        %12 = fp $anon/.:0.0.0::$lambda$_0(%1);
         %0 = ConstLoad 0;
         GOTO bb2;
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
@@ -13,14 +13,14 @@ sayHello function(ballerina/http:1.0.0:Caller, ballerina/http:1.0.0:Request) -> 
     %13(TEMP) ballerina/http:1.0.0:FilterContext | ();
     %17(SYNTHETIC) ballerina/http:1.0.0:RequestFilter | ballerina/http:1.0.0:ResponseFilter[];
     %19(TEMP) ballerina/http:1.0.0:ListenerConfiguration;
-    %23(SYNTHETIC) ballerina/lang.array:1.1.0:$anonType$1;
-    %26(TEMP) ballerina/lang.array:1.1.0:$anonType$1;
-    %27(SYNTHETIC) ballerina/lang.array:1.1.0:$anonType$0 | ();
-    %31(TEMP) ballerina/lang.array:1.1.0:$anonType$0 | ();
+    %23(SYNTHETIC) ballerina/lang.array:1.1.0:$anonType$_1;
+    %26(TEMP) ballerina/lang.array:1.1.0:$anonType$_1;
+    %27(SYNTHETIC) ballerina/lang.array:1.1.0:$anonType$_0 | ();
+    %31(TEMP) ballerina/lang.array:1.1.0:$anonType$_0 | ();
     %32(TEMP) boolean;
     %34(SYNTHETIC) ballerina/http:1.0.0:RequestFilter | ballerina/http:1.0.0:ResponseFilter;
     %36(TEMP) ballerina/http:1.0.0:RequestFilter | ballerina/http:1.0.0:ResponseFilter;
-    %37(TEMP) ballerina/lang.array:1.1.0:$anonType$0;
+    %37(TEMP) ballerina/lang.array:1.1.0:$anonType$_0;
     %44(SYNTHETIC) boolean;
     %46(TEMP) ballerina/http:1.0.0:RequestFilter;
     %58(SYNTHETIC) ();
@@ -48,26 +48,26 @@ sayHello function(ballerina/http:1.0.0:Caller, ballerina/http:1.0.0:Request) -> 
         %26 = iterator(%17) -> bb2;
     }
     bb2 {
-        %23 = <ballerina/lang.array:1.1.0:$anonType$1> %26;
-        %31 = $anonType$1.next(%23, %23) -> bb3;
+        %23 = <ballerina/lang.array:1.1.0:$anonType$_1> %26;
+        %31 = $anonType$_1.next(%23, %23) -> bb3;
     }
     bb3 {
-        %27 = <ballerina/lang.array:1.1.0:$anonType$0 | ()> %31;
+        %27 = <ballerina/lang.array:1.1.0:$anonType$_0 | ()> %31;
         GOTO bb4;
     }
     bb4 {
-        %32 = %27 is ballerina/lang.array:1.1.0:$anonType$0;
+        %32 = %27 is ballerina/lang.array:1.1.0:$anonType$_0;
         %32? bb5 : bb14;
     }
     bb5 {
-        %37 = <ballerina/lang.array:1.1.0:$anonType$0> %27;
+        %37 = <ballerina/lang.array:1.1.0:$anonType$_0> %27;
         %10 = ConstLoad value;
         %36 = %37[%10];
         %34 = <ballerina/http:1.0.0:RequestFilter> %36;
-        %31 = $anonType$1.next(%23, %23) -> bb6;
+        %31 = $anonType$_1.next(%23, %23) -> bb6;
     }
     bb6 {
-        %27 = <ballerina/lang.array:1.1.0:$anonType$0 | ()> %31;
+        %27 = <ballerina/lang.array:1.1.0:$anonType$_0 | ()> %31;
         %46 = <ballerina/http:1.0.0:RequestFilter> %34;
         %32 = %46 is ballerina/http:1.0.0:RequestFilter;
         %32? bb7 : bb9;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/rawtemplate/raw_template_literal_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/rawtemplate/raw_template_literal_test.bal
@@ -203,7 +203,7 @@ function testUseWithVar() {
     var rt = `Hello ${name}!`;
     typedesc<any> td = typeof rt;
 
-    assert("typedesc $rawTemplate$RawTemplate$12", td.toString());
+    assert("typedesc $rawTemplate$RawTemplate$_12", td.toString());
 }
 
 function testUseWithAny() {
@@ -211,7 +211,7 @@ function testUseWithAny() {
     any rt = `Hello ${name}!`;
     typedesc<any> td = typeof rt;
 
-    assert("typedesc $rawTemplate$RawTemplate$13", td.toString());
+    assert("typedesc $rawTemplate$RawTemplate$_13", td.toString());
 }
 
 public type Template3 object {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/variable/shadowing/shadowing.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/variable/shadowing/shadowing.bal
@@ -18,6 +18,9 @@ xmlns "http://sample.com/wso2/a1" as ns;
 
 const ASSERTION_ERROR_REASON = "AssertionError";
 
+final boolean serviceEPAvailable = false;
+final string LOCK_STORE = "lockStore";
+
 int name = 10;
 
 type Person record {
@@ -183,4 +186,20 @@ function testTypeNameAsVariable5() {
     }
     var t = typeof name;
     panic error(ASSERTION_ERROR_REASON, message = "expected 'string', found '" + t.toString() + "'");
+}
+
+function testGeneratedNames() {
+    assertEquality(serviceEPAvailable, false);
+    assertEquality(LOCK_STORE, "lockStore");
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+    if expected === actual {
+        return;
+    }
+    panic error(ASSERTION_ERROR_REASON,
+                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/variable/shadowing/shadowing.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/variable/shadowing/shadowing.bal
@@ -14,6 +14,8 @@
 // specific language governing permissions and limitations
 // under the License.
 
+import ballerina/test;
+
 xmlns "http://sample.com/wso2/a1" as ns;
 
 const ASSERTION_ERROR_REASON = "AssertionError";
@@ -189,17 +191,6 @@ function testTypeNameAsVariable5() {
 }
 
 function testGeneratedNames() {
-    assertEquality(serviceEPAvailable, false);
-    assertEquality(LOCK_STORE, "lockStore");
-}
-
-function assertEquality(any|error expected, any|error actual) {
-    if expected is anydata && actual is anydata && expected == actual {
-        return;
-    }
-    if expected === actual {
-        return;
-    }
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    test:assertFalse(serviceEPAvailable);
+    test:assertEquals(LOCK_STORE, "lockStore");
 }

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/assertions-error-messages/tests/assertions-error-messages.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/assertions-error-messages/tests/assertions-error-messages.bal
@@ -118,7 +118,8 @@ function testAssertAnnonymousRecords() {
 
     error? err = trap test:assertEquals(address, address2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <$anonType$1> '{\"newCity\":" + "\"London\",\"newCountry\":\"UK\"}'\nactual\t: <$anonType$0> '{\"city\":\"London\",\"country\":\"UK\"}'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <$anonType$_1> '{\"newCity\":" +
+    "\"London\",\"newCountry\":\"UK\"}'\nactual\t: <$anonType$_0> '{\"city\":\"London\",\"country\":\"UK\"}'");
 }
 
 @test:Config {}


### PR DESCRIPTION
## Purpose
The generated names which contains the pattern `$` followed by digits can clash with the encoding pattern introduced for the quoted identifiers. 
Eg: `$anonType$1234` 
The pattern at generated names is changed into `$` followed by `_` and digits to rectify this clash
Eg: `$anonType$_1234`

The generated variable names introduced at code generation are changed to contain at least a `$` to avoid clashes between user defined ones. 

Constants are introduced for the hard coded values used at codegen

Fixes #25745 
Fixes #26122 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
