### PR TITLE
Fix handling fail and return during exec validity

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -724,14 +724,13 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         if (this.statementReturns) {
             this.dlog.error(stmt.pos, DiagnosticCode.UNREACHABLE_CODE);
             this.resetStatementReturns();
+        } else if (errorThrown) {
+            this.dlog.error(stmt.pos, DiagnosticCode.UNREACHABLE_CODE);
+            this.resetErrorThrown();
         }
         if (lastStatement) {
             this.dlog.error(stmt.pos, DiagnosticCode.UNREACHABLE_CODE);
             this.resetLastStatement();
-        }
-        if (errorThrown) {
-            this.dlog.error(stmt.pos, DiagnosticCode.UNREACHABLE_CODE);
-            this.resetErrorThrown();
         }
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/whilestatement/WhileStmtTest.java
@@ -253,7 +253,7 @@ public class WhileStmtTest {
 
     @Test(description = "Check not incompatible types and reachable statements.")
     public void testNegative1() {
-        Assert.assertEquals(onfailNegativeCompileResult.getErrorCount(), 5);
+        Assert.assertEquals(onfailNegativeCompileResult.getErrorCount(), 7);
         BAssertUtil.validateError(onfailNegativeCompileResult, 0, "unreachable code", 17, 6);
         BAssertUtil.validateError(onfailNegativeCompileResult, 1, "incompatible error definition type: " +
                 "'ErrorTypeA' will not be matched to 'ErrorTypeB'", 34, 4);
@@ -261,5 +261,7 @@ public class WhileStmtTest {
         BAssertUtil.validateError(onfailNegativeCompileResult, 3, "this function must return a result", 74, 1);
         BAssertUtil.validateError(onfailNegativeCompileResult, 4, "incompatible error definition type: " +
                 "'ErrorTypeB' will not be matched to 'ErrorTypeA'", 102, 4);
+        BAssertUtil.validateError(onfailNegativeCompileResult, 5, "unreachable code", 116, 9);
+        BAssertUtil.validateError(onfailNegativeCompileResult, 6, "unreachable code", 118, 5);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt-on-fail-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/whilestatement/while-stmt-on-fail-negative.bal
@@ -106,3 +106,14 @@ function testOnFailWithUnion (int i) returns string {
    str += "-> Execution continues...";
    return str;
 }
+
+function testErrroDuplication() returns error? {
+    string str = "";
+    int i = 3;
+    while (i > 2) {
+        i -= 1;
+        fail error("Custom Error");
+        str += "-> unreachable";
+    }
+    str += "-> unreachable";
+}


### PR DESCRIPTION
## Purpose
> $subject

Fixes #26201

## Approach
> Check execution validity for error visits after return visit check

## Samples
> n/a

## Remarks
> n/a

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
