### PR TITLE
[WIP] Allow dependently-typed object method declarations and fix subtyping

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticCode.java
@@ -572,7 +572,7 @@ public enum DiagnosticCode {
 
     DISTINCT_TYPING_ONLY_SUPPORT_OBJECTS_AND_ERRORS("distinct.typing.only.support.objects.and.errors"),
 
-    INVALID_USE_OF_TYPEDESC_PARAM("invalid.use.of.typedesc.param"),
+    INVALID_NON_EXTERNAL_DEPENDENTLY_TYPED_FUNCTION("invalid.non.external.dependently.typed.function"),
     INVALID_PARAM_TYPE_FOR_RETURN_TYPE("invalid.param.type.for.return.type"),
     INVALID_TYPEDESC_PARAM("invalid.typedesc.param"),
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1280,8 +1280,8 @@ public class SymbolResolver extends BLangNodeVisitor {
                 BLangFunction func = (BLangFunction) env.node;
                 boolean errored = false;
 
-                if (func.returnTypeNode == null || !func.hasBody() ||
-                        func.body.getKind() != NodeKind.EXTERN_FUNCTION_BODY) {
+                if (func.returnTypeNode == null ||
+                        (func.hasBody() && func.body.getKind() != NodeKind.EXTERN_FUNCTION_BODY)) {
                     dlog.error(userDefinedTypeNode.pos, DiagnosticCode.INVALID_USE_OF_TYPEDESC_PARAM);
                     errored = true;
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1282,7 +1282,7 @@ public class SymbolResolver extends BLangNodeVisitor {
 
                 if (func.returnTypeNode == null ||
                         (func.hasBody() && func.body.getKind() != NodeKind.EXTERN_FUNCTION_BODY)) {
-                    dlog.error(userDefinedTypeNode.pos, DiagnosticCode.INVALID_USE_OF_TYPEDESC_PARAM);
+                    dlog.error(userDefinedTypeNode.pos, DiagnosticCode.INVALID_NON_EXTERNAL_DEPENDENTLY_TYPED_FUNCTION);
                     errored = true;
                 }
 
@@ -1421,7 +1421,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             params.add(symbol);
         }
 
-        BType retType = resolveTypeNode(retTypeVar, this.env);
+        BType retType = resolveTypeNode(retTypeVar, env);
         if (retType == symTable.noType) {
             return symTable.noType;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -568,6 +568,20 @@ public class Types {
             return isAssignable(source, ((BIntersectionType) target).effectiveType, unresolvedTypes);
         }
 
+        if (sourceTag == TypeTags.PARAMETERIZED_TYPE) {
+            BType resolvedSourceType = typeBuilder.build(source);
+
+            if (targetTag == TypeTags.PARAMETERIZED_TYPE) {
+                return isAssignable(resolvedSourceType, typeBuilder.build(target), unresolvedTypes);
+            }
+
+            return isAssignable(resolvedSourceType, target, unresolvedTypes);
+        }
+
+        if (targetTag == TypeTags.PARAMETERIZED_TYPE) {
+            return isAssignable(source, typeBuilder.build(target), unresolvedTypes);
+        }
+
         if (sourceTag == TypeTags.BYTE && targetTag == TypeTags.INT) {
             return true;
         }
@@ -715,16 +729,6 @@ public class Types {
 
         if (sourceTag == TypeTags.INVOKABLE && targetTag == TypeTags.INVOKABLE) {
             return isFunctionTypeAssignable((BInvokableType) source, (BInvokableType) target, new HashSet<>());
-        }
-
-        if (sourceTag == TypeTags.PARAMETERIZED_TYPE) {
-            BType resolvedSourceType = typeBuilder.build(source);
-
-            if (targetTag == TypeTags.PARAMETERIZED_TYPE) {
-                return isAssignable(resolvedSourceType, typeBuilder.build(target), unresolvedTypes);
-            }
-
-            return isAssignable(resolvedSourceType, target, unresolvedTypes);
         }
 
         return sourceTag == TypeTags.ARRAY && targetTag == TypeTags.ARRAY &&

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -718,8 +718,13 @@ public class Types {
         }
 
         if (sourceTag == TypeTags.PARAMETERIZED_TYPE) {
-            BType resolvedType = typeBuilder.build(source);
-            return isAssignable(resolvedType, target, unresolvedTypes);
+            BType resolvedSourceType = typeBuilder.build(source);
+
+            if (targetTag == TypeTags.PARAMETERIZED_TYPE) {
+                return isAssignable(resolvedSourceType, typeBuilder.build(target), unresolvedTypes);
+            }
+
+            return isAssignable(resolvedSourceType, target, unresolvedTypes);
         }
 
         return sourceTag == TypeTags.ARRAY && targetTag == TypeTags.ARRAY &&

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1442,7 +1442,7 @@ error.illegal.function.change.tuple.shape=\
   cannot call ''{0}'' on tuple(s) of type ''{1}'': cannot violate inherent type
 
 error.invalid.non.external.dependently.typed.function=\
-  a dependently-typed function must have an ''external'' function body
+  a function with a non-''external'' function body cannot be a dependently-typed function
 
 error.invalid.param.type.for.return.type=\
   invalid parameter reference: expected ''typedesc'', found ''{0}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1441,8 +1441,8 @@ error.illegal.function.change.list.size=\
 error.illegal.function.change.tuple.shape=\
   cannot call ''{0}'' on tuple(s) of type ''{1}'': cannot violate inherent type
 
-error.invalid.use.of.typedesc.param=\
-  use of ''typedesc'' parameters as types only allowed for return types in external functions
+error.invalid.non.external.dependently.typed.function=\
+  a dependently-typed function must have an ''external'' function body
 
 error.invalid.param.type.for.return.type=\
   invalid parameter reference: expected ''typedesc'', found ''{0}''

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -19,7 +19,6 @@ package org.ballerinalang.nativeimpl.jvm.tests;
 
 import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.StringUtils;
-import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFunctionPointer;
@@ -251,7 +250,7 @@ public class VariableReturnType {
         return objectValue.get(StringUtils.fromString("c"));
     }
 
-    public static Object outParameterObjectGet(ObjectValue objectValue, BTypedesc td) {
+    public static Object getIntFieldOrDefault(ObjectValue objectValue, BTypedesc td) {
         Type describingType = td.getDescribingType();
 
         if (describingType.getTag() == INT_TAG) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/VariableReturnType.java
@@ -18,6 +18,8 @@
 package org.ballerinalang.nativeimpl.jvm.tests;
 
 import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.StringUtils;
+import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BFunctionPointer;
@@ -235,5 +237,27 @@ public class VariableReturnType {
                 return person;
         }
         return null;
+    }
+
+    public static Object get(ObjectValue objectValue, BTypedesc td) {
+        Type describingType = td.getDescribingType();
+
+        switch (describingType.getTag()) {
+            case INT_TAG:
+                return objectValue.getIntValue(StringUtils.fromString("a"));
+            case STRING_TAG:
+                return objectValue.getStringValue(StringUtils.fromString("b"));
+        }
+        return objectValue.get(StringUtils.fromString("c"));
+    }
+
+    public static Object outParameterObjectGet(ObjectValue objectValue, BTypedesc td) {
+        Type describingType = td.getDescribingType();
+
+        if (describingType.getTag() == INT_TAG) {
+            return objectValue.getIntValue(StringUtils.fromString("i"));
+        }
+
+        return getValue(describingType);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -42,7 +42,7 @@ public class VariableReturnTypeTest {
         result = BCompileUtil.compile("test-src/javainterop/variable_return_type_test.bal");
     }
 
-    @Test (enabled = true)
+    @Test
     public void testNegatives() {
         CompileResult errors = BCompileUtil.compile("test-src/javainterop/variable_return_type_negative.bal");
         int indx = 0;
@@ -90,7 +90,10 @@ public class VariableReturnTypeTest {
                 " (other|error)'", 143, 5);
         validateError(errors, indx++, "a function with a non-'external' function body cannot be a dependently-typed " +
                 "function", 143, 64);
-        validateError(errors, indx++, "incompatible types: expected 'Bar', found 'Baz'", 159, 15);
+        validateError(errors, indx++, "incompatible types: expected 'Quux', found 'Qux'", 171, 17);
+        validateError(errors, indx++, "incompatible types: expected 'Qux', found 'Quux'", 172, 15);
+        validateError(errors, indx++, "incompatible types: expected 'Baz', found 'Quux'", 173, 16);
+        validateError(errors, indx++, "incompatible types: expected 'Quuz', found 'Qux'", 174, 17);
 
         Assert.assertEquals(errors.getErrorCount(), indx);
     }
@@ -138,7 +141,8 @@ public class VariableReturnTypeTest {
                 {"testFuture"},
                 {"testComplexTypes"},
                 {"testObjectExternFunctions"},
-                {"testDependentlyTypedMethodsWithObjectTypeInclusion"}
+                {"testDependentlyTypedMethodsWithObjectTypeInclusion"},
+                {"testSubtypingWithDependentlyTypedMethods"}
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -65,17 +65,14 @@ public class VariableReturnTypeTest {
         validateError(errors, indx++, "invalid error detail type 'detail', expected a subtype of " +
                 "'map<(anydata|readonly)>'", 86, 83);
         validateError(errors, indx++, "unknown type 'detail'", 86, 83);
-        validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
-                "in external functions", 93, 45);
-        validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
-                "in external functions", 93, 67);
+        validateError(errors, indx++, "a dependently-typed function must have an 'external' function body", 93, 45);
+        validateError(errors, indx++, "a dependently-typed function must have an 'external' function body", 93, 67);
         validateError(errors, indx++, "default value for a 'typedesc' parameter used in the return type" +
                 " should be a reference to a type", 97, 29);
         validateError(errors, indx++, "unknown type 'NonExistentParam'", 107, 77);
         validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 113, 54);
         validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 119, 45);
-        validateError(errors, indx++, "use of 'typedesc' parameters as types only allowed for return types " +
-                "in external functions", 119, 45);
+        validateError(errors, indx++, "a dependently-typed function must have an 'external' function body", 119, 45);
         validateError(errors, indx++, "incompatible types: expected 'function (typedesc<(string|int)>) returns " +
                 "(string)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 130, 61);
         validateError(errors, indx++, "unknown type 'td'", 131, 48);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -42,7 +42,7 @@ public class VariableReturnTypeTest {
         result = BCompileUtil.compile("test-src/javainterop/variable_return_type_test.bal");
     }
 
-    @Test (enabled = false)
+    @Test (enabled = true)
     public void testNegatives() {
         CompileResult errors = BCompileUtil.compile("test-src/javainterop/variable_return_type_negative.bal");
         int indx = 0;
@@ -61,23 +61,36 @@ public class VariableReturnTypeTest {
         validateError(errors, indx++, "incompatible types: expected 'float', found '(int|float)'", 61, 15);
         validateError(errors, indx++, "unknown type 'td'", 64, 73);
         validateError(errors, indx++, "unknown type 'td'", 72, 54);
-        validateError(errors, indx++, "unknown type 'td'", 74, 88);
         validateError(errors, indx++, "invalid error detail type 'detail', expected a subtype of " +
-                "'map<(anydata|readonly)>'", 86, 83);
-        validateError(errors, indx++, "unknown type 'detail'", 86, 83);
-        validateError(errors, indx++, "a dependently-typed function must have an 'external' function body", 93, 45);
-        validateError(errors, indx++, "a dependently-typed function must have an 'external' function body", 93, 67);
+                "'map<(anydata|readonly)>'", 81, 83);
+        validateError(errors, indx++, "unknown type 'detail'", 81, 83);
+        validateError(errors, indx++,
+                      "a function with a non-'external' function body cannot be a dependently-typed function", 88, 45);
+        validateError(errors, indx++,
+                      "a function with a non-'external' function body cannot be a dependently-typed function", 88, 67);
         validateError(errors, indx++, "default value for a 'typedesc' parameter used in the return type" +
-                " should be a reference to a type", 97, 29);
-        validateError(errors, indx++, "unknown type 'NonExistentParam'", 107, 77);
-        validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 113, 54);
-        validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 119, 45);
-        validateError(errors, indx++, "a dependently-typed function must have an 'external' function body", 119, 45);
+                " should be a reference to a type", 92, 29);
+        validateError(errors, indx++, "unknown type 'NonExistentParam'", 102, 77);
+        validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 108, 54);
+        validateError(errors, indx++,
+                      "a function with a non-'external' function body cannot be a dependently-typed function", 114, 45);
+        validateError(errors, indx++, "invalid parameter reference: expected 'typedesc', found 'string'", 114, 45);
         validateError(errors, indx++, "incompatible types: expected 'function (typedesc<(string|int)>) returns " +
-                "(string)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 130, 61);
-        validateError(errors, indx++, "unknown type 'td'", 131, 48);
+                "(string)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 125, 61);
+        validateError(errors, indx++, "unknown type 'td'", 126, 48);
         validateError(errors, indx++, "incompatible types: expected 'function (typedesc<(string|int)>) returns " +
-                "(other)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 131, 57);
+                "(other)', found 'function (typedesc<(int|string)>) returns (aTypeVar)'", 126, 57);
+        validateError(errors, indx++, "mismatched function signatures: expected 'public function get" +
+                "(typedesc<anydata> td) returns (td|error)', found 'public function get(typedesc<anydata> td) returns" +
+                " (other|error)'", 139, 5);
+        validateError(errors, indx++, "a function with a non-'external' function body cannot be a dependently-typed " +
+                "function", 139, 64);
+        validateError(errors, indx++, "mismatched function signatures: expected 'public function get" +
+                "(typedesc<anydata> td) returns (td|error)', found 'public function get(typedesc<anydata> td) returns" +
+                " (other|error)'", 143, 5);
+        validateError(errors, indx++, "a function with a non-'external' function body cannot be a dependently-typed " +
+                "function", 143, 64);
+        validateError(errors, indx++, "incompatible types: expected 'Bar', found 'Baz'", 159, 15);
 
         Assert.assertEquals(errors.getErrorCount(), indx);
     }
@@ -124,7 +137,8 @@ public class VariableReturnTypeTest {
                 {"testTypedesc"},
                 {"testFuture"},
                 {"testComplexTypes"},
-                {"testObjectExternFunctions"}
+                {"testObjectExternFunctions"},
+                {"testDependentlyTypedMethodsWithObjectTypeInclusion"}
         };
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -127,3 +127,36 @@ function testInvalidFunctionAssignment() {
 }
 
 type customType int|float;
+
+public type OutParameter object {
+    // This is OK, referencing classes/object constructors should have 'external' implementations.
+    public isolated function get(typedesc<anydata> td) returns td|error;
+};
+
+public class OutParameterClass {
+    *OutParameter;
+
+    public isolated function get(typedesc<anydata> td) returns td|error => error("oops!"); // error
+}
+
+var OutParameterObject = object OutParameter {
+    public isolated function get(typedesc<anydata> td) returns td|error => error("oops!"); // error
+};
+
+public class Bar {
+    public function get(typedesc<anydata> td) returns td|error = external;
+}
+
+public class Baz {
+    public function get(typedesc<anydata> td) returns anydata|error = external;
+}
+
+public class Qux {
+    public function get(typedesc<anydata> td) returns td|error = external;
+}
+
+public function testSubtypingAgainstConcreteReturnType() {
+    Bar bar = new Baz();
+    Baz baz = new Bar(); // OK
+    Bar bar2 = new Qux(); // OK
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_negative.bal
@@ -155,8 +155,21 @@ public class Qux {
     public function get(typedesc<anydata> td) returns td|error = external;
 }
 
+public class Quux {
+    public function get(typedesc<any> td) returns td|error = external;
+}
+
+public class Quuz {
+    public function get(typedesc<int|string> td) returns td|error = external;
+}
+
 public function testSubtypingAgainstConcreteReturnType() {
-    Bar bar = new Baz();
+    Bar bar = new Baz(); // OK
     Baz baz = new Bar(); // OK
     Bar bar2 = new Qux(); // OK
+
+    Quux quux = new Qux();
+    Qux qux = new Quux();
+    Baz baz2 = new Quux();
+    Quuz quuz = new Qux();
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -354,7 +354,7 @@ var outParameterObject = object OutParameter {
 
     public isolated function get(typedesc<anydata> td) returns td|error = @java:Method {
         'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
-        name: "outParameterObjectGet",
+        name: "getIntFieldOrDefault",
         paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
     } external;
 };
@@ -369,6 +369,73 @@ function testDependentlyTypedMethodsWithObjectTypeInclusion() {
     assert(321, <int> outParameterObject.get(int));
     decimal|error v2 = outParameterObject.get(decimal);
     assert(23.45d, <decimal> v2);
+}
+
+public class Bar {
+    int i = 1;
+
+    public function get(typedesc<anydata> td) returns td|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        name: "getIntFieldOrDefault",
+        paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
+    } external;
+}
+
+public class Baz {
+    int i = 2;
+
+    public function get(typedesc<anydata> td) returns anydata|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        name: "getIntFieldOrDefault",
+        paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
+    } external;
+}
+
+public class Qux {
+    int i = 3;
+
+    public function get(typedesc<anydata> td) returns td|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        name: "getIntFieldOrDefault",
+        paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
+    } external;
+}
+
+public class Quux {
+    int i = 4;
+
+    public function get(typedesc<any> td) returns td|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        name: "getIntFieldOrDefault",
+        paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
+    } external;
+}
+
+public function testSubtypingWithDependentlyTypedMethods() {
+    Bar bar = new;
+    Baz baz = new;
+    Qux qux = new;
+
+    assert(1, <int> bar.get(int));
+    assert(2, <int> baz.get(int));
+    assert(3, <int> qux.get(int));
+    decimal|error v2 = bar.get(decimal);
+    assert(23.45d, <decimal> v2);
+    anydata|error v3 = baz.get(decimal);
+    assert(23.45d, <decimal> v3);
+    v2 = qux.get(decimal);
+    assert(23.45d, <decimal> v2);
+
+    Baz baz1 = bar;
+    Bar bar1 = qux;
+    assert(1, <int> baz1.get(int));
+    assert(3, <int> bar1.get(int));
+
+    assert(true, <any> bar is Baz);
+    assert(true, <any> qux is Bar);
+    assert(true, <any> baz is Bar);
+    assert(false, <any> new Quux() is Qux);
+    assert(false, <any> qux is Quux);
 }
 
 // Util functions

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -325,6 +325,52 @@ function getValue2(typedesc<int|string> aTypeVar) returns aTypeVar = @java:Metho
     paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
 } external;
 
+public type OutParameter object {
+    // This is OK, referencing classes/object constructors should have 'external' implementations.
+    public function get(typedesc<anydata> td) returns td|error;
+};
+
+public class OutParameterClass {
+    *OutParameter;
+
+    int a;
+    string b;
+    error c = error("not a nor b");
+
+    function init() {
+        self.a = 1234;
+        self.b = "hello world";
+    }
+
+    public function get(typedesc<anydata> td) returns td|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
+    } external;
+}
+
+var outParameterObject = object OutParameter {
+
+    int i = 321;
+
+    public isolated function get(typedesc<anydata> td) returns td|error = @java:Method {
+        'class: "org.ballerinalang.nativeimpl.jvm.tests.VariableReturnType",
+        name: "outParameterObjectGet",
+        paramTypes: ["io.ballerina.runtime.api.values.BTypedesc"]
+    } external;
+};
+
+function testDependentlyTypedMethodsWithObjectTypeInclusion() {
+    OutParameterClass c1 = new;
+    int|error v1 = c1.get(int);
+    assert(1234, <int> v1);
+    assertSame(c1.c, c1.get(float));
+    assert("hello world", <string> c1.get(string));
+
+    assert(321, <int> outParameterObject.get(int));
+    decimal|error v2 = outParameterObject.get(decimal);
+    assert(23.45d, <decimal> v2);
+}
+
 // Util functions
 function assert(anydata expected, anydata actual) {
     if (expected != actual) {
@@ -336,10 +382,10 @@ function assert(anydata expected, anydata actual) {
     }
 }
 
-function assertSame(any expected, any actual) {
+function assertSame(any|error expected, any|error actual) {
     if (expected !== actual) {
-        typedesc<any> expT = typeof expected;
-        typedesc<any> actT = typeof actual;
+        typedesc<any|error> expT = typeof expected;
+        typedesc<any|error> actT = typeof actual;
         string detail = "expected value of type [" + expT.toString() + "] is not the same as actual value" +
                                 " of type [" + actT.toString() + "]";
         panic error("{AssertionError}", message = detail);


### PR DESCRIPTION
## Purpose
This PR
- allows dependently-typed object method declarations. Any class or object constructor that references/includes the type has to have an `external` implementation. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/26430.

```ballerina
type Foo object {
    public function get(typedesc<anydata> td) returns td|error;
};

class Bar {
    public function get(typedesc<anydata> td) returns td|error = external;
}
```

- Fixes subtyping for objects with dependently-typed methods. Fixes https://github.com/ballerina-platform/ballerina-lang/issues/26584.

The following is now allowed.

```ballerina
public class Foo {
    public function get(typedesc<anydata> td) returns td|error = external;
}

public class Bar {
    public function get(typedesc<anydata> td) returns td|error = external;
}

public function main() {
    Foo f = new Bar();
}
```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
