### PR TITLE
[Formatter] Remove the addition of missing tokens after formatting

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/NewFormattingTreeModifier.java
@@ -3583,7 +3583,7 @@ public class NewFormattingTreeModifier extends FormattingTreeModifier {
      */
     @SuppressWarnings("unchecked")
     private <T extends Node> T formatNode(T node, int trailingWS, int trailingNL) {
-        if (node == null) {
+        if (node == null || node.isMissing()) {
             return node;
         }
 
@@ -3624,7 +3624,7 @@ public class NewFormattingTreeModifier extends FormattingTreeModifier {
      * @return Formatted token
      */
     private <T extends Token> T formatToken(T token, int trailingWS, int trailingNL) {
-        if (token == null) {
+        if (token == null || token.isMissing()) {
             return token;
         }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/FormatterTest.java
@@ -60,7 +60,6 @@ public abstract class FormatterTest {
         TextDocument textDocument = TextDocuments.from(content);
         SyntaxTree syntaxTree = SyntaxTree.from(textDocument);
         SyntaxTree newSyntaxTree = Formatter.format(syntaxTree);
-        Assert.assertFalse(newSyntaxTree.hasDiagnostics());
         Assert.assertEquals(newSyntaxTree.toSourceCode(), getSourceText(assertFilePath));
     }
 


### PR DESCRIPTION
## Purpose
Removes the insertion of missing tokens to the formatted output.

Fixes #26092

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [X] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
