### PR TITLE
Fix the incorrect mandatory attribute in parser node `ServiceDeclarationNode`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -1048,7 +1048,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
     @Override
     public BLangNode transform(ServiceDeclarationNode serviceDeclrNode) {
-        return createService(serviceDeclrNode, serviceDeclrNode.serviceName(), false);
+        return createService(serviceDeclrNode, serviceDeclrNode.serviceName().orElse(null), false);
     }
 
     private BLangNode createService(Node serviceNode, IdentifierToken serviceNameNode, boolean isAnonServiceValue) {

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeFactory.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/NodeFactory.java
@@ -153,7 +153,6 @@ public abstract class NodeFactory extends AbstractNodeFactory {
             SeparatedNodeList<ExpressionNode> expressions,
             Node serviceBody) {
         Objects.requireNonNull(serviceKeyword, "serviceKeyword must not be null");
-        Objects.requireNonNull(serviceName, "serviceName must not be null");
         Objects.requireNonNull(onKeyword, "onKeyword must not be null");
         Objects.requireNonNull(expressions, "expressions must not be null");
         Objects.requireNonNull(serviceBody, "serviceBody must not be null");
@@ -161,7 +160,7 @@ public abstract class NodeFactory extends AbstractNodeFactory {
         STNode stServiceDeclarationNode = STNodeFactory.createServiceDeclarationNode(
                 getOptionalSTNode(metadata),
                 serviceKeyword.internalNode(),
-                serviceName.internalNode(),
+                getOptionalSTNode(serviceName),
                 onKeyword.internalNode(),
                 expressions.underlyingListNode().internalNode(),
                 serviceBody.internalNode());

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/ServiceDeclarationNode.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/ServiceDeclarationNode.java
@@ -41,8 +41,8 @@ public class ServiceDeclarationNode extends ModuleMemberDeclarationNode {
         return childInBucket(1);
     }
 
-    public IdentifierToken serviceName() {
-        return childInBucket(2);
+    public Optional<IdentifierToken> serviceName() {
+        return optionalChildInBucket(2);
     }
 
     public Token onKeyword() {
@@ -126,7 +126,7 @@ public class ServiceDeclarationNode extends ModuleMemberDeclarationNode {
             this.oldNode = oldNode;
             this.metadata = oldNode.metadata().orElse(null);
             this.serviceKeyword = oldNode.serviceKeyword();
-            this.serviceName = oldNode.serviceName();
+            this.serviceName = oldNode.serviceName().orElse(null);
             this.onKeyword = oldNode.onKeyword();
             this.expressions = oldNode.expressions();
             this.serviceBody = oldNode.serviceBody();

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/TreeModifier.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/syntax/tree/TreeModifier.java
@@ -157,7 +157,7 @@ public abstract class TreeModifier extends NodeTransformer<Node> {
         Token serviceKeyword =
                 modifyToken(serviceDeclarationNode.serviceKeyword());
         IdentifierToken serviceName =
-                modifyNode(serviceDeclarationNode.serviceName());
+                modifyNode(serviceDeclarationNode.serviceName().orElse(null));
         Token onKeyword =
                 modifyToken(serviceDeclarationNode.onKeyword());
         SeparatedNodeList<ExpressionNode> expressions =

--- a/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
+++ b/compiler/ballerina-treegen/src/main/resources/syntax_tree_descriptor.json
@@ -195,7 +195,8 @@
                 },
                 {
                     "name": "serviceName",
-                    "type": "IdentifierToken"
+                    "type": "IdentifierToken",
+                    "isOptional": true
                 },
                 {
                     "name": "onKeyword",

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -659,9 +659,13 @@ public class FormattingTreeModifier extends TreeModifier {
             MetadataNode metadata = formatNode(serviceDeclarationNode.metadata().get(), 1, 0);
             serviceDeclarationNode = serviceDeclarationNode.modify().withMetadata(metadata).apply();
         }
-
         Token serviceKeyword = formatToken(serviceDeclarationNode.serviceKeyword(), 1, 0);
-        IdentifierToken serviceName = formatToken(serviceDeclarationNode.serviceName(), 1, 0);
+
+        if (serviceDeclarationNode.serviceName().isPresent()) {
+            IdentifierToken serviceName = formatToken(serviceDeclarationNode.serviceName().get(), 1, 0);
+            serviceDeclarationNode = serviceDeclarationNode.modify().withServiceName(serviceName).apply();
+        }
+
         Token onKeyword = formatToken(serviceDeclarationNode.onKeyword(), 1, 0);
         SeparatedNodeList<ExpressionNode> expressions =
                 formatSeparatedNodeList(serviceDeclarationNode.expressions(), 0, 0, 1, 0);
@@ -669,7 +673,6 @@ public class FormattingTreeModifier extends TreeModifier {
 
         return serviceDeclarationNode.modify()
                 .withServiceKeyword(serviceKeyword)
-                .withServiceName(serviceName)
                 .withOnKeyword(onKeyword)
                 .withExpressions(expressions)
                 .withServiceBody(serviceBody)


### PR DESCRIPTION
## Purpose
The parser node `ServiceDeclarationNode` has the mandatory attribute `serviceName` which should actually be made optional as per the Ballerina specification [1].

[1] https://ballerina.io/spec/lang/draft/v2020-09-22/#service-decl

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
