### PR TITLE
Fix spec conformity for error detail type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2038,14 +2038,22 @@ public class Types {
     public boolean isValidErrorDetailType(BType detailType) {
         switch (detailType.tag) {
             case TypeTags.MAP:
-            case TypeTags.RECORD:
                 return isAssignable(detailType, symTable.detailType);
-
+            case TypeTags.RECORD: {
+                if (isSealed((BRecordType) detailType)) {
+                    return false;
+                }
+                return isAssignable(detailType, symTable.detailType);
+            }
         }
         return false;
     }
 
     // private methods
+
+    private boolean isSealed(BRecordType recordType) {
+        return recordType.sealed;
+    }
 
     private boolean isNullable(BType fieldType) {
         return fieldType.isNullable();

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-iterable-object-negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-iterable-object-negative.bal
@@ -106,11 +106,11 @@ class Iterable5 {
 }
 
 // ------------------- Error Related Tests -------------------
-type CustomErrorData record {|
+type CustomErrorData record {
     string message?;
     error cause?;
     int errorID?;
-|};
+};
 
 type CustomError error<CustomErrorData>;
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/source/errorUnionSuggestion1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/source/errorUnionSuggestion1.bal
@@ -5,11 +5,11 @@ type TrxErrorData record {|
     string data = "";
 |};
 
-type TrxErrorData2 record {|
+type TrxErrorData2 record {
     string message = "";
     error cause?;
     map<string> data = {};
-|};
+};
 
 const string reasonA = "ErrNo-1";
 type UserDefErrorTwoA error<reasonA, TrxErrorData2>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/errors/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/src/errors/errors.bal
@@ -3,10 +3,10 @@ public const APPLICATION_ERROR_REASON = "{ballerina/sql}ApplicationError";
 # Represents the properties which are related to Non SQL errors
 #
 # + message - Error message
-public type ApplicationErrorData record {|
+public type ApplicationErrorData record {
     string message;
     error cause?;
-|};
+};
 
 public type ApplicationError error<ApplicationErrorData>;
 
@@ -17,6 +17,6 @@ public type OrderCreationError2 distinct OrderCreationError;
 public type NewPostDefinedError distinct PostDefinedError;
 public type PostDefinedError error<ErrorData>;
 
-public type ErrorData record {|
+public type ErrorData record {
     string code;
-|};
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test.bal
@@ -10,10 +10,10 @@ function testFooError() returns Foo {
 }
 
 public type GraphAPIError distinct error<GraphAPIErrorDetails>;
-public type GraphAPIErrorDetails record {|
+public type GraphAPIErrorDetails record {
     string code;
     map<anydata> details;
-|};
+};
 
 public function testFunctionCallInDetailArgExpr() {
     json codeJson = "1234";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test_negative.bal
@@ -1,7 +1,7 @@
 
 type Foo distinct error;
 type Fee distinct Foo;
-type Bar distinct error<record {| int code; |}>;
+type Bar distinct error<record { int code; }>;
 
 function testFooError() returns Foo {
     //Foo foo = Foo("error message");

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_destructure_binding_pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_destructure_binding_pattern.bal
@@ -33,12 +33,12 @@ function getSampleError() returns SampleError {
     return e;
 }
 
-type Foo record {|
+type Foo record {
     string message?;
     error cause?;
     string detailMsg;
     boolean isFatal;
-|};
+};
 
 function getRecordConstrainedError() returns error<Foo> {
     error<Foo> e = <error<Foo>> error("Some Error", detailMsg = "Failed Message", isFatal = true);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -45,19 +45,19 @@ function errorTrapTest(int i) returns string|error {
     return val;
 }
 
-type TrxErrorData record {|
+type TrxErrorData record {
     string message = "";
     error cause?;
     string data = "";
-|};
+};
 
 type TrxError error<TrxErrorData>;
 
-type TrxErrorData2 record {|
+type TrxErrorData2 record {
     string message = "";
     error cause?;
     map<string> data = {};
-|};
+};
 
 public function testCustomErrorDetails() returns error {
     TrxError err = TrxError("trxErr", data = "test");
@@ -283,8 +283,8 @@ public function testStackTraceInNative() {
 const C1 = "x";
 const C2 = "y";
 
-type C1E error<record {| string message?; error cause?; |}>;
-type C2E error<record {| string message?; error cause?; int code; |}>;
+type C1E error<record { string message?; error cause?; }>;
+type C2E error<record { string message?; error cause?; int code; }>;
 
 public function testPanicOnErrorUnion(int i) returns string {
     var res = testFunc(i);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test_negative.bal
@@ -97,11 +97,11 @@ function testIndirectErrorDestructuring() {
     RNStrError e3 = RNStrError(message="Msg", fatal=false, other="k");
 }
 
-type TrxErrorData2 record {|
+type TrxErrorData2 record {
     string message = "";
     error cause?;
     map<string> data = {};
-|};
+};
 
 const string reasonA = "ErrNo-1";
 type UserDefErrorTwoA error<TrxErrorData2>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
@@ -77,18 +77,18 @@ type Person record {
     string name;
 };
 
-public type MyErrorData record {|
+public type MyErrorData record {
     string message?;
     error cause?;
-|};
+};
 
 type MyError error<MyErrorData>;
 
-public type CustomErrorData record {|
+public type CustomErrorData record {
     string data;
     string message?;
     error cause?;
-|};
+};
 
 type CustomError error<CustomErrorData>;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
@@ -302,12 +302,12 @@ function getSampleError() returns SampleError {
     return e;
 }
 
-type Foo record {|
+type Foo record {
     string message?;
     error cause?;
     string detailMsg;
     boolean isFatal;
-|};
+};
 
 type FooError error<Foo>;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/checked_expr_operator_basics.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/checked_expr_operator_basics.bal
@@ -77,18 +77,18 @@ type Person record {
     string name;
 };
 
-public type MyErrorData record {|
+public type MyErrorData record {
     string message?;
     error cause?;
-|};
+};
 
 type MyError error<MyErrorData>;
 
-public type CustomErrorData record {|
+public type CustomErrorData record {
     string data;
     string message?;
     error cause?;
-|};
+};
 
 type CustomError error<CustomErrorData>;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/errors.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/errors.bal
@@ -67,6 +67,6 @@ public function testSelfReferencingError() returns error {
 
 type MyError error<MyErrorData>;
 
-type MyErrorData record {|
+type MyErrorData record {
     *lang:Detail;
-|};
+};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-negative.bal
@@ -14,11 +14,11 @@
 // specific language governing permissions and limitations
 // under the License.
 
-type CustomErrorData record {|
+type CustomErrorData record {
     string message?;
     error cause?;
     int accountID?;
-|};
+};
 
 type CustomError distinct error<CustomErrorData>;
 type CustomError1 distinct error<CustomErrorData>;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
@@ -162,11 +162,11 @@ function testStreamReturnTypeImplicit() returns boolean {
 
 // ------------------- Error Related Tests -------------------
 
-type CustomErrorData record {|
+type CustomErrorData record {
     string message?;
     error cause?;
     int accountID?;
-|};
+};
 
 type CustomError distinct error<CustomErrorData>;
 boolean closed = false;


### PR DESCRIPTION
## Purpose
> $title

With the spec update, error detail type should be an inclusive-record-descriptor which is open to Cloneable.

Fixes #26565

## Approach
> A new check has been added at the semantic analyser phase to identify if closed record is passed as the detail type of an error.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [x] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
