### PR TITLE
Implement dummy listener for `lang.test` module

### DIFF
--- a/langlib/lang.test/src/main/ballerina/src/lang.test/MockListener.bal
+++ b/langlib/lang.test/src/main/ballerina/src/lang.test/MockListener.bal
@@ -74,6 +74,16 @@ public class MockListener {
     }
 }
 
+public client class Caller {
+    public remote function respond(string message) returns string {
+        return message;
+    }
+     public remote function badRequest(string message) returns string {
+        string response = message;
+        return self->respond(response);
+    }
+}
+
 function externMockInitEndpoint() = @java:Method {
     'class: "org.ballerinalang.langlib.test.InitEndPoint",
     name: "initEndPoint"

--- a/langlib/lang.test/src/main/ballerina/src/lang.test/MockListener.bal
+++ b/langlib/lang.test/src/main/ballerina/src/lang.test/MockListener.bal
@@ -1,0 +1,95 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/java;
+
+public type ListenerConfiguration record {|
+    string host = "0.0.0.0";
+    string httpVersion = "1.1";
+    string? server = ();
+    boolean webSocketCompressionEnabled = true;
+|};
+
+public class MockListener {
+
+    private int port = 0;
+    private ListenerConfiguration config = {};
+
+    public function __start() returns error? {
+        return self.startEndpoint();
+    }
+
+    public function __gracefulStop() returns error? {
+        
+    }
+
+    public function __immediateStop() returns error? {
+        
+    }
+
+    public function __attach(service s, string? name = ()) returns error? {
+        return self.register();
+    }
+
+    public function __detach(service s) returns error? {
+        return self.detach();
+    }
+
+    public function init(int port, ListenerConfiguration? config = ()) {
+        self.config = config ?: {};
+        self.port = port;
+        var err = self.initEndpoint();
+        if (err is error) {
+            panic err;
+        }
+    }
+
+    public function initEndpoint() returns error? {
+        return externMockInitEndpoint();
+    }
+
+    public function register() returns error? {
+        return externMockRegister();
+    }
+
+    public function startEndpoint() returns error? {
+        return externMockStart();
+    }
+
+    public function detach() returns error? {
+        return externMockDetach();
+    }
+}
+
+function externMockInitEndpoint() = @java:Method {
+    'class: "org.ballerinalang.langlib.test.InitEndPoint",
+    name: "initEndPoint"
+} external;
+
+function externMockRegister() = @java:Method {
+    'class: "org.ballerinalang.langlib.test.Register",
+    name: "register"
+} external;
+
+function externMockStart() = @java:Method {
+    'class: "org.ballerinalang.langlib.test.Start",
+    name: "start"
+} external;
+
+function externMockDetach() = @java:Method {
+    'class: "org.ballerinalang.langlib.test.DetachEndpoint",
+    name: "detach"
+} external;

--- a/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/DetachEndpoint.java
+++ b/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/DetachEndpoint.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langlib.test;
+
+/**
+ * @since 2.0.0
+ */
+public class DetachEndpoint {
+    public static void detach() {
+
+    }
+}

--- a/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/InitEndPoint.java
+++ b/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/InitEndPoint.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langlib.test;
+
+/**
+ * @since 2.0.0
+ */
+public class InitEndPoint {
+    public static void initEndPoint() {
+
+    }
+}

--- a/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/Register.java
+++ b/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/Register.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langlib.test;
+
+/**
+ * @since 2.0.0
+ */
+public class Register {
+    public static void register() {
+
+    }
+}

--- a/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/Start.java
+++ b/langlib/lang.test/src/main/java/org/ballerinalang/langlib/test/Start.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.langlib.test;
+
+/**
+ * @since 2.0.0
+ */
+public class Start {
+    public static void start() {
+
+    }
+}

--- a/tests/jballerina-unit-test/build.gradle
+++ b/tests/jballerina-unit-test/build.gradle
@@ -33,9 +33,9 @@ dependencies {
     implementation project(':testerina:testerina-core')
     implementation project(':ballerina-packerina')
     implementation project(':ballerina-logging')
-//    implementation project(':ballerina-http')
     implementation project(':ballerina-mime')
     implementation project(':ballerina-lang:java')
+    implementation project(':ballerina-lang-test')
     implementation project(':ballerina-runtime')
     implementation project(':docerina')
 
@@ -75,6 +75,7 @@ dependencies {
     baloTestImplementation project(path: ':ballerina-observability', configuration: 'baloImplementation')
     baloTestImplementation project(path: ':ballerina-system', configuration: 'baloImplementation')
     baloImplementation project(path: ':testerina:testerina-core', configuration: 'baloImplementation')
+    baloImplementation project(path: ':ballerina-lang-test', configuration: 'baloImplementation')
 }
 
 description = 'JBallerina - Unit Test Module'

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/BirVariableOptimizationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/bir/BirVariableOptimizationTest.java
@@ -49,12 +49,12 @@ public class BirVariableOptimizationTest {
         result = BCompileUtil.compileAndGetBIR("test-src/bir/biroptimizer.bal");
     }
 
-    @Test(description = "Test the liveness analysis on functions", enabled = false)
+    @Test(description = "Test the liveness analysis on functions")
     public void testFunctions() {
         ((BLangPackage) result.getAST()).symbol.bir.functions.forEach(this::assertFunctions);
     }
 
-    @Test(description = "Test the liveness analysis on attached functions", enabled = false)
+    @Test(description = "Test the liveness analysis on attached functions")
     public void testAttachedFunctions() {
         ((BLangPackage) result.getAST()).symbol.bir.typeDefs.forEach(
                 typeDefinition -> typeDefinition.attachedFuncs.forEach(this::assertFunctions));

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/dataflow/analysis/DataflowAnalysisTest.java
@@ -31,7 +31,7 @@ import org.testng.annotations.Test;
 @Test
 public class DataflowAnalysisTest {
 
-    @Test(description = "Test uninitialized variables", enabled = false)
+    @Test(description = "Test uninitialized variables")
     public void testSemanticsOfUninitializedVariables() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/dataflow/analysis/dataflow-analysis-semantics-negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MarkdownDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MarkdownDocumentationTest.java
@@ -366,7 +366,7 @@ public class MarkdownDocumentationTest {
         Assert.assertEquals(references.get(5).identifier, "baz");
     }
 
-    @Test(description = "Test doc negative cases.", groups = { "disableOnOldParser" }, enabled = false)
+    @Test(description = "Test doc negative cases.", groups = { "disableOnOldParser" })
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/documentation/markdown_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0);
@@ -416,18 +416,18 @@ public class MarkdownDocumentationTest {
                 "invalid usage of parameter reference outside of function definition 'invalidParameter'", 87, 3);
         BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'conn'", 88, 5);
         BAssertUtil.validateWarning(compileResult, index++, "no documentable return parameter", 89, 1);
-        BAssertUtil.validateWarning(compileResult, index++, "parameter 'req' already documented", 97, 9);
-        BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'reqest'", 98, 9);
-        BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'testConstd'", 109, 5);
-        BAssertUtil.validateWarning(compileResult, index++, "no documentable return parameter", 110, 1);
+        BAssertUtil.validateWarning(compileResult, index++, "parameter 'req' already documented", 94, 9);
+        BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'reqest'", 95, 9);
+        BAssertUtil.validateWarning(compileResult, index++, "no such documentable parameter 'testConstd'", 102, 5);
+        BAssertUtil.validateWarning(compileResult, index++, "no documentable return parameter", 103, 1);
         BAssertUtil.validateWarning(compileResult, index++,
-                "invalid identifier in documentation reference '9function'", 115, 13);
+                "invalid identifier in documentation reference '9function'", 108, 13);
         BAssertUtil.validateWarning(compileResult, index++,
-                "invalid reference in documentation 'filePath1' for type 'parameter'", 116, 3);
-        BAssertUtil.validateWarning(compileResult, index, "undocumented parameter 'filePath'", 117, 22);
+                "invalid reference in documentation 'filePath1' for type 'parameter'", 109, 3);
+        BAssertUtil.validateWarning(compileResult, index, "undocumented parameter 'filePath'", 110, 22);
     }
 
-    @Test(description = "Test doc service", enabled = false)
+    @Test(description = "Test doc service")
     public void testDocService() {
         CompileResult compileResult = BCompileUtil.compile("test-src/documentation/markdown_service.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0);
@@ -624,7 +624,7 @@ public class MarkdownDocumentationTest {
                 "    # ```");
     }
 
-    @Test(description = "Test doc multiple.", groups = { "disableOnOldParser" }, enabled = false)
+    @Test(description = "Test doc multiple.", groups = { "disableOnOldParser" })
     public void testMultiple() {
         CompileResult compileResult = BCompileUtil.compile("test-src/documentation/markdown_multiple.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
@@ -53,14 +53,13 @@ public class JavaCastTest {
         Assert.assertTrue(returns[0].stringValue().contains("{ballerina/java} Cannot cast `String1` to `ArrayList1`"));
     }
 
-    @Test(description = "Test java:cast function in ballerina/java for a typedesc without a handle argument in `init`",
-            enabled = false)
+    @Test(description = "Test java:cast function in ballerina/java for a typedesc without a handle argument in `init`")
     public void testJavaCastForInvalidTypedesc3() {
         BValue[] returns = BRunUtil.invoke(result, "testJavaCastForInvalidTypedesc3");
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(returns[0].stringValue().contains("{ballerina/java} Error while initializing the new " +
-               "object from `String4` type: java.lang.ClassCastException: io.ballerina.runtime.values.HandleValue " +
-               "cannot be cast to io.ballerina.runtime.api.values.BString"));
+               "object from `String4` type: java.lang.ClassCastException: class io.ballerina.runtime.values.HandleValue " +
+               "cannot be cast to class io.ballerina.runtime.api.values.BString"));
     }
 
     @Test(description = "Test java:cast function in ballerina/java for incorrect class in typedesc object annotation")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
@@ -58,8 +58,8 @@ public class JavaCastTest {
         BValue[] returns = BRunUtil.invoke(result, "testJavaCastForInvalidTypedesc3");
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(returns[0].stringValue().contains("{ballerina/java} Error while initializing the new " +
-               "object from `String4` type: java.lang.ClassCastException: class io.ballerina.runtime.values.HandleValue " +
-               "cannot be cast to class io.ballerina.runtime.api.values.BString"));
+               "object from `String4` type: java.lang.ClassCastException: class io.ballerina.runtime.values." +
+                "HandleValue cannot be cast to class io.ballerina.runtime.api.values.BString"));
     }
 
     @Test(description = "Test java:cast function in ballerina/java for incorrect class in typedesc object annotation")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordDocumentationTest.java
@@ -65,7 +65,7 @@ public class RecordDocumentationTest {
         Assert.assertNotNull(dNode);
     }
 
-    @Test(description = "Test doc struct.", groups = { "disableOnOldParser" })
+    @Test(description = "Test doc struct.")
     public void testDocStruct() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/record_doc_annotation.bal");
         Assert.assertEquals(compileResult.getWarnCount(), 0);
@@ -88,7 +88,7 @@ public class RecordDocumentationTest {
                 EMPTY_STRING), "struct `field c` documentation");
     }
 
-    @Test(description = "Test doc negative cases.", groups = { "disableOnOldParser" }, enabled = false)
+    @Test(description = "Test doc negative cases.", groups = { "disableOnOldParser" })
     public void testDocumentationNegative() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/record_documentation_negative.bal");
         Assert.assertEquals(compileResult.getErrorCount(), 0,
@@ -110,13 +110,13 @@ public class RecordDocumentationTest {
         BAssertUtil.validateWarning(compileResult, i++, "no such documentable parameter 'conn'", 79, 5);
         BAssertUtil.validateWarning(compileResult, i++, "parameter 'req' already documented", 85, 9);
         BAssertUtil.validateWarning(compileResult, i++, "no such documentable parameter 'reqest'", 86, 9);
-        BAssertUtil.validateWarning(compileResult, i++, "field 'abc' already documented", 96, 5);
-        BAssertUtil.validateWarning(compileResult, i++, "invalid reference in documentation 'Baz' for type 'type'", 96,
+        BAssertUtil.validateWarning(compileResult, i++, "field 'abc' already documented", 95, 5);
+        BAssertUtil.validateWarning(compileResult, i++, "invalid reference in documentation 'Baz' for type 'type'", 95,
                                     75);
-        BAssertUtil.validateWarning(compileResult, i++, "invalid reference in documentation 'Baz' for type 'type'", 100,
+        BAssertUtil.validateWarning(compileResult, i++, "invalid reference in documentation 'Baz' for type 'type'", 99,
                                     33);
-        BAssertUtil.validateWarning(compileResult, i++, "undocumented field 'def'", 104, 5);
-        BAssertUtil.validateWarning(compileResult, i, "invalid reference in documentation 'Baz' for type 'type'", 107,
+        BAssertUtil.validateWarning(compileResult, i++, "undocumented field 'def'", 103, 5);
+        BAssertUtil.validateWarning(compileResult, i, "invalid reference in documentation 'Baz' for type 'type'", 106,
                                     33);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/packageimport/PackageImportTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/packageimport/PackageImportTest.java
@@ -42,14 +42,14 @@ public class PackageImportTest {
         BAssertUtil.validateError(result, 0, "redeclared import module 'ballerina/java'", 2, 1);
     }
 
-    @Test (enabled = false)
+    @Test
     public void testImportSamePkgWithDifferentAlias() {
         CompileResult result =
                 BCompileUtil.compile("test-src/statements/package/imports/import-same-pkg-with-different-alias.bal");
         Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
-    @Test (enabled = false)
+    @Test
     public void testImportDifferentPkgsWithSameAlias() {
         CompileResult result = BCompileUtil
                 .compile("test-src/statements/package/imports/import-different-pkgs-with-same-alias-negative.bal");
@@ -72,12 +72,12 @@ public class PackageImportTest {
         BAssertUtil.validateError(result, 0, "cannot resolve module 'foo.x as x'", 1, 1);
     }
 
-    @Test (enabled = false)
+    @Test
     public void testImportsPerfile() {
         CompileResult result = BCompileUtil.compile("test-src/statements/package/sample-project-1", "invalid-imports");
         Assert.assertEquals(result.getErrorCount(), 6);
         int i = 0;
-        BAssertUtil.validateError(result, i++, "redeclared import module 'ballerina/io'", "src/file-negative1.bal", 3,
+        BAssertUtil.validateError(result, i++, "redeclared symbol 'int'", "src/file-negative1.bal", 3,
                 1);
         BAssertUtil.validateError(result, i++, "undefined module 'http'", "src/file-negative2.bal", 3, 5);
         BAssertUtil.validateError(result, i++, "unknown type 'Client'", "src/file-negative2.bal", 3, 5);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtNegativeTest.java
@@ -186,7 +186,7 @@ public class ReturnStmtNegativeTest {
         BAssertUtil.validateError(result, 0, "incompatible types: expected 'string', found '[string,int]'", 2, 13);
     }
 
-    @Test(description = "Test return statement in resource with mismatching types", enabled = false)
+    @Test(description = "Test return statement in resource with mismatching types")
     public void testReturnInResourceWithMismatchingTypes() {
         CompileResult result = BCompileUtil.compile("test-src/statements/returnstmt/return-in-resource-with-" +
                 "mismatching-types.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
@@ -35,7 +35,6 @@ import org.testng.annotations.Test;
  *
  * @since 0.990.4
  */
-@Test(groups = { "brokenOnNewParser" })
 public class ErrorVariableDefinitionTest {
     private CompileResult result;
 
@@ -231,20 +230,20 @@ public class ErrorVariableDefinitionTest {
                 compile("test-src/statements/variabledef/error_variable_definition_stmt_negative.bal");
         Assert.assertEquals(resultNegative.getErrorCount(), 13);
         int i = -1;
-        BAssertUtil.validateError(resultNegative, ++i, "redeclared symbol 'reason11'", 27, 9);
+        BAssertUtil.validateError(resultNegative, ++i, "redeclared symbol 'reason11'", 27, 16);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'SMS', found 'SMA'", 28, 85);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'boolean', found 'string'", 30, 26);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'string', found 'string?'", 31, 28);
-        BAssertUtil.validateError(resultNegative, ++i, "redeclared symbol 'reason11'", 41, 9);
+        BAssertUtil.validateError(resultNegative, ++i, "redeclared symbol 'reason11'", 41, 16);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'boolean', found 'string'", 44, 26);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'string', found 'string?'", 45, 28);
         BAssertUtil.validateError(resultNegative, ++i,
-                "redeclared symbol 'message'", 54, 26);
+                "redeclared symbol 'message'", 54, 36);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'int', found 'map<(anydata|readonly)>'", 56, 18);
         BAssertUtil.validateError(resultNegative, ++i,

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ListenerServiceTaintedStatusPropagationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/ListenerServiceTaintedStatusPropagationTest.java
@@ -29,20 +29,20 @@ import org.testng.annotations.Test;
 @Test
 public class ListenerServiceTaintedStatusPropagationTest {
 
-    @Test(groups = { "disableOnOldParser" }, enabled = false)
+    @Test(groups = { "disableOnOldParser" })
     public void testUntaintedListernBasedService() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/listener-taintedness-propagation-untainted-listener.bal");
         Assert.assertEquals(result.getDiagnostics().length, 0);
     }
 
-    @Test(enabled = false)
+    @Test
     public void testTaintednessPropagationFromTaintedListener() {
         CompileResult result = BCompileUtil.compile(
                 "test-src/taintchecking/propagation/listener-taintedness-propagation-tainted-listener.bal");
         Assert.assertEquals(result.getDiagnostics().length, 3);
         BAssertUtil.validateError(result, 0, "tainted value passed to untainted parameter 'p'", 26, 23);
         BAssertUtil.validateError(result, 1, "tainted value passed to untainted parameter 'p'", 27, 23);
-        BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'p'", 40, 23);
+        BAssertUtil.validateError(result, 2, "tainted value passed to untainted parameter 'p'", 35, 23);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
@@ -43,7 +43,7 @@ public class FinalAccessTest {
         finalLocalNoInitVarResult = BCompileUtil.compile("test-src/types/finaltypes/test_final_local_no_init_var.bal");
     }
 
-    @Test(description = "Test final field access failures", enabled = false)
+    @Test(description = "Test final field access failures")
     public void testFinalFailCase() {
         CompileResult compileResultNegative = BCompileUtil.compile(
                 "test-src/types/finaltypes/test_implicitly_final_negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/service/ServiceTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/service/ServiceTypeTest.java
@@ -42,7 +42,7 @@ public class ServiceTypeTest {
         compileResult = BCompileUtil.compile("test-src/types/service/service_test.bal");
     }
 
-    @Test (enabled = false)
+    @Test
     public void testServiceType() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testServiceType");
         Assert.assertTrue(returns[0] instanceof BMap);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
@@ -1,140 +1,15 @@
-sayHello function(ballerina/http:1.0.0:Caller, ballerina/http:1.0.0:Request) -> error{map<anydata | readonly>} | () {
+sayHello function() -> error{map<anydata | readonly>} | () {
     %1(RETURN) error | ();
-    %2(ARG) ballerina/http:1.0.0:Caller;
-    %3(ARG) ballerina/http:1.0.0:Request;
     %1(RETURN) error | ();
-    %2(ARG) ballerina/http:1.0.0:Caller;
-    %3(ARG) ballerina/http:1.0.0:Request;
-    %4(SYNTHETIC) ballerina/http:1.0.0:FilterContext;
-    %5(SYNTHETIC) ballerina/http:1.0.0:FilterContext;
-    %9(TEMP) string;
-    %10(TEMP) string;
-    %11(TEMP) ();
-    %13(TEMP) ballerina/http:1.0.0:FilterContext | ();
-    %17(SYNTHETIC) ballerina/http:1.0.0:RequestFilter | ballerina/http:1.0.0:ResponseFilter[];
-    %19(TEMP) ballerina/http:1.0.0:ListenerConfiguration;
-    %23(SYNTHETIC) ballerina/lang.array:1.1.0:$anonType$_1;
-    %26(TEMP) ballerina/lang.array:1.1.0:$anonType$_1;
-    %27(SYNTHETIC) ballerina/lang.array:1.1.0:$anonType$_0 | ();
-    %31(TEMP) ballerina/lang.array:1.1.0:$anonType$_0 | ();
-    %32(TEMP) boolean;
-    %34(SYNTHETIC) ballerina/http:1.0.0:RequestFilter | ballerina/http:1.0.0:ResponseFilter;
-    %36(TEMP) ballerina/http:1.0.0:RequestFilter | ballerina/http:1.0.0:ResponseFilter;
-    %37(TEMP) ballerina/lang.array:1.1.0:$anonType$_0;
-    %44(SYNTHETIC) boolean;
-    %46(TEMP) ballerina/http:1.0.0:RequestFilter;
-    %58(SYNTHETIC) ();
-    %59(SYNTHETIC) error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | error{map<anydata | readonly>} | ();
-    %61(TEMP) ballerina/http:1.0.0:Response | string | xml | json | byte[] | ballerina/io:0.5.0:ReadableByteChannel | ballerina/mime:1.0.0:Entity[];
-    %65(TEMP) ();
-    %67(SYNTHETIC) ();
-    %72(SYNTHETIC) error;
 
     bb0 {
-        %5 = new ballerina/http:1.0.0:FilterContext;
-        %9 = ConstLoad hello;
-        %10 = ConstLoad sayHello;
-        %11 = FilterContext.$init$(%5, %self, %9, %10) -> bb1;
+        %1 = ConstLoad 0;
+        GOTO bb2;
     }
     bb1 {
-        %4 = %5;
-        %13 = <ballerina/http:1.0.0:FilterContext | ()> %4;
-        %9 = ConstLoad filterContext;
-        %2[%9] = %13;
-        %10 = ConstLoad config;
-        %19;
-        %9 = ConstLoad filters;
-        %17 = %19[%9];
-        %26 = iterator(%17) -> bb2;
+        GOTO bb2;
     }
     bb2 {
-        %23 = <ballerina/lang.array:1.1.0:$anonType$_1> %26;
-        %31 = $anonType$_1.next(%23, %23) -> bb3;
-    }
-    bb3 {
-        %27 = <ballerina/lang.array:1.1.0:$anonType$_0 | ()> %31;
-        GOTO bb4;
-    }
-    bb4 {
-        %32 = %27 is ballerina/lang.array:1.1.0:$anonType$_0;
-        %32? bb5 : bb14;
-    }
-    bb5 {
-        %37 = <ballerina/lang.array:1.1.0:$anonType$_0> %27;
-        %10 = ConstLoad value;
-        %36 = %37[%10];
-        %34 = <ballerina/http:1.0.0:RequestFilter> %36;
-        %31 = $anonType$_1.next(%23, %23) -> bb6;
-    }
-    bb6 {
-        %27 = <ballerina/lang.array:1.1.0:$anonType$_0 | ()> %31;
-        %46 = <ballerina/http:1.0.0:RequestFilter> %34;
-        %32 = %46 is ballerina/http:1.0.0:RequestFilter;
-        %32? bb7 : bb9;
-    }
-    bb7 {
-        %46 = <ballerina/http:1.0.0:RequestFilter> %34;
-        %32 = RequestFilter.filterRequest(%46, %2, %3, %4) -> bb8;
-    }
-    bb8 {
-        %44 = not %32;
-        GOTO bb10;
-    }
-    bb9 {
-        %44 = ConstLoad false;
-        GOTO bb10;
-    }
-    bb10 {
-        %44? bb11 : bb13;
-    }
-    bb11 {
-        %1 = ConstLoad 0;
-        GOTO bb23;
-    }
-    bb12 {
-        GOTO bb13;
-    }
-    bb13 {
-        GOTO bb4;
-    }
-    bb14 {
-        %9 = ConstLoad Hello, World!;
-        %61 = <ballerina/http:1.0.0:Response | string | xml | json | byte[] | ballerina/io:0.5.0:ReadableByteChannel | ballerina/mime:1.0.0:Entity[]> %9;
-        %59 = Caller.respond(%2, %61) -> bb15;
-    }
-    bb15 {
-        %65 = ConstLoad 0;
-        %32 = %59 == %65;
-        %32? bb16 : bb17;
-    }
-    bb16 {
-        %67 = %59;
-        %58 = %67;
-        GOTO bb21;
-    }
-    bb17 {
-        %32 = %59 is error;
-        %32? bb18 : bb20;
-    }
-    bb18 {
-        %72 = <error> %59;
-        %1 = %72;
-        GOTO bb23;
-    }
-    bb19 {
-        GOTO bb20;
-    }
-    bb20 {
-        GOTO bb21;
-    }
-    bb21 {
-        %1 = ConstLoad 0;
-        GOTO bb23;
-    }
-    bb22 {
-        GOTO bb23;
-    }
-    bb23 {
         return;
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/bir-dump/sayHello
@@ -1,15 +1,29 @@
-sayHello function() -> error{map<anydata | readonly>} | () {
+sayHello function(string) -> error{map<anydata | readonly>} | () {
     %1(RETURN) error | ();
+    %2(ARG) string;
     %1(RETURN) error | ();
+    %2(ARG) string;
+    %3(LOCAL) ballerina/lang.test:1.0.0:Caller;
+    %4(SYNTHETIC) ballerina/lang.test:1.0.0:Caller;
+    %7(TEMP) ();
+    %9(LOCAL) string;
 
     bb0 {
-        %1 = ConstLoad 0;
-        GOTO bb2;
+        %4 = new ballerina/lang.test:1.0.0:Caller;
+        %7 = Caller.$init$(%4) -> bb1;
     }
     bb1 {
-        GOTO bb2;
+        %3 = %4;
+        %9 = Caller.respond(%3, %2) -> bb2;
     }
     bb2 {
+        %1 = ConstLoad 0;
+        GOTO bb4;
+    }
+    bb3 {
+        GOTO bb4;
+    }
+    bb4 {
         return;
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/biroptimizer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/biroptimizer.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
+import ballerina/lang.test;
 import ballerina/io;
 import ballerina/cache;
 
@@ -55,10 +55,9 @@ public function globalVarsAndAnonFunctions() {
     };
 }
 
-service hello on new http:Listener(9090) {
-    resource function sayHello(http:Caller caller,
-        http:Request req) returns error? {
-        check caller->respond("Hello, World!");
+service hello on new test:MockListener(9090) {
+    resource function sayHello() returns error? {
+
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/bir/biroptimizer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/bir/biroptimizer.bal
@@ -56,8 +56,9 @@ public function globalVarsAndAnonFunctions() {
 }
 
 service hello on new test:MockListener(9090) {
-    resource function sayHello() returns error? {
-
+    resource function sayHello(string s) returns error? {
+        test:Caller caller = new test:Caller();
+        string res = caller -> respond(s);
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-negative.bal
@@ -14,7 +14,7 @@
  // specific language governing permissions and limitations
  // under the License.
  
-import ballerina/http;
+import ballerina/lang.test;
 
  
  function testDataflow_1() returns string {
@@ -356,20 +356,20 @@ function testMatch_1() returns string {
     return val;
 }
 
-listener http:MockListener echoEP = new(9090);
+listener test:MockListener echoEP = new(9090);
 
 string x = "x";
 string y = "sample value";
 
 service echo on echoEP {
 
-    resource function echo_1(http:Caller conn, http:Request request) {
+    resource function echo_1(string conn, string request) {
         string a = x;
         a = y;
         x = "init within echo_1";
     }
 
-    resource function echo_2(http:Caller conn, http:Request request) {
+    resource function echo_2(string conn, string request) {
         string a = x;
         a = y;
         x = "init within echo_2";
@@ -440,13 +440,13 @@ public type D record {
 };
 
 
-listener http:MockListener testEP = new(9092);
+listener test:MockListener testEP = new(9092);
 
 int a = 0;
 
 service testService on testEP {
 
-    resource function resource_1(http:Caller conn, http:Request request) {
+    resource function resource_1(string conn, string request) {
         a = 5;
         int b = a;
         int c;
@@ -460,7 +460,7 @@ service testService on testEP {
         int d = c;
     }
 
-    resource function resource_2(http:Caller conn, http:Request request) {
+    resource function resource_2(string conn, string request) {
         int b = a;
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/dataflow/analysis/dataflow-analysis-semantics-negative.bal
@@ -14,7 +14,7 @@
  // specific language governing permissions and limitations
  // under the License.
  
-import ballerina/http;
+import ballerina/lang.test;
 
  
  function testDataflow_1() returns string {
@@ -356,20 +356,20 @@ function testMatch_1() returns string {
     return val;
 }
 
-listener http:MockListener echoEP = new(9090);
+listener test:MockListener echoEP = new(9090);
 
 string x = "x";
 string y = "sample value";
 
 service echo on echoEP {
 
-    resource function echo_1(http:Caller conn, http:Request request) {
+    resource function echo_1(string conn, string request) {
         string a = x;
         a = y;
         x = "init within echo_1";
     }
 
-    resource function echo_2(http:Caller conn, http:Request request) {
+    resource function echo_2(string conn, string request) {
         string a = x;
         a = y;
         x = "init within echo_2";
@@ -440,13 +440,13 @@ public type D record {
 };
 
 
-listener http:MockListener testEP = new(9092);
+listener test:MockListener testEP = new(9092);
 
 int a = 0;
 
 service testService on testEP {
 
-    resource function resource_1(http:Caller conn, http:Request request) {
+    resource function resource_1(string conn, string request) {
         a = 5;
         int b = a;
         int c;
@@ -460,7 +460,7 @@ service testService on testEP {
         int d = c;
     }
 
-    resource function resource_2(http:Caller conn, http:Request request) {
+    resource function resource_2(string conn, string request) {
         int b = a;
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_multiple.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_multiple.bal
@@ -1,4 +1,4 @@
-import ballerina/http;
+import ballerina/lang.test;
 
 # Documentation for Tst struct
 # + a - `field a` documentation
@@ -38,21 +38,19 @@ type Employee record {
 };
 
 # PizzaService HTTP Service
-service PizzaService on new http:MockListener(9090){
+service PizzaService on new test:MockListener(9090){
 
     # Check orderPizza resource.
-    # + conn - HTTP connection.
+    # + conn - connection.
     # + req - In request.
-    resource function orderPizza(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function orderPizza(string conn, string req) {
+
     }
 
     # Check status resource.
-    # + conn - HTTP connection.
+    # + conn - connection.
     # + req - In request.
-    resource function checkStatus(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function checkStatus(string conn, string req) {
+
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_negative.bal
@@ -1,4 +1,4 @@
-import ballerina/http;
+import ballerina/lang.test;
 
 # Documentation for Test annotation
 # function `9invalidFunc`
@@ -87,21 +87,14 @@ type TestConnector record {
 # parameter `invalidParameter`
 # + conn - HTTP connection.
 # + return - description
-@http:ServiceConfig {
-    basePath:"/hello"
-}
-service PizzaService on new http:MockListener(9090) {
+service PizzaService on new test:MockListener(9090) {
 
     # Check orderPizza resource.
     # + req - In request.
     # + req - In request.
     # + reqest - In request.
-    @http:ResourceConfig {
-        path:"/"
-    }
-    resource function orderPizza(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function orderPizza(string conn, string req) {
+
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_service.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/documentation/markdown_service.bal
@@ -1,7 +1,7 @@
-import ballerina/http;
+import ballerina/lang.test;
 
-listener http:MockListener echoEP = new(9090);
-listener http:MockListener echoEP2 = new(9091);
+listener test:MockListener echoEP = new(9090);
+listener test:MockListener echoEP2 = new(9091);
 
 # PizzaService HTTP Service
 service PizzaService on echoEP {
@@ -9,17 +9,14 @@ service PizzaService on echoEP {
     # Check orderPizza resource.
     # + conn - HTTP connection.
     # + req - In request.
-    resource function orderPizza(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function orderPizza(string conn, string req) {
     }
 
     # Check status resource.
     # + conn - HTTP connection.
     # + req - In request.
-    resource function checkStatus(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function checkStatus(string conn, string req) {
+
     }
 }
 
@@ -36,16 +33,14 @@ service PizzaService2 on echoEP2 {
     # Check orderPizza resource.
     # + conn - HTTP connection.
     # + req - In request.
-    resource function orderPizza(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function orderPizza(string conn, string req) {
+
     }
 
     # Check status resource.
     # + conn - HTTP connection.
     # + req - In request.
-    resource function checkStatus(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function checkStatus(string conn, string req) {
+
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_documentation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_documentation_negative.bal
@@ -1,4 +1,4 @@
-import ballerina/http;
+import ballerina/lang.test;
 
 # Documentation for Test annotation
 #
@@ -74,21 +74,20 @@ type TestConnector record {
   string url;
 };
 
-# PizzaService HTTP Service
+# PizzaService
 #
-# + conn - HTTP connection.
-service PizzaService on new http:MockListener(9090) {
+# + conn - connection.
+service PizzaService on new test:MockListener (9090) {
 
     # Check orderPizza resource.
     #
     # + req - In request.
     # + req - In request.
     # + reqest - In request.
-//  # + conn - HTTP connection. Commented due to https://github.com/ballerina-lang/ballerina/issues/5586 issue
+//  # + conn - connection. Commented due to https://github.com/ballerina-lang/ballerina/issues/5586 issue
 
-    resource function orderPizza(http:Caller conn, http:Request req) {
-        http:Response res = new;
-        checkpanic conn->respond(res);
+    resource function orderPizza(string conn, string req) {
+
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/imports/import-different-pkgs-with-same-alias-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/imports/import-different-pkgs-with-same-alias-negative.bal
@@ -1,6 +1,6 @@
-import ballerina/http as x;
-import ballerina/crypto as x;
+import ballerina/lang.'int as x;
+import ballerina/lang.'string as x;
 
 function testFunc() {
-    x:Client clientEndpoint1 = new("https://postman-echo.com");
+    int|error i1 = x:fromString("100");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/imports/import-same-pkg-with-different-alias.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/imports/import-same-pkg-with-different-alias.bal
@@ -1,9 +1,9 @@
-import ballerina/http;
-import ballerina/http as x;
-import ballerina/http as y;
+import ballerina/lang.'int;
+import ballerina/lang.'int as x;
+import ballerina/lang.'int as y;
 
 function testFunc() {
-    http:Client clientEndpoint1 = new("https://postman-echo.com");
-    x:Client clientEndpoint2 = new("https://postman-echo.com");
-    y:Client clientEndpoint3 = new("https://postman-echo.com");
+    int|error i1 = 'int:fromString("100");
+    int|error i2 = x:fromString("100");
+    int|error i3 = y:fromString("100");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/sample-project-1/src/invalid-imports/src/file-negative1.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/sample-project-1/src/invalid-imports/src/file-negative1.bal
@@ -1,7 +1,7 @@
-import ballerina/io;
-import ballerina/http;
-import ballerina/io;
+import ballerina/lang.'int;
+import ballerina/lang.'float;
+import ballerina/lang.'int;
 
 public function foo() {
-    io:println("Hello world!");
+    int|error i3 = 'int:fromString("100");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/sample-project-2/src/foo/foo-impl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/package/sample-project-2/src/foo/foo-impl.bal
@@ -1,7 +1,7 @@
-import ballerina/io;
+import ballerina/lang.'int;
 import bar as _;
-import ballerina/math as _;
+import ballerina/lang.'float as _;
 
 public function runFoo() {
-    io:println("Running foo");
+    int|error i3 = 'int:fromString("100");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/returnstmt/return-in-resource-with-mismatching-types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/returnstmt/return-in-resource-with-mismatching-types.bal
@@ -14,9 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
+import ballerina/lang.test;
 
-service helloWorld on new http:Listener(9090) {
+service helloWorld on new test:MockListener(9090) {
 
     resource function sayHelloWithString(int x) returns error? {
         return x;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/error_variable_definition_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/variabledef/error_variable_definition_stmt.bal
@@ -130,7 +130,7 @@ function testErrorInRecordWithDestructure() returns [int, string, anydata|readon
 
 function testErrorWithAnonErrorType() returns [string, anydata|readonly] {
     error err = error("Error Code", message = "Fatal");
-    error <record {| (anydata|readonly)...; |}> error(reason, message = message) = err;
+    error <simpleError> error(reason, message = message) = err;
     return [reason, message];
 }
 
@@ -170,7 +170,7 @@ type BeeError distinct error<Bee>;
 
 function testIndirectErrorDestructuring() returns [string?, boolean, map<anydata|error>] {
     BeeError e = BeeError(R, message="Msg", fatal=false, other="k");
-    var BeeError(_, message=m, fatal=f, ...rest) = e;
+    var error(_, message=m, fatal=f, ...rest) = e;
     return [m, f, rest];
 }
 
@@ -186,3 +186,5 @@ function testSealedDetailDestructuring() returns [string, map<anydata|readonly>]
     var error(reason, ...rest) = e;
     return [reason, rest];
 }
+
+type simpleError record {| (anydata|readonly)...; |};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/listener-taintedness-propagation-tainted-listener.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/listener-taintedness-propagation-tainted-listener.bal
@@ -14,15 +14,15 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
+import ballerina/lang.test;
 
-listener http:Listener helloWorldEP = new (19093);
-@tainted listener http:Listener helloWorldEP1 = new (19094);
+listener test:MockListener helloWorldEP = new (19093);
+@tainted listener test:MockListener helloWorldEP1 = new (19094);
 
 // Services created using service constructor expressions are dynamically bound to listeners using listener.__attach
 // mechanism hence we consider those services to be tainted.
 service ss = service {
-    resource function x(http:Caller caller, http:Request req) {
+    resource function x(string caller, string req) {
         sensitiveFunc(req);
         sensitiveFunc(caller);
     }
@@ -31,12 +31,7 @@ service ss = service {
 // Service bound to tainted listener is considered tainted.
 service sample on helloWorldEP1 {
 
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/path/{foo}"
-    }
-    resource function params (http:Caller caller, http:Request req, string foo) {
-        var bar = req.getQueryParamValue("bar");
+    resource function params (string foo) {
         sensitiveFunc(foo);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/listener-taintedness-propagation-untainted-listener.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/listener-taintedness-propagation-untainted-listener.bal
@@ -14,21 +14,16 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import ballerina/http;
+import ballerina/lang.test;
 
-@untainted listener http:Listener helloWorldEP = new (19293);
+@untainted listener test:MockListener helloWorldEP = new (19293);
 
 // Arguments to resource functions are provided by the listener and if the listener is statically verified to be
 // untainted we consider the arguments provided by the listener to be untainted as well.
 
 service sample on helloWorldEP {
 
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/path/{foo}"
-    }
-    resource function params (http:Caller caller, http:Request req, string foo) {
-        var bar = req.getQueryParamValue("bar");
+    resource function params (string foo) {
         sensitiveFunc(foo);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/test_implicitly_final_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/test_implicitly_final_negative.bal
@@ -1,4 +1,4 @@
-import ballerina/http;
+import ballerina/lang.test;
 
 public function testFieldAsFinalParameter() returns (int) {
     int i = 50;
@@ -30,7 +30,7 @@ function finalFunction() {
     int i = 0;
 }
 
-service FooService on new http:Listener(9090) {
+service FooService on new test:MockListener(9090) {
 
 }
 
@@ -39,10 +39,10 @@ function testCompound(int a) returns int {
     return a;
 }
 
-listener http:MockListener ml = new http:MockListener(8080);
+listener test:MockListener ml = new (8080);
 
 public function testChangingListenerVariableAfterDefining() {
-    ml = new http:MockListener(8081);
+    ml = new test:MockListener(8081);
 }
 
 service s on ml {}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/service/service_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/service/service_test.bal
@@ -1,28 +1,17 @@
-import ballerina/http;
+import ballerina/lang.test;
 
 function testServiceType () returns (service) {
     service ts = HelloWorld;
     return ts;
 }
 
-@http:ServiceConfig {basePath:"/hello"}
-service HelloWorld on new http:MockListener (9090) {
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/helloWorld"
-    }
-    resource function hello (http:Caller caller, http:Request req) {
-        http:Response res = new;
-        res.setTextPayload("Hello, World!");
-        checkpanic caller->respond(res);
+service HelloWorld on new test:MockListener (9090) {
+    resource function hello () {
+
     }
 
-    @http:ResourceConfig {
-        methods:["GET"],
-        path:"/returnError"
-    }
-    resource function returnError (http:Caller conn, http:Request request) returns error? {
-        error e = error("Http Error");
+    resource function returnError () returns error? {
+        error e = error("Service Error");
         return e;
     }
 }


### PR DESCRIPTION
## Purpose
> $title. Use this listener for testing in the ballerina-lang repository (replacement for HTTP listener).

Fixes #26636 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
