### PR TITLE
Add support for `fromBalString` method

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/BalStringUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/BalStringUtils.java
@@ -1,0 +1,288 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package io.ballerina.runtime;
+
+import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.StringUtils;
+import io.ballerina.runtime.api.TypeConstants;
+import io.ballerina.runtime.api.TypeTags;
+import io.ballerina.runtime.api.ValueCreator;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.api.values.BXML;
+import io.ballerina.runtime.types.BAnyType;
+import io.ballerina.runtime.types.BAnydataType;
+import io.ballerina.runtime.types.BArrayType;
+import io.ballerina.runtime.types.BMapType;
+import io.ballerina.runtime.types.BTableType;
+import io.ballerina.runtime.types.BTupleType;
+import io.ballerina.runtime.types.BType;
+import io.ballerina.runtime.types.BUnionType;
+import io.ballerina.runtime.values.ArrayValue;
+import io.ballerina.runtime.values.ArrayValueImpl;
+import io.ballerina.runtime.values.MappingInitialValueEntry;
+import io.ballerina.runtime.values.TableValueImpl;
+import io.ballerina.runtime.values.TupleValueImpl;
+import io.ballerina.runtime.values.XMLSequence;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Common utility methods used for Ballerina expression syntax manipulation.
+ *
+ * @since 2.0.0
+ */
+public class BalStringUtils {
+
+    /**
+     * Create an array from string literal.
+     *
+     * @param exprValue Ballerina expression syntax of the array
+     * @return array value
+     */
+    public static Object parseArrayExpressionStringValue(String exprValue) {
+        List<String> list = getElements(exprValue);
+        Object[] arrayElements = new Object[list.size()];
+        Set<Type> typeSet = new HashSet<>();
+        for (int i = 0; i < list.size(); i++) {
+            String e = list.get(i);
+            Object val = StringUtils.parseExpressionStringValue(e);
+            Type type = TypeChecker.getType(val);
+            typeSet.add(type);
+            arrayElements[i] = val;
+        }
+        if (typeSet.size() > 1) {
+            BUnionType bUnionType = new BUnionType(new ArrayList<>(typeSet));
+            return ValueCreator.createArrayValue(arrayElements, new BArrayType(bUnionType));
+        } else {
+            Type type = typeSet.iterator().next();
+            int tag = type.getTag();
+            switch (tag) {
+                case TypeTags.INT_TAG:
+                case TypeTags.SIGNED32_INT_TAG:
+                case TypeTags.SIGNED16_INT_TAG:
+                case TypeTags.SIGNED8_INT_TAG:
+                case TypeTags.UNSIGNED32_INT_TAG:
+                case TypeTags.UNSIGNED16_INT_TAG:
+                case TypeTags.UNSIGNED8_INT_TAG:
+                    long[] intValues = new long[arrayElements.length];
+                    for (int i = 0; i < arrayElements.length; i++) {
+                        intValues[i] = Long.parseLong(arrayElements[i].toString());
+                    }
+                    return ValueCreator.createArrayValue(intValues);
+                case TypeTags.BYTE_TAG:
+                    byte[] byteValues = new byte[arrayElements.length];
+                    for (int i = 0; i < arrayElements.length; i++) {
+                        byteValues[i] = Byte.parseByte(arrayElements[i].toString());
+                    }
+                    return ValueCreator.createArrayValue(byteValues);
+                case TypeTags.FLOAT_TAG:
+                    double[] floatValues = new double[arrayElements.length];
+                    for (int i = 0; i < arrayElements.length; i++) {
+                        floatValues[i] = Double.parseDouble(arrayElements[i].toString());
+                    }
+                    return ValueCreator.createArrayValue(floatValues);
+                case TypeTags.STRING_TAG:
+                case TypeTags.CHAR_STRING_TAG:
+                    BString[] bStringValues = new BString[arrayElements.length];
+                    for (int i = 0; i < arrayElements.length; i++) {
+                        bStringValues[i] = StringUtils.fromString(arrayElements[i].toString());
+                    }
+                    return ValueCreator.createArrayValue(bStringValues);
+                case TypeTags.BOOLEAN_TAG:
+                    boolean[] booleanValues = new boolean[arrayElements.length];
+                    for (int i = 0; i < arrayElements.length; i++) {
+                        booleanValues[i] = Boolean.parseBoolean(arrayElements[i].toString());
+                    }
+                    return ValueCreator.createArrayValue(booleanValues);
+                default:
+                    return ValueCreator.createArrayValue(arrayElements, new BArrayType(type));
+            }
+        }
+    }
+
+    /**
+     * Create a map from string literal.
+     *
+     * @param exprValue Ballerina expression syntax of the map
+     * @return map value
+     */
+    public static Object parseMapExpressionStringValue(String exprValue) {
+        List<String> list = getElements(exprValue);
+        Set<Type> typeSet = new HashSet<>();
+        MappingInitialValueEntry.KeyValueEntry[] keyValuesList =
+                new MappingInitialValueEntry.KeyValueEntry[list.size()];
+        HashMap<Object, Object> keyValuePair = new HashMap<>();
+        for (int i = 0; i < list.size(); i++) {
+            String e = list.get(i);
+            int colonIndex = e.indexOf(':');
+            int quotesCount = 0;
+            for (int j = 0; j < e.length(); j++) {
+                if (e.charAt(j) == '\"') {
+                    quotesCount++;
+                } else if (e.charAt(j) == ':' && quotesCount % 2 == 0) {
+                    colonIndex = j;
+                    break;
+                }
+            }
+            String key = e.substring(1, colonIndex - 1);
+            Object val = StringUtils.parseExpressionStringValue(e.substring(colonIndex + 1));
+            Type type = TypeChecker.getType(val);
+            typeSet.add(type);
+            keyValuesList[i] = new MappingInitialValueEntry.KeyValueEntry(StringUtils.fromString(key), val);
+        }
+        if (typeSet.size() > 1) {
+            BUnionType bUnionType = new BUnionType(new ArrayList<>(typeSet));
+            return ValueCreator.createMapValue(new BMapType(bUnionType), keyValuesList);
+        } else {
+            Type type = typeSet.iterator().next();
+            return ValueCreator.createMapValue(new BMapType(type), keyValuesList);
+        }
+    }
+
+    /**
+     * Create a table from string literal.
+     *
+     * @param exprValue Ballerina expression syntax of the array
+     * @return table value
+     */
+    public static Object parseTableExpressionStringValue(String exprValue) {
+        String[] keys = exprValue.substring
+                (exprValue.indexOf('(') + 1, exprValue.indexOf(')')).split(",");
+        ArrayValue fieldNames = (ArrayValue) ValueCreator.createArrayValue(StringUtils.fromStringArray(keys));
+        ArrayValueImpl data = (ArrayValueImpl) StringUtils.parseExpressionStringValue(exprValue.substring
+                (exprValue.indexOf(')') + 2));
+
+        BType typeAnydata = new BAnydataType(TypeConstants.ANYDATA_TNAME, new Module(null, null, null),
+                false);
+        BType typeAny = new BAnyType(TypeConstants.ANY_TNAME, new Module(null, null, null), false);
+        BType typeMap = new BMapType(TypeConstants.MAP_TNAME, typeAny, new Module(null, null, null));
+
+        return new TableValueImpl<>(new BTableType(typeMap, typeAnydata, false), data, fieldNames);
+    }
+
+    /**
+     * Create a tuple from string literal.
+     *
+     * @param exprValue Ballerina expression syntax of the tuple
+     * @return tuple value
+     */
+    public static Object parseTupleExpressionStringValue(String exprValue) {
+        String[] stringElements = exprValue.split(" ");
+        Object[] elements = new Object[stringElements.length];
+        List<Type> typeList = new ArrayList<>();
+        for (int i = 0; i < stringElements.length; i++) {
+            Object value = StringUtils.parseExpressionStringValue(stringElements[i].trim());
+            elements[i] = value;
+            Type type = TypeChecker.getType(value);
+            typeList.add(type);
+        }
+        return new TupleValueImpl(elements, new BTupleType(typeList));
+    }
+
+    /**
+     * Create an xml from string literal.
+     *
+     * @param exprValue Ballerina expression syntax of the xml
+     * @return xml value
+     */
+    public static Object parseXmlExpressionStringValue(String exprValue) {
+        if (exprValue.matches("<[\\!--](.*?)[\\-\\-\\!]>")) {
+            String comment = exprValue.substring(exprValue.indexOf("<!--") + 4, exprValue.lastIndexOf("-->"));
+            return XMLFactory.createXMLComment(comment);
+        } else if (exprValue.matches("<\\?(.*?)\\?>")) {
+            String pi = exprValue.substring(exprValue.indexOf("<?") + 2, exprValue.lastIndexOf("?>"));
+            String[] piArgs = pi.split(" ", 2);
+            return XMLFactory.createXMLProcessingInstruction(StringUtils.fromString(piArgs[0]),
+                    StringUtils.fromString(piArgs[1]));
+        } else if (exprValue.matches("<(\\S+?)(.*?)>(.*?)</\\1>")) {
+            return XMLFactory.parse(exprValue);
+        } else if (!exprValue.startsWith("<?") && !exprValue.startsWith("<!--") && !exprValue.startsWith("<")) {
+            return XMLFactory.createXMLText(StringUtils.fromString(exprValue));
+        } else {
+            Pattern pattern = Pattern.compile("<(\\S+?)(.*?)>(.*?)</\\1>|<[\\!--](.*?)[\\-\\-\\!]>" +
+                    "|<\\?(.*?)\\?>");
+            Matcher matcher = pattern.matcher(exprValue);
+            List<BXML> children = new ArrayList<>();
+            String part = exprValue;
+            while (matcher.find()) {
+                String item = matcher.group();
+                String[] splitParts = part.split(item, 2);
+                String splitItem = splitParts[0];
+                if (splitItem.isEmpty()) {
+                    children.add((BXML) parseXmlExpressionStringValue(item));
+                } else {
+                    children.add((BXML) parseXmlExpressionStringValue(splitItem));
+                    if (!item.equals(splitItem)) {
+                        children.add((BXML) parseXmlExpressionStringValue(item));
+                    }
+                }
+                if (splitParts.length == 2) {
+                    part = splitParts[1];
+                }
+            }
+            return new XMLSequence(children);
+        }
+    }
+
+    /**
+     * Identify elements of an array or map from a string.
+     *
+     * @param exprValue Ballerina expression syntax of the array/map
+     * @return List of elements
+     */
+    public static List<String> getElements(String exprValue) {
+        List<String> list = new ArrayList<>();
+        StringBuilder part = new StringBuilder();
+        int balance = 0;
+        int quotesCount = 0;
+        char[] strChars = exprValue.substring(1, exprValue.length() - 1).toCharArray();
+        for (char strChar : strChars) {
+            part.append(strChar);
+            if (strChar == '\"') {
+                quotesCount++;
+            } else if (strChar == '[' && quotesCount % 2 == 0) {
+                balance++;
+            } else if (strChar == '{' && quotesCount % 2 == 0) {
+                balance++;
+            } else if (strChar == '(' && quotesCount % 2 == 0) {
+                balance++;
+            } else if (strChar == ']' && quotesCount % 2 == 0) {
+                balance--;
+            } else if (strChar == '}' && quotesCount % 2 == 0) {
+                balance--;
+            } else if (strChar == ')' && quotesCount % 2 == 0) {
+                balance--;
+            } else if (strChar == ',' && balance == 0 && quotesCount % 2 == 0) {
+                list.add(part.substring(0, part.length() - 1));
+                part = new StringBuilder();
+            }
+        }
+        if (part.length() > 0) {
+            list.add(part.toString());
+        }
+        return list;
+    }
+}

--- a/langlib/lang.value/src/main/ballerina/src/lang.value/value.bal
+++ b/langlib/lang.value/src/main/ballerina/src/lang.value/value.bal
@@ -117,6 +117,17 @@ public isolated function toBalString(any|error v) returns string = @java:Method 
   name: "toBalString"
 } external;
 
+# Parses and evaluates a subset of Ballerina expression syntax.
+# + s - the string to be parsed and evaluated
+# + return - the result of evaluating the parsed expression, or
+# an error if the string cannot be parsed
+# The subset of Ballerina expression syntax supported is that produced
+# by toBalString when applied to an anydata value.
+public isolated function fromBalString(string s) returns anydata|error = @java:Method {
+    'class: "org.ballerinalang.langlib.value.FromBalString",
+    name: "fromBalString"
+} external;
+
 // JSON conversion
 
 # Converts a value of type `anydata` to `json`.

--- a/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromBalString.java
+++ b/langlib/lang.value/src/main/java/org/ballerinalang/langlib/value/FromBalString.java
@@ -1,0 +1,37 @@
+/*
+ *   Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.value;
+
+import io.ballerina.runtime.api.StringUtils;
+import io.ballerina.runtime.api.values.BString;
+
+/**
+ * Returns the result of evaluating a Ballerina expression syntax.
+ *
+ * @since 2.0.0
+ */
+public class FromBalString {
+    public static Object fromBalString(BString value) {
+        String str = value.getValue();
+        if (str.equals("null")) {
+            return null;
+        }
+        return StringUtils.parseExpressionStringValue(str);
+    }
+}

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -253,6 +253,23 @@ public class LangLibValueTest {
         BRunUtil.invokeFunction(testFile, "testToBalStringOnCycles");
     }
 
+    @Test
+    public void testXmlFromBalString() {
+        CompileResult file = BCompileUtil.compile("test-src/valuelib_fromBalString_test.bal");
+        BRunUtil.invokeFunction(file, "testIntValueFromBalString");
+        BRunUtil.invokeFunction(file, "testStringValueFromBalString");
+        BRunUtil.invokeFunction(file, "testFloatingPointNumbersFromBalString");
+        BRunUtil.invokeFunction(file, "testAnydataNilFromBalString");
+        BRunUtil.invokeFunction(file, "testMapFromBalString");
+        BRunUtil.invokeFunction(file, "testTableFromBalString");
+        BRunUtil.invokeFunction(file, "testArrayFromBalString");
+        BRunUtil.invokeFunction(file, "testTupleFromBalString");
+        BRunUtil.invokeFunction(file, "testJsonFromBalString");
+        BRunUtil.invokeFunction(file, "testXmlFromBalString");
+        BRunUtil.invokeFunction(file, "testObjectFromString");
+        BRunUtil.invokeFunction(file, "testFromBalStringOnCycles");
+    }
+
     @DataProvider(name = "mergeJsonFunctions")
     public Object[][] mergeJsonFunctions() {
         return new Object[][] {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromBalString_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromBalString_test.bal
@@ -1,0 +1,312 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.'int as ints;
+import ballerina/lang.'string as strings;
+
+type UndergradStudent record {|
+    readonly int id;
+    readonly string name;
+    int grade;
+|};
+
+public class Student {
+    string name;
+    string school;
+
+    public function init(string name, string school) {
+        self.name = name;
+        self.school = school;
+    }
+
+    public function getDetails() returns string {
+        return self.name + " from " + self.school;
+    }
+}
+
+public class Teacher {
+    string name;
+    string school;
+
+    public function init(string name, string school) {
+        self.name = name;
+        self.school = school;
+    }
+
+    public function getDetails() returns string {
+        return self.name + " from " + self.school;
+    }
+
+    public function toString() returns string {
+        return self.getDetails();
+    }
+}
+
+function testIntValueFromBalString() {
+    int x1 = 12;
+    ints:Signed32 x2 = 2147483647;
+    ints:Signed16 x3 = -32768;
+    ints:Signed8 x4 = 100;
+    ints:Unsigned32 x5 = 4294967295;
+    ints:Unsigned16 x6 = 450;
+    ints:Unsigned8 x7 = 221;
+    byte x8 = 10;
+
+    string s1 = "12";
+    string s2 = "2147483647";
+    string s3 = "-32768";
+    string s4 = "100";
+    string s5 = "4294967295";
+    string s6 = "450";
+    string s7 = "221";
+    string s8 = "10";
+
+    assert(s1.fromBalString(), x1);
+    assert(s2.fromBalString(), x2);
+    assert(s3.fromBalString(), x3);
+    assert(s4.fromBalString(), x4);
+    assert(s5.fromBalString(), x5);
+    assert(s6.fromBalString(), x6);
+    assert(s7.fromBalString(), x7);
+    assert(s8.fromBalString(), x8);
+}
+
+function testStringValueFromBalString() {
+    string a = "Anne";
+    strings:Char b = "m";
+
+    string aa = a.toBalString();
+    string bb = b.toBalString();
+
+    assert(aa.fromBalString(), a);
+    assert(bb.fromBalString(), b);
+}
+
+function testFloatingPointNumbersFromBalString() {
+    float x1 = 12.342;
+    float x2 = 0.0/0.0;
+    float x3 = 4.0/0.0;
+    decimal x4 = 345.2425341;
+    decimal x5 = 1;
+
+    string s1 = "12.342";
+    string s2 = "float:NaN";
+    string s3 = "float:Infinity";
+    string s4 = "345.2425341d";
+    string s5 = "1d";
+
+    assert(s1.fromBalString(), x1);
+    assert(s2.fromBalString(), x2);
+    assert(s3.fromBalString(), x3);
+    assert(s4.fromBalString(), x4);
+    assert(s5.fromBalString(), x5);
+}
+
+function testAnydataNilFromBalString() {
+    anydata a = 99;
+    () b = ();
+
+    string s1 = "99";
+    string s2 = "()";
+
+    assert(s1.fromBalString(), a);
+    assert(s2.fromBalString(), b);
+}
+
+function testMapFromBalString() {
+    map<string> mapVal1 = {"name":"ABC", "school":"City College"};
+    map<anydata|error> mapVal2 = {"1":12, "2":"James", "3":{"x":"AA","y":(1.0/0.0)}, "4":(),
+            "5":error("Failed to get account balance", details = true)};
+
+    string s1 = "{\"name\":\"ABC\",\"school\":\"City College\"}";
+    string s2 = "{\"1\":12,\"2\":\"James\",\"3\":{\"x\":\"AA\",\"y\":float:Infinity},\"4\":()," +
+                         "\"5\":error error (\"Failed to get account balance\",details=true)}";
+
+    anydata|error result1 = s1.fromBalString();
+    anydata|error result2 = s2.fromBalString();
+
+    if (result1 is map<string>) {
+        assert(result1, mapVal1);
+        assert(result1.keys(), ["name","school"]);
+        string str = "";
+        result1.forEach(function (string val) {
+            str += val;
+        });
+        assert(str, "ABCCity College");
+    }
+
+    if (result2 is map<anydata|error>) {
+        assert(result2.keys(), ["1","2","3","4","5"]);
+        assert(result2.get("1"), mapVal2.get("1"));
+        assert(result2.get("2"), mapVal2.get("2"));
+        assert(result2.get("3"), mapVal2.get("3"));
+        assert(result2.get("4"), mapVal2.get("4"));
+        assert(result2.get("5") is error, true);
+    }
+}
+
+
+function testTableFromBalString() {
+    string s1 = "table key(name) [{\"id\":1,\"name\":\"Mary\",\"grade\":12}," +
+                      "{\"id\":2,\"name\":\"John\",\"grade\":13}]";
+    string s2 = "table key() [{\"id\":1,\"name\":\"Mary\",\"grade\":12}," +
+                       "{\"id\":2,\"name\":\"John\",\"grade\":13}]";
+
+    anydata|error tbl = s1.fromBalString();
+    if (tbl is table<any|error>) {
+        tbl.add({ id: 3, name: "Jane", grade: 13 });
+    }
+}
+
+function testArrayFromBalString() {
+    decimal x1 = 345.2425341;
+    error err = error("Failed to get account balance", details = true, val1 = (0.0/0.0), val2 = "This Error",
+           val3 = {"x":"AA","y":(1.0/0.0)});
+    xml xmlVal = xml `<CATALOG><CD><TITLE>Empire Burlesque</TITLE><ARTIST>Bob Dylan</ARTIST></CD></CATALOG>`;
+    table<UndergradStudent> underGradTable = table key(id,name) [
+            { id: 1, name: "Mary", grade: 12 },
+            { id: 2, name: "John", grade: 13 }
+    ];
+
+    int[] arr1 = [1, 2, 3, 4, 5];
+    float[] arr2 = [12, 12.34, (0.0/0.0), (1.0/0.0)];
+    boolean[] arr3 = [true, false, true, true];
+    byte[] arr4 = [12, 10, 9, 8];
+    string[] arr5 = ["ABC", "XYZ", "LMN"];
+    decimal[] arr6 = [12.65, 1, 2, 90.0];
+    (anydata|error)[] arr7 = ["str", 23, 23.4, true, {"x":"AA","y":(1.0/0.0),"z":1.23}, x1, ["X", (0.0/0.0),
+    x1], underGradTable, err, xmlVal];
+
+    string s1 = "[1,2,3,4,5]";
+    string s2 = "[12.0,12.34,float:NaN,float:Infinity]";
+    string s3 = "[true,false,true,true]";
+    string s4 = "[12,10,9,8]";
+    string s5 = "[\"ABC\",\"XYZ\",\"LMN\"]";
+    string s6 = "[12.65d,1d,2d,90.0d]";
+    string s7 = "[\"str\",23,23.4,true,{\"x\":\"AA\",\"y\":float:Infinity,\"z\":1.23},345.2425341d," +
+      "[\"X\",float:NaN,345.2425341d],error error (\"Failed to get account balance\",details=true," +
+      "val1=float:NaN,val2=\"This Error\",val3={\"x\":\"AA\",\"y\":float:Infinity}),xml`<CATALOG><CD>" +
+      "<TITLE>Empire Burlesque</TITLE><ARTIST>Bob Dylan</ARTIST></CD></CATALOG>`]";
+
+    assert(s1.fromBalString(), arr1);
+    assert(s2.fromBalString(), arr2);
+    assert(s3.fromBalString(), arr3);
+    assert(s4.fromBalString(), arr4);
+    assert(s5.fromBalString(), arr5);
+    assert(s6.fromBalString(), arr6);
+
+    anydata|error result = s7.fromBalString();
+    if (result is (anydata|error)[]) {
+        assert(result[0], arr7[0]);
+        assert(result[1], arr7[1]);
+        assert(result[2], arr7[2]);
+        assert(result[3], arr7[3]);
+        assert(result[4], arr7[4]);
+        assert(result[5], arr7[5]);
+        assert(result[6], arr7[6]);
+        assert(result[7] is error && result[7] != arr7[8], true);
+        assert(result[8], arr7[9]);
+    }
+}
+
+function testTupleFromBalString() {
+    [string, int, decimal, float] tupleVal = ["TOM", 10, 90.12, (0.0/0.0)];
+
+    string s1 = "\"TOM\" 10 90.12d float:NaN";
+
+    anydata|error result = s1.fromBalString();
+
+    if (result is [string, int, decimal, float]) {
+        assert(result, tupleVal);
+    }
+}
+
+function testJsonFromBalString() {
+    json jsonVal = {a: "STRING", b: 12, c: 12.4, d: true, e: {x:"x", y: ()}};
+
+    string s1 = "{\"a\":\"STRING\",\"b\":12,\"c\":12.4,\"d\":true,\"e\":{\"x\":\"x\",\"y\":()}}";
+
+    anydata|error result = s1.fromBalString();
+
+    if (result is json) {
+        assert(result, jsonVal);
+    }
+}
+
+function testXmlFromBalString() {
+    xml x1 = xml `<CATALOG><CD><TITLE>Empire Burlesque</TITLE><ARTIST>Bob Dylan</ARTIST></CD></CATALOG>`;
+    xml x2 = xml `Hello, world!`;
+    xml x3 = xml `<!--I am a comment-->`;
+    xml x4 = xml `<?xxtarget this mk data this?>`;
+    xml x5 = x1 + x2 + x3 + x4;
+
+    string s1 = x1.toBalString();
+    string s2 = x2.toBalString();
+    string s3 = x3.toBalString();
+    string s4 = x4.toBalString();
+    string s5 = x5.toBalString();
+
+    anydata|error result1 = s1.fromBalString();
+    anydata|error result2 = s2.fromBalString();
+    anydata|error result3 = s3.fromBalString();
+    anydata|error result4 = s4.fromBalString();
+    anydata|error result5 = s5.fromBalString();
+
+    if (result1 is xml && result2 is xml && result3 is xml && result4 is xml && result5 is xml) {
+        assert(result1, x1);
+        assert(result2, x2);
+        assert(result3, x3);
+        assert(result4, x4);
+        assert(result5, x5);
+    }
+}
+
+function testObjectFromString() {
+    Student obj1 = new("Alaa", "MMV");
+    Teacher obj2 = new("Rola", "MMV");
+
+    string s1 = obj1.toBalString();
+    string s2 = obj2.toBalString();
+
+    anydata|error result1 = s1.fromBalString();
+    anydata|error result2 = s2.fromBalString();
+
+    assert(result1 is error, true);
+    assert(result2 is error, true);
+}
+
+function testFromBalStringOnCycles() {
+     string s1 = "{\"ee\":3,\"1\":{\"mm\":5,\"1\":...[1],\"2\":{\"qq\":5,\"1\":[2,3,5,...[1]]," +
+        "\"2\":...[1],\"3\":...[1],\"4\":...[1]}},\"2\":{\"qq\":5,\"1\":[2,3,5,...[1]],\"2\":...[1],\"3\":...[1]," +
+        "\"4\":{\"mm\":5,\"1\":...[1],\"2\":...[1]}},\"3\":...[1]}";
+
+     anydata|error result = s1.fromBalString();
+
+     if (result is map<anydata|error>) {
+         assert(result.get("3") is error, true);
+     }
+}
+
+function assert(anydata|error actual, anydata|error expected) {
+    if (expected != actual) {
+        typedesc<anydata|error> expT = typeof expected;
+        typedesc<anydata|error> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}


### PR DESCRIPTION
## Purpose
$title

Fixes #26057

## Approach
Parses and evaluates a subset of Ballerina expression syntax. 
Return the result of evaluating the parsed expression, or an error if the string cannot be parsed.
The subset of Ballerina expression syntax supported is that produced by toBalString when applied to an `anydata` value

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
