### PR TITLE
Update signature help parameter detection by range

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -213,7 +213,7 @@ public class SymbolFactory {
         if (symbol == null) {
             return null;
         }
-        String name = symbol.getName().getValue();
+        String name = symbol.getName().getValue().isBlank() ? null : symbol.getName().getValue();
         TypeSymbol typeDescriptor = TypesFactory.getTypeDescriptor(symbol.getType());
         List<Qualifier> qualifiers = new ArrayList<>();
         if ((symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -105,7 +105,6 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
 
         completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_NAMESPACE_DECLARATION.get()));
-        completionItems.add(new SnippetCompletionItem(context, Snippet.CLAUSE_ON_FAIL.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_XMLNS.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_VAR.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.KW_WAIT.get()));
@@ -138,9 +137,22 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
         completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_RETURN.get()));
         completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_PANIC.get()));
         Optional<Node> nodeBeforeCursor = this.nodeBeforeCursor(context, node);
-        if (nodeBeforeCursor.isPresent() && nodeBeforeCursor.get().kind() == SyntaxKind.IF_ELSE_STATEMENT) {
-            completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_ELSE_IF.get()));
-            completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_ELSE.get()));
+        if (nodeBeforeCursor.isPresent()) {
+            switch (nodeBeforeCursor.get().kind()) {
+                case IF_ELSE_STATEMENT:
+                    completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_ELSE_IF.get()));
+                    completionItems.add(new SnippetCompletionItem(context, Snippet.STMT_ELSE.get()));
+                    break;
+                case DO_STATEMENT:
+                case MATCH_STATEMENT:
+                case FOREACH_STATEMENT:
+                case WHILE_STATEMENT:
+                case LOCK_STATEMENT:
+                    completionItems.add(new SnippetCompletionItem(context, Snippet.CLAUSE_ON_FAIL.get()));
+                    break;
+                default:
+                    break;
+            }
         }
         if (withinLoop) {
             /*

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -100,7 +100,8 @@ public class SignatureHelpUtil {
         labelBuilder.append("(");
         // Join the function parameters to generate the function's signature
         List<ParameterInfoModel> parameterInfoModels = signatureInfoModel.getParameterInfoModels();
-        for (ParameterInfoModel paramModel : parameterInfoModels) {
+        for (int i = 0; i < parameterInfoModels.size(); i++) {
+            ParameterInfoModel paramModel = parameterInfoModels.get(i);
             int labelOffset = labelBuilder.toString().length();
             labelBuilder.append(paramModel.parameter.getType());
             ParameterInformation paramInfo = new ParameterInformation();
@@ -112,7 +113,7 @@ public class SignatureHelpUtil {
                 paramEnd += (paramModel.parameter.getName().get() + " ").length();
                 labelBuilder.append(" ").append(paramModel.parameter.getName().get());
             }
-            if (parameterInfoModels.indexOf(paramModel) < parameterInfoModels.size() - 1) {
+            if (i < parameterInfoModels.size() - 1) {
                 labelBuilder.append(", ");
             }
             paramInfo.setLabel(Tuple.two(paramStart, paramEnd));

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/latest/StatementContextTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/completion/latest/StatementContextTest.java
@@ -35,87 +35,13 @@ public class StatementContextTest extends CompletionTestNew {
     }
 
     @Override
-    public Object[][] testSubset() {
-        return new Object[][] {
-                {"assignment_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"assignment_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"assignment_stmt_ctx_config3.json", this.getTestResourceDir()},
-                {"assignment_stmt_ctx_config4.json", this.getTestResourceDir()},
-                {"assignment_stmt_ctx_config5.json", this.getTestResourceDir()},
-                {"async_send_action_ctx_config1.json", this.getTestResourceDir()},
-                {"async_send_action_ctx_config2.json", this.getTestResourceDir()},
-                {"checking_call_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"checking_call_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"continue_break_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"continue_break_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"do_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"do_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"else_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"else_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"elseif_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"elseif_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"elseif_stmt_ctx_config4.json", this.getTestResourceDir()},
-                {"elseif_stmt_ctx_config5.json", this.getTestResourceDir()},
-                {"elseif_stmt_ctx_config6.json", this.getTestResourceDir()},
-                {"flush_action_ctx_config1.json", this.getTestResourceDir()},
-                {"flush_action_ctx_config2.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config3.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config4.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config5.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config6.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config7.json", this.getTestResourceDir()},
-                {"foreach_stmt_ctx_config8.json", this.getTestResourceDir()},
-                {"fork_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"fork_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"function_call_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"function_call_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"if_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"if_stmt_ctx_config2.json", this.getTestResourceDir()},
-//                {"if_stmt_ctx_config3.json", this.getTestResourceDir()}, // Blocked By #26317
-                {"if_stmt_ctx_config4.json", this.getTestResourceDir()},
-                {"if_stmt_ctx_config5.json", this.getTestResourceDir()},
-                {"if_stmt_ctx_config6.json", this.getTestResourceDir()},
-                {"if_stmt_ctx_config7.json", this.getTestResourceDir()},
-                {"if_stmt_ctx_config8.json", this.getTestResourceDir()},
-                {"lock_stmt_ctx_config1.json", this.getTestResourceDir()},
-//                {"match_stmt_ctx_config1.json", this.getTestResourceDir()}, // Blocked by #26455
-                {"receive_action_ctx_config1.json", this.getTestResourceDir()},
-                {"receive_action_ctx_config2.json", this.getTestResourceDir()},
-                {"remote_action_config1.json", this.getTestResourceDir()},
-                {"sync_send_action_ctx_config1.json", this.getTestResourceDir()},
-                {"sync_send_action_ctx_config2.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config1.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config2.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config3.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config4.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config5.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config6.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config7.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config8.json", this.getTestResourceDir()},
-                {"wait_action_ctx_config9.json", this.getTestResourceDir()},
-                {"while_stmt_ctx_config1.json", this.getTestResourceDir()},
-                {"while_stmt_ctx_config2.json", this.getTestResourceDir()},
-                {"while_stmt_ctx_config3.json", this.getTestResourceDir()},
-                {"while_stmt_ctx_config4.json", this.getTestResourceDir()},
-                {"while_stmt_ctx_config5.json", this.getTestResourceDir()},
-                {"while_stmt_ctx_config6.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config1.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config2.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config3.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config4.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config5.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config6.json", this.getTestResourceDir()},
-                {"worker_declaration_ctx_config7.json", this.getTestResourceDir()},
-                {"xmlns_ctx_config1.json", this.getTestResourceDir()},
-                {"xmlns_ctx_config2.json", this.getTestResourceDir()},
-        };
-    }
-
-    @Override
     public List<String> skipList() {
-        return Arrays.asList("if_stmt_ctx_config3.json", "elseif_stmt_ctx_config3.json");
+        return Arrays.asList(
+                "if_stmt_ctx_config3.json",
+                "elseif_stmt_ctx_config3.json",
+                "if_stmt_ctx_config3.json", // Blocked By #26317
+                "match_stmt_ctx_config1.json" // Blocked by #26455
+        );
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/anon_func_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/anon_func_expr_ctx_config10.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_body/config/config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/continue_break_stmt_ctx_config2.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/do_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/do_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/else_stmt_ctx_config2.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/elseif_stmt_ctx_config2.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config7.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/foreach_stmt_ctx_config8.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/function_call_stmt_ctx_config2.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config2.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config7.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/if_stmt_ctx_config8.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/lock_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/lock_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config1.json
@@ -1,0 +1,237 @@
+{
+  "position": {
+    "line": 7,
+    "character": 6
+  },
+  "source": "statement_context/source/onfail_clause_ctx_source1.bal",
+  "items": [
+    {
+      "label": "testValue",
+      "kind": "Variable",
+      "detail": "int",
+      "insertText": "testValue",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "testFunction()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'array;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.transaction",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'transaction",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'transaction;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/java",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.query",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'query",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'query;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.float",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.xml",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'xml",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.decimal",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.object",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.string",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.error",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.stream",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.map",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.table",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.int",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.boolean",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.future",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.typedesc",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'typedesc",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config2.json
@@ -1,9 +1,9 @@
 {
   "position": {
-    "line": 2,
-    "character": 9
+    "line": 7,
+    "character": 7
   },
-  "source": "statement_context/source/while_stmt_ctx_source2.bal",
+  "source": "statement_context/source/onfail_clause_ctx_source2.bal",
   "items": [
     {
       "label": "xmlns",
@@ -167,17 +167,17 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "continue",
+      "label": "on fail clause",
       "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "continue;",
+      "detail": "Snippet",
+      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "break",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "break;",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -265,28 +265,6 @@
             }
           },
           "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -595,16 +573,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "doSomeTask()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `()`   \n  \n"
-        }
-      },
-      "insertText": "doSomeTask();",
+      "label": "testValue",
+      "kind": "Variable",
+      "detail": "int",
+      "insertText": "testValue",
       "insertTextFormat": "Snippet"
     },
     {
@@ -618,6 +590,13 @@
         }
       },
       "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "worker",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config3.json
@@ -1,29 +1,15 @@
 {
   "position": {
-    "line": 3,
-    "character": 5
+    "line": 18,
+    "character": 10
   },
-  "source": "function_body/source/source2.bal",
+  "source": "statement_context/source/onfail_clause_ctx_source3.bal",
   "items": [
     {
-      "label": "xmlns",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "xmlns \"${1}\" as ${2:ns};",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "xmlns",
+      "label": "start",
       "kind": "Keyword",
       "detail": "Keyword",
-      "insertText": "xmlns ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "var",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "insertText": "var ",
+      "insertText": "start ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -34,13 +20,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "start",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "insertText": "start ",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "flush",
       "kind": "Keyword",
       "detail": "Keyword",
@@ -48,24 +27,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "function",
+      "label": "from",
       "kind": "Keyword",
       "detail": "Keyword",
-      "insertText": "function ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "isolated",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "insertText": "isolated ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "checkpanic",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "insertText": "checkpanic ",
+      "insertText": "from ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -76,94 +41,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "final",
+      "label": "checkpanic",
       "kind": "Keyword",
       "detail": "Keyword",
-      "insertText": "final ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "fail",
-      "kind": "Keyword",
-      "detail": "Keyword",
-      "insertText": "fail ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "if",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "if (${1:true}) {\n\t${2}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "while",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "while (${1:true}) {\n\t${2}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "do",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "do {\n\t${1}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "lock",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "lock {\n\t${1}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "foreach",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "foreach ${1:var} ${2:item} in ${3:itemList} {\n\t${4}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "fork",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "fork {\n\t${1}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "transaction",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "transaction {\n\t${1}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "retry transaction",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "retry transaction {\n\t${1}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "match",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "match ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "return",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "return ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "panic",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "panic ",
+      "insertText": "checkpanic ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -375,180 +256,87 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "StrandData",
-      "kind": "Struct",
-      "detail": "Record",
-      "documentation": {
-        "left": "Describes Strand execution details for the runtime.\n"
-      },
-      "insertText": "StrandData",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Thread",
-      "detail": "Union",
-      "insertText": "Thread",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "float",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "float",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "xml",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "xml",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "readonly",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "readonly",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "handle",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "handle",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "never",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "never",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "decimal",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "decimal",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "string",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "string",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "stream",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "stream",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "json",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "json",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "table",
-      "kind": "Unit",
-      "detail": "type",
+      "kind": "Keyword",
+      "detail": "Keyword",
       "insertText": "table",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "anydata",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "anydata",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "any",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "any",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "int",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "int",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "boolean",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "boolean",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "future",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "future",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "service",
-      "kind": "Unit",
-      "detail": "type",
+      "kind": "Keyword",
+      "detail": "Keyword",
       "insertText": "service",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "typedesc",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "typedesc",
+      "label": "string",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "string",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "byte",
-      "kind": "Unit",
-      "detail": "type",
-      "insertText": "byte",
+      "label": "xml",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "xml",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "map",
-      "kind": "Unit",
-      "detail": "type ",
-      "insertText": "map",
+      "label": "new",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "new ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isolated",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "isolated ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "function",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "function ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "let",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "let",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typeof",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "typeof ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "trap",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "insertText": "trap",
       "insertTextFormat": "Snippet"
     },
     {
       "label": "error",
-      "kind": "Event",
-      "detail": "error",
+      "kind": "Keyword",
+      "detail": "Keyword",
       "insertText": "error",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "record",
+      "label": "client",
       "kind": "Keyword",
       "detail": "Keyword",
-      "insertText": "record ",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "record {}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "record {\n\t${1}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "record {||}",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "record {|\n\t${1}\n|}",
+      "insertText": "client ",
       "insertTextFormat": "Snippet"
     },
     {
@@ -559,10 +347,31 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "object {}",
+      "label": "error constructor",
       "kind": "Snippet",
       "detail": "Snippet",
-      "insertText": "object {\n\t${1}\n}",
+      "insertText": "error(\"${1}\")",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object constructor",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "insertText": "object {\n\t\n};",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "animals",
+      "kind": "Variable",
+      "detail": "string[]",
+      "insertText": "animals",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "animal",
+      "kind": "Variable",
+      "detail": "string",
+      "insertText": "animal",
       "insertTextFormat": "Snippet"
     },
     {
@@ -576,13 +385,6 @@
         }
       },
       "insertText": "testFunction();",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "worker",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config4.json
@@ -1,9 +1,9 @@
 {
   "position": {
-    "line": 2,
-    "character": 9
+    "line": 19,
+    "character": 7
   },
-  "source": "statement_context/source/while_stmt_ctx_source2.bal",
+  "source": "statement_context/source/onfail_clause_ctx_source4.bal",
   "items": [
     {
       "label": "xmlns",
@@ -167,17 +167,17 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "continue",
+      "label": "on fail clause",
       "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "continue;",
+      "detail": "Snippet",
+      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "break",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "break;",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -265,28 +265,6 @@
             }
           },
           "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -595,16 +573,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "doSomeTask()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `()`   \n  \n"
-        }
-      },
-      "insertText": "doSomeTask();",
+      "label": "animals",
+      "kind": "Variable",
+      "detail": "string[]",
+      "insertText": "animals",
       "insertTextFormat": "Snippet"
     },
     {
@@ -618,6 +590,13 @@
         }
       },
       "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "worker",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/onfail_clause_ctx_config5.json
@@ -1,9 +1,9 @@
 {
   "position": {
-    "line": 2,
-    "character": 9
+    "line": 6,
+    "character": 7
   },
-  "source": "statement_context/source/while_stmt_ctx_source2.bal",
+  "source": "statement_context/source/onfail_clause_ctx_source5.bal",
   "items": [
     {
       "label": "xmlns",
@@ -167,17 +167,17 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "continue",
+      "label": "on fail clause",
       "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "continue;",
+      "detail": "Snippet",
+      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "break",
-      "kind": "Snippet",
-      "detail": "Statement",
-      "insertText": "break;",
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "module1",
       "insertTextFormat": "Snippet"
     },
     {
@@ -265,28 +265,6 @@
             }
           },
           "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1;\n"
         }
       ]
     },
@@ -595,16 +573,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "doSomeTask()",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `()`   \n  \n"
-        }
-      },
-      "insertText": "doSomeTask();",
+      "label": "animals",
+      "kind": "Variable",
+      "detail": "string[]",
+      "insertText": "animals",
       "insertTextFormat": "Snippet"
     },
     {
@@ -618,6 +590,13 @@
         }
       },
       "insertText": "testFunction();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "worker",
+      "kind": "Snippet",
+      "detail": "Snippet",
+      "insertText": "worker ${1:name} {\n\t${2}\n}",
       "insertTextFormat": "Snippet"
     }
   ]

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/while_stmt_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config1.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/worker_declaration_ctx_config2.json
@@ -13,13 +13,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "on fail clause",
-      "kind": "Snippet",
-      "detail": "Snippet",
-      "insertText": "on fail ${1:var} ${2:varName} {\n\t${3}\n}",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "xmlns",
       "kind": "Keyword",
       "detail": "Keyword",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source1.bal
@@ -1,0 +1,9 @@
+import ballerina/module1;
+
+function testFunction() {
+    int testValue = 12;
+    
+    while (testValue > 5) {
+        testValue -= 1;
+    } 
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source2.bal
@@ -1,0 +1,9 @@
+import ballerina/module1;
+
+function testFunction() {
+    int testValue = 12;
+    
+    do {
+    
+    } o
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source3.bal
@@ -1,0 +1,21 @@
+import ballerina/module1;
+
+function testFunction() {
+    string[] animals = ["Cat", "Canine", "Mouse", "Horse"];
+    foreach string animal in animals {
+        match animal {
+            "Mouse" => {
+                // logic goes here
+            }
+            "Dog"|"Canine" => {
+                // logic goes here
+            }
+            "Cat"|"Feline" => {
+                // logic goes here
+            }
+            _ => {
+                // logic goes here
+            }
+        } 
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source4.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source4.bal
@@ -1,0 +1,21 @@
+import ballerina/module1;
+
+function testFunction() {
+    string[] animals = ["Cat", "Canine", "Mouse", "Horse"];
+    foreach string animal in animals {
+        match animal {
+            "Mouse" => {
+                // logic goes here
+            }
+            "Dog"|"Canine" => {
+                // logic goes here
+            }
+            "Cat"|"Feline" => {
+                // logic goes here
+            }
+            _ => {
+                // logic goes here
+            }
+        } 
+    } o
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source5.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/source/onfail_clause_ctx_source5.bal
@@ -1,0 +1,8 @@
+import ballerina/module1;
+
+function testFunction() {
+    string[] animals = ["Cat", "Canine", "Mouse", "Horse"];
+    lock {
+    
+    } o
+}

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionCheckPanic.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionCheckPanic.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionPanic.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionPanic.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionQuery.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionQuery.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionRemoteMethodCall.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionRemoteMethodCall.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "string msg"
+                                "right": {
+                                    "first": 12,
+                                    "second": 15
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionSend.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionSend.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "string msg"
+                                "right": {
+                                    "first": 12,
+                                    "second": 15
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionStart.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionStart.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionTrap.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionTrap.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionTypeCast.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionTypeCast.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "any a"
+                                "right": {
+                                    "first": 9,
+                                    "second": 10
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionWait.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/actions/config/actionWait.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float n"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAdditive1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAdditive1.json
@@ -4,7 +4,7 @@
         "character": 35
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAdditive2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAdditive2.json
@@ -4,7 +4,7 @@
         "character": 35
     },
     "source": "expressions/expressions.bal",
-    	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAnnotationAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAnnotationAccess.json
@@ -4,7 +4,7 @@
         "character": 26
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }
@@ -37,9 +43,6 @@
             ],
             "activeSignature": 0,
             "activeParameter": 1
-        },
-        "id": {
-            "left": "324"
         },
         "jsonrpc": "2.0"
     }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAnonFunction.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprAnonFunction.json
@@ -4,7 +4,7 @@
         "character": 29
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprBinaryBitwise1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprBinaryBitwise1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprBinaryBitwise2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprBinaryBitwise2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprBinaryBitwise3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprBinaryBitwise3.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprChecking1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprChecking1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprChecking2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprChecking2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional1.json
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional3.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional4.json
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional5.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprConditional5.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality3.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprEquality4.json
@@ -4,7 +4,7 @@
         "character": 41
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFieldAccess1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFieldAccess1.json
@@ -4,7 +4,7 @@
         "character": 16
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFieldAccess2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFieldAccess2.json
@@ -4,7 +4,7 @@
         "character": 30
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFieldAccess3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFieldAccess3.json
@@ -4,7 +4,7 @@
         "character": 20
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallNamed.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallNamed.json
@@ -4,7 +4,7 @@
         "character": 28
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallNested1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallNested1.json
@@ -4,7 +4,7 @@
         "character": 24
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallNested2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallNested2.json
@@ -4,7 +4,7 @@
         "character": 32
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallRestArgs1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallRestArgs1.json
@@ -4,7 +4,7 @@
         "character": 20
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "int... b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`int...`b**: "
+                                    "value": "**Parameter**  \n**`int...`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallRestArgs2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionCallRestArgs2.json
@@ -4,7 +4,7 @@
         "character": 31
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionTypeDesc.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionTypeDesc.json
@@ -1,46 +1,39 @@
 {
     "position": {
-        "line": 103,
-        "character": 19
+        "line": 398,
+        "character": 11
     },
-    "source": "expressions/expressions.bal",
     "expected": {
         "result": {
             "signatures": [
                 {
-                    "label": "foo(float a, boolean b)",
-                    "documentation": {
-                        "right": {
-                            "kind": "markdown",
-                            "value": "**Description**  \nFunction Foo"
-                        }
-                    },
+                    "label": "concat(string, string)",
                     "parameters": [
                         {
                             "label": {
                                 "right": {
-                                    "first": 10,
-                                    "second": 11
+                                    "first": 7,
+                                    "second": 13
                                 }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: a float"
+                                    "value": "**Parameter**  \n**`string`**"
                                 }
                             }
                         },
                         {
                             "label": {
                                 "right": {
-                                    "first": 21,
-                                    "second": 22
+                                    "first": 15,
+                                    "second": 21
                                 }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: b bool"
+                                    "value": "**Parameter**  \n**`string`**"
                                 }
                             }
                         }
@@ -48,7 +41,7 @@
                 }
             ],
             "activeSignature": 0,
-            "activeParameter": 1
+            "activeParameter": 0
         },
         "jsonrpc": "2.0"
     }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionTypeDesc.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprFunctionTypeDesc.json
@@ -3,6 +3,7 @@
         "line": 398,
         "character": 11
     },
+    "source": "expressions/expressions.bal",
     "expected": {
         "result": {
             "signatures": [

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprIs.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprIs.json
@@ -4,7 +4,7 @@
         "character": 26
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprLet.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprLet.json
@@ -4,7 +4,7 @@
         "character": 39
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprListConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprListConstructor.json
@@ -4,7 +4,7 @@
         "character": 24
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprLogical1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprLogical1.json
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprLogical2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprLogical2.json
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMappingConstructor1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMappingConstructor1.json
@@ -4,7 +4,7 @@
         "character": 32
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMappingConstructor2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMappingConstructor2.json
@@ -4,7 +4,7 @@
         "character": 29
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMemberAccess1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMemberAccess1.json
@@ -4,7 +4,7 @@
         "character": 23
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMemberAccess2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMemberAccess2.json
@@ -4,7 +4,7 @@
         "character": 26
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMethodCall.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMethodCall.json
@@ -4,7 +4,7 @@
         "character": 20
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative1.json
@@ -4,7 +4,7 @@
         "character": 19
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative2.json
@@ -4,7 +4,7 @@
         "character": 35
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative3.json
@@ -4,7 +4,7 @@
         "character": 19
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative4.json
@@ -4,7 +4,7 @@
         "character": 35
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative5.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative5.json
@@ -4,7 +4,7 @@
         "character": 19
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative6.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprMultiplicative6.json
@@ -4,7 +4,7 @@
         "character": 35
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison1.json
@@ -4,7 +4,7 @@
         "character": 39
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison3.json
@@ -4,7 +4,7 @@
         "character": 40
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprNumericalComparison4.json
@@ -4,7 +4,7 @@
         "character": 40
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprOptionalFieldAccess.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprOptionalFieldAccess.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprQueryFrom.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprQueryFrom.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 14,
+                                    "second": 15
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 25,
+                                    "second": 26
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprQueryLet.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprQueryLet.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprQueryWhere.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprQueryWhere.json
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange1.json
@@ -4,7 +4,7 @@
         "character": 27
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange2.json
@@ -4,7 +4,7 @@
         "character": 45
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange3.json
@@ -4,7 +4,7 @@
         "character": 27
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRange4.json
@@ -4,7 +4,7 @@
         "character": 45
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRawTemplate.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprRawTemplate.json
@@ -4,7 +4,7 @@
         "character": 35
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprServiceConstructor.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprServiceConstructor.json
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprShift1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprShift1.json
@@ -4,7 +4,7 @@
         "character": 36
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprShift2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprShift2.json
@@ -4,7 +4,7 @@
         "character": 36
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprShift3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprShift3.json
@@ -4,7 +4,7 @@
         "character": 37
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprStringTemplate.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprStringTemplate.json
@@ -4,7 +4,7 @@
         "character": 32
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprTrap.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprTrap.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprTypeCast.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprTypeCast.json
@@ -4,7 +4,7 @@
         "character": 24
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprTypeOf.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprTypeOf.json
@@ -4,7 +4,7 @@
         "character": 36
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary1.json
@@ -4,7 +4,7 @@
         "character": 20
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary2.json
@@ -4,7 +4,7 @@
         "character": 20
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary3.json
@@ -4,7 +4,7 @@
         "character": 20
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprUnary4.json
@@ -4,7 +4,7 @@
         "character": 25
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -12,23 +12,29 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`float`a**: "
+                                    "value": "**Parameter**  \n**`float`a**"
                                 }
                             }
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {
                                     "kind": "markdown",
-                                    "value": "**Parameter**  \n**`boolean`b**: "
+                                    "value": "**Parameter**  \n**`boolean`b**"
                                 }
                             }
                         }

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprVariableReference.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprVariableReference.json
@@ -4,7 +4,7 @@
         "character": 21
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprXML.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/config/exprXML.json
@@ -4,7 +4,7 @@
         "character": 31
     },
     "source": "expressions/expressions.bal",
-	"expected": {
+    "expected": {
         "result": {
             "signatures": [
                 {
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/expressions/expressions.bal
+++ b/language-server/modules/langserver-core/src/test/resources/signature/expressions/expressions.bal
@@ -390,3 +390,11 @@ public class MockListener {
 }
 
 listener MockListener ep = new MockListener();
+
+function testConcat() {
+    function (string, string) returns string concat = function (string x, string y) returns string {
+        returns x + y;
+    };
+    
+    concat();
+}

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtAssignment.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtAssignment.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallCheck.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallCheck.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "int a"
+                                "right": {
+                                    "first": 9,
+                                    "second": 10
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 20,
+                                    "second": 21
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallCheckPanic.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallCheckPanic.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "int a"
+                                "right": {
+                                    "first": 9,
+                                    "second": 10
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 20,
+                                    "second": 21
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallFunction.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallFunction.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallMethod.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCallMethod.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment10.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment10.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment3.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment4.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment5.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment5.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment6.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment6.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment7.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment7.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment8.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment8.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment9.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtCompAssignment9.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment3.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment3.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 13,
+                                    "second": 14
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 24,
+                                    "second": 25
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment4.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtDestructAssignment4.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 16,
+                                    "second": 17
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 27,
+                                    "second": 28
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtForEach1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtForEach1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtForEach2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtForEach2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIf.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfBlock.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfBlock.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfElseBlock.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfElseBlock.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfElseIf.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfElseIf.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfElseIfBlock.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtIfElseIfBlock.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtInitVarDeclaration.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtInitVarDeclaration.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 10,
+                                    "second": 11
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 21,
+                                    "second": 22
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtLock.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtLock.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtMatch1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtMatch1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtMatch2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtMatch2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtPanic.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtPanic.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "int a"
+                                "right": {
+                                    "first": 9,
+                                    "second": 10
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 20,
+                                    "second": 21
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtWhile1.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtWhile1.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {

--- a/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtWhile2.json
+++ b/language-server/modules/langserver-core/src/test/resources/signature/statements/config/stmtWhile2.json
@@ -18,7 +18,10 @@
                     "parameters": [
                         {
                             "label": {
-                                "left": "float a"
+                                "right": {
+                                    "first": 11,
+                                    "second": 12
+                                }
                             },
                             "documentation": {
                                 "right": {
@@ -29,7 +32,10 @@
                         },
                         {
                             "label": {
-                                "left": "boolean b"
+                                "right": {
+                                    "first": 22,
+                                    "second": 23
+                                }
                             },
                             "documentation": {
                                 "right": {


### PR DESCRIPTION
## Purpose
> In the old implementation of signature help, we had set the sub-string to identify and underline the parameters in the signature label. This lead us to a point where we cannot specifically identify the parameters without the names (for the function type descriptors). With this change, instead of relying on the sub-strings in the signature label to identify the parameter range to underline, we moved to the start and end positions.

Fixes #25971

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
