### PR TITLE
Provide support to add optional parameters in OAuth2 introspection request [1.2.x]

### DIFF
--- a/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
+++ b/stdlib/oauth2/src/main/ballerina/src/oauth2/inbound_oauth2_provider.bal
@@ -90,7 +90,7 @@ public type InboundOAuth2Provider object {
         map<json>? optionalParameters = self.optionalParameters;
         if (optionalParameters is map<json>) {
             foreach var [key, value] in optionalParameters.entries() {
-                textPayload += "&" + key + "=" + value;
+                textPayload += "&" + key + "=" + value.toJsonString();
             }
         }
         req.setTextPayload(textPayload, mime:APPLICATION_FORM_URLENCODED);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/OAuth2ServiceTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/OAuth2ServiceTest.java
@@ -51,12 +51,12 @@ public class OAuth2ServiceTest extends AuthBaseTest {
         assertUnauthorized(response);
     }
 
-    @Test(description = "Test inbound OAuth2 success with valid token and custom field in the introspection response")
-    public void testOAuth2SuccessWithCustomResponseFieldTest() throws Exception {
+    @Test(description = "Test inbound OAuth2 success with valid token and custom parameter in the introspection request and response")
+    public void testOAuth2SuccessWithCustomParameterTest() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", "Bearer 2YotnFZFEjr1zCsicMWpAA");
         HttpResponse response = HttpsClientRequest.doGet(serverInstance.getServiceURLHttps(servicePort, "echo/test"),
                                                          headers, serverInstance.getServerHome());
-        assertContains(response, "twenty-seven");
+        assertContains(response, "custom-value");
     }
 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/OAuth2ServiceTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/auth/OAuth2ServiceTest.java
@@ -51,7 +51,8 @@ public class OAuth2ServiceTest extends AuthBaseTest {
         assertUnauthorized(response);
     }
 
-    @Test(description = "Test inbound OAuth2 success with valid token and custom parameter in the introspection request and response")
+    @Test(description = "Test inbound OAuth2 success with valid token and custom parameter in the introspection " +
+            "request and response")
     public void testOAuth2SuccessWithCustomParameterTest() throws Exception {
         Map<String, String> headers = new HashMap<>();
         headers.put("Authorization", "Bearer 2YotnFZFEjr1zCsicMWpAA");

--- a/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/21_oauth2_service_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/21_oauth2_service_test.bal
@@ -28,6 +28,10 @@ http:BasicAuthHandler basicAuthHandler = new(basicAuthProvider);
 
 oauth2:IntrospectionServerConfig introspectionServerConfig = {
     url: "https://localhost:20102/oauth2/token/introspect",
+    tokenTypeHint: "access_token",
+    optionalParameters: {
+        "custom": "custom-value"
+    },
     clientConfig: {
         auth: {
             authHandler: basicAuthHandler

--- a/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/oauth2-mock-server.bal
+++ b/tests/jballerina-integration-test/src/test/resources/auth/src/authservices/oauth2-mock-server.bal
@@ -333,11 +333,15 @@ function getResponseForIntrospectRequest(http:Request req, string authorizationH
             string[] params = stringutils:split(payload, "&");
             string token = "";
             string tokenTypeHint = "";
+            string optionalParameter = "";
             foreach string param in params {
                 if (stringutils:contains(param, "token")) {
                     token = stringutils:split(param, "=")[1];
                 } else if (stringutils:contains(param, "token_type_hint")) {
                     tokenTypeHint = stringutils:split(param, "=")[1];
+                } else {
+                    // For demo purpose, keep only the last optional parameter.
+                    optionalParameter = stringutils:split(param, "=")[1];
                 }
             }
 
@@ -357,7 +361,7 @@ function getResponseForIntrospectRequest(http:Request req, string authorizationH
                                          "iss": "https://server.example.com/",
                                          "exp": 1419356238,
                                          "iat": 1419350238,
-                                         "extension_field": "twenty-seven"
+                                         "extension_field": optionalParameter
                                        };
                 res.setPayload(responsePayload);
             } else {


### PR DESCRIPTION
## Purpose
This PR provide the capability to add the optional parameters to the OAuth2 introspection request [1]. The updated `oauth2:IntrospectionServerConfig` is as follows:

```balllerina
public type IntrospectionServerConfig record {|
    string url;
    string tokenTypeHint?;
    map<json> optionalParameters?;
    cache:Cache oauth2Cache?;
    int defaultTokenExpTimeInSeconds = 3600;
    http:ClientConfiguration clientConfig = {};
|};
```

Example:

```ballerina
oauth2:IntrospectionServerConfig introspectionServerConfig = {
    url: "https://localhost:20102/oauth2/token/introspect",
    tokenTypeHint: "access_token",
    optionalParameters: {
        "custom": "custom-value"
    },
    clientConfig: {
        auth: {
            authHandler: basicAuthHandler
        },
        secureSocket: {
           trustStore: {
               path: config:getAsString("truststore"),
               password: "ballerina"
           }
        }
    }
};
```

[1] https://tools.ietf.org/html/rfc7662#section-2.1

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
