### PR TITLE
[Testerina] Allow function mocking to mock isolated functions with non-isolated functions

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestAnnotationProcessor.java
@@ -38,6 +38,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.BLangFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
@@ -50,9 +51,11 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
@@ -356,6 +359,15 @@ public class TestAnnotationProcessor extends AbstractCompilerPlugin {
                     BType functionToMockType = getFunctionType(packageEnvironmentMap, functionToMockID, vals[1]);
                     BType mockFunctionType = getFunctionType(packageEnvironmentMap, parent.packageID,
                             ((BLangFunction) functionNode).name.toString());
+                    if (functionToMockType != null && Symbols.isFlagOn(functionToMockType.flags, Flags.ISOLATED) &&
+                            !Symbols.isFlagOn(mockFunctionType.flags, Flags.ISOLATED)) {
+                        Set<Flag> flagList = Flags.unMask(functionToMockType.flags);
+                        if (flagList.contains(Flag.ISOLATED)) {
+                            flagList.remove(Flag.ISOLATED);
+                        }
+                        functionToMockType.flags = Flags.asMask(flagList);
+                    }
+
 
                     if (functionToMockType != null && mockFunctionType != null) {
                         if (!typeChecker.isAssignable(mockFunctionType, functionToMockType)) {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
@@ -156,7 +156,7 @@ public class BasicCasesTest extends BaseTestCase {
 
     @Test
     public void testIsolatedFunctions() throws BallerinaTestException {
-        String msg = "2 passing";
+        String msg = "3 passing";
         LogLeecher clientLeecher = new LogLeecher(msg);
         balClient.runMain("test", new String[]{"isolated-functions"}, null,
                 new String[]{}, new LogLeecher[]{clientLeecher}, projectPath);

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/isolated-functions/isolated-functions.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/isolated-functions/isolated-functions.bal
@@ -13,5 +13,26 @@
 // KIND, either express or implied.  See the License for the
 // specific language governing permissions and limitations
 // under the License.
+import ballerina/java;
+
+isolated function system_out() returns handle = @java:FieldGet {
+    name: "out",
+    'class: "java.lang.System"
+} external;
+
+isolated function println(handle receiver, handle arg0) = @java:Method {
+    name: "println",
+    'class: "java.io.PrintStream",
+    paramTypes: ["java.lang.String"]
+} external;
+
+isolated function print(string str) {
+    println(system_out(), java:fromString(str));
+}
+
+public function main() {
+   print("hello-isolated");
+   print("hello-non-isolated");
+}
 
 isolated function bar() returns int => 34;

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/isolated-functions/tests/test-isolated-functions.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/isolated-functions/tests/test-isolated-functions.bal
@@ -16,6 +16,9 @@
 
 import ballerina/test;
 
+string[] outputs = [];
+int counter = 0;
+
 @test:Config {}
 function testCallingIsolatedFunction() {
     test:assertEquals(bar(), 34);
@@ -24,4 +27,19 @@ function testCallingIsolatedFunction() {
 @test:Config {}
 isolated function testIsolatedTestFunction() {
     test:assertTrue(true);
+}
+
+@test:Mock {
+    functionName: "print"
+}
+public function mockPrint(string s) {
+    outputs[counter] = s;
+    counter += 1;
+}
+
+@test:Config {}
+function testFunc() {
+    main();
+    test:assertEquals(outputs[0], "hello-isolated");
+    test:assertEquals(outputs[1], "hello-non-isolated");
 }


### PR DESCRIPTION
## Purpose
> Allow function mocking to mock isolated functions with non-isolated functions

Fixes #26498

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
