### PR TITLE
Improve error path when publishing traces

### DIFF
--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
@@ -169,9 +169,9 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
                             }
 
                             traceSpans.addAll(swappedTraceSpans);
-                            LOGGER.error("failed to publish traces to Choreo due to " + t.getMessage() +
-                                    " : Removed " + spanCount + " spans");
+                            LOGGER.error("dropped " + spanCount + " spans");
                         }
+                        LOGGER.error("failed to publish traces to Choreo due to " + t.getMessage());
                     }
                 }
             }

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
@@ -148,8 +148,8 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
                         choreoClient.publishTraceSpans(swappedTraceSpans);
                     } catch (Throwable t) {
                         synchronized (this) {
-                            int spanCount = 0;
                             if (swappedTraceSpans.size() > SPAN_LIST_BOUND) {
+                                int spanCount = 0;
                                 Random random = new Random();
                                 // Remove 10% of the SPAN_LIST_BOUND
                                 while (spanCount < SPANS_TO_REMOVE) {
@@ -166,10 +166,9 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
                                         }
                                     }
                                 }
+                                LOGGER.info("span buffer is full : " + "dropped " + spanCount + " spans");
                             }
-
                             traceSpans.addAll(swappedTraceSpans);
-                            LOGGER.error("dropped " + spanCount + " spans");
                         }
                         LOGGER.error("failed to publish traces to Choreo due to " + t.getMessage());
                     }

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
@@ -164,6 +164,8 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
                                                 spanCount++;
                                             }
                                         }
+                                    } else {
+                                        break;
                                     }
                                 }
                                 LOGGER.info("span buffer is full : " + "dropped " + spanCount + " spans");

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/ChoreoJaegerReporter.java
@@ -31,11 +31,12 @@ import org.ballerinalang.observe.trace.extension.choreo.logging.Logger;
 import org.ballerinalang.observe.trace.extension.choreo.model.ChoreoTraceSpan;
 
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Random;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -47,6 +48,7 @@ import java.util.concurrent.TimeUnit;
  */
 public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
     private static final int PUBLISH_INTERVAL_SECS = 10;
+    private static final int SPAN_LIST_BOUND = 50000;
     private static final Logger LOGGER = LogFactory.getLogger();
 
     private final ScheduledExecutorService executorService;
@@ -94,7 +96,8 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
      */
     private static class Task implements Runnable {
         private final ChoreoClient choreoClient;
-        private final List<ChoreoTraceSpan> traceSpans;
+        private List<ChoreoTraceSpan> traceSpans;
+        private List<ChoreoTraceSpan> swappedTraceSpans;
 
         private Task(ChoreoClient choreoClient) {
             this.choreoClient = choreoClient;
@@ -129,22 +132,41 @@ public class ChoreoJaegerReporter implements Reporter, AutoCloseable {
 
         @Override
         public void run() {
-            ChoreoTraceSpan[] spansToBeSent;
+
             synchronized (this) {
                 if (traceSpans.size() > 0) {
-                    spansToBeSent = traceSpans.toArray(new ChoreoTraceSpan[0]);
-                    traceSpans.clear();
+                    swappedTraceSpans = traceSpans;
+                    traceSpans = new ArrayList<>();
                 } else {
-                    spansToBeSent = new ChoreoTraceSpan[0];
+                    swappedTraceSpans = Collections.emptyList();
                 }
             }
-            if (spansToBeSent.length > 0) {
+            if (swappedTraceSpans.size() > 0) {
                 if (!Objects.isNull(choreoClient)) {
                     try {
-                        choreoClient.publishTraceSpans(spansToBeSent);
+                        choreoClient.publishTraceSpans(swappedTraceSpans);
                     } catch (Throwable t) {
                         synchronized (this) {
-                            traceSpans.addAll(Arrays.asList(spansToBeSent));
+                            if (swappedTraceSpans.size() > SPAN_LIST_BOUND) {
+                                Random random = new Random();
+                                //remove 10% of the trace spans
+                                int spansToRemove = (int) (swappedTraceSpans.size() * (10.0f / 100.0f));
+                                for (int i = 0; i < spansToRemove; i++) {
+                                    if (swappedTraceSpans.size() > 0) {
+                                        int randomSpanPos = random.nextInt(swappedTraceSpans.size());
+                                        long traceID = swappedTraceSpans.get(randomSpanPos).getTraceId();
+                                        for (int j = 0; j < swappedTraceSpans.size(); j++) {
+                                            if (swappedTraceSpans.get(j).getTraceId() == traceID) {
+                                                swappedTraceSpans.remove(j);
+                                                //reduce the count as well since the size of the arryList shrink
+                                                j--;
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+
+                            traceSpans.addAll(swappedTraceSpans);
                         }
                         LOGGER.error("failed to publish traces to Choreo due to " + t.getMessage());
                     }

--- a/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClient.java
+++ b/misc/tracing-extensions/modules/ballerina-choreo-extension/src/main/java/org/ballerinalang/observe/trace/extension/choreo/client/ChoreoClient.java
@@ -34,6 +34,7 @@ import org.ballerinalang.observe.trace.extension.choreo.logging.Logger;
 import org.ballerinalang.observe.trace.extension.choreo.model.ChoreoMetric;
 import org.ballerinalang.observe.trace.extension.choreo.model.ChoreoTraceSpan;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
@@ -173,14 +174,14 @@ public class ChoreoClient implements AutoCloseable {
         LOGGER.debug("Successfully published " + metrics.length + " metrics to Choreo");
     }
 
-    public void publishTraceSpans(ChoreoTraceSpan[] traceSpans) {
+    public void publishTraceSpans(List<ChoreoTraceSpan> traceSpans) {
         int i = 0;
-        while (i < traceSpans.length) {
+        while (i < traceSpans.size()) {
             TelemetryOuterClass.TracesPublishRequest.Builder requestBuilder =
                     TelemetryOuterClass.TracesPublishRequest.newBuilder();
             int messageSize = 0;
-            while (i < traceSpans.length && messageSize < SERVER_MAX_FRAME_SIZE_BYTES) {
-                ChoreoTraceSpan traceSpan = traceSpans[i];
+            while (i < traceSpans.size() && messageSize < SERVER_MAX_FRAME_SIZE_BYTES) {
+                ChoreoTraceSpan traceSpan = traceSpans.get(i);
                 TelemetryOuterClass.TraceSpan.Builder traceSpanBuilder
                         = TelemetryOuterClass.TraceSpan.newBuilder()
                                                        .setTraceId(traceSpan.getTraceId())
@@ -219,7 +220,7 @@ public class ChoreoClient implements AutoCloseable {
                                                         .setProjectSecret(projectSecret)
                                                         .build());
         }
-        LOGGER.debug("Successfully published " + traceSpans.length + " traces to Choreo");
+        LOGGER.debug("Successfully published " + traceSpans.size() + " traces to Choreo");
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Handle the error path when publishing the traces in choreo extension. By this approach it will inhibit the infinite growth of the span list if there is a service downtime.


## Approach
> Once the predefined bound is reached, randomly pick spans and delete the related spans based on the TraceID.

## Check List 
- [x]  Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
