### PR TITLE
Make positions 0-based in the compiler

### DIFF
--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/util/BAssertUtil.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/util/BAssertUtil.java
@@ -45,10 +45,11 @@ public class BAssertUtil {
         Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.diagnosticInfo().severity(), DiagnosticSeverity.ERROR, "incorrect diagnostic type");
         Assert.assertEquals(diag.message().replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING),
-                expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedErrLine, "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedErrCol,
-                "incorrect column position:");
+                            expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedErrLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedErrCol,
+                            "incorrect column position:");
     }
 
     /**
@@ -62,9 +63,10 @@ public class BAssertUtil {
     public static void validateError(CompileResult result, int errorIndex, int expectedErrLine, int expectedErrCol) {
         Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.diagnosticInfo().severity(), DiagnosticSeverity.ERROR, "incorrect diagnostic type");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedErrLine, "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedErrCol,
-                "incorrect column position:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedErrLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedErrCol,
+                            "incorrect column position:");
     }
 
     /**
@@ -116,8 +118,9 @@ public class BAssertUtil {
         Diagnostic diag = result.getDiagnostics()[warningIndex];
         Assert.assertEquals(diag.diagnosticInfo().severity(), DiagnosticSeverity.WARNING, "incorrect diagnostic type");
         Assert.assertEquals(diag.message(), expectedWarnMsg, "incorrect warning message:");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedWarnLine, "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedWarnCol,
-                "incorrect column position:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedWarnLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedWarnCol,
+                            "incorrect column position:");
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -44,11 +44,11 @@ public interface SemanticModel {
     /**
      * Lookup the symbol at the given location.
      *
-     * @param srcFile  path for the file in which we need to look up symbols, relative to the source root path
+     * @param fileName  path for the file in which we need to look up symbols, relative to the source root path
      * @param position text position in the source
      * @return {@link Symbol} in the given location
      */
-    Optional<Symbol> symbol(String srcFile, LinePosition position);
+    Optional<Symbol> symbol(String fileName, LinePosition position);
 
     /**
      * Retrieves the symbols of module-scoped constructs in the semantic model.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -101,8 +101,8 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public Optional<Symbol> symbol(String srcFile, LinePosition position) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(srcFile);
+    public Optional<Symbol> symbol(String fileName, LinePosition position) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(fileName);
         SymbolFinder symbolFinder = new SymbolFinder();
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/Compiler.java
@@ -200,7 +200,8 @@ public class Compiler {
             }
 
             LinePosition line = lineRange.startLine();
-            strPos = strPos + line.line() + ":" + line.offset() + ":";
+            // Add +1 since it's 0-based
+            strPos = strPos + (line.line() + 1) + ":" + (line.offset() + 1) + ":";
 
             DiagnosticSeverity kind = diagnostic.diagnosticInfo().severity();
             switch (kind) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -565,7 +565,8 @@ public class JvmCodeGenUtil {
     private static void generateDiagnosticPos(DiagnosticPos pos, MethodVisitor mv, Label label) {
         if (pos != null && pos.sLine != 0x80000000) {
             mv.visitLabel(label);
-            mv.visitLineNumber(pos.sLine, label);
+            // Adding +1 since 'pos' is 0-based and we want 1-based positions at run time
+            mv.visitLineNumber(pos.sLine + 1, label);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -872,7 +872,7 @@ class JvmObservabilityGen {
      * @return The generated ID
      */
     private String generatePositionId(DiagnosticPos pos) {
-        return String.format("%s:%d:%d", pos.src.cUnitName, pos.sLine, pos.sCol);
+        return String.format("%s:%d:%d", pos.src.cUnitName, pos.sLine + 1, pos.sCol + 1);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/packaging/converters/FileSystemSourceInput.java
@@ -74,7 +74,7 @@ public class FileSystemSourceInput implements CompilerInput {
         if (this.tree != null) {
             return this.tree;
         }
-        this.tree = SyntaxTree.from(TextDocuments.from(new String(getCode())));
+        this.tree = SyntaxTree.from(TextDocuments.from(new String(getCode())), this.path.getFileName().toString());
         return this.tree;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -486,8 +486,8 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         LineRange lineRange = node.lineRange();
         LinePosition startPos = lineRange.startLine();
         LinePosition endPos = lineRange.endLine();
-        return new DiagnosticPos(diagnosticSource, startPos.line() + 1, endPos.line() + 1, startPos.offset() + 1,
-                endPos.offset() + 1);
+        return new DiagnosticPos(diagnosticSource, startPos.line(), endPos.line(), startPos.offset(),
+                                 endPos.offset());
     }
 
     private DiagnosticPos getPositionWithoutMetadata(Node node) {
@@ -506,8 +506,8 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             startPos = nodeLineRange.startLine();
         }
         LinePosition endPos = nodeLineRange.endLine();
-        return new DiagnosticPos(diagnosticSource, startPos.line() + 1, endPos.line() + 1, startPos.offset() + 1,
-                endPos.offset() + 1);
+        return new DiagnosticPos(diagnosticSource, startPos.line(), endPos.line(), startPos.offset(),
+                                 endPos.offset());
     }
 
     @Override
@@ -528,10 +528,10 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         for (ModuleMemberDeclarationNode member : modulePart.members()) {
             compilationUnit.addTopLevelNode((TopLevelNode) member.apply(this));
         }
-        pos.sLine = 1;
-        pos.sCol = 1;
-        pos.eLine = 1;
-        pos.eCol = 1;
+        pos.sLine = 0;
+        pos.sCol = 0;
+        pos.eLine = 0;
+        pos.eCol = 0;
 
         compilationUnit.pos = pos;
         this.currentCompilationUnit = null;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/Parser.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/Parser.java
@@ -19,9 +19,6 @@ package org.wso2.ballerinalang.compiler.parser;
 
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.tools.diagnostics.Diagnostic;
-import io.ballerina.tools.diagnostics.Location;
-import io.ballerina.tools.text.LinePosition;
-import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
@@ -29,8 +26,6 @@ import org.ballerinalang.model.tree.CompilationUnitNode;
 import org.ballerinalang.repository.CompilerInput;
 import org.ballerinalang.repository.PackageSource;
 import org.wso2.ballerinalang.compiler.PackageCache;
-import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnostic;
-import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.packaging.converters.FileSystemSourceInput;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
@@ -145,17 +140,7 @@ public class Parser {
 
     private void reportSyntaxDiagnostics(BDiagnosticSource diagnosticSource, SyntaxTree tree) {
         for (Diagnostic syntaxDiagnostic : tree.diagnostics()) {
-            // This conversion is needed because the compiler diagnostic locations starting index 
-            // is 1, where as syntax diagnostics locations starting index is 0.
-            Location syntaxLocation = syntaxDiagnostic.location();
-            LineRange lineRange = syntaxLocation.lineRange();
-            LinePosition startLine = lineRange.startLine();
-            LinePosition endLine = lineRange.endLine();
-            Location location = new BLangDiagnosticLocation(diagnosticSource.cUnitName, startLine.line(),
-                                                            endLine.line(), startLine.offset(), endLine.offset());
-            BLangDiagnostic diag =
-                    new BLangDiagnostic(location, syntaxDiagnostic.message(), syntaxDiagnostic.diagnosticInfo());
-            dlog.logDiagnostic(diagnosticSource.pkgID, diag);
+            dlog.logDiagnostic(diagnosticSource.pkgID, syntaxDiagnostic);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/Parser.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/Parser.java
@@ -100,7 +100,7 @@ public class Parser {
             }
         }
 
-        pkgNode.pos = new DiagnosticPos(new BDiagnosticSource(pkgId, pkgSource.getName()), 1, 1, 1, 1);
+        pkgNode.pos = new DiagnosticPos(new BDiagnosticSource(pkgId, pkgSource.getName()), 0, 0, 0, 0);
         pkgNode.repos = pkgSource.getRepoHierarchy();
         return pkgNode;
     }
@@ -150,9 +150,9 @@ public class Parser {
             Location syntaxLocation = syntaxDiagnostic.location();
             LineRange lineRange = syntaxLocation.lineRange();
             LinePosition startLine = lineRange.startLine();
-            LinePosition endLine = lineRange.startLine();
-            Location location = new BLangDiagnosticLocation(diagnosticSource.cUnitName, startLine.line() + 1,
-                    endLine.line() + 1, startLine.offset() + 1, endLine.offset() + 1);
+            LinePosition endLine = lineRange.endLine();
+            Location location = new BLangDiagnosticLocation(diagnosticSource.cUnitName, startLine.line(),
+                                                            endLine.line(), startLine.offset(), endLine.offset());
             BLangDiagnostic diag =
                     new BLangDiagnostic(location, syntaxDiagnostic.message(), syntaxDiagnostic.diagnosticInfo());
             dlog.logDiagnostic(diagnosticSource.pkgID, diag);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -213,8 +213,8 @@ public class SymbolTable {
 
         this.rootPkgNode = (BLangPackage) TreeBuilder.createPackageNode();
         this.rootPkgSymbol = new BPackageSymbol(PackageID.ANNOTATIONS, null, null, BUILTIN);
-        this.builtinPos = new DiagnosticPos(new BDiagnosticSource(rootPkgSymbol.pkgID, Names.EMPTY.value), 0, 0,
-                                            0, 0);
+        this.builtinPos = new DiagnosticPos(new BDiagnosticSource(rootPkgSymbol.pkgID, Names.EMPTY.value), -1, -1,
+                                            -1, -1);
         this.rootPkgNode.pos = this.builtinPos;
         this.rootPkgNode.symbol = this.rootPkgSymbol;
         this.rootScope = new Scope(rootPkgSymbol);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DiagnosticsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DiagnosticsTest.java
@@ -65,7 +65,7 @@ public class DiagnosticsTest {
         BallerinaSemanticModel model = new BallerinaSemanticModel(pkg, context);
 
         LineRange range = LineRange.from("type_checking_errors.bal", LinePosition.from(1, 0),
-                                         LinePosition.from(19, 20));
+                                         LinePosition.from(18, 19));
         List<Diagnostic> diagnostics = model.diagnostics(range);
 
         assertEquals(diagnostics.size(), 1);
@@ -76,11 +76,11 @@ public class DiagnosticsTest {
 
     private Object[][] getExpectedErrors() {
         return new Object[][]{
-                {"missing semicolon token", 19, 1},
-                {"missing identifier", 22, 9},
-                {"invalid token 'string'", 22, 16},
-                {"incompatible types: expected 'int', found 'string'", 18, 13},
-                {"incompatible types: 'int' cannot be cast to 'string'", 20, 16}
+                {"missing semicolon token", 18, 0},
+                {"missing identifier", 21, 8},
+                {"invalid token 'string'", 21, 15},
+                {"incompatible types: expected 'int', found 'string'", 17, 12},
+                {"incompatible types: 'int' cannot be cast to 'string'", 19, 15}
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -61,39 +61,39 @@ public class SymbolAtCursorTest {
     @DataProvider(name = "BasicsPosProvider")
     public Object[][] getPositionsForExactLookup() {
         return new Object[][]{
-                {17, 7, null},
-                {17, 8, "aString"},
-                {17, 10, "aString"},
-                {17, 15, null},
-                {20, 9, null},
-                {20, 10, "test"},
-                {20, 12, "test"},
-                {20, 14, null},
-                {27, 12, null},
-                {27, 13, "a"},
-                {27, 14, null},
-                {24, 8, "greet"},
-                {41, 8, "Person"},
-                {42, 8, "PersonObj"},
-                {43, 21, "pObj"},
-                {43, 30, "PersonObj.getFullName"},
-                {44, 12, "p"},
-                {44, 17, "name"},
-                {45, 20, "p"},
-                {45, 23, "name"},
-                {50, 5, null},
-                {50, 9, "Person"},
-                {50, 15, null},
-                {51, 15, "name"},
-                {54, 11, "PersonObj"},
-                {55, 15, "fname"},
-                {56, 15, "lname"},
-                {59, 16, "fname"},
-                {60, 12, "self"},
-                {64, 24, "fname"},
-                {64, 42, "lname"},
-                {73, 5, "test"},
-                {73, 8, "test"},
+                {16, 6, null},
+                {16, 7, "aString"},
+                {16, 9, "aString"},
+                {16, 14, null},
+                {19, 8, null},
+                {19, 9, "test"},
+                {19, 11, "test"},
+                {19, 13, null},
+                {26, 11, null},
+                {26, 12, "a"},
+                {26, 13, null},
+                {23, 7, "greet"},
+                {40, 7, "Person"},
+                {41, 7, "PersonObj"},
+                {42, 20, "pObj"},
+                {42, 29, "PersonObj.getFullName"},
+                {43, 11, "p"},
+                {43, 15, "name"},
+                {44, 19, "p"},
+                {44, 22, "name"},
+                {49, 4, null},
+                {49, 8, "Person"},
+                {49, 14, null},
+                {50, 14, "name"},
+                {53, 10, "PersonObj"},
+                {54, 14, "fname"},
+                {55, 14, "lname"},
+                {58, 15, "fname"},
+                {59, 11, "self"},
+                {63, 23, "fname"},
+                {63, 41, "lname"},
+                {72, 4, "test"},
+                {72, 7, "test"},
         };
     }
 
@@ -115,12 +115,12 @@ public class SymbolAtCursorTest {
     @DataProvider(name = "EnumPosProvider")
     public Object[][] getEnumPos() {
         return new Object[][]{
-                {18, 7, "RED"},
-//                {22, 19, "RED"}, // TODO: issue #25841
-                {23, 9, "Colour"},
-                {27, 46, "Colour"},
-//                {31, 18, "GREEN"}, // TODO: issue #25841
-//                {32, 29, "BLUE"}, // TODO: issue #25841
+                {17, 6, "RED"},
+//                {21, 18, "RED"}, // TODO: issue #25841
+                {22, 8, "Colour"},
+                {26, 45, "Colour"},
+//                {30, 17, "GREEN"}, // TODO: issue #25841
+//                {31, 28, "BLUE"}, // TODO: issue #25841
         };
     }
 
@@ -142,13 +142,13 @@ public class SymbolAtCursorTest {
     @DataProvider(name = "WorkerSymbolPosProvider")
     public Object[][] getWorkerPos() {
         return new Object[][]{
-                {22, 13, "w1"},
-                {24, 13, "w2"},
-                {27, 14, "w2"},
-                {29, 24, "w2"},
-                {35, 15, "w1"},
-                {37, 21, "w1"},
-                {40, 21, "w2"},
+                {21, 12, "w1"},
+                {23, 12, "w2"},
+                {26, 13, "w2"},
+                {28, 23, "w2"},
+                {34, 14, "w1"},
+                {36, 20, "w1"},
+                {39, 20, "w2"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -77,7 +77,7 @@ public class SymbolBIRTest {
         List<String> expSymbolNames = getSymbolNames(annotationModuleSymbols, moduleLevelSymbols, moduleSymbols);
 
         Map<String, Symbol> symbolsInScope =
-                model.visibleSymbols("symbol_lookup_with_imports_test.bal", LinePosition.from(19, 1))
+                model.visibleSymbols("symbol_lookup_with_imports_test.bal", LinePosition.from(18, 0))
                         .stream().collect(Collectors.toMap(Symbol::name, s -> s));
         assertList(symbolsInScope, expSymbolNames);
 
@@ -114,15 +114,15 @@ public class SymbolBIRTest {
     @DataProvider(name = "ImportSymbolPosProvider")
     public Object[][] getImportSymbolPos() {
         return new Object[][]{
-                {17, 7, null},
-                {17, 11, "foo"},
-                {17, 17, "foo"},
-                {17, 19, null},
-//                {20, 18, "foo"}, // TODO: issue #25841
-                {21, 14, "foo"},
-                {23, 6, "foo"},
-//                {27, 13, "foo"}, // TODO: issue #25841
-                {32, 21, "PersonObj.getName"},
+                {16, 6, null},
+                {16, 10, "foo"},
+                {16, 16, "foo"},
+                {16, 18, null},
+//                {19, 17, "foo"}, // TODO: issue #25841
+                {20, 13, "foo"},
+                {22, 5, "foo"},
+//                {26, 12, "foo"}, // TODO: issue #25841
+                {31, 20, "PersonObj.getName"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
@@ -78,16 +78,16 @@ public class SymbolFlagToQualifierMappingTest {
     @DataProvider(name = "QualifierProvider")
     public Object[][] getPositionsAndQualifiers() {
         return new Object[][]{
-                {19, 28, getQualifiers(LISTENER, FINAL)},
-                {21, 14, Collections.EMPTY_SET},
-                {24, 26, getQualifiers(PUBLIC)},
-                {40, 20, getQualifiers(READONLY)},
-                {54, 21, getQualifiers(ISOLATED)},
-                {57, 23, getQualifiers(READONLY)},
-                {61, 17, getQualifiers(CLIENT)},
-                {62, 23, getQualifiers(REMOTE)},
-                {71, 25, getQualifiers(RESOURCE)},
-//                {76, 14, getQualifiers(DISTINCT)}, // TODO: enable once issue #26212 is fixed
+                {18, 27, getQualifiers(LISTENER, FINAL)},
+                {20, 13, Collections.EMPTY_SET},
+                {23, 25, getQualifiers(PUBLIC)},
+                {39, 19, getQualifiers(READONLY)},
+                {53, 20, getQualifiers(ISOLATED)},
+                {56, 22, getQualifiers(READONLY)},
+                {60, 16, getQualifiers(CLIENT)},
+                {61, 22, getQualifiers(REMOTE)},
+                {70, 24, getQualifiers(RESOURCE)},
+//                {75, 13, getQualifiers(DISTINCT)}, // TODO: enable once issue #26212 is fixed
         };
     }
 
@@ -102,9 +102,9 @@ public class SymbolFlagToQualifierMappingTest {
     @DataProvider(name = "SymbolKindProvider")
     public Object[][] getSymbolKinds() {
         return new Object[][]{
-                {24, 26, SymbolKind.METHOD},
-                {70, 11, SymbolKind.SERVICE},
-                {82, 8, SymbolKind.CONSTANT},
+                {23, 25, SymbolKind.METHOD},
+                {69, 10, SymbolKind.SERVICE},
+                {81, 7, SymbolKind.CONSTANT},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -199,7 +199,7 @@ public class SymbolLookupTest {
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
         BallerinaSemanticModel model = new BallerinaSemanticModel(pkg, context);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "missing_node_filtering_test.bal", 20, 5,
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "missing_node_filtering_test.bal", 19, 4,
                                                              moduleID);
         assertList(symbolsInFile, Arrays.asList("test", "x"));
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -71,14 +71,14 @@ public class SymbolLookupTest {
     public Object[][] getPositions() {
         List<String> moduleLevelSymbols = asList("aString", "anInt", "test", "HELLO");
         return new Object[][]{
-                {3, 14, 4, moduleLevelSymbols},
-                {20, 18, 4, moduleLevelSymbols},
-//                {21, 31, 4, moduleLevelSymbols}, // TODO: Feature not yet supported - issue #25607
-                {21, 39, 5, asList("aString", "anInt", "test", "HELLO", "greet")},
-                {22, 1, 5, asList("aString", "anInt", "test", "HELLO", "greet")},
+                {2, 13, 4, moduleLevelSymbols},
+                {19, 17, 4, moduleLevelSymbols},
+//                {20, 30, 4, moduleLevelSymbols}, // TODO: Feature not yet supported - issue #25607
+                {20, 38, 5, asList("aString", "anInt", "test", "HELLO", "greet")},
+                {21, 0, 5, asList("aString", "anInt", "test", "HELLO", "greet")},
                 // TODO: issue #25607
-//                {23, 60, 6, asList("aString", "anInt", "test", "HELLO", "greet", "name")},
-                {31, 13, 8, getSymbolNames(moduleLevelSymbols, "greet", "a", "x", "greetFn")},
+//                {22, 59, 6, asList("aString", "anInt", "test", "HELLO", "greet", "name")},
+                {30, 12, 8, getSymbolNames(moduleLevelSymbols, "greet", "a", "x", "greetFn")},
         };
     }
 
@@ -103,14 +103,14 @@ public class SymbolLookupTest {
     public Object[][] getPositionsForWorkers() {
         List<String> moduleLevelSymbols = asList("aString", "anInt", "workerSendToWorker", "HELLO");
         return new Object[][]{
-                {20, 51, 6, getSymbolNames(moduleLevelSymbols, "w1", "w2")},
-                {22, 16, 6, getSymbolNames(moduleLevelSymbols, "w1", "w2")},
-                {26, 1, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "i")},
-                {24, 15, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "i")},
-                {31, 13, 6, getSymbolNames(moduleLevelSymbols, "w1", "w2")},
-                {35, 13, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "j")},
-                {40, 23, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "ret")},
-                {44, 1, 4, moduleLevelSymbols},
+                {19, 50, 6, getSymbolNames(moduleLevelSymbols, "w1", "w2")},
+                {21, 15, 6, getSymbolNames(moduleLevelSymbols, "w1", "w2")},
+                {25, 0, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "i")},
+                {23, 14, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "i")},
+                {30, 12, 6, getSymbolNames(moduleLevelSymbols, "w1", "w2")},
+                {34, 12, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "j")},
+                {39, 22, 7, getSymbolNames(moduleLevelSymbols, "w1", "w2", "ret")},
+                {43, 0, 4, moduleLevelSymbols},
         };
     }
 
@@ -135,19 +135,19 @@ public class SymbolLookupTest {
     public Object[][] getPositionsForTypedefs() {
         List<String> moduleLevelSymbols = asList("aString", "anInt", "HELLO", "testAnonTypes", "Person", "PersonObj");
         return new Object[][]{
-                {19, 1, 6, moduleLevelSymbols},
-//                {23, 21, 6, moduleLevelSymbols}, // TODO: Filter out field symbols
-//                {29, 23, 6, moduleLevelSymbols}, // TODO: Filter out field symbols
-                {31, 66, 13, getSymbolNames(moduleLevelSymbols, "parent", "pParent", "name", "pName", "age", "pAge",
+                {18, 0, 6, moduleLevelSymbols},
+//                {22, 20, 6, moduleLevelSymbols}, // TODO: Filter out field symbols
+//                {28, 22, 6, moduleLevelSymbols}, // TODO: Filter out field symbols
+                {30, 65, 13, getSymbolNames(moduleLevelSymbols, "parent", "pParent", "name", "pName", "age", "pAge",
                                             "self")},
-                {40, 9, 10, getSymbolNames(moduleLevelSymbols, "parent", "name", "age", "self")},
-                {47, 10, 7, getSymbolNames(moduleLevelSymbols, "x")},
-                {49, 20, 7, getSymbolNames(moduleLevelSymbols, "x")},
+                {39, 8, 10, getSymbolNames(moduleLevelSymbols, "parent", "name", "age", "self")},
+                {46, 9, 7, getSymbolNames(moduleLevelSymbols, "x")},
+                {48, 19, 7, getSymbolNames(moduleLevelSymbols, "x")},
                 // TODO: Fix filtering out 'person'
-                {51, 16, 8, getSymbolNames(moduleLevelSymbols, "x", "person")},
-//                {51, 17, 9, getSymbolNames(moduleLevelSymbols, "x", "person", "name", "age")},
-                {52, 1, 8, getSymbolNames(moduleLevelSymbols, "x", "person")},
-//                {53, 18, 11, getSymbolNames(moduleLevelSymbols, "x", "person", "p2", "name", "age")},
+                {50, 15, 8, getSymbolNames(moduleLevelSymbols, "x", "person")},
+//                {50, 16, 9, getSymbolNames(moduleLevelSymbols, "x", "person", "name", "age")},
+                {51, 0, 8, getSymbolNames(moduleLevelSymbols, "x", "person")},
+//                {52, 17, 11, getSymbolNames(moduleLevelSymbols, "x", "person", "p2", "name", "age")},
         };
     }
 
@@ -168,14 +168,27 @@ public class SymbolLookupTest {
     public Object[][] getPositionsForExprs() {
         List<String> moduleLevelSymbols = asList("aString", "anInt", "test");
         return new Object[][]{
-                {21, 13, getSymbolNames(moduleLevelSymbols, "b")},
-                {21, 17, getSymbolNames(moduleLevelSymbols, "b")},
-                {21, 28, getSymbolNames(moduleLevelSymbols, "b", "x")},
-                {21, 36, getSymbolNames(moduleLevelSymbols, "b", "x", "z")},
-                {21, 43, getSymbolNames(moduleLevelSymbols, "b", "x", "z")},
-                {23, 51, getSymbolNames(moduleLevelSymbols, "b", "strTemp")},
-                {25, 54, getSymbolNames(moduleLevelSymbols, "b", "strTemp", "rawTemp")},
+                {20, 12, getSymbolNames(moduleLevelSymbols, "b")},
+                {20, 16, getSymbolNames(moduleLevelSymbols, "b")},
+                {20, 27, getSymbolNames(moduleLevelSymbols, "b", "x")},
+                {20, 35, getSymbolNames(moduleLevelSymbols, "b", "x", "z")},
+                {20, 42, getSymbolNames(moduleLevelSymbols, "b", "x", "z")},
+                {22, 50, getSymbolNames(moduleLevelSymbols, "b", "strTemp")},
+                {24, 53, getSymbolNames(moduleLevelSymbols, "b", "strTemp", "rawTemp")},
         };
+    }
+
+    @Test
+    public void testSymbolLookupInFollowingLine() {
+        CompilerContext context = new CompilerContext();
+        CompileResult result = compile("test-src/symbol_lookup_in_assignment.bal", context);
+        BLangPackage pkg = (BLangPackage) result.getAST();
+        ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
+        BallerinaSemanticModel model = new BallerinaSemanticModel(pkg, context);
+
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_in_assignment.bal", 18, 9,
+                                                             moduleID);
+        assertList(symbolsInFile, Arrays.asList("test", "v1"));
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -72,19 +72,19 @@ public class SymbolPositionTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getPositions() {
         return new Object[][]{
-                {17, 8, 17, 15, "aString"},
-                {20, 10, 20, 14, "test"},
-                {21, 12, 21, 17, "greet"},
-                {26, 7, 26, 12, "HELLO"},
-                {28, 6, 28, 12, "Person"},
-                {32, 6, 32, 15, "PersonObj"},
-                {33, 12, 33, 16, "name"},
-                {35, 14, 35, 21, "PersonObj.getName"},
-                {38, 7, 38, 18, "PersonClass"},
-                {41, 14, 41, 18, "PersonClass.init"},
-                {45, 14, 45, 21, "PersonClass.getName"},
-                {52, 6, 52, 12, "Colour"},
-                {55, 12, 55, 14, "w1"},
+                {16, 7, 16, 14, "aString"},
+                {19, 9, 19, 13, "test"},
+                {20, 11, 20, 16, "greet"},
+                {25, 6, 25, 11, "HELLO"},
+                {27, 5, 27, 11, "Person"},
+                {31, 5, 31, 14, "PersonObj"},
+                {32, 11, 32, 15, "name"},
+                {34, 13, 34, 20, "PersonObj.getName"},
+                {37, 6, 37, 17, "PersonClass"},
+                {40, 13, 40, 17, "PersonClass.init"},
+                {44, 13, 44, 20, "PersonClass.getName"},
+                {51, 5, 51, 11, "Colour"},
+                {54, 11, 54, 13, "w1"},
         };
     }
 
@@ -96,19 +96,19 @@ public class SymbolPositionTest {
 
         Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
-        assertEquals(pos.lineRange().startLine().line(), 61);
-        assertEquals(pos.lineRange().startLine().offset(), 22);
-        assertEquals(pos.lineRange().endLine().line(), 61);
-        assertEquals(pos.lineRange().endLine().offset(), 25);
+        assertEquals(pos.lineRange().startLine().line(), 60);
+        assertEquals(pos.lineRange().startLine().offset(), 21);
+        assertEquals(pos.lineRange().endLine().line(), 60);
+        assertEquals(pos.lineRange().endLine().offset(), 24);
     }
 
     @DataProvider(name = "PositionProvider2")
     public Object[][] getTypeNarrowedPositions() {
         return new Object[][]{
-                {65, 14},
-                {68, 22},
-                {70, 24},
-                {73, 21},
+                {64, 13},
+                {67, 21},
+                {69, 23},
+                {72, 20},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -93,7 +93,7 @@ public class TypedescriptorTest {
 
     @Test
     public void testAnnotationType() {
-        Symbol symbol = getSymbol(23, 38);
+        Symbol symbol = getSymbol(22, 37);
         TypeReferenceTypeDescriptor type =
                 (TypeReferenceTypeDescriptor) ((AnnotationSymbol) symbol).typeDescriptor().get();
         assertEquals(type.typeDescriptor().kind(), TypeDescKind.RECORD);
@@ -101,14 +101,14 @@ public class TypedescriptorTest {
 
     @Test
     public void testConstantType() {
-        Symbol symbol = getSymbol(17, 8);
+        Symbol symbol = getSymbol(16, 7);
         BallerinaTypeDescriptor type = ((ConstantSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), FLOAT);
     }
 
     @Test
     public void testFunctionType() {
-        Symbol symbol = getSymbol(44, 13);
+        Symbol symbol = getSymbol(43, 12);
         FunctionTypeDescriptor type = (FunctionTypeDescriptor) ((FunctionSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), TypeDescKind.FUNCTION);
 
@@ -129,7 +129,7 @@ public class TypedescriptorTest {
 
     @Test
     public void testFutureType() {
-        Symbol symbol = getSymbol(46, 17);
+        Symbol symbol = getSymbol(45, 16);
         FutureTypeDescriptor type = (FutureTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), FUTURE);
         assertEquals(type.typeParameter().get().kind(), INT);
@@ -137,7 +137,7 @@ public class TypedescriptorTest {
 
     @Test
     public void testArrayType() {
-        Symbol symbol = getSymbol(48, 19);
+        Symbol symbol = getSymbol(47, 18);
         ArrayTypeDescriptor type = (ArrayTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), ARRAY);
         assertEquals(((TypeReferenceTypeDescriptor) type.memberTypeDescriptor()).typeDescriptor().kind(), OBJECT);
@@ -145,7 +145,7 @@ public class TypedescriptorTest {
 
     @Test
     public void testMapType() {
-        Symbol symbol = getSymbol(50, 17);
+        Symbol symbol = getSymbol(49, 16);
         MapTypeDescriptor type = (MapTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), MAP);
         assertEquals(type.typeParameter().get().kind(), STRING);
@@ -153,14 +153,14 @@ public class TypedescriptorTest {
 
     @Test
     public void testNilType() {
-        Symbol symbol = getSymbol(39, 10);
+        Symbol symbol = getSymbol(38, 9);
         FunctionTypeDescriptor type = (FunctionTypeDescriptor) ((FunctionSymbol) symbol).typeDescriptor();
         assertEquals(type.returnTypeDescriptor().get().kind(), NIL);
     }
 
     @Test
     public void testObjectType() {
-        Symbol symbol = getSymbol(29, 7);
+        Symbol symbol = getSymbol(28, 6);
         TypeReferenceTypeDescriptor typeRef =
                 (TypeReferenceTypeDescriptor) ((TypeSymbol) symbol).typeDescriptor();
         ObjectTypeDescriptor type = (ObjectTypeDescriptor) typeRef.typeDescriptor();
@@ -182,7 +182,7 @@ public class TypedescriptorTest {
 
     @Test
     public void testRecordType() {
-        Symbol symbol = getSymbol(19, 6);
+        Symbol symbol = getSymbol(18, 5);
         TypeReferenceTypeDescriptor typeRef =
                 (TypeReferenceTypeDescriptor) ((TypeSymbol) symbol).typeDescriptor();
         RecordTypeDescriptor type = (RecordTypeDescriptor) typeRef.typeDescriptor();
@@ -199,7 +199,7 @@ public class TypedescriptorTest {
 
     @Test
     public void testTupleType() {
-        Symbol symbol = getSymbol(52, 29);
+        Symbol symbol = getSymbol(51, 28);
         TupleTypeDescriptor type = (TupleTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), TUPLE);
 
@@ -224,14 +224,14 @@ public class TypedescriptorTest {
     @DataProvider(name = "TypedescDataProvider")
     public Object[][] getTypedescPositions() {
         return new Object[][]{
-                {54, 23, ANYDATA},
-                {55, 14, UNION}
+                {53, 22, ANYDATA},
+                {54, 13, UNION}
         };
     }
 
     @Test
     public void testUnionType() {
-        Symbol symbol = getSymbol(57, 22);
+        Symbol symbol = getSymbol(56, 21);
         UnionTypeDescriptor type = (UnionTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.kind(), UNION);
 
@@ -243,7 +243,7 @@ public class TypedescriptorTest {
 
     @Test(enabled = false)
     public void testNamedUnion() {
-        Symbol symbol = getSymbol(59, 12);
+        Symbol symbol = getSymbol(58, 11);
         TypeReferenceTypeDescriptor typeRef =
                 (TypeReferenceTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(typeRef.kind(), TYPE_REFERENCE);
@@ -259,7 +259,7 @@ public class TypedescriptorTest {
     // TODO: issue #26276
     @Test(enabled = false)
     public void testFiniteType() {
-        Symbol symbol = getSymbol(61, 11);
+        Symbol symbol = getSymbol(60, 10);
         TypeReferenceTypeDescriptor typeRef =
                 (TypeReferenceTypeDescriptor) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(typeRef.kind(), TYPE_REFERENCE);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_assignment.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_in_assignment.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    int v1;
+    v1 = 
+}

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BAssertUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BAssertUtil.java
@@ -45,10 +45,11 @@ public class BAssertUtil {
         Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.diagnosticInfo().severity(), DiagnosticSeverity.ERROR, "incorrect diagnostic type");
         Assert.assertEquals(diag.message().replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING),
-                expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedErrLine, "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedErrCol,
-                "incorrect column position:");
+                            expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedErrLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedErrCol,
+                            "incorrect column position:");
     }
 
     public static void validateError(CompileResult result, int errorIndex, String expectedErrMsg, String fileName,
@@ -58,10 +59,10 @@ public class BAssertUtil {
                 "incorrect diagnostic type");
         Assert.assertEquals(diag.message().replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING),
                 expectedErrMsg.replace(CARRIAGE_RETURN_CHAR, EMPTY_STRING), "incorrect error message:");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedErrLine,
-                "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedErrCol,
-                "incorrect column position:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedErrLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedErrCol,
+                            "incorrect column position:");
         Assert.assertEquals(diag.location().lineRange().filePath(),
                 fileName, "incorrect file name:");
     }
@@ -77,9 +78,10 @@ public class BAssertUtil {
     public static void validateError(CompileResult result, int errorIndex, int expectedErrLine, int expectedErrCol) {
         Diagnostic diag = result.getDiagnostics()[errorIndex];
         Assert.assertEquals(diag.diagnosticInfo().severity(), DiagnosticSeverity.ERROR, "incorrect diagnostic type");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedErrLine, "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedErrCol,
-                "incorrect column position:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedErrLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedErrCol,
+                            "incorrect column position:");
     }
 
     /**
@@ -131,8 +133,9 @@ public class BAssertUtil {
         Diagnostic diag = result.getDiagnostics()[warningIndex];
         Assert.assertEquals(diag.diagnosticInfo().severity(), DiagnosticSeverity.WARNING, "incorrect diagnostic type");
         Assert.assertEquals(diag.message(), expectedWarnMsg, "incorrect warning message:");
-        Assert.assertEquals(diag.location().lineRange().startLine().line(), expectedWarnLine, "incorrect line number:");
-        Assert.assertEquals(diag.location().lineRange().startLine().offset(), expectedWarnCol,
-                "incorrect column position:");
+        Assert.assertEquals(diag.location().lineRange().startLine().line() + 1, expectedWarnLine,
+                            "incorrect line number:");
+        Assert.assertEquals(diag.location().lineRange().startLine().offset() + 1, expectedWarnCol,
+                            "incorrect column position:");
     }
 }


### PR DESCRIPTION
## Purpose
This PR modifies the position info of AST nodes in the compiler to 0-based positioning. This is to unify every component to make use of the same scheme. Where appropriate, the positions will be converted to 1-based (e.g., compiler errors given to users, stack traces in panics)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
