### PR TITLE
Disable multi-module code coverage

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -153,15 +153,14 @@ public class CoverageReport {
                         }
 
                         // Only add the source files that belong to the same module
-                        if (sourceFileModule.equals(moduleName)) {
-                            ModuleCoverage.getInstance().addSourceFileCoverage(sourceFileModule,
+                        if (sourceFileModule.equals(moduleName.replace(".", "_"))) {
+                            ModuleCoverage.getInstance().addSourceFileCoverage(moduleName,
                                     sourceFileCoverage.getName(), coveredLines, missedLines);
                         } else {
-                            // <org>/<modulename>/<version>
-                            String jsonCachePath = this.jsonCache.toString() +
-                                    resolveSourcePackage(sourceFileCoverage.getPackageName());
-                            ModuleCoverage.getInstance().updateSourceFileCoverage(jsonCachePath, sourceFileModule,
-                                    sourceFileCoverage.getName(), coveredLines, missedLines);
+                            // Disabling temporarily till support for modules with '.' is implemented
+//                            // <org>/<modulename>/<version>
+//                            ModuleCoverage.getInstance().updateSourceFileCoverage(jsonCachePath, sourceFileModule,
+//                                    sourceFileCoverage.getName(), coveredLines, missedLines);
                         }
                     }
                 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/ModuleCoverage.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/ModuleCoverage.java
@@ -183,7 +183,7 @@ public class ModuleCoverage {
             try (Stream<String> stream = Files.lines(sourceFile, StandardCharsets.UTF_8)) {
                 stream.forEach(s -> contentBuilder.append(s).append("\n"));
             } catch (IOException e) {
-                errStream.println("error while analyzing code coverage" + e);
+                errStream.println("error while analyzing code coverage source files : " + e);
                 Runtime.getRuntime().exit(1);
             }
             this.sourceCode = contentBuilder.toString();

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -150,17 +150,17 @@ public class TestReportTest extends BaseTestCase {
         int fooCovered = fooMainCovered.length, fooMissed = fooMainMissed.length;
 
         //bar module
-        int[] barMainCovered = new int[] {19}, barMainMissed = new int[] {};
-        float barMainPercentageVal =
-                (float) (barMainCovered.length) / (barMainMissed.length + barMainCovered.length) * 100;
-        float barMainPercentage =
-                (float) (Math.round(barMainPercentageVal * 100.0) / 100.0);
-
-        int barCovered = barMainCovered.length, barMissed = barMainMissed.length;
+//        int[] barMainCovered = new int[] {19}, barMainMissed = new int[] {};
+//        float barMainPercentageVal =
+//                (float) (barMainCovered.length) / (barMainMissed.length + barMainCovered.length) * 100;
+//        float barMainPercentage =
+//                (float) (Math.round(barMainPercentageVal * 100.0) / 100.0);
+//
+//        int barCovered = barMainCovered.length, barMissed = barMainMissed.length;
 
         // project
-        int totalCovered = mathCovered + barCovered + fooCovered;
-        int totalMissed =  mathMissed + barMissed + fooMissed;
+        int totalCovered = mathCovered + fooCovered;
+        int totalMissed =  mathMissed + fooMissed;
         float coveragePercentageVal = (float) (totalCovered) / (totalCovered + totalMissed) * 100;
         float coveragePercentage = (float) (Math.round(coveragePercentageVal * 100.0) / 100.0);
 
@@ -210,18 +210,18 @@ public class TestReportTest extends BaseTestCase {
                 Assert.assertEquals(fooMissed, moduleObj.get("missedLines").getAsInt());
                 Assert.assertEquals(fooMainPercentage, moduleObj.get("coveragePercentage").getAsFloat());
             } else if ("bar".equals(moduleObj.get("name").getAsString())) {
-                JsonObject fileObj = (JsonObject) moduleObj.get("sourceFiles").getAsJsonArray().get(0);
-                Assert.assertEquals("main.bal", fileObj.get("name").getAsString());
-                Assert.assertEquals(parser.parse(Arrays.toString(barMainCovered)),
-                        parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
-                Assert.assertEquals(parser.parse(Arrays.toString(barMainMissed)),
-                        parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
-                Assert.assertEquals(barMainPercentage, fileObj.get("coveragePercentage").getAsFloat());
-
-                // Verify coverage of module
-                Assert.assertEquals(barCovered, moduleObj.get("coveredLines").getAsInt());
-                Assert.assertEquals(barMissed, moduleObj.get("missedLines").getAsInt());
-                Assert.assertEquals(barMainPercentage, moduleObj.get("coveragePercentage").getAsFloat());
+//                JsonObject fileObj = (JsonObject) moduleObj.get("sourceFiles").getAsJsonArray().get(0);
+//                Assert.assertEquals("main.bal", fileObj.get("name").getAsString());
+//                Assert.assertEquals(parser.parse(Arrays.toString(barMainCovered)),
+//                        parser.parse(fileObj.get("coveredLines").getAsJsonArray().toString()));
+//                Assert.assertEquals(parser.parse(Arrays.toString(barMainMissed)),
+//                        parser.parse(fileObj.get("missedLines").getAsJsonArray().toString()));
+//                Assert.assertEquals(barMainPercentage, fileObj.get("coveragePercentage").getAsFloat());
+//
+//                // Verify coverage of module
+//                Assert.assertEquals(barCovered, moduleObj.get("coveredLines").getAsInt());
+//                Assert.assertEquals(barMissed, moduleObj.get("missedLines").getAsInt());
+//                Assert.assertEquals(barMainPercentage, moduleObj.get("coveragePercentage").getAsFloat());
             } else if ("bartests".equals(moduleObj.get("name").getAsString())) {
                 // No module coverage for bar_tests
             } else {


### PR DESCRIPTION
## Purpose
Disable multi-module coverage for modules with 'dot .'
Fixes 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
