### PR TITLE
Add dependency and native dependency details to PackageDescriptor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageDescriptor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageDescriptor.java
@@ -19,6 +19,7 @@ package io.ballerina.projects;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a Ballerina.toml file.
@@ -31,15 +32,20 @@ public class PackageDescriptor {
     private final PackageVersion packageVersion;
 
     private final List<Dependency> dependencies;
+    // Other entries hold other key/value pairs available in the Ballerina.toml file.
+    // These keys are not part of the Ballerina package specification.
+    private final Map<String, Object> otherEntries;
 
     public PackageDescriptor(PackageName packageName,
                              PackageOrg packageOrg,
                              PackageVersion packageVersion,
-                             List<Dependency> dependencies) {
+                             List<Dependency> dependencies,
+                             Map<String, Object> otherEntries) {
         this.packageName = packageName;
         this.packageOrg = packageOrg;
         this.packageVersion = packageVersion;
         this.dependencies = Collections.unmodifiableList(dependencies);
+        this.otherEntries = Collections.unmodifiableMap(otherEntries);
     }
 
     public PackageName name() {
@@ -56,6 +62,11 @@ public class PackageDescriptor {
 
     public List<Dependency> dependencies() {
         return dependencies;
+    }
+
+    // TODO Do we need to custom key/value par mapping here
+    public Object getValue(String key) {
+        return otherEntries.get(key);
     }
 
     /**

--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/balo/BaloPackageLoader.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/balo/BaloPackageLoader.java
@@ -47,7 +47,7 @@ public class BaloPackageLoader extends PackageLoader {
         PackageOrg packageOrg = PackageOrg.from(getOrgFromBaloName(String.valueOf(baloName)));
         PackageVersion packageVersion = PackageVersion.from(getVersionFromBaloName(String.valueOf(baloName)));
         PackageDescriptor packageDescriptor = new PackageDescriptor(packageName,
-                packageOrg, packageVersion, Collections.emptyList());
+                packageOrg, packageVersion, Collections.emptyList(), Collections.emptyMap());
         return createPackageConfig(packageData, packageDescriptor);
     }
 }

--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/directory/BuildProject.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/directory/BuildProject.java
@@ -26,7 +26,6 @@ import io.ballerina.projects.Project;
 import io.ballerina.projects.env.BuildEnvContext;
 import io.ballerina.projects.environment.EnvironmentContext;
 import io.ballerina.projects.model.BallerinaToml;
-import io.ballerina.projects.model.BallerinaTomlProcessor;
 import io.ballerina.projects.utils.ProjectConstants;
 import io.ballerina.projects.utils.ProjectUtils;
 import org.ballerinalang.toml.exceptions.TomlException;

--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/directory/ProjectFiles.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/directory/ProjectFiles.java
@@ -18,11 +18,6 @@
 package io.ballerina.projects.directory;
 
 import io.ballerina.projects.PackageDescriptor;
-import io.ballerina.projects.PackageName;
-import io.ballerina.projects.PackageOrg;
-import io.ballerina.projects.PackageVersion;
-import io.ballerina.projects.model.BallerinaToml;
-import io.ballerina.projects.model.BallerinaTomlProcessor;
 import io.ballerina.projects.utils.ProjectUtils;
 import org.ballerinalang.toml.exceptions.TomlException;
 
@@ -156,13 +151,8 @@ public class ProjectFiles {
     }
 
     public static PackageDescriptor createPackageDescriptor(Path ballerinaTomlFilePath) {
-        BallerinaToml ballerinaToml;
         try {
-            ballerinaToml = BallerinaTomlProcessor.parse(ballerinaTomlFilePath);
-            PackageName packageName = PackageName.from(ballerinaToml.getPackage().getName());
-            PackageOrg packageOrg = PackageOrg.from(ballerinaToml.getPackage().getOrg());
-            PackageVersion packageVersion = PackageVersion.from(ballerinaToml.getPackage().getVersion());
-            return new PackageDescriptor(packageName, packageOrg, packageVersion, Collections.emptyList());
+            return BallerinaTomlProcessor.parseAsPackageDescriptor(ballerinaTomlFilePath);
         } catch (IOException | TomlException e) {
             throw new RuntimeException(e.getMessage(), e);
         }

--- a/project-api/ballerina-projects/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
+++ b/project-api/ballerina-projects/src/main/java/io/ballerina/projects/directory/SingleFileProject.java
@@ -81,7 +81,7 @@ public class SingleFileProject extends Project {
         PackageOrg packageOrg = PackageOrg.from(ProjectConstants.ANON_ORG);
         PackageVersion packageVersion = PackageVersion.from(ProjectConstants.DEFAULT_VERSION);
         PackageDescriptor packageDescriptor = new PackageDescriptor(packageName,
-                packageOrg, packageVersion, Collections.emptyList());
+                packageOrg, packageVersion, Collections.emptyList(), Collections.emptyMap());
         PackageConfig packageConfig = PackageLoader.loadPackage(projectPath, true, packageDescriptor);
         this.addPackage(packageConfig);
     }

--- a/project-api/ballerina-projects/src/test/java/io/ballerina/projects/test/TestBallerinaTomlProcessor.java
+++ b/project-api/ballerina-projects/src/test/java/io/ballerina/projects/test/TestBallerinaTomlProcessor.java
@@ -18,9 +18,9 @@
 
 package io.ballerina.projects.test;
 
-import com.google.gson.internal.LinkedTreeMap;
+import io.ballerina.projects.PackageDescriptor;
+import io.ballerina.projects.directory.BallerinaTomlProcessor;
 import io.ballerina.projects.model.BallerinaToml;
-import io.ballerina.projects.model.BallerinaTomlProcessor;
 import io.ballerina.projects.model.Package;
 import org.ballerinalang.toml.exceptions.TomlException;
 import org.testng.Assert;
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 
 /**
  * Contains cases to test the ballerina toml processor.
@@ -38,21 +39,24 @@ import java.nio.file.Paths;
 public class TestBallerinaTomlProcessor {
     private static final Path RESOURCE_DIRECTORY = Paths.get("src/test/resources/");
 
-    @Test(description = "Test parse `ballerina.toml` file in to `BallerinaToml` object")
+    @Test(description = "Test parse `ballerina.toml` file in to `PackageDescriptor` object")
     public void testParse() throws IOException, TomlException {
         Path ballerinaTomlPath = RESOURCE_DIRECTORY.resolve("ballerinatoml").resolve("Ballerina.toml");
-        BallerinaToml ballerinaToml = BallerinaTomlProcessor.parse(ballerinaTomlPath);
+        PackageDescriptor packageDescriptor = BallerinaTomlProcessor.parseAsPackageDescriptor(ballerinaTomlPath);
 
-        Assert.assertEquals(ballerinaToml.getPackage().getOrg(), "foo");
-        Assert.assertEquals(ballerinaToml.getPackage().getName(), "winery");
-        Assert.assertEquals(ballerinaToml.getPackage().getVersion(), "0.1.0");
+        Assert.assertEquals(packageDescriptor.org().value(), "foo");
+        Assert.assertEquals(packageDescriptor.name().value(), "winery");
+        Assert.assertEquals(packageDescriptor.version().toString(), "0.1.0");
 
-        Assert.assertEquals(ballerinaToml.getDependencies().get("wso2/twitter"), "2.3.4");
-        Assert.assertEquals(((LinkedTreeMap) ballerinaToml.getDependencies().get("wso2/github")).get("path"),
-                "path/to/github.balo");
-        Assert.assertEquals(((LinkedTreeMap) ballerinaToml.getDependencies().get("wso2/github")).get("version"),
-                "1.2.3");
+        List<PackageDescriptor.Dependency> dependencyList = packageDescriptor.dependencies();
+        Assert.assertEquals(dependencyList.size(), 2);
+        Assert.assertEquals(dependencyList.get(0).org().value(), "wso2");
+        Assert.assertEquals(dependencyList.get(0).name().value(), "twitter");
+        Assert.assertEquals(dependencyList.get(0).version().toString(), "2.3.4");
 
+        Assert.assertEquals(dependencyList.get(1).org().value(), "wso2");
+        Assert.assertEquals(dependencyList.get(1).name().value(), "github");
+        Assert.assertEquals(dependencyList.get(1).version().toString(), "1.2.3");
     }
 
     @Test(description = "Test validate ballerina toml package section which contains build options")

--- a/project-api/ballerina-projects/src/test/resources/ballerinatoml/Ballerina.toml
+++ b/project-api/ballerina-projects/src/test/resources/ballerinatoml/Ballerina.toml
@@ -1,18 +1,31 @@
 [package]
-org = "foo"
 name = "winery"
+org = "foo"
 version = "0.1.0"
 
-[dependencies]
-"wso2/twitter" = "2.3.4"
-"wso2/github" = { path = "path/to/github.balo", version = "1.2.3"}
+[[dependency]]
+org = "wso2"
+name = "twitter"
+version = "2.3.4"
 
-[platform]
-target = "java8"
+[[dependency]]
+org = "wso2"
+name = "github"
+version = "1.2.3"
 
-    [[platform.libraries]]
-    artifactId = "ldap"
-    version = "1.0.0"
-    path = "./lib/ballerina-ldap-1.0.0-java.jar"
-    groupId = "ballerina"
-    modules = ["ldap"]
+[[platform.java11.dependency]]
+path = "/user/sameera/libs/toml4j.jar"
+artafactId = "toml4j"
+version = "0.7.2"
+groupId = "com.moandjiezana.toml"
+
+[[platform.java11.dependency]]
+path = "path/to/swagger.jar"
+artafactId = "swagger"
+version = "0.7.2"
+groupId = "swagger.io"
+
+[build-options]
+observability-included = true
+
+


### PR DESCRIPTION
With this PR, I am introducing the following format in `Ballerina.toml` to declare dependencies and platform-specific dependencies.

```toml
[package]
name = "winery"
org = "foo"
version = "0.1.0"

[[dependency]]
org = "wso2"
name = "twitter"
version = "2.3.4"

[[dependency]]
org = "wso2"
name = "github"
version = "1.2.3"

[[platform.java11.dependency]]
path = "/user/sameera/libs/toml4j.jar"
artafactId = "toml4j"
version = "0.7.2"
groupId = "com.moandjiezana.toml"

[[platform.java11.dependency]]
path = "path/to/swagger.jar"
artafactId = "swagger"
version = "0.7.2"
groupId = "swagger.io"

[build-options]
observability-included = true



```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
