### PR TITLE
Filter symbols of nodes added by the parser

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
@@ -34,6 +34,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
+import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
+
 /**
  * @since 0.94
  */
@@ -66,7 +68,12 @@ public class BSymbol implements Symbol {
         this.type = type;
         this.owner = owner;
         this.pos = pos;
-        this.origin = origin;
+
+        if (name.value.startsWith("$missingNode$")) {
+            this.origin = VIRTUAL;
+        } else {
+            this.origin = origin;
+        }
     }
 
     public MarkdownDocAttachment getMarkdownDocAttachment() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BSymbol.java
@@ -34,8 +34,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
-import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
-
 /**
  * @since 0.94
  */
@@ -68,12 +66,7 @@ public class BSymbol implements Symbol {
         this.type = type;
         this.owner = owner;
         this.pos = pos;
-
-        if (name.value.startsWith("$missingNode$")) {
-            this.origin = VIRTUAL;
-        } else {
-            this.origin = origin;
-        }
+        this.origin = origin;
     }
 
     public MarkdownDocAttachment getMarkdownDocAttachment() {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -175,6 +176,19 @@ public class SymbolLookupTest {
                 {23, 51, getSymbolNames(moduleLevelSymbols, "b", "strTemp")},
                 {25, 54, getSymbolNames(moduleLevelSymbols, "b", "strTemp", "rawTemp")},
         };
+    }
+
+    @Test
+    public void testMissingNodeFiltering() {
+        CompilerContext context = new CompilerContext();
+        CompileResult result = compile("test-src/missing_node_filtering_test.bal", context);
+        BLangPackage pkg = (BLangPackage) result.getAST();
+        ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
+        BallerinaSemanticModel model = new BallerinaSemanticModel(pkg, context);
+
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "missing_node_filtering_test.bal", 20, 5,
+                                                             moduleID);
+        assertList(symbolsInFile, Arrays.asList("test", "x"));
     }
 
     private CompileResult compile(String path, CompilerContext context) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/missing_node_filtering_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/missing_node_filtering_test.bal
@@ -1,0 +1,25 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    int x = 10;
+    string = "foo";
+
+}
+
+function () {
+
+}


### PR DESCRIPTION
## Purpose
This PR marks symbols defined for nodes added by the parser when recovering as `VIRTUAL` so that they are filtered out when looking up symbols.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
