### PR TITLE
Move Strand properties access to Environment api

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Environment.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Environment.java
@@ -17,7 +17,6 @@
  */
 package io.ballerina.runtime.api;
 
-import io.ballerina.runtime.scheduling.Scheduler;
 import io.ballerina.runtime.scheduling.State;
 import io.ballerina.runtime.scheduling.Strand;
 
@@ -44,7 +43,6 @@ public class Environment {
      * @return BalFuture which will resume the current strand when completed.
      */
     public Future markAsync() {
-        Strand strand = Scheduler.getStrand();
         strand.blockedOnExtern = true;
         strand.setState(State.BLOCK_AND_YIELD);
         return new Future(this.strand);
@@ -52,5 +50,13 @@ public class Environment {
 
     public Runtime getRuntime() {
         return new Runtime(strand.scheduler);
+    }
+
+    public void setStrandLocal(String key, Object value) {
+        strand.setProperty(key, value);
+    }
+
+    public Object getStrandLocal(String key) {
+        return strand.getProperty(key);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Runtime.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/Runtime.java
@@ -19,9 +19,6 @@ package io.ballerina.runtime.api;
 import io.ballerina.runtime.api.async.Callback;
 import io.ballerina.runtime.api.async.StrandMetadata;
 import io.ballerina.runtime.api.values.BObject;
-import io.ballerina.runtime.observability.ObservabilityConstants;
-import io.ballerina.runtime.observability.ObserveUtils;
-import io.ballerina.runtime.observability.ObserverContext;
 import io.ballerina.runtime.scheduling.Scheduler;
 import io.ballerina.runtime.scheduling.Strand;
 
@@ -86,15 +83,10 @@ public class Runtime {
      */
     public void invokeMethodAsync(BObject object, String methodName, String strandName, StrandMetadata metadata,
                                   Callback callback, Map<String, Object> properties, Object... args) {
-        Function<Object[], Object> func = objects -> {
-            Strand strand = (Strand) objects[0];
-            if (ObserveUtils.isObservabilityEnabled() && properties != null &&
-                    properties.containsKey(ObservabilityConstants.KEY_OBSERVER_CONTEXT)) {
-                strand.observerContext =
-                        (ObserverContext) properties.remove(ObservabilityConstants.KEY_OBSERVER_CONTEXT);
-            }
-            return object.call(strand, methodName, args);
-        };
+        if (object == null) {
+            throw new NullPointerException();
+        }
+        Function<?, ?> func = o -> object.call((Strand) (((Object[]) o)[0]), methodName, args);
         scheduler.schedule(new Object[1], func, null, callback, properties, PredefinedTypes.TYPE_NULL, strandName,
                            metadata);
     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -18,11 +18,11 @@
 
 package io.ballerina.runtime.observability;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.observability.tracer.BSpan;
 import io.ballerina.runtime.scheduling.Scheduler;
-import io.ballerina.runtime.scheduling.Strand;
 import io.ballerina.runtime.values.ErrorValue;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.config.ConfigRegistry;
@@ -31,12 +31,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.Supplier;
 
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_METRICS_ENABLED;
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
+import static io.ballerina.runtime.observability.ObservabilityConstants.KEY_OBSERVER_CONTEXT;
 import static io.ballerina.runtime.observability.ObservabilityConstants.PROPERTY_KEY_HTTP_STATUS_CODE;
 import static io.ballerina.runtime.observability.ObservabilityConstants.STATUS_CODE_GROUP_SUFFIX;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ACTION;
@@ -93,19 +93,16 @@ public class ObserveUtils {
      * @param pkg The package the resource belongs to
      * @param position The source code position the resource in defined in
      */
-    public static void startResourceObservation(BString serviceName, BString resourceName, BString pkg,
+    public static void startResourceObservation(Environment env, BString serviceName, BString resourceName, BString pkg,
                                                 BString position) {
         if (!enabled) {
             return;
         }
 
-        ObserverContext observerContext;
-        Strand strand = Scheduler.getStrand();
-        if (strand.observerContext != null) {
-            observerContext = strand.observerContext;
-        } else {
+        ObserverContext observerContext = getObserverContextOfCurrentFrame(env);
+        if (observerContext == null) {
             observerContext = new ObserverContext();
-            setObserverContextToCurrentFrame(strand, observerContext);
+            setObserverContextToCurrentFrame(env, observerContext);
         }
         String service = serviceName.getValue() == null ? UNKNOWN_SERVICE : serviceName.getValue();
         observerContext.setServiceName(service);
@@ -120,22 +117,22 @@ public class ObserveUtils {
         observerContext.addMainTag(TAG_KEY_CONNECTOR_NAME, observerContext.getObjectName());
 
         observerContext.setStarted();
-        observers.forEach(observer -> observer.startServerObservation(strand.observerContext));
-        strand.setProperty(ObservabilityConstants.SERVICE_NAME, service);
+        ObserverContext copyOfObserverContext = observerContext;
+        observers.forEach(observer -> observer.startServerObservation(copyOfObserverContext));
+        env.setStrandLocal(ObservabilityConstants.SERVICE_NAME, service);
     }
 
     /**
      * Stop observation of an observer context.
      */
-    public static void stopObservation() {
+    public static void stopObservation(Environment env) {
         if (!enabled) {
             return;
         }
-        Strand strand = Scheduler.getStrand();
-        if (strand.observerContext == null) {
+        ObserverContext observerContext = getObserverContextOfCurrentFrame(env);
+        if (observerContext == null) {
             return;
         }
-        ObserverContext observerContext = strand.observerContext;
 
         Integer statusCode = (Integer) observerContext.getProperty(PROPERTY_KEY_HTTP_STATUS_CODE);
         if (statusCode != null && statusCode >= 100) {
@@ -147,7 +144,7 @@ public class ObserveUtils {
         } else {
             observers.forEach(observer -> observer.stopClientObservation(observerContext));
         }
-        setObserverContextToCurrentFrame(strand, observerContext.getParent());
+        setObserverContextToCurrentFrame(env, observerContext.getParent());
         observerContext.setFinished();
     }
 
@@ -156,15 +153,14 @@ public class ObserveUtils {
      *
      * @param errorValue the error value to be attached to the observer context
      */
-    public static void reportError(ErrorValue errorValue) {
+    public static void reportError(Environment env, ErrorValue errorValue) {
         if (!enabled) {
             return;
         }
-        Strand strand = Scheduler.getStrand();
-        if (strand.observerContext == null) {
+        ObserverContext observerContext = getObserverContextOfCurrentFrame(env);
+        if (observerContext == null) {
             return;
         }
-        ObserverContext observerContext = strand.observerContext;
         observers.forEach(observer -> {
             observerContext.addTag(ObservabilityConstants.TAG_KEY_ERROR, TAG_TRUE_VALUE);
             observerContext.addProperty(ObservabilityConstants.PROPERTY_BSTRUCT_ERROR, errorValue);
@@ -182,14 +178,13 @@ public class ObserveUtils {
      * @param pkg The package the resource belongs to
      * @param position The source code position the resource in defined in
      */
-    public static void startCallableObservation(boolean isRemote, boolean isMainEntryPoint, boolean isWorker,
-                                                BObject typeDef, BString functionName, BString pkg,
+    public static void startCallableObservation(Environment env, boolean isRemote, boolean isMainEntryPoint,
+                                                boolean isWorker, BObject typeDef, BString functionName, BString pkg,
                                                 BString position) {
         if (!enabled) {
             return;
         }
-        Strand strand = Scheduler.getStrand();
-        ObserverContext observerCtx = strand.observerContext;
+        ObserverContext observerCtx = getObserverContextOfCurrentFrame(env);
 
         ObserverContext newObContext = new ObserverContext();
         newObContext.setParent(observerCtx);
@@ -232,7 +227,7 @@ public class ObserveUtils {
         }
 
         newObContext.setStarted();
-        setObserverContextToCurrentFrame(strand, newObContext);
+        setObserverContextToCurrentFrame(env, newObContext);
         observers.forEach(observer -> observer.startClientObservation(newObContext));
     }
 
@@ -262,12 +257,12 @@ public class ObserveUtils {
         if (!tracingEnabled) {
             return;
         }
-        Strand strand = Scheduler.getStrand();
-        Optional<ObserverContext> observerContext = getObserverContextOfCurrentFrame(strand);
-        if (!observerContext.isPresent()) {
+        Environment balEnv = new Environment(Scheduler.getStrand());
+        ObserverContext observerContext = (ObserverContext) balEnv.getStrandLocal(KEY_OBSERVER_CONTEXT);
+        if (observerContext == null) {
             return;
         }
-        BSpan span = (BSpan) observerContext.get().getProperty(KEY_SPAN);
+        BSpan span = (BSpan) observerContext.getProperty(KEY_SPAN);
         if (span == null) {
             return;
         }
@@ -310,26 +305,27 @@ public class ObserveUtils {
     /**
      * Get observer context of the current frame.
      *
-     * @param strand current context
+     * @param env current env
      * @return observer context of the current frame
      */
-    public static Optional<ObserverContext> getObserverContextOfCurrentFrame(Strand strand) {
-        if (!enabled || strand.observerContext == null) {
-            return Optional.empty();
+    public static ObserverContext getObserverContextOfCurrentFrame(Environment env) {
+        if (!enabled) {
+            return null;
         }
-        return Optional.of(strand.observerContext);
+
+        return (ObserverContext) env.getStrandLocal(KEY_OBSERVER_CONTEXT);
     }
 
     /**
      * Set the observer context to the current frame.
      *
-     * @param strand current strand
+     * @param env current env
      * @param observerContext observer context to be set
      */
-    public static void setObserverContextToCurrentFrame(Strand strand, ObserverContext observerContext) {
+    public static void setObserverContextToCurrentFrame(Environment env, ObserverContext observerContext) {
         if (!enabled) {
             return;
         }
-        strand.observerContext = observerContext;
+        env.setStrandLocal(KEY_OBSERVER_CONTEXT, observerContext);
     }
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/scheduling/Scheduler.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/scheduling/Scheduler.java
@@ -455,9 +455,6 @@ public class Scheduler {
     }
 
     private FutureValue createFuture(Strand parent, Callback callback, Type constraint, Strand newStrand) {
-        if (parent != null) {
-            newStrand.observerContext = parent.observerContext;
-        }
         FutureValue future = new FutureValue(newStrand, callback, constraint);
         future.strand.frames = new Object[100];
         return future;

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -25,7 +25,11 @@ module io.ballerina.runtime {
     exports io.ballerina.runtime.util.exceptions;
     exports io.ballerina.runtime.launch;
     exports io.ballerina.runtime;
-    exports io.ballerina.runtime.scheduling;
+    exports io.ballerina.runtime.scheduling to
+                io.ballerina.lang.array, io.ballerina.testerina.runtime, io.ballerina.lang.error, io.ballerina.java,
+                io.ballerina.lang.map, io.ballerina.lang.table, io.ballerina.lang.value, io.ballerina.lang.xml,
+                io.ballerina.lang.transaction, io.ballerina.log.api, io.ballerina.testerina.core,
+                io.ballerina.cli.utils;
     exports io.ballerina.runtime.observability;
     exports io.ballerina.runtime.transactions;
     exports io.ballerina.runtime.services;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -81,6 +81,7 @@ import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ENV;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
@@ -578,8 +579,8 @@ class JvmObservabilityGen {
         JIMethodCall observeStartCallTerminator = new JIMethodCall(null);
         observeStartCallTerminator.invocationType = INVOKESTATIC;
         observeStartCallTerminator.jClassName = OBSERVE_UTILS;
-        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;L%s;L%s;L%s;)V", B_STRING_VALUE, B_STRING_VALUE,
-                                                                B_STRING_VALUE, B_STRING_VALUE);
+        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;L%s;L%s;L%s;L%s;)V",
+                                        BAL_ENV, B_STRING_VALUE, B_STRING_VALUE, B_STRING_VALUE, B_STRING_VALUE);
         observeStartCallTerminator.name = START_RESOURCE_OBSERVATION_METHOD;
         observeStartCallTerminator.args = Arrays.asList(serviceNameOperand, resourceOperand, pkgOperand,
                 originalInsPosOperand);
@@ -617,8 +618,8 @@ class JvmObservabilityGen {
         JIMethodCall observeStartCallTerminator = new JIMethodCall(desugaredInsPos);
         observeStartCallTerminator.invocationType = INVOKESTATIC;
         observeStartCallTerminator.jClassName = OBSERVE_UTILS;
-        observeStartCallTerminator.jMethodVMSig = String.format("(ZZZL%s;L%s;L%s;L%s;)V", B_OBJECT, B_STRING_VALUE,
-                                                                B_STRING_VALUE, B_STRING_VALUE);
+        observeStartCallTerminator.jMethodVMSig = String.format("(L%s;ZZZL%s;L%s;L%s;L%s;)V", BAL_ENV, B_OBJECT,
+                                                                B_STRING_VALUE, B_STRING_VALUE, B_STRING_VALUE);
         observeStartCallTerminator.name = START_CALLABLE_OBSERVATION_METHOD;
         observeStartCallTerminator.args = Arrays.asList(isRemoteOperand, isMainEntryPointOperand, isWorkerOperand,
                 objectOperand, actionOperand, pkgOperand, originalInsPosOperand);
@@ -672,7 +673,7 @@ class JvmObservabilityGen {
         JIMethodCall reportErrorCallTerminator = new JIMethodCall(pos);
         reportErrorCallTerminator.invocationType = INVOKESTATIC;
         reportErrorCallTerminator.jClassName = OBSERVE_UTILS;
-        reportErrorCallTerminator.jMethodVMSig = String.format("(L%s;)V", ERROR_VALUE);
+        reportErrorCallTerminator.jMethodVMSig = String.format("(L%s;L%s;)V", BAL_ENV, ERROR_VALUE);
         reportErrorCallTerminator.name = REPORT_ERROR_METHOD;
         reportErrorCallTerminator.args = Collections.singletonList(castedErrorOperand);
         errorReportBB.terminator = reportErrorCallTerminator;
@@ -688,7 +689,7 @@ class JvmObservabilityGen {
         JIMethodCall observeEndCallTerminator = new JIMethodCall(pos);
         observeEndCallTerminator.invocationType = INVOKESTATIC;
         observeEndCallTerminator.jClassName = OBSERVE_UTILS;
-        observeEndCallTerminator.jMethodVMSig = "()V";
+        observeEndCallTerminator.jMethodVMSig = String.format("(L%s;)V", BAL_ENV);
         observeEndCallTerminator.name = STOP_OBSERVATION_METHOD;
         observeEndCallTerminator.args = Collections.emptyList();
         observeEndBB.terminator = observeEndCallTerminator;

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/AddTagToSpan.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/AddTagToSpan.java
@@ -19,10 +19,10 @@
 
 package org.ballerinalang.observe.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.ErrorCreator;
 import io.ballerina.runtime.api.StringUtils;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.runtime.scheduling.Scheduler;
 
 /**
  * This function adds tags to a span.
@@ -30,9 +30,8 @@ import io.ballerina.runtime.scheduling.Scheduler;
 public class AddTagToSpan {
     private static final OpenTracerBallerinaWrapper otWrapperInstance = OpenTracerBallerinaWrapper.getInstance();
 
-    public static Object addTagToSpan(BString tagKey, BString tagValue, long spanId) {
-        boolean tagAdded = otWrapperInstance.addTag(tagKey.getValue(), tagValue.getValue(),
-                                                    spanId, Scheduler.getStrand());
+    public static Object addTagToSpan(Environment env, BString tagKey, BString tagValue, long spanId) {
+        boolean tagAdded = otWrapperInstance.addTag(env, tagKey.getValue(), tagValue.getValue(), spanId);
 
         if (tagAdded) {
             return null;

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/FinishSpan.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/FinishSpan.java
@@ -19,9 +19,9 @@
 
 package org.ballerinalang.observe.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.ErrorCreator;
 import io.ballerina.runtime.api.StringUtils;
-import io.ballerina.runtime.scheduling.Scheduler;
 
 /**
  * This function which implements the finishSpan method for observe.
@@ -30,8 +30,8 @@ import io.ballerina.runtime.scheduling.Scheduler;
 public class FinishSpan {
     private static final OpenTracerBallerinaWrapper otWrapperInstance = OpenTracerBallerinaWrapper.getInstance();
 
-    public static Object finishSpan(long spanId) {
-        boolean isFinished = OpenTracerBallerinaWrapper.getInstance().finishSpan(Scheduler.getStrand(), spanId);
+    public static Object finishSpan(Environment env, long spanId) {
+        boolean isFinished = OpenTracerBallerinaWrapper.getInstance().finishSpan(env, spanId);
 
         if (isFinished) {
             return null;

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -19,17 +19,16 @@
 
 package org.ballerinalang.observe.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.observability.ObserveUtils;
 import io.ballerina.runtime.observability.ObserverContext;
 import io.ballerina.runtime.observability.TracingUtils;
 import io.ballerina.runtime.observability.tracer.TracersStore;
-import io.ballerina.runtime.scheduling.Strand;
 import io.opentracing.Tracer;
 import org.ballerinalang.config.ConfigRegistry;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_TRACING_ENABLED;
@@ -70,22 +69,22 @@ public class OpenTracerBallerinaWrapper {
     /**
      * Method to start a span using parent span context.
      *
+     * @param env          native context
      * @param serviceName  name of the service to which the span is attached to
      * @param spanName     name of the span
      * @param tags         key value paired tags to attach to the span
      * @param parentSpanId id of parent span
-     * @param strand       native context
      * @return unique id of the created span
      */
-    public long startSpan(String serviceName, String spanName, Map<String, String> tags, long parentSpanId,
-                          Strand strand) {
+    public long startSpan(Environment env, String serviceName, String spanName, Map<String, String> tags,
+                          long parentSpanId) {
         if (!enabled) {
             return -1;
         }
 
-        Optional<ObserverContext> observerContextOfCurrentFrame = ObserveUtils.getObserverContextOfCurrentFrame(strand);
-        if (serviceName == null && observerContextOfCurrentFrame.isPresent()) {
-            serviceName = observerContextOfCurrentFrame.get().getServiceName();
+        ObserverContext currentObserverContext = ObserveUtils.getObserverContextOfCurrentFrame(env);
+        if (serviceName == null && currentObserverContext != null) {
+            serviceName = currentObserverContext.getServiceName();
         }
         if (serviceName == null) {
             serviceName = UNKNOWN_SERVICE;
@@ -98,15 +97,16 @@ public class OpenTracerBallerinaWrapper {
 
         ObserverContext observerContext = new ObserverContext();
         observerContext.setServiceName(serviceName);
-        observerContext.setResourceName(observerContextOfCurrentFrame.isPresent()
-                ? observerContextOfCurrentFrame.get().getResourceName()
-                : UNKNOWN_RESOURCE);
+        observerContext.setResourceName(currentObserverContext != null ? currentObserverContext.getResourceName()
+                                                                       : UNKNOWN_RESOURCE);
         tags.forEach((observerContext::addTag));
 
         if (parentSpanId == SYSTEM_TRACE_INDICATOR) {
             observerContext.setSystemSpan(true);
-            observerContextOfCurrentFrame.ifPresent(observerContext::setParent);
-            ObserveUtils.setObserverContextToCurrentFrame(strand, observerContext);
+            if (currentObserverContext != null) {
+                observerContext.setParent(currentObserverContext);
+            }
+            ObserveUtils.setObserverContextToCurrentFrame(env, observerContext);
             return startSpan(observerContext, true, spanName);
         } else if (parentSpanId != ROOT_SPAN_INDICATOR) {
             ObserverContext parentOContext = observerContextMap.get(parentSpanId);
@@ -124,18 +124,18 @@ public class OpenTracerBallerinaWrapper {
      * Method to mark a span as finished.
      *
      *
-     * @param strand current context
+     * @param env current environment
      * @param spanId id of the Span
      * @return boolean to indicate if span was finished
      */
-    public boolean finishSpan(Strand strand, long spanId) {
+    public boolean finishSpan(Environment env, long spanId) {
         if (!enabled) {
             return false;
         }
         ObserverContext observerContext = observerContextMap.get(spanId);
         if (observerContext != null) {
             if (observerContext.isSystemSpan()) {
-                ObserveUtils.setObserverContextToCurrentFrame(strand, observerContext.getParent());
+                ObserveUtils.setObserverContextToCurrentFrame(env, observerContext.getParent());
             }
             TracingUtils.stopObservation(observerContext);
             observerContext.setFinished();
@@ -149,20 +149,20 @@ public class OpenTracerBallerinaWrapper {
     /**
      * Method to add tags to an existing span.
      *
+     * @param env current environment
      * @param tagKey the key of the tag
      * @param tagValue the value of the tag
      * @param spanId id of the Span
-     * @param strand current strand
      * @return boolean to indicate if tag was added to the span
      */
-    public boolean addTag(String tagKey, String tagValue, long spanId, Strand strand) {
+    public boolean addTag(Environment env, String tagKey, String tagValue, long spanId) {
         if (!enabled) {
             return false;
         }
         if (spanId == -1) {
-            Optional<ObserverContext> observer = ObserveUtils.getObserverContextOfCurrentFrame(strand);
-            if (observer.isPresent()) {
-                observer.get().addTag(tagKey, tagValue);
+            ObserverContext observer = ObserveUtils.getObserverContextOfCurrentFrame(env);
+            if (observer != null) {
+                observer.addTag(tagKey, tagValue);
                 return true;
             }
         }

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/StartRootSpan.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/StartRootSpan.java
@@ -19,10 +19,10 @@
 
 package org.ballerinalang.observe.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.observability.ObservabilityConstants;
-import io.ballerina.runtime.scheduling.Scheduler;
 
 import static org.ballerinalang.observe.nativeimpl.OpenTracerBallerinaWrapper.ROOT_SPAN_INDICATOR;
 
@@ -32,10 +32,9 @@ import static org.ballerinalang.observe.nativeimpl.OpenTracerBallerinaWrapper.RO
 
 public class StartRootSpan {
 
-    public static long startRootSpan(BString spanName, Object tags) {
-        return OpenTracerBallerinaWrapper.getInstance().startSpan(
-                (String) Scheduler.getStrand().getProperty(ObservabilityConstants.SERVICE_NAME),
-                spanName.getValue(), Utils.toStringMap((BMap<BString, ?>) tags), ROOT_SPAN_INDICATOR,
-                Scheduler.getStrand());
+    public static long startRootSpan(Environment env,  BString spanName, Object tags) {
+        return OpenTracerBallerinaWrapper.getInstance().startSpan(env,
+                        (String) env.getStrandLocal(ObservabilityConstants.SERVICE_NAME),
+                        spanName.getValue(), Utils.toStringMap((BMap<BString, ?>) tags), ROOT_SPAN_INDICATOR);
     }
 }

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/StartSpan.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/StartSpan.java
@@ -19,27 +19,28 @@
 
 package org.ballerinalang.observe.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.ErrorCreator;
 import io.ballerina.runtime.api.StringUtils;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.observability.ObservabilityConstants;
-import io.ballerina.runtime.scheduling.Scheduler;
 
 /**
  * This function which implements the startSpan method for observe.
  */
 
 public class StartSpan {
-    public static Object startSpan(BString spanName, Object tags, long parentSpanId) {
+    public static Object startSpan(Environment env, BString spanName, Object tags, long parentSpanId) {
         if (parentSpanId < -1) {
             return ErrorCreator.createError(
                     StringUtils.fromString(("The given parent span ID " + parentSpanId + " " + "is invalid.")));
         } else {
             long spanId = OpenTracerBallerinaWrapper.getInstance().startSpan(
-                    (String) Scheduler.getStrand().getProperty(ObservabilityConstants.SERVICE_NAME),
+                    env,
+                    (String) env.getStrandLocal(ObservabilityConstants.SERVICE_NAME),
                     spanName.getValue(),
-                    Utils.toStringMap((BMap<BString, ?>) tags), parentSpanId, Scheduler.getStrand());
+                    Utils.toStringMap((BMap<BString, ?>) tags), parentSpanId);
             if (spanId == -1) {
                 return ErrorCreator.createError(StringUtils.fromString((
                         "No parent span for ID " + parentSpanId + " found. Please recheck the parent span Id")));

--- a/stdlib/auth/src/main/java/org/ballerinalang/stdlib/auth/nativeimpl/GetInvocationContext.java
+++ b/stdlib/auth/src/main/java/org/ballerinalang/stdlib/auth/nativeimpl/GetInvocationContext.java
@@ -18,11 +18,10 @@
 
 package org.ballerinalang.stdlib.auth.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.ValueCreator;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.runtime.scheduling.Scheduler;
-import io.ballerina.runtime.scheduling.Strand;
 
 import static io.ballerina.runtime.util.BLangConstants.BALLERINA_AUTH_PKG_ID;
 
@@ -32,19 +31,19 @@ import static io.ballerina.runtime.util.BLangConstants.BALLERINA_AUTH_PKG_ID;
  */
 public class GetInvocationContext {
 
-    public static BMap<BString, Object> getInvocationContext() {
-        return getInvocationContextRecord(Scheduler.getStrand());
+    public static BMap<BString, Object> getInvocationContext(Environment env) {
+        return getInvocationContextRecord(env);
     }
 
     private static final String AUTH_INVOCATION_CONTEXT_PROPERTY = "AuthInvocationContext";
     private static final String RECORD_TYPE_INVOCATION_CONTEXT = "InvocationContext";
 
-    private static BMap<BString, Object> getInvocationContextRecord(Strand strand) {
+    private static BMap<BString, Object> getInvocationContextRecord(Environment env) {
         BMap<BString, Object> invocationContext =
-                (BMap<BString, Object>) strand.getProperty(AUTH_INVOCATION_CONTEXT_PROPERTY);
+                (BMap<BString, Object>) env.getStrandLocal(AUTH_INVOCATION_CONTEXT_PROPERTY);
         if (invocationContext == null) {
             invocationContext = ValueCreator.createRecordValue(BALLERINA_AUTH_PKG_ID, RECORD_TYPE_INVOCATION_CONTEXT);
-            strand.setProperty(AUTH_INVOCATION_CONTEXT_PROPERTY, invocationContext);
+            env.setStrandLocal(AUTH_INVOCATION_CONTEXT_PROPERTY, invocationContext);
         }
         return invocationContext;
     }

--- a/stdlib/runtime-api/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/GetInvocationContext.java
+++ b/stdlib/runtime-api/src/main/java/org/ballerinalang/stdlib/runtime/nativeimpl/GetInvocationContext.java
@@ -18,12 +18,11 @@
 
 package org.ballerinalang.stdlib.runtime.nativeimpl;
 
+import io.ballerina.runtime.api.Environment;
 import io.ballerina.runtime.api.StringUtils;
 import io.ballerina.runtime.api.ValueCreator;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.runtime.scheduling.Scheduler;
-import io.ballerina.runtime.scheduling.Strand;
 
 import java.util.UUID;
 
@@ -36,8 +35,8 @@ import static io.ballerina.runtime.util.BLangConstants.BALLERINA_RUNTIME_PKG_ID;
  */
 public class GetInvocationContext {
 
-    public static BMap<BString, Object> getInvocationContext() {
-        return getInvocationContextRecord(Scheduler.getStrand());
+    public static BMap<BString, Object> getInvocationContext(Environment env) {
+        return getInvocationContextRecord(env);
     }
 
     private static final String RUNTIME_INVOCATION_CONTEXT_PROPERTY = "RuntimeInvocationContext";
@@ -45,12 +44,12 @@ public class GetInvocationContext {
     private static final String INVOCATION_ID_KEY = "id";
     private static final String INVOCATION_ATTRIBUTES = "attributes";
 
-    private static BMap<BString, Object> getInvocationContextRecord(Strand strand) {
+    private static BMap<BString, Object> getInvocationContextRecord(Environment env) {
         BMap<BString, Object> invocationContext =
-                (BMap<BString, Object>) strand.getProperty(RUNTIME_INVOCATION_CONTEXT_PROPERTY);
+                (BMap<BString, Object>) env.getStrandLocal(RUNTIME_INVOCATION_CONTEXT_PROPERTY);
         if (invocationContext == null) {
             invocationContext = initInvocationContext();
-            strand.setProperty(RUNTIME_INVOCATION_CONTEXT_PROPERTY, invocationContext);
+            env.setStrandLocal(RUNTIME_INVOCATION_CONTEXT_PROPERTY, invocationContext);
         }
         return invocationContext;
     }


### PR DESCRIPTION
## Purpose

properties are access is moved to Environment api, now there is no need to use strand internal api to use properties. 

Properties are now inherited by child strands

Part of #25457
