### PR TITLE
Remove skipping of compilation when module exists in packageCache

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -196,11 +196,6 @@ class ModuleContext {
             bootstrap.loadLangLibSymbols(compilerContext);
         }
 
-        // if this is already loaded from BALO, then skip rest of the compilation
-        if (packageCache.get(pkgId) != null) {
-            return;
-        }
-
         BLangPackage pkgNode = (BLangPackage) TreeBuilder.createPackageNode();
         packageCache.put(pkgId, pkgNode);
 


### PR DESCRIPTION
## Purpose
> Remove skipping of compilation when module exists in packageCache

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
