### PR TITLE
Update Netty-tcnative to 2.0.31.Final

### DIFF
--- a/distribution/zip/jballerina-tools/LICENSE
+++ b/distribution/zip/jballerina-tools/LICENSE
@@ -203,7 +203,7 @@ java.arrays.jar                                                                 
 xml-1.1.0.jar                                                                                       jar            apache2
 lang.string.jar                                                                                     jar            apache2
 netty-codec-4.1.39.Final.jar                                                                        bundle         apache2
-netty-tcnative-boringssl-static-2.0.25.Final.jar                                                    bundle         apache2
+netty-tcnative-boringssl-static-2.0.31.Final.jar                                                    bundle         apache2
 axiom-dom-1.2.22.jar                                                                                bundle         apache2
 ballerina-system-1.1.0.jar                                                                          jar            apache2
 lang.float.jar                                                                                      jar            apache2

--- a/distribution/zip/jballerina/LICENSE
+++ b/distribution/zip/jballerina/LICENSE
@@ -203,7 +203,7 @@ java.arrays.jar                                                                 
 xml-1.1.0.jar                                                                                       jar            apache2
 lang.string.jar                                                                                     jar            apache2
 netty-codec-4.1.39.Final.jar                                                                        bundle         apache2
-netty-tcnative-boringssl-static-2.0.25.Final.jar                                                    bundle         apache2
+netty-tcnative-boringssl-static-2.0.31.Final.jar                                                    bundle         apache2
 axiom-dom-1.2.22.jar                                                                                bundle         apache2
 ballerina-system-1.1.0.jar                                                                          jar            apache2
 lang.float.jar                                                                                      jar            apache2

--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -65,7 +65,7 @@ dependencies {
     dist 'io.netty:netty-handler-proxy:4.1.50.Final'
     dist 'io.netty:netty-handler:4.1.50.Final'
     dist 'io.netty:netty-resolver:4.1.50.Final'
-    dist 'io.netty:netty-tcnative-boringssl-static:2.0.25.Final'
+    dist 'io.netty:netty-tcnative-boringssl-static:2.0.31.Final'
     dist 'io.netty:netty-transport:4.1.50.Final'
     dist 'commons-pool.wso2:commons-pool:1.5.6.wso2v1'
     dist 'org.wso2.carbon.messaging:org.wso2.carbon.messaging:2.3.7'

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -113,7 +113,7 @@ dependencies {
         implementation 'io.netty:netty-codec-http:4.1.50.Final'
         implementation 'io.netty:netty-codec-http2:4.1.50.Final'
         implementation 'io.netty:netty-handler:4.1.50.Final'
-        implementation 'io.netty:netty-tcnative-boringssl-static:2.0.25.Final'
+        implementation 'io.netty:netty-tcnative-boringssl-static:2.0.31.Final'
         implementation 'io.netty:netty-transport:4.1.50.Final'
         implementation 'io.nats:java-nats-streaming:2.2.1'
         implementation 'io.nats:jnats:2.6.0'

--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -119,8 +119,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "netty-tcnative-boringssl-static"
-    version = "2.0.25.Final"
-    path = "./lib/netty-tcnative-boringssl-static-2.0.25.Final.jar"
+    version = "2.0.31.Final"
+    path = "./lib/netty-tcnative-boringssl-static-2.0.31.Final.jar"
     groupId = "io.netty"
     modules = ["grpc"]
 

--- a/stdlib/http/src/main/ballerina/Ballerina.toml
+++ b/stdlib/http/src/main/ballerina/Ballerina.toml
@@ -112,8 +112,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "netty-tcnative-boringssl-static"
-    version = "2.0.25.Final"
-    path = "./lib/netty-tcnative-boringssl-static-2.0.25.Final.jar"
+    version = "2.0.31.Final"
+    path = "./lib/netty-tcnative-boringssl-static-2.0.31.Final.jar"
     groupId = "io.netty"
     modules = ["http"]
 

--- a/stdlib/mime/src/main/ballerina/Ballerina.toml
+++ b/stdlib/mime/src/main/ballerina/Ballerina.toml
@@ -119,7 +119,7 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "netty-tcnative-boringssl-static"
-    version = "2.0.25.Final"
-    path = "./lib/netty-tcnative-boringssl-static-2.0.25.Final.jar"
+    version = "2.0.31.Final"
+    path = "./lib/netty-tcnative-boringssl-static-2.0.31.Final.jar"
     groupId = "io.netty"
     modules = ["mime"]

--- a/stdlib/websub/src/main/ballerina/Ballerina.toml
+++ b/stdlib/websub/src/main/ballerina/Ballerina.toml
@@ -112,8 +112,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "netty-tcnative-boringssl-static"
-    version = "2.0.25.Final"
-    path = "./lib/netty-tcnative-boringssl-static-2.0.25.Final.jar"
+    version = "2.0.31.Final"
+    path = "./lib/netty-tcnative-boringssl-static-2.0.31.Final.jar"
     groupId = "io.netty"
     modules = ["web-sub"]
 


### PR DESCRIPTION
## Purpose
Tests of product-microgateway package was failing on aarch64 as "ballerina-lang" is using older netty-tcnative-boringssl-static(2.0.25.Final) libraries that don't have support for aarch64. 
Refer: https://github.com/wso2/product-microgateway/issues/1326

Fixes #26373

## Approach
Update Netty-tcnative to 2.0.31.Final which have aarch64 support