### PR TITLE
Add a multi-language extension support

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/module-info.java
+++ b/language-server/modules/langserver-commons/src/main/java/module-info.java
@@ -3,6 +3,7 @@ module io.ballerina.language.server.commons {
     requires io.ballerina.parser;
     requires io.ballerina.tools.api;
     requires org.eclipse.lsp4j;
+    requires org.eclipse.lsp4j.jsonrpc;
     exports org.ballerinalang.langserver.commons;
     exports org.ballerinalang.langserver.commons.client;
     exports org.ballerinalang.langserver.commons.semantichighlighter;

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/CompletionExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/CompletionExtension.java
@@ -18,9 +18,7 @@
 package org.ballerinalang.langserver.commons;
 
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.util.List;
 
@@ -29,8 +27,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public interface CompletionExtension
-        extends LanguageExtension<CompletionParams, Either<List<CompletionItem>, CompletionList>> {
+public interface CompletionExtension extends LanguageExtension<CompletionParams, List<CompletionItem>> {
 
     /**
      * {@inheritDoc}

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/CompletionExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/CompletionExtension.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.commons;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.List;
+
+/**
+ * Represents a completion extension.
+ *
+ * @since 2.0.0
+ */
+public interface CompletionExtension
+        extends LanguageExtension<CompletionParams, Either<List<CompletionItem>, CompletionList>> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default LanguageFeatureKind kind() {
+        return LanguageFeatureKind.COMPLETION;
+    }
+}

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DiagnosticsExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DiagnosticsExtension.java
@@ -19,12 +19,14 @@ package org.ballerinalang.langserver.commons;
 
 import org.eclipse.lsp4j.PublishDiagnosticsParams;
 
+import java.util.List;
+
 /**
  * Represents a completion extension.
  *
  * @since 2.0.0
  */
-public interface DiagnosticsExtension extends LanguageExtension<String, PublishDiagnosticsParams> {
+public interface DiagnosticsExtension extends LanguageExtension<String, List<PublishDiagnosticsParams>> {
 
     /**
      * {@inheritDoc}

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DiagnosticsExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DiagnosticsExtension.java
@@ -1,0 +1,36 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.commons;
+
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+
+/**
+ * Represents a completion extension.
+ *
+ * @since 2.0.0
+ */
+public interface DiagnosticsExtension extends LanguageExtension<String, PublishDiagnosticsParams> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default LanguageFeatureKind kind() {
+        return LanguageFeatureKind.DIAGNOSTIC;
+    }
+}

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/FormattingExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/FormattingExtension.java
@@ -1,0 +1,40 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.commons;
+
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.List;
+
+/**
+ * Represents a completion extension.
+ *
+ * @since 2.0.0
+ */
+public interface FormattingExtension
+        extends LanguageExtension<DocumentFormattingParams, List<? extends TextEdit>> {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    default LanguageFeatureKind kind() {
+        return LanguageFeatureKind.FORMAT;
+    }
+}

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageExtension.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.commons;
+
+/**
+ * Represents the language extension SPI to cater the multi-language support in the language server.
+ * 
+ * @param <I> Input parameter type
+ * @param <O> output parameter type
+ *
+ * @since 2.0.0
+ */
+public interface LanguageExtension<I, O> {
+
+    /**
+     * Get the language feature kind which the particular extension caters.
+     *
+     * @return language feature kind.
+     */
+    LanguageFeatureKind kind();
+
+    /**
+     * Pre-validation to be done against the URI. Not only the document extension, but also against the document name or
+     * the file path can ber utilized to validate the given document.
+     *
+     * @param inputParams input parameters to validate
+     * @return {@link Boolean} whether the document URI matches the validation criteria
+     */
+    boolean validate(I inputParams);
+
+    /**
+     * Execute the operation and output the result.
+     * 
+     * @param inputParams input params for the opration
+     * @return {@link O} output of the operation
+     */
+    O execute(I inputParams, LSContext context);
+}

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageExtension.java
@@ -19,10 +19,9 @@ package org.ballerinalang.langserver.commons;
 
 /**
  * Represents the language extension SPI to cater the multi-language support in the language server.
- * 
+ *
  * @param <I> Input parameter type
  * @param <O> output parameter type
- *
  * @since 2.0.0
  */
 public interface LanguageExtension<I, O> {
@@ -45,9 +44,11 @@ public interface LanguageExtension<I, O> {
 
     /**
      * Execute the operation and output the result.
-     * 
+     *
      * @param inputParams input params for the opration
      * @return {@link O} output of the operation
+     * @throws Throwable while executing. Here we throw the Throwable rather than a narrower exception since the
+     *                   executor has to handle the exceptions accordingly.
      */
-    O execute(I inputParams, LSContext context);
+    O execute(I inputParams, LSContext context) throws Throwable;
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageFeatureKind.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageFeatureKind.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.commons;
+
+/**
+ * Represents the language server features.
+ * 
+ * @since 2.0.0
+ */
+public enum LanguageFeatureKind {
+    COMPLETION,
+    DIAGNOSTIC,
+    FORMAT
+}

--- a/language-server/modules/langserver-core/src/main/java/module-info.java
+++ b/language-server/modules/langserver-core/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module io.ballerina.language.server.core {
+    uses org.ballerinalang.langserver.commons.LanguageExtension;
     requires gson;
     requires io.ballerina.formatter.core;
     requires org.eclipse.lsp4j;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -161,7 +161,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
             // Note: If the source is a cached stdlib source or path does not exist, then return early and ignore
             if (completionPath.isEmpty() || CommonUtil.isCachedExternalSource(fileUri)) {
-                return Either.forLeft(new ArrayList<>());
+                return Either.forLeft(Collections.emptyList());
             }
 
             Path compilationPath = getUntitledFilePath(completionPath.toString()).orElse(completionPath.get());
@@ -187,7 +187,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 lock.ifPresent(Lock::unlock);
             }
 
-            return Either.forLeft(new ArrayList<>());
+            return Either.forLeft(Collections.emptyList());
         });
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LangExtensionDelegator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LangExtensionDelegator.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver;
+
+import org.ballerinalang.langserver.commons.CompletionExtension;
+import org.ballerinalang.langserver.commons.DiagnosticsExtension;
+import org.ballerinalang.langserver.commons.FormattingExtension;
+import org.ballerinalang.langserver.commons.LSContext;
+import org.ballerinalang.langserver.commons.LanguageExtension;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.ServiceLoader;
+
+/**
+ * Delegate the operation to the valid extension.
+ *
+ * @since 2.0.0
+ */
+public class LangExtensionDelegator {
+
+    private static final LangExtensionDelegator INSTANCE = new LangExtensionDelegator();
+
+    private final List<CompletionExtension> completionExtensions = new ArrayList<>();
+    private final List<FormattingExtension> formatExtensions = new ArrayList<>();
+    private final List<DiagnosticsExtension> diagExtensions = new ArrayList<>();
+
+    private LangExtensionDelegator() {
+        ServiceLoader.load(LanguageExtension.class).forEach(languageExtension -> {
+            switch (languageExtension.kind()) {
+                case COMPLETION:
+                    completionExtensions.add((CompletionExtension) languageExtension);
+                    break;
+                case FORMAT:
+                    formatExtensions.add((FormattingExtension) languageExtension);
+                    break;
+                case DIAGNOSTIC:
+                    diagExtensions.add((DiagnosticsExtension) languageExtension);
+                    break;
+                default:
+                    break;
+            }
+        });
+    }
+
+    /**
+     * Get the completions.
+     *
+     * @param params completion parameters
+     * @return {@link Either} completion results
+     */
+    public Either<List<CompletionItem>, CompletionList> completion(CompletionParams params, LSContext context) {
+        return completionExtensions.stream().filter(ext -> ext.validate(params))
+                .map(ext -> ext.execute(params, context))
+                .findFirst()
+                .orElse(Either.forRight(new CompletionList()));
+    }
+
+    /**
+     * Get the formatting.
+     *
+     * @param params formatting parameters
+     * @return {@link List} of text edits
+     */
+    public List<? extends TextEdit> formatting(DocumentFormattingParams params, LSContext context) {
+        return formatExtensions.stream().filter(ext -> ext.validate(params))
+                .map(ext -> ext.execute(params, context))
+                .findFirst()
+                .orElse(new ArrayList<>());
+    }
+
+    /**
+     * Get the Diagnostics.
+     *
+     * @param uri document URI
+     * @return {@link PublishDiagnosticsParams} diagnostic params calculated
+     */
+    public PublishDiagnosticsParams diagnostics(String uri, LSContext context) {
+        return diagExtensions.stream().filter(ext -> ext.validate(uri))
+                .map(ext -> ext.execute(uri, context))
+                .findFirst()
+                .orElse(new PublishDiagnosticsParams());
+    }
+
+    public static LangExtensionDelegator instance() {
+        return INSTANCE;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/BallerinaCompletionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/BallerinaCompletionExtension.java
@@ -20,20 +20,15 @@ package org.ballerinalang.langserver.completions;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.CompletionExtension;
 import org.ballerinalang.langserver.commons.LSContext;
-import org.ballerinalang.langserver.commons.completion.LSCompletionException;
-import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.completions.util.CompletionUtil;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
-import java.util.ArrayList;
 import java.util.List;
 
 /**
  * Completion extension implementation for ballerina.
- * 
+ *
  * @since 2.0.0
  */
 @JavaSPIService("org.ballerinalang.langserver.commons.LanguageExtension")
@@ -45,13 +40,9 @@ public class BallerinaCompletionExtension implements CompletionExtension {
     }
 
     @Override
-    public Either<List<CompletionItem>, CompletionList> execute(CompletionParams inputParams, LSContext context) {
+    public List<CompletionItem> execute(CompletionParams inputParams, LSContext context)
+            throws Throwable {
         CompletionUtil.resolveSymbols(context);
-        try {
-            return Either.forLeft(CompletionUtil.getCompletionItems(context));
-        } catch (WorkspaceDocumentException | LSCompletionException e) {
-            // TODO: Handle this properly
-        }
-        return Either.forLeft(new ArrayList<>());
+        return CompletionUtil.getCompletionItems(context);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/BallerinaCompletionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/BallerinaCompletionExtension.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.completions;
+
+import org.ballerinalang.annotation.JavaSPIService;
+import org.ballerinalang.langserver.commons.CompletionExtension;
+import org.ballerinalang.langserver.commons.LSContext;
+import org.ballerinalang.langserver.commons.completion.LSCompletionException;
+import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.completions.util.CompletionUtil;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Completion extension implementation for ballerina.
+ * 
+ * @since 2.0.0
+ */
+@JavaSPIService("org.ballerinalang.langserver.commons.LanguageExtension")
+public class BallerinaCompletionExtension implements CompletionExtension {
+    @Override
+    public boolean validate(CompletionParams inputParams) {
+        // Here we check the .bal extension
+        return inputParams.getTextDocument().getUri().endsWith(".bal");
+    }
+
+    @Override
+    public Either<List<CompletionItem>, CompletionList> execute(CompletionParams inputParams, LSContext context) {
+        CompletionUtil.resolveSymbols(context);
+        try {
+            return Either.forLeft(CompletionUtil.getCompletionItems(context));
+        } catch (WorkspaceDocumentException | LSCompletionException e) {
+            // TODO: Handle this properly
+        }
+        return Either.forLeft(new ArrayList<>());
+    }
+}


### PR DESCRIPTION
## Purpose
> With this add the multi-language extension support for language server. Currently we have added three Language Feature extensions along with this PR.
1. Completion Extension
2. Formatting Extension
3. Diagnostic Extension

Also, with this PR we migrated the `completion` feature to delegate to the particular completion extension(Currently Ballerina only)

## Samples
Writing a feature extension
- Implement the `CompletionExtension`, `FormattingExtension` or `DiagnosticsExtension`
- Implements the `execute` method
- `execute` method is the entry point
- LangExtensionDelegator is the publicly exposed delegate API.

Ex: Implementing a language extension for completion feature
```
@JavaSPIService("org.ballerinalang.langserver.commons.LanguageExtension")
public class BallerinaCompletionExtension implements CompletionExtension {
    @Override
    public boolean validate(CompletionParams inputParams) {
        // language validation based on the input parameters
    }

    @Override
    public Either<List<CompletionItem>, CompletionList> execute(CompletionParams inputParams, LSContext context) {
        // resolving logic
    }
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
