### PR TITLE
Fix the return type of the createSeparatedNodeList

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/AbstractNodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/AbstractNodeFactory.java
@@ -189,7 +189,7 @@ public abstract class AbstractNodeFactory {
                         .collect(Collectors.toList())).createUnlinkedFacade());
     }
 
-    public static <T extends Node> NodeList<T> createSeparatedNodeList(T... nodes) {
+    public static <T extends Node> SeparatedNodeList<T> createSeparatedNodeList(T... nodes) {
         STNode[] internalNodes = new STNode[nodes.length];
         for (int index = 0; index < nodes.length; index++) {
             T node = nodes[index];
@@ -199,7 +199,7 @@ public abstract class AbstractNodeFactory {
         return new SeparatedNodeList<>(STNodeFactory.createNodeList(internalNodes).createUnlinkedFacade());
     }
 
-    public static <T extends Node> NodeList<T> createSeparatedNodeList(Collection<T> nodes) {
+    public static <T extends Node> SeparatedNodeList<T> createSeparatedNodeList(Collection<T> nodes) {
         return new SeparatedNodeList<>(STNodeFactory.createNodeList(
                 nodes.stream()
                         .map(node -> Objects.requireNonNull(node, "node should not be null"))


### PR DESCRIPTION
## Purpose
> The return type of the method `createSeparatedNodeList` returns a `NodeList` instead of `SeparatedNodeList` which forces Syntax API user to always explicitly cast the returning value to `SeparatedNodeList`.

Fixes #26378

## Approach
> Changed the return type to `SeparatedNodeList`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
