### PR TITLE
Fix issue when calling function with error return in service

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/MockListener.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/MockListener.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.nativeimpl.jvm.tests;
+
+import org.ballerinalang.jvm.api.BRuntime;
+import org.ballerinalang.jvm.api.BalEnv;
+import org.ballerinalang.jvm.api.connector.CallableUnitCallback;
+import org.ballerinalang.jvm.api.values.BError;
+import org.ballerinalang.jvm.api.values.BObject;
+import org.ballerinalang.jvm.api.values.BString;
+
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A mock listener for testing services. It can be used to invoke a resource in the service.
+ */
+public class MockListener {
+
+    private static BObject service;
+    private static BError err;
+
+    public static Object attach(BObject servObj) {
+        service = servObj;
+        return null;
+    }
+
+    public static Object invokeResource(BalEnv env, BString name) throws InterruptedException {
+        if (service != null) {
+            CountDownLatch latch = new CountDownLatch(1);
+            BRuntime runtime = env.getRuntime();
+            runtime.invokeMethodAsync(service, name.getValue(), null, null,
+                                      new CallableUnitCallback() {
+                                          @Override
+                                          public void notifySuccess() {
+                                              latch.countDown();
+                                          }
+
+                                          @Override
+                                          public void notifyFailure(BError error) {
+                                              err = error;
+                                              latch.countDown();
+                                          }
+                             }, new HashMap<>(), null);
+            latch.await();
+        }
+        return err;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/Timer.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/Timer.java
@@ -14,6 +14,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.nativeimpl.jvm.tests;
 
 import org.ballerinalang.jvm.api.BRuntime;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/JsonSerializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/JsonSerializerTest.java
@@ -15,6 +15,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.test.serializer.json;
 
 import org.ballerinalang.core.model.types.BArrayType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/ErrorReturnTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/services/ErrorReturnTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * you may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.services;
+
+import org.ballerinalang.test.util.BCompileUtil;
+import org.ballerinalang.test.util.BRunUtil;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.Test;
+
+/**
+ * Tests calling of a function with error return inside a service.
+ */
+public class ErrorReturnTest {
+
+    @Test(description = "Tests invoking a function returning an error in a service")
+    public void testErrorReturnFunction() {
+        CompileResult compileResult = BCompileUtil.compile("test-src/services/error_return_function.bal");
+        BRunUtil.invoke(compileResult, "testErrorFunction");
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
@@ -1,0 +1,74 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/java;
+import ballerina/test;
+import ballerina/lang.'object as lang;
+
+public class Listener {
+    *lang:Listener;
+    public isolated function __start() returns error? {
+    }
+    public isolated function __gracefulStop() returns error? {
+    }
+    public isolated function __immediateStop() returns error? {
+    }
+    public isolated function __detach(service s) returns error? {
+    }
+     public isolated function __attach(service s, string? name = ()) returns error? {
+        return self.register(s, name);
+    }
+    isolated function register(service s, string? name) returns error? {
+        return externAttach(s);
+    }
+}
+
+isolated function externAttach(service s) returns error? = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.tests.MockListener",
+    name: "attach"
+} external;
+
+listener Listener lsn = new();
+error err = error("An Error");
+error diff = error("A different error");
+service hello on lsn {
+    resource function processRequest() returns error? {
+        error? aDifferentError = createADifferentError();
+        test:assertEquals(diff, aDifferentError);
+        error? anotherErr = self.createError();
+        test:assertEquals(err, anotherErr);
+    }
+
+    function createError() returns @tainted error? {
+        return err;
+    }
+}
+
+function createADifferentError() returns @tainted error? {
+    return diff;
+}
+
+function invokeResource(string name) returns error? = @java:Method {
+    'class: "org.ballerinalang.nativeimpl.jvm.tests.MockListener",
+    name: "invokeResource"
+} external;
+
+public function testErrorFunction() {
+    var err = invokeResource("processRequest");
+    if(err is error) {
+        panic err;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/testng-new-parser.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng-new-parser.xml
@@ -136,6 +136,7 @@
             <package name="org.ballerinalang.test.statements.retrystmt.*"/>
             <package name="org.ballerinalang.test.types.readonly.*"/>
             <package name="org.ballerinalang.test.strand.*"/>
+            <package name="org.ballerinalang.test.services.*"/>
         </packages>
 
         <classes>

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -142,6 +142,7 @@
             <package name="org.ballerinalang.test.types.readonly.*"/>
             <package name="org.ballerinalang.test.strand.*"/>
             <package name="org.ballerinalang.test.klass.*"/>
+            <package name="org.ballerinalang.test.services.*"/>
         </packages>
 
         <classes>


### PR DESCRIPTION



## Purpose
Resolve https://github.com/ballerina-platform/ballerina-lang/issues/24795

## Approach
The issue is in generating the method call of a function in a service. Earlier since only resources were allowed in a service the method calls of all functions in a service were throwing errors when it has an error return. Now a check has been added to throw an error only for a resource.

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
