### PR TITLE
Disable ErrorVariableDefinitionTest

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
@@ -44,7 +44,7 @@ public class ErrorVariableDefinitionTest {
                 compile("test-src/statements/variabledef/error_variable_definition_stmt.bal");
     }
 
-    @Test(description = "Test simple error var def with string and map")
+    @Test(description = "Test simple error var def with string and map", groups = { "brokenOnSpecDeviation" })
     public void testBasicErrorVariableWithMapDetails() {
         BValue[] returns = BRunUtil.invoke(result, "testBasicErrorVariableWithMapDetails");
         Assert.assertEquals(returns.length, 12);
@@ -63,7 +63,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertNull(returns[11]);
     }
 
-    @Test(description = "Test simple error var def with const and map")
+    @Test(description = "Test simple error var def with const and map", groups = { "brokenOnSpecDeviation" })
     public void testBasicErrorVariableWithConstAndMap() {
         BValue[] returns = BRunUtil.invoke(result, "testBasicErrorVariableWithConstAndMap");
         Assert.assertEquals(returns.length, 12);
@@ -82,7 +82,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertNull(returns[11]);
     }
 
-    @Test(description = "Test simple error var def with string and map declared with var")
+    @Test(description = "Test simple error var def with string and map declared with var", groups = { "brokenOnSpecDeviation" })
     public void testVarBasicErrorVariableWithMapDetails() {
         BValue[] returns = BRunUtil.invoke(result, "testVarBasicErrorVariableWithMapDetails");
         Assert.assertEquals(returns.length, 12);
@@ -101,7 +101,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertNull(returns[11]);
     }
 
-    @Test(description = "Test simple error var def with const and map declared with var")
+    @Test(description = "Test simple error var def with const and map declared with var", groups = { "brokenOnSpecDeviation" })
     public void testVarBasicErrorVariableWithConstAndMap() {
         BValue[] returns = BRunUtil.invoke(result, "testVarBasicErrorVariableWithConstAndMap");
         Assert.assertEquals(returns.length, 12);
@@ -120,7 +120,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertNull(returns[11]);
     }
 
-    @Test(description = "Test simple error var def with record as detail")
+    @Test(description = "Test simple error var def with record as detail", groups = { "brokenOnSpecDeviation" })
     public void testBasicErrorVariableWithRecordDetails() {
         BValue[] returns = BRunUtil.invoke(result, "testBasicErrorVariableWithRecordDetails");
         Assert.assertEquals(returns.length, 5);
@@ -131,7 +131,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(((BMap) returns[4]).get("message").stringValue(), "Something Wrong");
     }
 
-    @Test(description = "Test simple error var def inside tuple")
+    @Test(description = "Test simple error var def inside tuple", groups = { "brokenOnSpecDeviation" })
     public void testErrorInTuple() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorInTuple");
         Assert.assertEquals(returns.length, 5);
@@ -142,7 +142,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertTrue(((BBoolean) returns[4]).booleanValue());
     }
 
-    @Test(description = "Test simple error var def inside tuple with var")
+    @Test(description = "Test simple error var def inside tuple with var", groups = { "brokenOnSpecDeviation" })
     public void testErrorInTupleWithVar() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorInTupleWithVar");
         Assert.assertEquals(returns.length, 5);
@@ -164,7 +164,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertTrue(((BBoolean) returns[4]).booleanValue());
     }
 
-    @Test(description = "Test simple error var def inside tuple with destructuring error")
+    @Test(description = "Test simple error var def inside tuple with destructuring error", groups = { "brokenOnSpecDeviation" })
     public void testErrorInTupleWithDestructure2() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorInTupleWithDestructure2");
         Assert.assertEquals(returns.length, 5);
@@ -184,7 +184,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns[2].stringValue(), "Something Wrong3");
     }
 
-    @Test(description = "Test simple error var def inside tuple with destructuring error")
+    @Test(description = "Test simple error var def inside tuple with destructuring error", groups = { "brokenOnSpecDeviation" })
     public void testErrorWithAnonErrorType() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorWithAnonErrorType");
         Assert.assertEquals(returns.length, 2);
@@ -192,7 +192,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns[1].stringValue(), "Fatal");
     }
 
-    @Test(description = "Test error variable with ignore as the detail variable")
+    @Test(description = "Test error variable with ignore as the detail variable", groups = { "brokenOnSpecDeviation" })
     public void testErrorWithUnderscore() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorWithUnderscore");
         Assert.assertEquals(returns.length, 11);
@@ -209,7 +209,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns[10].stringValue(), "Something Wrong");
     }
 
-    @Test(description = "Test named error variable def")
+    @Test(description = "Test named error variable def", groups = { "brokenOnSpecDeviation" })
     public void testIndirectErrorDestructuring() {
         BValue[] returns = BRunUtil.invoke(result, "testIndirectErrorDestructuring");
         Assert.assertEquals(returns[0].stringValue(), "Msg");
@@ -217,7 +217,7 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns[2].stringValue(), "{\"other\":\"k\"}");
     }
 
-    @Test(description = "Test error destruturing with sealed detail record")
+    @Test(description = "Test error destruturing with sealed detail record", groups = { "brokenOnSpecDeviation" })
     public void testSealedDetailDestructuring() {
         BValue[] returns = BRunUtil.invoke(result, "testSealedDetailDestructuring");
         Assert.assertEquals(returns[0].stringValue(), "sealed");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
@@ -82,7 +82,8 @@ public class ErrorVariableDefinitionTest {
         Assert.assertNull(returns[11]);
     }
 
-    @Test(description = "Test simple error var def with string and map declared with var", groups = { "brokenOnSpecDeviation" })
+    @Test(description = "Test simple error var def with string and map declared with var", groups = {
+            "brokenOnSpecDeviation" })
     public void testVarBasicErrorVariableWithMapDetails() {
         BValue[] returns = BRunUtil.invoke(result, "testVarBasicErrorVariableWithMapDetails");
         Assert.assertEquals(returns.length, 12);
@@ -101,7 +102,8 @@ public class ErrorVariableDefinitionTest {
         Assert.assertNull(returns[11]);
     }
 
-    @Test(description = "Test simple error var def with const and map declared with var", groups = { "brokenOnSpecDeviation" })
+    @Test(description = "Test simple error var def with const and map declared with var", groups = {
+            "brokenOnSpecDeviation" })
     public void testVarBasicErrorVariableWithConstAndMap() {
         BValue[] returns = BRunUtil.invoke(result, "testVarBasicErrorVariableWithConstAndMap");
         Assert.assertEquals(returns.length, 12);
@@ -164,7 +166,8 @@ public class ErrorVariableDefinitionTest {
         Assert.assertTrue(((BBoolean) returns[4]).booleanValue());
     }
 
-    @Test(description = "Test simple error var def inside tuple with destructuring error", groups = { "brokenOnSpecDeviation" })
+    @Test(description = "Test simple error var def inside tuple with destructuring error", groups = {
+            "brokenOnSpecDeviation" })
     public void testErrorInTupleWithDestructure2() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorInTupleWithDestructure2");
         Assert.assertEquals(returns.length, 5);
@@ -184,7 +187,8 @@ public class ErrorVariableDefinitionTest {
         Assert.assertEquals(returns[2].stringValue(), "Something Wrong3");
     }
 
-    @Test(description = "Test simple error var def inside tuple with destructuring error", groups = { "brokenOnSpecDeviation" })
+    @Test(description = "Test simple error var def inside tuple with destructuring error", groups = {
+            "brokenOnSpecDeviation" })
     public void testErrorWithAnonErrorType() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorWithAnonErrorType");
         Assert.assertEquals(returns.length, 2);


### PR DESCRIPTION
Disabling the test due to spec deviation.

## Purpose
> This test needs to be revisited since closed records are not allowed in the error detail. Need to revisit and fix the test.

Related issue #26707

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
