### PR TITLE
Make TypeSymbol an extension of Symbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -159,7 +159,7 @@ public class SymbolFactory {
     public static BallerinaMethodSymbol createMethodSymbol(BInvokableSymbol invokableSymbol, String name) {
         TypeSymbol typeDescriptor = TypesFactory.getTypeDescriptor(invokableSymbol.type);
         BallerinaFunctionSymbol functionSymbol = SymbolFactory.createFunctionSymbol(invokableSymbol, name);
-        if (typeDescriptor.kind() == TypeDescKind.FUNCTION) {
+        if (typeDescriptor.typeKind() == TypeDescKind.FUNCTION) {
             return new BallerinaMethodSymbol(functionSymbol);
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/AbstractTypeSymbol.java
@@ -18,13 +18,17 @@
 package io.ballerina.compiler.api.impl.types;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.types.TypeDescKind;
 import io.ballerina.compiler.api.types.TypeSymbol;
+import io.ballerina.tools.diagnostics.Location;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a Ballerina Type Descriptor.
@@ -54,6 +58,26 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
 
     @Override
     public abstract String signature();
+
+    @Override
+    public String name() {
+        return "";
+    }
+
+    @Override
+    public SymbolKind kind() {
+        return SymbolKind.TYPE;
+    }
+
+    @Override
+    public Optional<Documentation> docAttachment() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Location location() {
+        return null;
+    }
 
     @Override
     public List<MethodSymbol> builtinMethods() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/AbstractTypeSymbol.java
@@ -43,7 +43,7 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     }
 
     @Override
-    public TypeDescKind kind() {
+    public TypeDescKind typeKind() {
         return typeDescKind;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/types/BallerinaTypeDescTypeSymbol.java
@@ -51,8 +51,8 @@ public class BallerinaTypeDescTypeSymbol extends AbstractTypeSymbol implements T
     @Override
     public String signature() {
         if (this.typeParameter().isPresent()) {
-            return this.kind().name() + "<" + this.typeParameter().get().signature() + ">";
+            return this.typeKind().name() + "<" + this.typeParameter().get().signature() + ">";
         }
-        return this.kind().name();
+        return this.typeKind().name();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/types/TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/types/TypeSymbol.java
@@ -28,7 +28,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public interface TypeSymbol {
+public interface TypeSymbol extends Symbol {
 
     /**
      * Get the Type Kind.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/types/TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/types/TypeSymbol.java
@@ -19,6 +19,7 @@ package io.ballerina.compiler.api.types;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
 
 import java.util.List;
 
@@ -34,7 +35,7 @@ public interface TypeSymbol {
      *
      * @return {@link TypeDescKind} represented by the model
      */
-    TypeDescKind kind();
+    TypeDescKind typeKind();
 
     /**
      * Get the module ID.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/impl/ErrorTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/impl/ErrorTypeCodeAction.java
@@ -79,11 +79,11 @@ public class ErrorTypeCodeAction implements DiagBasedCodeAction {
         // add code action for `check`
         if (symbol != null) {
             boolean hasError = false;
-            if (typeDescriptor.kind() == TypeDescKind.ERROR) {
+            if (typeDescriptor.typeKind() == TypeDescKind.ERROR) {
                 hasError = true;
-            } else if (typeDescriptor.kind() == TypeDescKind.UNION) {
+            } else if (typeDescriptor.typeKind() == TypeDescKind.UNION) {
                 UnionTypeSymbol unionType = (UnionTypeSymbol) typeDescriptor;
-                hasError = unionType.memberTypeDescriptors().stream().anyMatch(s -> s.kind() == TypeDescKind.ERROR);
+                hasError = unionType.memberTypeDescriptors().stream().anyMatch(s -> s.typeKind() == TypeDescKind.ERROR);
             }
             if (hasError) {
                 String panicCmd = String.format(CommandConstants.CREATE_VARIABLE_TITLE + " with '%s'", "Check");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/impl/IgnoreReturnCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/impl/IgnoreReturnCodeAction.java
@@ -50,11 +50,11 @@ public class IgnoreReturnCodeAction implements DiagBasedCodeAction {
         String uri = context.get(DocumentServiceKeys.FILE_URI_KEY);
         Position pos = diagnostic.getRange().getStart();
         boolean hasError = false;
-        if (typeDescriptor.kind() == TypeDescKind.ERROR) {
+        if (typeDescriptor.typeKind() == TypeDescKind.ERROR) {
             hasError = true;
-        } else if (typeDescriptor.kind() == TypeDescKind.UNION) {
+        } else if (typeDescriptor.typeKind() == TypeDescKind.UNION) {
             UnionTypeSymbol unionType = (UnionTypeSymbol) typeDescriptor;
-            hasError = unionType.memberTypeDescriptors().stream().anyMatch(s -> s.kind() == TypeDescKind.ERROR);
+            hasError = unionType.memberTypeDescriptors().stream().anyMatch(s -> s.typeKind() == TypeDescKind.ERROR);
         }
         // Add ignore return value code action
         if (!hasError) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/VariableAssignmentRequiredCodeActionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/VariableAssignmentRequiredCodeActionProvider.java
@@ -253,7 +253,7 @@ public class VariableAssignmentRequiredCodeActionProvider extends AbstractCodeAc
         }
 
         @Override
-        public TypeDescKind kind() {
+        public TypeDescKind typeKind() {
             return typeDescKind;
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/VariableAssignmentRequiredCodeActionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/VariableAssignmentRequiredCodeActionProvider.java
@@ -18,9 +18,11 @@ package org.ballerinalang.langserver.codeaction.providers;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.types.FunctionTypeSymbol;
@@ -29,6 +31,7 @@ import io.ballerina.compiler.api.types.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
+import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -49,6 +52,7 @@ import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
@@ -245,6 +249,7 @@ public class VariableAssignmentRequiredCodeActionProvider extends AbstractCodeAc
         private final TypeDescKind typeDescKind;
         private final ModuleID moduleID;
         private final String definitionName;
+        private final Location location = new BLangDiagnosticLocation("$builtin$", -1, -1, -1, -1);
 
         TempTypeSymbol(String definitionName, TypeDescKind typeDescKind, ModuleID moduleID) {
             this.typeDescKind = typeDescKind;
@@ -271,6 +276,26 @@ public class VariableAssignmentRequiredCodeActionProvider extends AbstractCodeAc
             return !ANON_ORG.equals(moduleID.orgName()) ? moduleID.orgName() + Names.ORG_NAME_SEPARATOR +
                     moduleID.moduleName() + Names.VERSION_SEPARATOR + moduleID.version() + ":" +
                     definitionName : definitionName;
+        }
+
+        @Override
+        public String name() {
+            return "";
+        }
+
+        @Override
+        public SymbolKind kind() {
+            return SymbolKind.TYPE;
+        }
+
+        @Override
+        public Optional<Documentation> docAttachment() {
+            return Optional.empty();
+        }
+
+        @Override
+        public Location location() {
+            return this.location;
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/AnnotationUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/AnnotationUtil.java
@@ -177,16 +177,16 @@ public class AnnotationUtil {
             Optional<TypeSymbol> attachedType
                     = Optional.ofNullable(CommonUtil.getRawType(annotationSymbol.typeDescriptor().get()));
             Optional<TypeSymbol> resultType;
-            if (attachedType.isPresent() && attachedType.get().kind() == TypeDescKind.ARRAY) {
+            if (attachedType.isPresent() && attachedType.get().typeKind() == TypeDescKind.ARRAY) {
                 resultType = Optional.of(((ArrayTypeSymbol) attachedType.get()).memberTypeDescriptor());
             } else {
                 resultType = attachedType;
             }
-            if (resultType.isPresent() && (resultType.get().kind() == TypeDescKind.RECORD
-                    || resultType.get().kind() == TypeDescKind.MAP)) {
+            if (resultType.isPresent() && (resultType.get().typeKind() == TypeDescKind.RECORD
+                    || resultType.get().typeKind() == TypeDescKind.MAP)) {
                 List<FieldSymbol> requiredFields = new ArrayList<>();
                 annotationStart.append(" ").append(CommonKeys.OPEN_BRACE_KEY).append(LINE_SEPARATOR);
-                if (resultType.get().kind() == TypeDescKind.RECORD) {
+                if (resultType.get().typeKind() == TypeDescKind.RECORD) {
                     requiredFields.addAll(CommonUtil.getMandatoryRecordFields((RecordTypeSymbol) resultType.get()));
                 }
                 List<String> insertTexts = new ArrayList<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -238,7 +238,7 @@ public class CommonUtil {
         if (bType == null) {
             return "()";
         }
-        switch (bType.kind()) {
+        switch (bType.typeKind()) {
             case INT:
                 typeString = Integer.toString(0);
                 break;
@@ -558,13 +558,13 @@ public class CommonUtil {
         signature.append(")");
         insertText.append(")");
         Optional<TypeSymbol> returnType = functionTypeDesc.returnTypeDescriptor();
-        if (returnType.isEmpty() || returnType.get().kind() == TypeDescKind.NIL) {
+        if (returnType.isEmpty() || returnType.get().typeKind() == TypeDescKind.NIL) {
             insertText.append(";");
         }
         String initString = "(";
         String endString = ")";
 
-        if (returnType.isPresent() && returnType.get().kind() != TypeDescKind.NIL) {
+        if (returnType.isPresent() && returnType.get().typeKind() != TypeDescKind.NIL) {
             signature.append(initString).append(returnType.get().signature());
             signature.append(endString);
         }
@@ -593,7 +593,7 @@ public class CommonUtil {
     public static String getRecordFieldCompletionInsertText(FieldSymbol bField, int tabOffset) {
         TypeSymbol fieldType = bField.typeDescriptor();
         StringBuilder insertText = new StringBuilder(bField.name() + ": ");
-        if (fieldType.kind() == TypeDescKind.RECORD) {
+        if (fieldType.typeKind() == TypeDescKind.RECORD) {
             List<FieldSymbol> requiredFields = getMandatoryRecordFields((RecordTypeSymbol) fieldType);
             if (requiredFields.isEmpty()) {
                 insertText.append("{").append("${1}}");
@@ -615,7 +615,7 @@ public class CommonUtil {
                     .append("}");
         } else if (fieldType instanceof BArrayType) {
             insertText.append("[").append("${1}").append("]");
-        } else if (fieldType.kind() == TypeDescKind.STRING) {
+        } else if (fieldType.typeKind() == TypeDescKind.STRING) {
             insertText.append("\"").append("${1}").append("\"");
         } else {
             insertText.append("${1:").append(getDefaultValueForType(bField.typeDescriptor())).append("}");
@@ -1032,7 +1032,7 @@ public class CommonUtil {
      * @return {@link TypeSymbol} extracted type descriptor
      */
     public static TypeSymbol getRawType(TypeSymbol typeDescriptor) {
-        return typeDescriptor.kind() == TypeDescKind.TYPE_REFERENCE
+        return typeDescriptor.typeKind() == TypeDescKind.TYPE_REFERENCE
                 ? ((TypeReferenceTypeSymbol) typeDescriptor).typeDescriptor() : typeDescriptor;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -59,7 +59,7 @@ public class SymbolUtil {
                 return false;
         }
 
-        return CommonUtil.getRawType(typeDescriptor).kind() == TypeDescKind.OBJECT;
+        return CommonUtil.getRawType(typeDescriptor).typeKind() == TypeDescKind.OBJECT;
     }
 
     /**
@@ -81,7 +81,7 @@ public class SymbolUtil {
                 return false;
         }
 
-        return CommonUtil.getRawType(typeDescriptor).kind() == TypeDescKind.RECORD;
+        return CommonUtil.getRawType(typeDescriptor).typeKind() == TypeDescKind.RECORD;
     }
 
     /**
@@ -150,7 +150,7 @@ public class SymbolUtil {
     public static boolean isListener(Symbol symbol) {
         Optional<? extends TypeSymbol> symbolTypeDesc = getTypeDescriptor(symbol);
         
-        if (symbolTypeDesc.isEmpty() || CommonUtil.getRawType(symbolTypeDesc.get()).kind() != TypeDescKind.OBJECT) {
+        if (symbolTypeDesc.isEmpty() || CommonUtil.getRawType(symbolTypeDesc.get()).typeKind() != TypeDescKind.OBJECT) {
             return false;
         }
         List<String> attachedMethods = ((ObjectTypeSymbol) CommonUtil.getRawType(symbolTypeDesc.get())).methods()
@@ -187,7 +187,7 @@ public class SymbolUtil {
         }
         TypeSymbol typeDescriptor = ((VariableSymbol) symbol).typeDescriptor();
 
-        return typeDescriptor.kind() == TypeDescKind.ERROR;
+        return typeDescriptor.typeKind() == TypeDescKind.ERROR;
     }
 
     /**
@@ -201,6 +201,6 @@ public class SymbolUtil {
             return Optional.empty();
         }
 
-        return Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor().kind());
+        return Optional.ofNullable(((VariableSymbol) symbol).typeDescriptor().typeKind());
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
@@ -99,16 +99,16 @@ public class BLangRecordLiteralUtil {
     }
 
     private static List<TypeSymbol> getTypeListForMapAndRecords(TypeSymbol typeDesc) {
-        if (typeDesc.kind() == TypeDescKind.MAP) {
+        if (typeDesc.typeKind() == TypeDescKind.MAP) {
             Optional<TypeSymbol> memberType = ((MapTypeSymbol) typeDesc).typeParameter();
             if (memberType.isEmpty()) {
                 return new ArrayList<>();
             }
-            if (memberType.get().kind() == TypeDescKind.UNION) {
+            if (memberType.get().typeKind() == TypeDescKind.UNION) {
                 return new ArrayList<>(((UnionTypeSymbol) memberType.get()).memberTypeDescriptors());
             }
             return Collections.singletonList(memberType.get());
-        } else if (typeDesc.kind() == TypeDescKind.RECORD) {
+        } else if (typeDesc.typeKind() == TypeDescKind.RECORD) {
             return ((RecordTypeSymbol) typeDesc).fieldDescriptors().stream()
                     .map(FieldSymbol::typeDescriptor)
                     .collect(Collectors.toList());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -98,7 +98,7 @@ public final class FunctionCompletionItemBuilder {
         CompletionItem item = new CompletionItem();
         setMeta(item, initMethod, ctx);
         String functionName;
-        if (mode == InitializerBuildMode.EXPLICIT && typeDesc.kind() == TypeDescKind.TYPE_REFERENCE) {
+        if (mode == InitializerBuildMode.EXPLICIT && typeDesc.typeKind() == TypeDescKind.TYPE_REFERENCE) {
             functionName = ((TypeReferenceTypeSymbol) typeDesc).name();
             // TODO: Following is blocked due to the Type Referencing issue in Semantic Model
 //            Optional<BLangIdentifier> moduleAlias = ctx.get(DocumentServiceKeys.CURRENT_DOC_IMPORTS_KEY).stream()
@@ -190,7 +190,7 @@ public final class FunctionCompletionItemBuilder {
         if (!paramsStr.isEmpty()) {
             documentation += "**Params**" + CommonUtil.MD_LINE_SEPARATOR + paramsStr;
         }
-        if (functionTypeDesc.kind() != TypeDescKind.NIL) {
+        if (functionTypeDesc.typeKind() != TypeDescKind.NIL) {
             String desc = "";
             if (docAttachment.isPresent() && docAttachment.get().returnDescription().isPresent()
                     && !docAttachment.get().returnDescription().get().isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeCompletionItemBuilder.java
@@ -69,10 +69,10 @@ public class TypeCompletionItemBuilder {
             return;
         }
         Optional<? extends TypeSymbol> typeDescriptor = SymbolUtil.getTypeDescriptor(bSymbol);
-        typeDescriptor = (typeDescriptor.isPresent() && typeDescriptor.get().kind() == TypeDescKind.TYPE_REFERENCE)
+        typeDescriptor = (typeDescriptor.isPresent() && typeDescriptor.get().typeKind() == TypeDescKind.TYPE_REFERENCE)
                 ? Optional.of(((TypeReferenceTypeSymbol) typeDescriptor.get()).typeDescriptor()) : typeDescriptor;
 
-        if (typeDescriptor.isEmpty() || typeDescriptor.get().kind() == null) {
+        if (typeDescriptor.isEmpty() || typeDescriptor.get().typeKind() == null) {
             item.setKind(CompletionItemKind.Unit);
             item.setDetail("type");
             return;
@@ -83,15 +83,15 @@ public class TypeCompletionItemBuilder {
             // Finite types
             item.setKind(CompletionItemKind.TypeParameter);
         }*/
-        switch (typeDescriptor.get().kind()) {
+        switch (typeDescriptor.get().typeKind()) {
             case UNION:
                 // Union types
                 List<TypeSymbol> memberTypes = new ArrayList<>(((UnionTypeSymbol) typeDescriptor.get())
                         .memberTypeDescriptors());
                 boolean allMatch = memberTypes.stream()
-                        .allMatch(typeDesc -> typeDesc.kind() == memberTypes.get(0).kind());
+                        .allMatch(typeDesc -> typeDesc.typeKind() == memberTypes.get(0).typeKind());
                 if (allMatch) {
-                    switch (memberTypes.get(0).kind()) {
+                    switch (memberTypes.get(0).typeKind()) {
                         case ERROR:
                             item.setKind(CompletionItemKind.Event);
                             break;
@@ -124,7 +124,7 @@ public class TypeCompletionItemBuilder {
             item.setDocumentation(bSymbol.docAttachment().get().description().get());
         }
         // set sub bType
-        String name = typeDescriptor.get().kind().getName();
+        String name = typeDescriptor.get().typeKind().getName();
         String detail = name.substring(0, 1).toUpperCase(Locale.ENGLISH)
                 + name.substring(1).toLowerCase(Locale.ENGLISH);
         item.setDetail(detail);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
@@ -72,12 +72,13 @@ public class ArrayTypeDescriptorNodeContext extends AbstractCompletionProvider<A
     private Predicate<Symbol> constantFilter() {
         return symbol -> {
             Optional<? extends TypeSymbol> typeDescriptor = SymbolUtil.getTypeDescriptor(symbol);
-            typeDescriptor = typeDescriptor.isPresent() && typeDescriptor.get().kind() == TypeDescKind.TYPE_REFERENCE ?
-                    Optional.ofNullable(((TypeReferenceTypeSymbol) typeDescriptor.get()).typeDescriptor())
-                    : typeDescriptor;
+            typeDescriptor =
+                    typeDescriptor.isPresent() && typeDescriptor.get().typeKind() == TypeDescKind.TYPE_REFERENCE ?
+                            Optional.ofNullable(((TypeReferenceTypeSymbol) typeDescriptor.get()).typeDescriptor())
+                            : typeDescriptor;
             return symbol.kind() == SymbolKind.CONSTANT
                     && typeDescriptor.isPresent()
-                    && typeDescriptor.get().kind() == TypeDescKind.INT;
+                    && typeDescriptor.get().typeKind() == TypeDescKind.INT;
         };
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -222,7 +222,7 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                         return false;
                     }
                     TypeSymbol typeDesc = ((VariableSymbol) symbol).typeDescriptor();
-                    return typeDesc.kind() == TypeDescKind.UNION && !capturedSymbols.contains(symbol.name());
+                    return typeDesc.typeKind() == TypeDescKind.UNION && !capturedSymbols.contains(symbol.name());
                 })
                 .map(symbol -> {
                     capturedSymbols.add(symbol.name());
@@ -232,7 +232,7 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                             = new ArrayList<>(((UnionTypeSymbol) ((VariableSymbol) symbol).typeDescriptor())
                             .memberTypeDescriptors());
                     members.forEach(bType -> {
-                        if (bType.kind() == TypeDescKind.ERROR) {
+                        if (bType.typeKind() == TypeDescKind.ERROR) {
                             errorTypes.add(bType);
                         } else {
                             resultTypes.add(bType);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorTypeParamsNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ErrorTypeParamsNodeContext.java
@@ -66,8 +66,8 @@ public class ErrorTypeParamsNodeContext extends AbstractCompletionProvider<Error
                 return false;
             }
             TypeSymbol typeDesc = ((TypeDefinitionSymbol) symbol).typeDescriptor();
-            return (CommonUtil.getRawType(typeDesc).kind() == TypeDescKind.MAP
-                    || CommonUtil.getRawType(typeDesc).kind() == TypeDescKind.RECORD);
+            return (CommonUtil.getRawType(typeDesc).typeKind() == TypeDescKind.MAP
+                    || CommonUtil.getRawType(typeDesc).typeKind() == TypeDescKind.RECORD);
         };
         List<Symbol> mappingTypes;
         if (this.onQualifiedNameIdentifier(context, nodeAtCursor)) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -133,9 +133,9 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
 
         List<FieldSymbol> fieldSymbols = new ArrayList<>();
         TypeSymbol rawType = CommonUtil.getRawType(typeDescriptor.get());
-        if (rawType.kind() == TypeDescKind.OBJECT) {
+        if (rawType.typeKind() == TypeDescKind.OBJECT) {
             fieldSymbols.addAll(((ObjectTypeSymbol) rawType).fieldDescriptors());
-        } else if (rawType.kind() == TypeDescKind.RECORD) {
+        } else if (rawType.typeKind() == TypeDescKind.RECORD) {
             fieldSymbols.addAll(((RecordTypeSymbol) rawType).fieldDescriptors());
         }
 
@@ -188,7 +188,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         }
         TypeSymbol rawType = CommonUtil.getRawType(fieldTypeDesc.get());
         List<MethodSymbol> visibleMethods = rawType.builtinMethods();
-        if (rawType.kind() == TypeDescKind.OBJECT) {
+        if (rawType.typeKind() == TypeDescKind.OBJECT) {
             visibleMethods.addAll(((ObjectTypeSymbol) rawType).methods());
         }
         Optional<MethodSymbol> filteredMethod = visibleMethods.stream()
@@ -206,7 +206,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
                                                              TypeSymbol typeDescriptor) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
         TypeSymbol rawType = CommonUtil.getRawType(typeDescriptor);
-        switch (rawType.kind()) {
+        switch (rawType.typeKind()) {
             case RECORD:
                 ((RecordTypeSymbol) rawType).fieldDescriptors().forEach(fieldDescriptor -> {
                     CompletionItem completionItem = new CompletionItem();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
@@ -121,7 +121,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
                     continue;
                 }
                 String sortText = genSortTextForInitContextItem(context, lsItem,
-                        (assignableType.get().typeDescriptor()).kind());
+                        (assignableType.get().typeDescriptor()).typeKind());
                 cItem.setSortText(sortText);
             }
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -202,7 +202,7 @@ public class MappingConstructorExpressionNodeContext extends
             TypeSymbol typeDescriptor = ((VariableSymbol) symbol).typeDescriptor();
             String symbolName = symbol.name();
             if (fieldTypeMap.containsKey(symbolName)
-                    && fieldTypeMap.get(symbolName).kind() == typeDescriptor.kind()) {
+                    && fieldTypeMap.get(symbolName).typeKind() == typeDescriptor.typeKind()) {
                 String bTypeName = typeDescriptor.signature();
                 CompletionItem cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbolName,
                         bTypeName);
@@ -246,7 +246,7 @@ public class MappingConstructorExpressionNodeContext extends
                     .filter(fieldDescriptor -> fieldDescriptor.name().equals(fieldName))
                     .findAny();
             if (fieldDesc.isEmpty()
-                    || CommonUtil.getRawType(fieldDesc.get().typeDescriptor()).kind() != TypeDescKind.RECORD) {
+                    || CommonUtil.getRawType(fieldDesc.get().typeDescriptor()).typeKind() != TypeDescKind.RECORD) {
                 return Optional.empty();
             }
             recordType = (RecordTypeSymbol) CommonUtil.getRawType(fieldDesc.get().typeDescriptor());
@@ -282,7 +282,7 @@ public class MappingConstructorExpressionNodeContext extends
                 .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION && symbol.name().equals(annotationName))
                 .map(entry -> ((AnnotationSymbol) entry).typeDescriptor().orElse(null))
                 .findAny();
-        if (bTypeSymbol.isEmpty() || bTypeSymbol.get().kind() != TypeDescKind.RECORD) {
+        if (bTypeSymbol.isEmpty() || bTypeSymbol.get().typeKind() != TypeDescKind.RECORD) {
             return Optional.empty();
         }
         return Optional.of((RecordTypeSymbol) bTypeSymbol.get());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
@@ -97,7 +97,7 @@ public abstract class VariableDeclarationProvider<T extends Node> extends Abstra
             }
             String identifier = ((QualifiedNameReferenceNode) typeDescriptorNode).identifier().text();
             objectType = module.get().typeDefinitions().stream()
-                    .filter(typeSymbol -> CommonUtil.getRawType(typeSymbol.typeDescriptor()).kind()
+                    .filter(typeSymbol -> CommonUtil.getRawType(typeSymbol.typeDescriptor()).typeKind()
                             == TypeDescKind.OBJECT
                             && typeSymbol.name().equals(identifier))
                     .map(typeSymbol -> (ObjectTypeSymbol) CommonUtil.getRawType(typeSymbol.typeDescriptor()))
@@ -106,7 +106,7 @@ public abstract class VariableDeclarationProvider<T extends Node> extends Abstra
             String identifier = ((SimpleNameReferenceNode) typeDescriptorNode).name().text();
             objectType = visibleSymbols.stream()
                     .filter(symbol -> symbol.kind() == SymbolKind.TYPE
-                            && CommonUtil.getRawType(((TypeDefinitionSymbol) symbol).typeDescriptor()).kind()
+                            && CommonUtil.getRawType(((TypeDefinitionSymbol) symbol).typeDescriptor()).typeKind()
                             == TypeDescKind.OBJECT
                             && symbol.name().equals(identifier))
                     .map(symbol -> (ObjectTypeSymbol) CommonUtil

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -402,10 +402,10 @@ public class SignatureHelpUtil {
 
         List<FieldSymbol> fieldSymbols = new ArrayList<>();
 
-        if (CommonUtil.getRawType(typeDescriptor.get()).kind() == TypeDescKind.OBJECT) {
+        if (CommonUtil.getRawType(typeDescriptor.get()).typeKind() == TypeDescKind.OBJECT) {
             fieldSymbols.addAll(((ObjectTypeSymbol) CommonUtil
                     .getRawType(typeDescriptor.get())).fieldDescriptors());
-        } else if (CommonUtil.getRawType(typeDescriptor.get()).kind() == TypeDescKind.RECORD) {
+        } else if (CommonUtil.getRawType(typeDescriptor.get()).typeKind() == TypeDescKind.RECORD) {
             fieldSymbols.addAll(((RecordTypeSymbol) CommonUtil
                     .getRawType(typeDescriptor.get())).fieldDescriptors());
         }
@@ -459,7 +459,7 @@ public class SignatureHelpUtil {
         }
 
         List<MethodSymbol> visibleMethods = fieldTypeDesc.get().builtinMethods();
-        if (CommonUtil.getRawType(fieldTypeDesc.get()).kind() == TypeDescKind.OBJECT) {
+        if (CommonUtil.getRawType(fieldTypeDesc.get()).typeKind() == TypeDescKind.OBJECT) {
             visibleMethods.addAll(((ObjectTypeSymbol) CommonUtil.getRawType(fieldTypeDesc.get())).methods());
         }
         Optional<MethodSymbol> filteredMethod = visibleMethods.stream()
@@ -475,7 +475,7 @@ public class SignatureHelpUtil {
 
     private static List<FunctionSymbol> getFunctionSymbolsForTypeDesc(TypeSymbol typeDescriptor) {
         List<FunctionSymbol> functionSymbols = new ArrayList<>();
-        if (CommonUtil.getRawType(typeDescriptor).kind() == TypeDescKind.OBJECT) {
+        if (CommonUtil.getRawType(typeDescriptor).typeKind() == TypeDescKind.OBJECT) {
             ObjectTypeSymbol objTypeDesc = (ObjectTypeSymbol) CommonUtil.getRawType(typeDescriptor);
             functionSymbols.addAll(objTypeDesc.methods());
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -95,8 +95,8 @@ public class ExpressionTypeTest {
     @Test
     public void testByteLiteral() {
         TypeSymbol type = getExprType(19, 13, 19, 42);
-        assertEquals(type.kind(), ARRAY);
-        assertEquals(((ArrayTypeSymbol) type).memberTypeDescriptor().kind(), BYTE);
+        assertEquals(type.typeKind(), ARRAY);
+        assertEquals(((ArrayTypeSymbol) type).memberTypeDescriptor().typeKind(), BYTE);
     }
 
     @Test(dataProvider = "TemplateExprProvider")
@@ -115,35 +115,35 @@ public class ExpressionTypeTest {
     @Test
     public void testRawTemplate() {
         TypeSymbol type = getExprType(25, 29, 25, 50);
-        assertEquals(type.kind(), TYPE_REFERENCE);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
 
         TypeSymbol objType = ((TypeReferenceTypeSymbol) type).typeDescriptor();
-        assertEquals(objType.kind(), OBJECT);
+        assertEquals(objType.typeKind(), OBJECT);
 
         type = getExprType(25, 32, 25, 33);
-        assertEquals(type.kind(), STRING);
+        assertEquals(type.typeKind(), STRING);
     }
 
     @Test
     public void testArrayLiteral() {
         TypeSymbol type = getExprType(29, 20, 29, 34);
-        assertEquals(type.kind(), ARRAY);
+        assertEquals(type.typeKind(), ARRAY);
 
         TypeSymbol memberType = ((ArrayTypeSymbol) type).memberTypeDescriptor();
-        assertEquals(memberType.kind(), STRING);
+        assertEquals(memberType.typeKind(), STRING);
     }
 
     @Test(dataProvider = "TupleLiteralPosProvider")
     public void testTupleLiteral(int sLine, int sCol, int eLine, int eCol, List<TypeDescKind> memberKinds) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
-        assertEquals(type.kind(), TUPLE);
+        assertEquals(type.typeKind(), TUPLE);
 
         List<TypeSymbol> memberTypes = ((TupleTypeSymbol) type).memberTypeDescriptors();
 
         assertEquals(memberTypes.size(), memberKinds.size());
         for (int i = 0; i < memberTypes.size(); i++) {
             TypeSymbol memberType = memberTypes.get(i);
-            assertEquals(memberType.kind(), memberKinds.get(i));
+            assertEquals(memberType.typeKind(), memberKinds.get(i));
         }
     }
 
@@ -158,10 +158,10 @@ public class ExpressionTypeTest {
     @Test
     public void testMapLiteral() {
         TypeSymbol type = getExprType(34, 20, 34, 34);
-        assertEquals(type.kind(), MAP);
+        assertEquals(type.typeKind(), MAP);
 
         TypeSymbol constraint = ((MapTypeSymbol) type).typeParameter().get();
-        assertEquals(constraint.kind(), STRING);
+        assertEquals(constraint.typeKind(), STRING);
 
         assertType(34, 28, 34, 33, STRING);
     }
@@ -169,10 +169,10 @@ public class ExpressionTypeTest {
     @Test
     public void testInferredMappingConstructorType() {
         TypeSymbol type = getExprType(35, 13, 35, 43);
-        assertEquals(type.kind(), TYPE_REFERENCE);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
 
         TypeSymbol referredType = ((TypeReferenceTypeSymbol) type).typeDescriptor();
-        assertEquals(referredType.kind(), RECORD);
+        assertEquals(referredType.typeKind(), RECORD);
 
         assertType(35, 14, 35, 20, STRING);
         assertType(35, 22, 35, 31, STRING);
@@ -183,7 +183,7 @@ public class ExpressionTypeTest {
     @Test
     public void testRecordLiteral() {
         TypeSymbol type = getExprType(40, 16, 40, 43);
-        assertEquals(type.kind(), RECORD);
+        assertEquals(type.typeKind(), RECORD);
 
         // Disabled ones due to #26628
 //        assertType(40, 17, 40, 21, STRING);
@@ -195,10 +195,10 @@ public class ExpressionTypeTest {
     @Test
     public void testJSONObject() {
         TypeSymbol type = getExprType(42, 13, 42, 40);
-        assertEquals(type.kind(), MAP);
+        assertEquals(type.typeKind(), MAP);
 
         TypeSymbol constraint = ((MapTypeSymbol) type).typeParameter().get();
-        assertEquals(constraint.kind(), JSON);
+        assertEquals(constraint.typeKind(), JSON);
 
         // Disabled ones due to #26628
 //        assertType(42, 14, 42, 18, STRING);
@@ -231,9 +231,9 @@ public class ExpressionTypeTest {
     @Test(dataProvider = "TypeInitPosProvider")
     public void testObjecTypeInit(int sLine, int sCol, int eLine, int eCol) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
-        assertEquals(type.kind(), TYPE_REFERENCE);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
         assertEquals(((TypeReferenceTypeSymbol) type).name(), "PersonObj");
-        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().kind(), OBJECT);
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), OBJECT);
     }
 
     @DataProvider(name = "TypeInitPosProvider")
@@ -306,7 +306,7 @@ public class ExpressionTypeTest {
 
     private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
-        assertEquals(type.kind(), kind);
+        assertEquals(type.typeKind(), kind);
     }
 
     private TypeSymbol getExprType(int sLine, int sCol, int eLine, int eCol) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -97,21 +97,21 @@ public class TypedescriptorTest {
         Symbol symbol = getSymbol(22, 37);
         TypeReferenceTypeSymbol type =
                 (TypeReferenceTypeSymbol) ((AnnotationSymbol) symbol).typeDescriptor().get();
-        assertEquals(type.typeDescriptor().kind(), TypeDescKind.RECORD);
+        assertEquals(type.typeDescriptor().typeKind(), TypeDescKind.RECORD);
     }
 
     @Test
     public void testConstantType() {
         Symbol symbol = getSymbol(16, 7);
         TypeSymbol type = ((ConstantSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), FLOAT);
+        assertEquals(type.typeKind(), FLOAT);
     }
 
     @Test
     public void testFunctionType() {
         Symbol symbol = getSymbol(43, 12);
         FunctionTypeSymbol type = ((FunctionSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), TypeDescKind.FUNCTION);
+        assertEquals(type.typeKind(), TypeDescKind.FUNCTION);
 
         List<ParameterSymbol> parameters = type.parameters();
         assertEquals(parameters.size(), 2);
@@ -123,38 +123,38 @@ public class TypedescriptorTest {
         validateParam(restParam, "rest", REST, ARRAY);
 
         TypeSymbol returnType = type.returnTypeDescriptor().get();
-        assertEquals(returnType.kind(), INT);
+        assertEquals(returnType.typeKind(), INT);
     }
 
     @Test
     public void testFutureType() {
         Symbol symbol = getSymbol(45, 16);
         FutureTypeSymbol type = (FutureTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), FUTURE);
-        assertEquals(type.typeParameter().get().kind(), INT);
+        assertEquals(type.typeKind(), FUTURE);
+        assertEquals(type.typeParameter().get().typeKind(), INT);
     }
 
     @Test
     public void testArrayType() {
         Symbol symbol = getSymbol(47, 18);
         ArrayTypeSymbol type = (ArrayTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), ARRAY);
-        assertEquals(((TypeReferenceTypeSymbol) type.memberTypeDescriptor()).typeDescriptor().kind(), OBJECT);
+        assertEquals(type.typeKind(), ARRAY);
+        assertEquals(((TypeReferenceTypeSymbol) type.memberTypeDescriptor()).typeDescriptor().typeKind(), OBJECT);
     }
 
     @Test
     public void testMapType() {
         Symbol symbol = getSymbol(49, 16);
         MapTypeSymbol type = (MapTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), MAP);
-        assertEquals(type.typeParameter().get().kind(), STRING);
+        assertEquals(type.typeKind(), MAP);
+        assertEquals(type.typeParameter().get().typeKind(), STRING);
     }
 
     @Test
     public void testNilType() {
         Symbol symbol = getSymbol(38, 9);
         FunctionTypeSymbol type = (FunctionTypeSymbol) ((FunctionSymbol) symbol).typeDescriptor();
-        assertEquals(type.returnTypeDescriptor().get().kind(), NIL);
+        assertEquals(type.returnTypeDescriptor().get().typeKind(), NIL);
     }
 
     @Test
@@ -163,13 +163,13 @@ public class TypedescriptorTest {
         TypeReferenceTypeSymbol typeRef =
                 (TypeReferenceTypeSymbol) ((TypeDefinitionSymbol) symbol).typeDescriptor();
         ObjectTypeSymbol type = (ObjectTypeSymbol) typeRef.typeDescriptor();
-        assertEquals(type.kind(), OBJECT);
+        assertEquals(type.typeKind(), OBJECT);
 
         List<FieldSymbol> fields = type.fieldDescriptors();
         FieldSymbol field = fields.get(0);
         assertEquals(fields.size(), 1);
         assertEquals(field.name(), "name");
-        assertEquals(field.typeDescriptor().kind(), STRING);
+        assertEquals(field.typeDescriptor().typeKind(), STRING);
 
         List<MethodSymbol> methods = type.methods();
         MethodSymbol method = methods.get(0);
@@ -185,7 +185,7 @@ public class TypedescriptorTest {
         TypeReferenceTypeSymbol typeRef =
                 (TypeReferenceTypeSymbol) ((TypeDefinitionSymbol) symbol).typeDescriptor();
         RecordTypeSymbol type = (RecordTypeSymbol) typeRef.typeDescriptor();
-        assertEquals(type.kind(), RECORD);
+        assertEquals(type.typeKind(), RECORD);
         assertFalse(type.inclusive());
         assertFalse(type.restTypeDescriptor().isPresent());
 
@@ -193,31 +193,31 @@ public class TypedescriptorTest {
         FieldSymbol field = fields.get(0);
         assertEquals(fields.size(), 1);
         assertEquals(field.name(), "path");
-        assertEquals(field.typeDescriptor().kind(), STRING);
+        assertEquals(field.typeDescriptor().typeKind(), STRING);
     }
 
     @Test
     public void testTupleType() {
         Symbol symbol = getSymbol(51, 28);
         TupleTypeSymbol type = (TupleTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), TUPLE);
+        assertEquals(type.typeKind(), TUPLE);
 
         List<TypeSymbol> members = type.memberTypeDescriptors();
         assertEquals(members.size(), 2);
-        assertEquals(members.get(0).kind(), INT);
-        assertEquals(members.get(1).kind(), STRING);
+        assertEquals(members.get(0).typeKind(), INT);
+        assertEquals(members.get(1).typeKind(), STRING);
 
         assertTrue(type.restTypeDescriptor().isPresent());
-        assertEquals(type.restTypeDescriptor().get().kind(), FLOAT);
+        assertEquals(type.restTypeDescriptor().get().typeKind(), FLOAT);
     }
 
     @Test(dataProvider = "TypedescDataProvider")
     public void testTypedescType(int line, int col, TypeDescKind kind) {
         Symbol symbol = getSymbol(line, col);
         TypeDescTypeSymbol type = (TypeDescTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), TYPEDESC);
+        assertEquals(type.typeKind(), TYPEDESC);
         assertTrue(type.typeParameter().isPresent());
-        assertEquals(type.typeParameter().get().kind(), kind);
+        assertEquals(type.typeParameter().get().typeKind(), kind);
     }
 
     @DataProvider(name = "TypedescDataProvider")
@@ -232,12 +232,12 @@ public class TypedescriptorTest {
     public void testUnionType() {
         Symbol symbol = getSymbol(56, 21);
         UnionTypeSymbol type = (UnionTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(type.kind(), UNION);
+        assertEquals(type.typeKind(), UNION);
 
         List<TypeSymbol> members = type.memberTypeDescriptors();
-        assertEquals(members.get(0).kind(), INT);
-        assertEquals(members.get(1).kind(), STRING);
-        assertEquals(members.get(2).kind(), FLOAT);
+        assertEquals(members.get(0).typeKind(), INT);
+        assertEquals(members.get(1).typeKind(), STRING);
+        assertEquals(members.get(2).typeKind(), FLOAT);
     }
 
     @Test(enabled = false)
@@ -245,26 +245,26 @@ public class TypedescriptorTest {
         Symbol symbol = getSymbol(58, 11);
         TypeReferenceTypeSymbol typeRef =
                 (TypeReferenceTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(typeRef.kind(), TYPE_REFERENCE);
+        assertEquals(typeRef.typeKind(), TYPE_REFERENCE);
 
         UnionTypeSymbol type = (UnionTypeSymbol) typeRef.typeDescriptor();
 
         List<TypeSymbol> members = type.memberTypeDescriptors();
-        assertEquals(members.get(0).kind(), INT);
-        assertEquals(members.get(1).kind(), FLOAT);
-        assertEquals(members.get(2).kind(), DECIMAL);
+        assertEquals(members.get(0).typeKind(), INT);
+        assertEquals(members.get(1).typeKind(), FLOAT);
+        assertEquals(members.get(2).typeKind(), DECIMAL);
     }
 
     @Test(dataProvider = "FiniteTypeDataProvider")
     public void testFiniteType(int line, int column, List<String> expSignatures) {
         Symbol symbol = getSymbol(line, column);
         UnionTypeSymbol union = (UnionTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
-        assertEquals(union.kind(), UNION);
+        assertEquals(union.typeKind(), UNION);
 
         List<TypeSymbol> members = union.memberTypeDescriptors();
         for (int i = 0; i < members.size(); i++) {
             TypeSymbol member = members.get(i);
-            assertEquals(member.kind(), SINGLETON);
+            assertEquals(member.typeKind(), SINGLETON);
             assertEquals(member.signature(), expSignatures.get(i));
         }
     }
@@ -284,6 +284,6 @@ public class TypedescriptorTest {
     private void validateParam(ParameterSymbol param, String name, ParameterKind kind, TypeDescKind typeKind) {
         assertEquals(param.name().get(), name);
         assertEquals(param.kind(), kind);
-        assertEquals(param.typeDescriptor().kind(), typeKind);
+        assertEquals(param.typeDescriptor().typeKind(), typeKind);
     }
 }


### PR DESCRIPTION
## Purpose
This PR is to make `TypeSymbol` an extension of `Symbol` to address #26587.

## Remarks
Since both `Symbol` and `TypeSymbol` had `kind()` as a method, had to rename the one in `TypeSymbol` to `typeKind()` to avoid the conflict when extending from `Symbol`. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
