### PR TITLE
Fix Decimal value comparison

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/TypeChecker.java
@@ -424,7 +424,7 @@ public class TypeChecker {
      * @return True if left hand value is less than right hand side value, else false.
      */
     public static boolean checkDecimalLessThan(DecimalValue lhsValue, DecimalValue rhsValue) {
-        return checkDecimalGreaterThanOrEqual(rhsValue, lhsValue);
+        return !checkDecimalEqual(lhsValue, rhsValue) && checkDecimalGreaterThanOrEqual(rhsValue, lhsValue);
     }
 
     /**
@@ -435,7 +435,7 @@ public class TypeChecker {
      * @return True if left hand value is less than or equal right hand side value, else false.
      */
     public static boolean checkDecimalLessThanOrEqual(DecimalValue lhsValue, DecimalValue rhsValue) {
-        return checkDecimalGreaterThan(rhsValue, lhsValue);
+        return checkDecimalEqual(lhsValue, rhsValue) || checkDecimalGreaterThan(rhsValue, lhsValue);
     }
 
     /**

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/GreaterLessThanOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/GreaterLessThanOperationTest.java
@@ -145,4 +145,9 @@ public class GreaterLessThanOperationTest {
         BAssertUtil.validateError(resultNegative, 6, "operator '<' not defined for 'int' and 'string'", 53, 12);
         BAssertUtil.validateError(resultNegative, 7, "operator '<=' not defined for 'int' and 'string'", 59, 12);
     }
+
+    @Test(description = "Test decimal greater than, less than expression")
+    public void testDecimalComparison() {
+        BRunUtil.invoke(result, "testDecimalComparison");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation.bal
@@ -1,3 +1,5 @@
+import ballerina/test;
+
 function testIntRanges(int a) returns (int) {
     int retunType = 0;
     if (a <= 0) {
@@ -56,4 +58,25 @@ function intGTEFloat(int a, float b) returns (boolean) {
 
 function floatGTEInt(float a, int b) returns (boolean) {
     return a >= b;
+}
+
+function testDecimalComparison() {
+    decimal lowValue = 3;
+    decimal highValue = 5;
+
+    test:assertTrue(lowValue < highValue);
+    test:assertTrue(lowValue <= highValue);
+
+    test:assertTrue(highValue > lowValue);
+    test:assertTrue(highValue >= lowValue);
+
+    test:assertFalse(highValue < lowValue);
+    test:assertFalse(highValue <= lowValue);
+    test:assertFalse(lowValue > highValue);
+    test:assertFalse(lowValue >= highValue);
+
+    test:assertFalse(lowValue > lowValue);
+    test:assertFalse(lowValue < lowValue);
+    test:assertTrue(lowValue >= lowValue);
+    test:assertTrue(lowValue <= lowValue);
 }


### PR DESCRIPTION
## Purpose

Fixes #26366 

## Approach
>  Previously, decimal value comparison expressions (`<` , `<=`) did not consider equals scenario at the implementation. This PR fixes it.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
