### PR TITLE
Remove separation of main tags & additional tags

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -112,12 +112,12 @@ public class ObserveUtils {
         observerContext.setResourceName(resourceName.getValue());
         observerContext.setServer();
 
-        observerContext.addMainTag(TAG_KEY_MODULE, pkg.getValue());
-        observerContext.addMainTag(TAG_KEY_INVOCATION_POSITION, position.getValue());
-        observerContext.addMainTag(TAG_KEY_IS_RESOURCE_ENTRY_POINT, TAG_TRUE_VALUE);
-        observerContext.addMainTag(TAG_KEY_SERVICE, observerContext.getServiceName());
-        observerContext.addMainTag(TAG_KEY_RESOURCE, observerContext.getResourceName());
-        observerContext.addMainTag(TAG_KEY_CONNECTOR_NAME, observerContext.getObjectName());
+        observerContext.addTag(TAG_KEY_MODULE, pkg.getValue());
+        observerContext.addTag(TAG_KEY_INVOCATION_POSITION, position.getValue());
+        observerContext.addTag(TAG_KEY_IS_RESOURCE_ENTRY_POINT, TAG_TRUE_VALUE);
+        observerContext.addTag(TAG_KEY_SERVICE, observerContext.getServiceName());
+        observerContext.addTag(TAG_KEY_RESOURCE, observerContext.getResourceName());
+        observerContext.addTag(TAG_KEY_CONNECTOR_NAME, observerContext.getObjectName());
 
         observerContext.setStarted();
         observers.forEach(observer -> observer.startServerObservation(strand.observerContext));
@@ -206,29 +206,29 @@ public class ObserveUtils {
         }
         newObContext.setFunctionName(functionName.getValue());
 
-        newObContext.addMainTag(TAG_KEY_MODULE, pkg.getValue());
-        newObContext.addMainTag(TAG_KEY_INVOCATION_POSITION, position.getValue());
+        newObContext.addTag(TAG_KEY_MODULE, pkg.getValue());
+        newObContext.addTag(TAG_KEY_INVOCATION_POSITION, position.getValue());
         if (isRemote) {
-            newObContext.addMainTag(TAG_KEY_IS_REMOTE, TAG_TRUE_VALUE);
-            newObContext.addMainTag(TAG_KEY_ACTION, newObContext.getFunctionName());
-            newObContext.addMainTag(TAG_KEY_CONNECTOR_NAME, newObContext.getObjectName());
+            newObContext.addTag(TAG_KEY_IS_REMOTE, TAG_TRUE_VALUE);
+            newObContext.addTag(TAG_KEY_ACTION, newObContext.getFunctionName());
+            newObContext.addTag(TAG_KEY_CONNECTOR_NAME, newObContext.getObjectName());
         }
         if (isMainEntryPoint) {
-            newObContext.addMainTag(TAG_KEY_IS_MAIN_ENTRY_POINT, TAG_TRUE_VALUE);
+            newObContext.addTag(TAG_KEY_IS_MAIN_ENTRY_POINT, TAG_TRUE_VALUE);
         }
         if (isWorker) {
-            newObContext.addMainTag(TAG_KEY_IS_WORKER, TAG_TRUE_VALUE);
+            newObContext.addTag(TAG_KEY_IS_WORKER, TAG_TRUE_VALUE);
         }
         if (!isRemote && !isWorker) {
-            newObContext.addMainTag(TAG_KEY_FUNCTION, newObContext.getFunctionName());
+            newObContext.addTag(TAG_KEY_FUNCTION, newObContext.getFunctionName());
             if (!StringUtils.isEmpty(newObContext.getObjectName())) {
-                newObContext.addMainTag(TAG_KEY_OBJECT_NAME, newObContext.getObjectName());
+                newObContext.addTag(TAG_KEY_OBJECT_NAME, newObContext.getObjectName());
             }
         }
         if (!UNKNOWN_SERVICE.equals(newObContext.getServiceName())) {
             // If service is present, resource should be too
-            newObContext.addMainTag(TAG_KEY_SERVICE, newObContext.getServiceName());
-            newObContext.addMainTag(TAG_KEY_RESOURCE, newObContext.getResourceName());
+            newObContext.addTag(TAG_KEY_SERVICE, newObContext.getServiceName());
+            newObContext.addTag(TAG_KEY_RESOURCE, newObContext.getResourceName());
         }
 
         newObContext.setStarted();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/BallerinaMetricsObserver.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/BallerinaMetricsObserver.java
@@ -81,10 +81,10 @@ public class BallerinaMetricsObserver implements BallerinaObserver {
 
     private void startObservation(ObserverContext observerContext) {
         observerContext.addProperty(PROPERTY_START_TIME, System.nanoTime());
-        Set<Tag> mainTags = observerContext.getMainTags();
+        Set<Tag> tags = observerContext.getAllTags();
         try {
             Gauge inProgressGauge = metricRegistry.gauge(new MetricId("inprogress_requests", "In-progress requests",
-                    mainTags));
+                    tags));
             inProgressGauge.increment();
             /*
              * The in progress counter is stored so that the same counter can be decremted when the observation
@@ -93,24 +93,24 @@ public class BallerinaMetricsObserver implements BallerinaObserver {
              */
             observerContext.addProperty(PROPERTY_IN_PROGRESS_COUNTER, inProgressGauge);
         } catch (RuntimeException e) {
-            handleError("inprogress_requests", mainTags, e);
+            handleError("inprogress_requests", tags, e);
         }
     }
 
     private void stopObservation(ObserverContext observerContext) {
-        Set<Tag> allTags = observerContext.getAllTags();
+        Set<Tag> tags = observerContext.getAllTags();
         try {
             Long startTime = (Long) observerContext.getProperty(PROPERTY_START_TIME);
             long duration = System.nanoTime() - startTime;
             ((Gauge) observerContext.getProperty(PROPERTY_IN_PROGRESS_COUNTER)).decrement();
-            metricRegistry.gauge(new MetricId("response_time_seconds", "Response time",
-                    allTags), responseTimeStatisticConfigs).setValue(duration / 1E9);
+            metricRegistry.gauge(new MetricId("response_time_seconds",
+                    "Response time", tags), responseTimeStatisticConfigs).setValue(duration / 1E9);
             metricRegistry.counter(new MetricId("response_time_nanoseconds_total",
-                    "Total response response time for all requests", allTags)).increment(duration);
+                    "Total response response time for all requests", tags)).increment(duration);
             metricRegistry.counter(new MetricId("requests_total",
-                    "Total number of requests", allTags)).increment();
+                    "Total number of requests", tags)).increment();
         } catch (RuntimeException e) {
-            handleError("multiple metrics", allTags, e);
+            handleError("multiple metrics", tags, e);
         }
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/MetricRegistry.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/MetricRegistry.java
@@ -133,12 +133,12 @@ public class MetricRegistry {
     }
 
     private <M extends Metric> M getOrCreate(MetricId id, Class<M> metricClass, Supplier<M> metricSupplier) {
-        Metric metric = readMetric(id, metricClass);
+        M metric = readMetric(id, metricClass);
         if (metric == null) {
-            Metric newMetric = metricSupplier.get();
+            M newMetric = metricSupplier.get();
             return writeMetricIfNotExists(newMetric, metricClass);
         } else {
-            return (M) metric;
+            return metric;
         }
     }
 
@@ -155,7 +155,7 @@ public class MetricRegistry {
         return null;
     }
 
-    private <M extends Metric> M writeMetricIfNotExists(Metric metric, Class<M> metricClass) {
+    private <M extends Metric> M writeMetricIfNotExists(M metric, Class<M> metricClass) {
         final Metric existing = metrics.putIfAbsent(metric.getId(), metric);
         if (existing != null) {
             if (metricClass.isInstance(existing)) {
@@ -165,19 +165,19 @@ public class MetricRegistry {
                         + metricClass.getSimpleName());
             }
         }
-        return (M) metric;
+        return metric;
     }
 
-    private <M extends Metric> M register(Metric registerMetric, Class<M> metricClass) {
-        Metric metric = readMetric(registerMetric.getId(), metricClass);
+    private <M extends Metric> M register(M registerMetric, Class<M> metricClass) {
+        M metric = readMetric(registerMetric.getId(), metricClass);
         if (metric == null) {
             return writeMetricIfNotExists(registerMetric, metricClass);
         } else {
-            return (M) metric;
+            return metric;
         }
     }
 
-    private void unregister(Metric registerMetric, Class metricClass) {
+    private <M extends Metric> void unregister(Metric registerMetric, Class<M> metricClass) {
         Metric metric = readMetric(registerMetric.getId(), metricClass);
         if (metric != null) {
             metrics.remove(registerMetric.getId());

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
@@ -51,9 +51,8 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
 
     private final ScheduledExecutorService executorService;
     private final Task task;
-    private final int maxQueueSize;
 
-    public ChoreoJaegerReporter(int maxQueueSize) {
+    public ChoreoJaegerReporter() {
         ChoreoClient choreoClient;
         try {
             choreoClient = ChoreoClientHolder.getChoreoClient(this);
@@ -67,7 +66,6 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
             throw new IllegalStateException("Choreo client is not initialized");
         }
 
-        this.maxQueueSize = maxQueueSize;
         executorService = new ScheduledThreadPoolExecutor(1);
         task = new Task(choreoClient);
         executorService.scheduleAtFixedRate(task, PUBLISH_INTERVAL_SECS, PUBLISH_INTERVAL_SECS, TimeUnit.SECONDS);
@@ -77,9 +75,6 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
     @Override
     public void report(JaegerSpan jaegerSpan) {
         task.append(jaegerSpan);
-        if (task.getSpanCount() >= maxQueueSize) {
-            executorService.execute(task);
-        }
     }
 
     @Override

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/OpenTracerExtension.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/OpenTracerExtension.java
@@ -67,7 +67,7 @@ public class OpenTracerExtension implements OpenTracer {
         if (reporterInstance == null) { // Singleton instance is used since getTracer can get called multiple times
             synchronized (this) {
                 if (reporterInstance == null) {
-                    reporterInstance = new ChoreoJaegerReporter(2000);
+                    reporterInstance = new ChoreoJaegerReporter();
                 }
             }
         }


### PR DESCRIPTION
## Purpose
> Two separate tags maps were added initially to support the inprogress requests gauge.

## Approach
> This had been removed with this PR and the complications in inprogress requests gauge had been handled by storing the gauge as a property when the Observation starts. Moreover, this contains some minor fixes to the Metrics Registry and some of the Observability extensions.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
