### PR TITLE
Fix minor bug in VisibleEndpointVisitor

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/VisibleEndpointVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/VisibleEndpointVisitor.java
@@ -243,6 +243,7 @@ public class VisibleEndpointVisitor extends LSNodeVisitor {
     }
 
     private boolean isClient(BSymbol symbol) {
-        return (symbol.flags & Flags.CLIENT) == Flags.CLIENT;
+        return symbol.type != null && symbol.type.tsymbol != null
+                && (symbol.type.tsymbol.flags & Flags.CLIENT) == Flags.CLIENT;
     }
 }


### PR DESCRIPTION
## Purpose
> The visible endpoint visitor was failing to identify caller objects as clients.

## Approach
> Checking for client flag should be done through the type symbol. The isClient method had been updated to check this.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
