### PR TITLE
Allow formatting assertion errors in readable manner

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/src/test/assert.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/src/test/assert.bal
@@ -133,7 +133,7 @@ public isolated function assertFail(string msg = "Test Failed!") {
 # + msg - Assertion error message
 #
 # + return - Error message constructed based on the compared values
-isolated function getInequalityErrorMsg(any|error actual, any|error expected, string msg = "Assertion Failed!") returns string {
+isolated function getInequalityErrorMsg(any|error actual, any|error expected, string msg = "\nAssertion Failed!") returns string {
         string expectedType = getBallerinaType(expected);
         string actualType = getBallerinaType(actual);
         string errorMsg = "";
@@ -146,14 +146,14 @@ isolated function getInequalityErrorMsg(any|error actual, any|error expected, st
             actualStr = actualStr.substring(0, maxArgLength) + "...";
         }
         if (expectedType != actualType) {
-            errorMsg = string `${msg}` + "\nexpected: " + string `<${expectedType}> '${expectedStr}'` + "\nactual\t: "
+            errorMsg = string `${msg}` + "\n \nexpected: " + string `<${expectedType}> '${expectedStr}'` + "\nactual\t: "
                 + string `<${actualType}> '${actualStr}'`;
         } else if (actual is string && expected is string) {
             string diff = getStringDiff(<string>actual, <string>expected);
-            errorMsg = string `${msg}` + "\nexpected: " + string `'${expectedStr}'` + "\nactual\t: "
-                                     + string `'${actualStr}'` + "\n\nDiff\t:\n\n" + string `${diff}` + "\n\n";
+            errorMsg = string `${msg}` + "\n \nexpected: " + string `'${expectedStr}'` + "\nactual\t: "
+                                     + string `'${actualStr}'` + "\n \nDiff\t:\n \n" + string `${diff}` + " \n";
         } else {
-            errorMsg = string `${msg}` + "\nexpected: " + string `'${expectedStr}'` + "\nactual\t: "
+            errorMsg = string `${msg}` + "\n \nexpected: " + string `'${expectedStr}'` + "\nactual\t: "
                                                  + string `'${actualStr}'`;
         }
         return errorMsg;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/AssertionDiffEvaluator.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/AssertionDiffEvaluator.java
@@ -78,12 +78,13 @@ public class AssertionDiffEvaluator {
                         output = output.concat("\n" + line + "\n");
                     }
                 } else if (line.startsWith("@@ -")) {
-                    output = output.concat(line + "\n\n");
+                    output = output.concat("\n" + line + "\n\n");
                 } else {
                     output = output.concat(line + "\n");
                 }
             }
         }
+        output = output.replaceAll("\n\n", " \n \n ");
         return StringUtils.fromString(output);
     }
 

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/assertions-error-messages/tests/assertions-diff-error-messages.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/assertions-error-messages/tests/assertions-diff-error-messages.bal
@@ -20,9 +20,9 @@ import ballerina/test;
 
 @test:Config {}
 function testAssertStringValues() {
-    error? err = trap test:assertEquals("hello dilhasha","hello dilhashaaa");
+    error? err = trap test:assertEquals("hello user1","hello user2");
     error result = <error>err;
-    test:assertTrue(result.message().toString().endsWith("--- expected\n+++ actual\n@@ -1,1 +1,1 @@\n\n-hello dilhasha\n+hello dilhashaaa\n\n\n"));
+    test:assertTrue(result.message().toString().endsWith("--- expected\n+++ actual \n \n @@ -1,1 +1,1 @@ \n \n -hello user1\n+hello user2\n \n"));
 }
 
 @test:Config {}
@@ -31,14 +31,14 @@ function testAssertLongStringValues() {
         string value2 = "Ballerina is an open source programming language and platform for cloud-era application " + "programmersss.\nSequence diagrams have been everyone’s favorite tool to describe how distributed & concurrent " + "programs work.";
         error? err = trap test:assertEquals(value1, value2);
         error result = <error>err;
-        test:assertTrue(result.message().toString().endsWith("Sequence diagrams have been everyone’s favorite tool to " + "describe how distributed\n- & conccurrent programs work.\n+ & concurrent programs work.\n\n\n"));
+        test:assertTrue(result.message().toString().endsWith("--- expected\n+++ actual \n \n @@ -1,4 +1,4 @@ \n \n  Ballerina is an open source programming language and platform for cloud-era appl\n-ication programmers.\n+ication programmersss.\n Sequence diagrams have been everyone’s favorite tool to describe how distributed\n- & conccurrent programs work.\n+ & concurrent programs work.\n \n"));
 }
 
 @test:Config {}
 function testAssertIntValues() {
     error? err = trap test:assertEquals(124, 123);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: '123'\nactual\t: '124'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: '123'\nactual\t: '124'");
 }
 
 @test:Config {}
@@ -47,7 +47,7 @@ function testAssertDecimalValues() {
     decimal f = 27.6;
     error? err = trap test:assertEquals(d, f);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: '27.6'\nactual\t: '27.5'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: '27.6'\nactual\t: '27.5'");
 }
 
 @test:Config {}
@@ -57,7 +57,7 @@ function testAssertJsonValues() {
     error? err = trap test:assertEquals(bioData, bioData2);
     error result = <error>err;
     test:assertEquals(result.message().toString(),
-    "Assertion Failed!\nexpected: '{\"name\":\"John Doe New\",\"age\":25,\"address\":{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka...'\nactual\t: '{\"name\":\"John Doe\",\"age\":25,\"address\":{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka\"}}'");
+    "Assertion Failed!\n \nexpected: '{\"name\":\"John Doe New\",\"age\":25,\"address\":{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka...'\nactual\t: '{\"name\":\"John Doe\",\"age\":25,\"address\":{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka\"}}'");
 }
 
 @test:Config {}
@@ -66,7 +66,7 @@ function testAssertLongJsonValues() {
     json bioData2 = {name:"John Doe New", age:25, designation: "SSE", address:{city:"Colombo", country:"Sri Lanka"}};
     error? err = trap test:assertEquals(bioData, bioData2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: '{\"name\":\"John Doe New\"," + "\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",...'\nactual\t: '{\"name\":" + 
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: '{\"name\":\"John Doe New\"," + "\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",...'\nactual\t: '{\"name\":" + 
     "\"John Doe Old\",\"age\":25,\"designation\":\"SSE\",\"address\":{\"city\":\"Colombo\",...'");
 }
 
@@ -76,7 +76,7 @@ function testAssertTuples() {
     [int, string] b = [12, "John"];
     error? err = trap test:assertEquals(a, b);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: '12 John'\nactual\t: '10 John'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: '12 John'\nactual\t: '10 John'");
 }
 
 @test:Config {}
@@ -86,5 +86,5 @@ function testAssertObjects() {
     person.name = "dilhasha";
     error? err = trap test:assertExactEquals(person, person2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: 'object assertions-error-messages:Person'\nactual\t: 'object assertions-error-messages:Person'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: 'object assertions-error-messages:Person'\nactual\t: 'object assertions-error-messages:Person'");
 }

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/assertions-error-messages/tests/assertions-error-messages.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/basic-tests/src/assertions-error-messages/tests/assertions-error-messages.bal
@@ -40,7 +40,7 @@ type CustomerTable table<map<any>>;
 function testAssertStringAndInt() {
     error? err = trap test:assertEquals(1, "1");
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <string> '1'\nactual\t: <int> '1'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <string> '1'\nactual\t: <int> '1'");
 }
 
 @test:Config {}
@@ -49,7 +49,7 @@ function testAssertDecimalAndFloat() {
     float f = 27.5;
     error? err = trap test:assertEquals(d, f);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <float> '27.5'\nactual\t: <decimal> '27.5'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <float> '27.5'\nactual\t: <decimal> '27.5'");
 }
 
 @test:Config {}
@@ -59,7 +59,7 @@ function testAssertJsonAndString() {
     error? err = trap test:assertEquals(bioData, bioDataString);
     error result = <error>err;
     test:assertEquals(result.message().toString(), 
-    "Assertion Failed!\nexpected: <string> '{name:\"John Doe\", age:25, address:{city:\"Colombo\", country:\"Sri " + "Lanka\"}}'\nactual\t: <map> '{\"name\":\"John Doe\",\"age\":25,\"address\":{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka\"}}'");
+    "Assertion Failed!\n \nexpected: <string> '{name:\"John Doe\", age:25, address:{city:\"Colombo\", country:\"Sri " + "Lanka\"}}'\nactual\t: <map> '{\"name\":\"John Doe\",\"age\":25,\"address\":{\"city\":\"Colombo\"," + "\"country\":\"Sri Lanka\"}}'");
 }
 
 @test:Config {}
@@ -69,7 +69,7 @@ function testAssertXmlAndString() {
     error? err = trap test:assertEquals(xmlString, xmlValue);
     error result = <error>err;
     test:assertEquals(result.message().toString(), 
-    "Assertion Failed!\nexpected: <xml> '<book>The Lost World</book>Hello, world!<!--I am a comment--><?target data?" + ">'\nactual\t: <string> '<book>The Lost World</book>Hello, world!<!--I am a comment--><?target data?>'");
+    "Assertion Failed!\n \nexpected: <xml> '<book>The Lost World</book>Hello, world!<!--I am a comment--><?target data?" + ">'\nactual\t: <string> '<book>The Lost World</book>Hello, world!<!--I am a comment--><?target data?>'");
 }
 
 @test:Config {}
@@ -79,7 +79,7 @@ function testAssertDifferentTuples() {
     error? err = trap test:assertEquals(a, b);
     error result = <error>err;
     test:assertEquals(result.message().toString(), 
-    "Assertion Failed!\nexpected: <[string,string]> '10 John'\nactual\t: <[int,string]> '10 John'");
+    "Assertion Failed!\n \nexpected: <[string,string]> '10 John'\nactual\t: <[int,string]> '10 John'");
 }
 
 @test:Config {}
@@ -92,7 +92,7 @@ function testAssertTableAndString() {
     error? err = trap test:assertEquals(customerTab, customerTabString);
     error result = <error>err;
     test:assertEquals(result.message().toString(), 
-    "Assertion Failed!\nexpected: <string> 'table [{id: 1, name: \"John\", salary: 300.50},{id: 2, name: \"Bella\", " + "salary: 500....'\nactual\t: <table> '[{\"id\":1,\"name\":\"John\",\"salary\":300.5},{\"id\":2,\"name\":\"Bella\"," + "\"salary\":500.5}]'");
+    "Assertion Failed!\n \nexpected: <string> 'table [{id: 1, name: \"John\", salary: 300.50},{id: 2, name: \"Bella\", " + "salary: 500....'\nactual\t: <table> '[{\"id\":1,\"name\":\"John\",\"salary\":300.5},{\"id\":2,\"name\":\"Bella\"," + "\"salary\":500.5}]'");
 }
 
 @test:Config {}
@@ -101,7 +101,7 @@ function testAssertDifferentObjects() {
     Employee employee = new();
     error? err = trap test:assertExactEquals(person, employee);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <Employee> 'object assertions-error-messages:Employee'\nactual\t: <Person> 'object assertions-error-messages:Person'");
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <Employee> 'object assertions-error-messages:Employee'\nactual\t: <Person> 'object assertions-error-messages:Person'");
 }
 
 @test:Config {}
@@ -118,7 +118,7 @@ function testAssertAnnonymousRecords() {
 
     error? err = trap test:assertEquals(address, address2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <$anonType$_1> '{\"newCity\":" +
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <$anonType$_1> '{\"newCity\":" +
     "\"London\",\"newCountry\":\"UK\"}'\nactual\t: <$anonType$_0> '{\"city\":\"London\",\"country\":\"UK\"}'");
 }
 
@@ -129,6 +129,6 @@ function testAssertLongValues() {
 
     error? err = trap test:assertEquals(value1, value2);
     error result = <error>err;
-    test:assertEquals(result.message().toString(), "Assertion Failed!\nexpected: <map> '{\"description\":\"Ballerina" + " is an open source programming language and platform fo...'\nactual\t: <string> 'Ballerina is an open source" + 
+    test:assertEquals(result.message().toString(), "Assertion Failed!\n \nexpected: <map> '{\"description\":\"Ballerina" + " is an open source programming language and platform fo...'\nactual\t: <string> 'Ballerina is an open source" + 
     " programming language and platform for cloud-era appl...'");
 }


### PR DESCRIPTION
## Purpose
Change the String diff functionality according to the error reporting behavior to support formatting in a readable manner using new line characters

Fixes #26571

## Approach
Add a ' ' between new line characters, to consider the line to have content as described in #26571

## Samples


## Remarks


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
