### PR TITLE
Add support to read custom fields of OAuth2 introspection response

### DIFF
--- a/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
+++ b/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
@@ -96,48 +96,19 @@ public type InboundOAuth2Provider object {
             json payload = <json>result;
             boolean active = <boolean>payload.active;
             if (active) {
-                map<json> claims = {};
-                if (payload.scope is string) {
-                    claims["scopes"] = <@untainted> <string>payload.scope;
-                }
-                if (payload.client_id is string) {
-                    claims["clientId"] = <@untainted> <string>payload.client_id;
-                }
-                if (payload.username is string) {
-                    claims["username"] = <@untainted> <string>payload.username;
-                }
-                if (payload.token_type is string) {
-                    claims["tokenType"] = <@untainted> <string>payload.token_type;
-                }
-                if (payload.exp is int) {
-                    claims["exp"] = <@untainted> <int>payload.exp;
-                }
-                if (payload.iat is int) {
-                    claims["iat"] = <@untainted> <int>payload.iat;
-                }
-                if (payload.nbf is int) {
-                    claims["nbf"] = <@untainted> <int>payload.nbf;
-                }
-                if (payload.sub is string) {
-                    claims["sub"] = <@untainted> <string>payload.sub;
-                }
-                if (payload.aud is string) {
-                    claims["aud"] = <@untainted> <string>payload.aud;
-                }
-                if (payload.iss is string) {
-                    claims["iss"] = <@untainted> <string>payload.iss;
-                }
-                if (payload.jti is string) {
-                    claims["jti"] = <@untainted> <string>payload.jti;
+                map<json>|error payloadMap = map<json>.constructFrom(payload);
+                if (payloadMap is error) {
+                    return <@untainted> prepareAuthError(payloadMap.reason(), payloadMap);
                 }
 
+                map<json> claims = <map<json>>payloadMap;
                 if (oauth2Cache is cache:Cache) {
                     addToAuthenticationCache(oauth2Cache, credential, claims, self.defaultTokenExpTimeInSeconds);
                 }
                 auth:setAuthenticationContext("oauth2", credential);
                 auth:setPrincipal(claims["username"] is string ? <string>claims["username"] : (),
                                   claims["username"] is string ? <string>claims["username"] : (),
-                                  getScopes(claims["scopes"] is string ? <string>claims["scopes"] : ""), claims);
+                                  getScopes(claims["scope"] is string ? <string>claims["scope"] : ""), claims);
                 return true;
             }
             return false;

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/OAuth2ServiceTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/OAuth2ServiceTest.java
@@ -50,4 +50,13 @@ public class OAuth2ServiceTest extends AuthBaseTest {
                 headers, serverInstance.getServerHome());
         assertUnauthorized(response);
     }
+
+    @Test(description = "Test inbound OAuth2 success with valid token and custom field in the introspection response")
+    public void testOAuth2SuccessWithCustomResponseFieldTest() throws Exception {
+        Map<String, String> headers = new HashMap<>();
+        headers.put("Authorization", "Bearer 2YotnFZFEjr1zCsicMWpAA");
+        HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test"),
+                                                         headers, serverInstance.getServerHome());
+        assertContains(response, "twenty-seven");
+    }
 }

--- a/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/21_oauth2_service_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/21_oauth2_service_test.bal
@@ -18,6 +18,7 @@ import ballerina/auth;
 import ballerina/config;
 import ballerina/oauth2;
 import ballerina/http;
+import ballerina/runtime;
 
 auth:OutboundBasicAuthProvider basicAuthProvider = new({
     username: "3MVG9YDQS5WtC11paU2WcQjBB3L5w4gz52uriT8ksZ3nUVjKvrfQMrU4uvZohTftxStwNEW4cfStBEGRxRL68",
@@ -63,6 +64,13 @@ service echo21 on listener21 {
         methods: ["GET"]
     }
     resource function test(http:Caller caller, http:Request req) {
+        map<any>? claims = runtime:getInvocationContext()?.principal?.claims;
+        if (claims is map<any>) {
+            any customField = claims["extension_field"];
+            if (customField is string) {
+                checkpanic caller->respond(customField);
+            }
+        }
         checkpanic caller->respond();
     }
 }

--- a/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/oauth2-mock-server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/oauth2-mock-server.bal
@@ -348,7 +348,17 @@ function getResponseForIntrospectRequest(http:Request req, string authorizationH
                 }
             }
             if (tokenAvailable) {
-                json responsePayload = { "active": true };
+                json responsePayload = { "active": true,
+                                         "client_id": "l238j323ds-23ij4",
+                                         "username": "jdoe",
+                                         "scope": "read write dolphin",
+                                         "sub": "Z5O3upPC88QrAjx00dis",
+                                         "aud": "https://protected.example.net/resource",
+                                         "iss": "https://server.example.com/",
+                                         "exp": 1419356238,
+                                         "iat": 1419350238,
+                                         "extension_field": "twenty-seven"
+                                       };
                 res.setPayload(responsePayload);
             } else {
                 json responsePayload = { "active": false };


### PR DESCRIPTION
## Purpose
This PR provide the capability to read the custom fields of the OAuth2 introspection response [1]. By converting the OAuth2 introspection response to a Ballerina `map` data type directly and adding that to `runtime:InvocationContext` will provide the facility to read back the complete json response.

NOTE: The `scope`, `client_id` and `token_type` attributes of the introspection response was added to the `claims` map using keys in camel case. With this change, all the keys will be as same as the response json.

[1] https://tools.ietf.org/html/rfc7662#section-2.2

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/26350

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
