### PR TITLE
Remove use of optional values for typedescs in symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -30,7 +30,6 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -68,8 +67,8 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     }
 
     @Override
-    public Optional<BallerinaTypeDescriptor> typeDescriptor() {
-        return Optional.ofNullable(typeDescriptor);
+    public BallerinaTypeDescriptor typeDescriptor() {
+        return this.typeDescriptor;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -43,7 +43,7 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     }
 
     @Override
-    public Optional<BallerinaTypeDescriptor> typeDescriptor() {
+    public BallerinaTypeDescriptor typeDescriptor() {
         return this.functionSymbol.typeDescriptor();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
@@ -28,7 +28,6 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -66,8 +65,8 @@ public class BallerinaTypeSymbol extends BallerinaSymbol implements TypeSymbol {
     }
 
     @Override
-    public Optional<BallerinaTypeDescriptor> typeDescriptor() {
-        return Optional.ofNullable(typeDescriptor);
+    public BallerinaTypeDescriptor typeDescriptor() {
+        return this.typeDescriptor;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -29,7 +29,6 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -71,8 +70,8 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
      * @return {@link BallerinaTypeDescriptor} of the variable
      */
     @Override
-    public Optional<BallerinaTypeDescriptor> typeDescriptor() {
-        return Optional.ofNullable(typeDescriptorImpl);
+    public BallerinaTypeDescriptor typeDescriptor() {
+        return typeDescriptorImpl;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/BallerinaObjectTypeDescriptor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/BallerinaObjectTypeDescriptor.java
@@ -132,11 +132,7 @@ public class BallerinaObjectTypeDescriptor extends AbstractTypeDescriptor implem
         // this.getObjectTypeReference()
         //         .ifPresent(typeDescriptor -> fieldJoiner.add("*" + typeDescriptor.getSignature()));
         this.fieldDescriptors().forEach(objectFieldDescriptor -> fieldJoiner.add(objectFieldDescriptor.signature()));
-        this.methods().forEach(method -> {
-            if (method.typeDescriptor().isPresent()) {
-                methodJoiner.add(method.typeDescriptor().get().signature());
-            }
-        });
+        this.methods().forEach(method -> methodJoiner.add(method.typeDescriptor().signature()));
 
         return signature.append(fieldJoiner.toString())
                 .append(methodJoiner.toString())

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
@@ -19,8 +19,6 @@ package io.ballerina.compiler.api.symbols;
 
 import io.ballerina.compiler.api.types.BallerinaTypeDescriptor;
 
-import java.util.Optional;
-
 /**
  * Represent Function Symbol.
  *
@@ -33,7 +31,7 @@ public interface FunctionSymbol extends Symbol, Qualifiable, Deprecatable {
      *
      * @return {@link BallerinaTypeDescriptor}
      */
-    Optional<BallerinaTypeDescriptor> typeDescriptor();
+    BallerinaTypeDescriptor typeDescriptor();
 
     /**
      * Checks whether the function body is external or not.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
@@ -19,8 +19,6 @@ package io.ballerina.compiler.api.symbols;
 
 import io.ballerina.compiler.api.types.BallerinaTypeDescriptor;
 
-import java.util.Optional;
-
 /**
  * Represents a ballerina type definition.
  *
@@ -40,7 +38,7 @@ public interface TypeSymbol extends Symbol, Qualifiable, Deprecatable {
      *
      * @return {@link BallerinaTypeDescriptor} attached
      */
-    Optional<BallerinaTypeDescriptor> typeDescriptor();
+    BallerinaTypeDescriptor typeDescriptor();
 
     /**
      * Checks whether the type is a readonly type.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
@@ -19,8 +19,6 @@ package io.ballerina.compiler.api.symbols;
 
 import io.ballerina.compiler.api.types.BallerinaTypeDescriptor;
 
-import java.util.Optional;
-
 /**
  * Represents a ballerina variable.
  *
@@ -33,5 +31,5 @@ public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable {
      *
      * @return {@link BallerinaTypeDescriptor} of the variable
      */
-    Optional<BallerinaTypeDescriptor> typeDescriptor();
+    BallerinaTypeDescriptor typeDescriptor();
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -102,14 +102,14 @@ public class TypedescriptorTest {
     @Test
     public void testConstantType() {
         Symbol symbol = getSymbol(17, 8);
-        BallerinaTypeDescriptor type = ((ConstantSymbol) symbol).typeDescriptor().get();
+        BallerinaTypeDescriptor type = ((ConstantSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), FLOAT);
     }
 
     @Test
     public void testFunctionType() {
         Symbol symbol = getSymbol(44, 13);
-        FunctionTypeDescriptor type = (FunctionTypeDescriptor) ((FunctionSymbol) symbol).typeDescriptor().get();
+        FunctionTypeDescriptor type = (FunctionTypeDescriptor) ((FunctionSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), TypeDescKind.FUNCTION);
 
         List<Parameter> reqParams = type.requiredParams();
@@ -130,7 +130,7 @@ public class TypedescriptorTest {
     @Test
     public void testFutureType() {
         Symbol symbol = getSymbol(46, 17);
-        FutureTypeDescriptor type = (FutureTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+        FutureTypeDescriptor type = (FutureTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), FUTURE);
         assertEquals(type.typeParameter().get().kind(), INT);
     }
@@ -138,7 +138,7 @@ public class TypedescriptorTest {
     @Test
     public void testArrayType() {
         Symbol symbol = getSymbol(48, 19);
-        ArrayTypeDescriptor type = (ArrayTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+        ArrayTypeDescriptor type = (ArrayTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), ARRAY);
         assertEquals(((TypeReferenceTypeDescriptor) type.memberTypeDescriptor()).typeDescriptor().kind(), OBJECT);
     }
@@ -146,7 +146,7 @@ public class TypedescriptorTest {
     @Test
     public void testMapType() {
         Symbol symbol = getSymbol(50, 17);
-        MapTypeDescriptor type = (MapTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+        MapTypeDescriptor type = (MapTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), MAP);
         assertEquals(type.typeParameter().get().kind(), STRING);
     }
@@ -154,7 +154,7 @@ public class TypedescriptorTest {
     @Test
     public void testNilType() {
         Symbol symbol = getSymbol(39, 10);
-        FunctionTypeDescriptor type = (FunctionTypeDescriptor) ((FunctionSymbol) symbol).typeDescriptor().get();
+        FunctionTypeDescriptor type = (FunctionTypeDescriptor) ((FunctionSymbol) symbol).typeDescriptor();
         assertEquals(type.returnTypeDescriptor().get().kind(), NIL);
     }
 
@@ -162,7 +162,7 @@ public class TypedescriptorTest {
     public void testObjectType() {
         Symbol symbol = getSymbol(29, 7);
         TypeReferenceTypeDescriptor typeRef =
-                (TypeReferenceTypeDescriptor) ((TypeSymbol) symbol).typeDescriptor().get();
+                (TypeReferenceTypeDescriptor) ((TypeSymbol) symbol).typeDescriptor();
         ObjectTypeDescriptor type = (ObjectTypeDescriptor) typeRef.typeDescriptor();
         assertEquals(type.kind(), OBJECT);
 
@@ -184,7 +184,7 @@ public class TypedescriptorTest {
     public void testRecordType() {
         Symbol symbol = getSymbol(19, 6);
         TypeReferenceTypeDescriptor typeRef =
-                (TypeReferenceTypeDescriptor) ((TypeSymbol) symbol).typeDescriptor().get();
+                (TypeReferenceTypeDescriptor) ((TypeSymbol) symbol).typeDescriptor();
         RecordTypeDescriptor type = (RecordTypeDescriptor) typeRef.typeDescriptor();
         assertEquals(type.kind(), RECORD);
         assertFalse(type.inclusive());
@@ -200,7 +200,7 @@ public class TypedescriptorTest {
     @Test
     public void testTupleType() {
         Symbol symbol = getSymbol(52, 29);
-        TupleTypeDescriptor type = (TupleTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+        TupleTypeDescriptor type = (TupleTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), TUPLE);
 
         List<BallerinaTypeDescriptor> members = type.memberTypeDescriptors();
@@ -215,7 +215,7 @@ public class TypedescriptorTest {
     @Test(dataProvider = "TypedescDataProvider")
     public void testTypedescType(int line, int col, TypeDescKind kind) {
         Symbol symbol = getSymbol(line, col);
-        TypeDescTypeDescriptor type = (TypeDescTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+        TypeDescTypeDescriptor type = (TypeDescTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), TYPEDESC);
         assertTrue(type.typeParameter().isPresent());
         assertEquals(type.typeParameter().get().kind(), kind);
@@ -232,7 +232,7 @@ public class TypedescriptorTest {
     @Test
     public void testUnionType() {
         Symbol symbol = getSymbol(57, 22);
-        UnionTypeDescriptor type = (UnionTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+        UnionTypeDescriptor type = (UnionTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), UNION);
 
         List<BallerinaTypeDescriptor> members = type.memberTypeDescriptors();
@@ -245,7 +245,7 @@ public class TypedescriptorTest {
     public void testNamedUnion() {
         Symbol symbol = getSymbol(59, 12);
         TypeReferenceTypeDescriptor typeRef =
-                (TypeReferenceTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+                (TypeReferenceTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(typeRef.kind(), TYPE_REFERENCE);
 
         UnionTypeDescriptor type = (UnionTypeDescriptor) typeRef.typeDescriptor();
@@ -261,7 +261,7 @@ public class TypedescriptorTest {
     public void testFiniteType() {
         Symbol symbol = getSymbol(61, 11);
         TypeReferenceTypeDescriptor typeRef =
-                (TypeReferenceTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor().get();
+                (TypeReferenceTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(typeRef.kind(), TYPE_REFERENCE);
     }
 


### PR DESCRIPTION
## Purpose
This PR changes the symbol APIs which returns typedescs to return the typedesc directly. This is because there is no reason for the typedesc to be `null`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
