### PR TITLE
Convert TypesFactory and SymbolFactory to per-context instances

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -57,6 +57,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     private final BLangPackage bLangPackage;
     private final CompilerContext compilerContext;
     private final EnvironmentResolver envResolver;
+    private final TypesFactory typesFactory;
 
     public BallerinaSemanticModel(BLangPackage bLangPackage, CompilerContext context) {
         this.compilerContext = context;
@@ -65,6 +66,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         SymbolTable symbolTable = SymbolTable.getInstance(context);
         SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(bLangPackage.symbol);
         this.envResolver = new EnvironmentResolver(pkgEnv);
+        this.typesFactory = TypesFactory.getInstance(context);
     }
 
     /**
@@ -146,7 +148,7 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Optional.empty();
         }
 
-        return Optional.ofNullable(TypesFactory.getTypeDescriptor(node.type));
+        return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -57,6 +57,7 @@ public class BallerinaSemanticModel implements SemanticModel {
     private final BLangPackage bLangPackage;
     private final CompilerContext compilerContext;
     private final EnvironmentResolver envResolver;
+    private final SymbolFactory symbolFactory;
     private final TypesFactory typesFactory;
 
     public BallerinaSemanticModel(BLangPackage bLangPackage, CompilerContext context) {
@@ -66,6 +67,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         SymbolTable symbolTable = SymbolTable.getInstance(context);
         SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(bLangPackage.symbol);
         this.envResolver = new EnvironmentResolver(pkgEnv);
+        this.symbolFactory = SymbolFactory.getInstance(context);
         this.typesFactory = TypesFactory.getInstance(context);
     }
 
@@ -92,7 +94,7 @@ public class BallerinaSemanticModel implements SemanticModel {
                 BSymbol symbol = scopeEntry.symbol;
 
                 if (hasCursorPosPassedSymbolPos(symbol, cursorPos) || isImportedSymbol(symbol)) {
-                    compiledSymbols.add(SymbolFactory.getBCompiledSymbol(symbol, name.getValue()));
+                    compiledSymbols.add(symbolFactory.getBCompiledSymbol(symbol, name.getValue()));
                 }
             }
         }
@@ -113,7 +115,7 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Optional.empty();
         }
 
-        return Optional.ofNullable(SymbolFactory.getBCompiledSymbol(symbolAtCursor, symbolAtCursor.name.value));
+        return Optional.ofNullable(symbolFactory.getBCompiledSymbol(symbolAtCursor, symbolAtCursor.name.value));
     }
 
     /**
@@ -128,7 +130,7 @@ public class BallerinaSemanticModel implements SemanticModel {
             Scope.ScopeEntry value = e.getValue();
 
             if (value.symbol.origin == SOURCE) {
-                compiledSymbols.add(SymbolFactory.getBCompiledSymbol(value.symbol, key.value));
+                compiledSymbols.add(symbolFactory.getBCompiledSymbol(value.symbol, key.value));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/TypesFactory.java
@@ -52,6 +52,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -67,7 +68,26 @@ import static org.ballerinalang.model.types.TypeKind.RECORD;
  */
 public class TypesFactory {
 
-    public static TypeSymbol getTypeDescriptor(BType bType) {
+    private static final CompilerContext.Key<TypesFactory> TYPES_FACTORY_KEY = new CompilerContext.Key<>();
+
+    private final CompilerContext context;
+
+    private TypesFactory(CompilerContext context) {
+        context.put(TYPES_FACTORY_KEY, this);
+
+        this.context = context;
+    }
+
+    public static TypesFactory getInstance(CompilerContext context) {
+        TypesFactory typesFactory = context.get(TYPES_FACTORY_KEY);
+        if (typesFactory == null) {
+            typesFactory = new TypesFactory(context);
+        }
+
+        return typesFactory;
+    }
+
+    public TypeSymbol getTypeDescriptor(BType bType) {
         return getTypeDescriptor(bType, false);
     }
 
@@ -78,7 +98,7 @@ public class TypesFactory {
      * @param rawTypeOnly Whether to convert the type descriptor to type reference or keep the raw type
      * @return {@link TypeSymbol} generated
      */
-    public static TypeSymbol getTypeDescriptor(BType bType, boolean rawTypeOnly) {
+    public TypeSymbol getTypeDescriptor(BType bType, boolean rawTypeOnly) {
         if (bType == null || bType.tag == TypeTags.NONE) {
             return null;
         }
@@ -86,49 +106,51 @@ public class TypesFactory {
         ModuleID moduleID = bType.tsymbol == null ? null : new BallerinaModuleID(bType.tsymbol.pkgID);
 
         if (isTypeReference(bType, rawTypeOnly)) {
-            return new BallerinaTypeReferenceTypeSymbol(moduleID, bType, bType.tsymbol.getName().getValue());
+            return new BallerinaTypeReferenceTypeSymbol(this.context, moduleID, bType,
+                                                        bType.tsymbol.getName().getValue());
         }
 
         switch (bType.getKind()) {
             case OBJECT:
-                return new BallerinaObjectTypeSymbol(moduleID, (BObjectType) bType);
+                return new BallerinaObjectTypeSymbol(this.context, moduleID, (BObjectType) bType);
             case RECORD:
-                return new BallerinaRecordTypeSymbol(moduleID, (BRecordType) bType);
+                return new BallerinaRecordTypeSymbol(this.context, moduleID, (BRecordType) bType);
             case ERROR:
-                return new BallerinaErrorTypeSymbol(moduleID, (BErrorType) bType);
+                return new BallerinaErrorTypeSymbol(this.context, moduleID, (BErrorType) bType);
             case UNION:
-                return new BallerinaUnionTypeSymbol(moduleID, (BUnionType) bType);
+                return new BallerinaUnionTypeSymbol(this.context, moduleID, (BUnionType) bType);
             case FUTURE:
-                return new BallerinaFutureTypeSymbol(moduleID, (BFutureType) bType);
+                return new BallerinaFutureTypeSymbol(this.context, moduleID, (BFutureType) bType);
             case MAP:
-                return new BallerinaMapTypeSymbol(moduleID, (BMapType) bType);
+                return new BallerinaMapTypeSymbol(this.context, moduleID, (BMapType) bType);
             case STREAM:
-                return new BallerinaStreamTypeSymbol(moduleID, (BStreamType) bType);
+                return new BallerinaStreamTypeSymbol(this.context, moduleID, (BStreamType) bType);
             case ARRAY:
-                return new BallerinaArrayTypeSymbol(moduleID, (BArrayType) bType);
+                return new BallerinaArrayTypeSymbol(this.context, moduleID, (BArrayType) bType);
             case TUPLE:
-                return new BallerinaTupleTypeSymbol(moduleID, (BTupleType) bType);
+                return new BallerinaTupleTypeSymbol(this.context, moduleID, (BTupleType) bType);
             case TYPEDESC:
-                return new BallerinaTypeDescTypeSymbol(moduleID, (BTypedescType) bType);
+                return new BallerinaTypeDescTypeSymbol(this.context, moduleID, (BTypedescType) bType);
             case NIL:
-                return new BallerinaNilTypeSymbol(moduleID, (BNilType) bType);
+                return new BallerinaNilTypeSymbol(this.context, moduleID, (BNilType) bType);
             case FINITE:
                 BFiniteType finiteType = (BFiniteType) bType;
                 Set<BLangExpression> valueSpace = finiteType.getValueSpace();
 
                 if (valueSpace.size() == 1) {
                     BLangExpression shape = valueSpace.iterator().next();
-                    return new BallerinaSingletonTypeSymbol(moduleID, shape, bType);
+                    return new BallerinaSingletonTypeSymbol(this.context, moduleID, shape, bType);
                 }
 
-                return new BallerinaUnionTypeSymbol(moduleID, finiteType);
+                return new BallerinaUnionTypeSymbol(this.context, moduleID, finiteType);
             case OTHER:
                 if (bType instanceof BInvokableType) {
-                    return new BallerinaFunctionTypeSymbol(moduleID, (BInvokableTypeSymbol) bType.tsymbol);
+                    return new BallerinaFunctionTypeSymbol(this.context, moduleID,
+                                                           (BInvokableTypeSymbol) bType.tsymbol);
                 }
                 // fall through
             default:
-                return new BallerinaSimpleTypeSymbol(moduleID, bType);
+                return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,15 +32,19 @@ import java.util.Optional;
 
 /**
  * Represents a Ballerina Type Descriptor.
- * 
+ *
  * @since 2.0.0
  */
 public abstract class AbstractTypeSymbol implements TypeSymbol {
+
+    protected final CompilerContext context;
+
     private final TypeDescKind typeDescKind;
     private final ModuleID moduleID;
     private final BType bType;
 
-    public AbstractTypeSymbol(TypeDescKind typeDescKind, ModuleID moduleID, BType bType) {
+    public AbstractTypeSymbol(CompilerContext context, TypeDescKind typeDescKind, ModuleID moduleID, BType bType) {
+        this.context = context;
         this.typeDescKind = typeDescKind;
         this.moduleID = moduleID;
         this.bType = bType;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
@@ -42,7 +42,8 @@ public class BallerinaArrayTypeSymbol extends AbstractTypeSymbol implements Arra
     @Override
     public TypeSymbol memberTypeDescriptor() {
         if (this.memberTypeDesc == null) {
-            this.memberTypeDesc = TypesFactory.getTypeDescriptor(((BArrayType) this.getBType()).eType);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.memberTypeDesc = typesFactory.getTypeDescriptor(((BArrayType) this.getBType()).eType);
         }
         return memberTypeDesc;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Optional;
 
@@ -34,8 +35,8 @@ public class BallerinaArrayTypeSymbol extends AbstractTypeSymbol implements Arra
 
     private TypeSymbol memberTypeDesc;
 
-    public BallerinaArrayTypeSymbol(ModuleID moduleID, BArrayType arrayType) {
-        super(TypeDescKind.ARRAY, moduleID, arrayType);
+    public BallerinaArrayTypeSymbol(CompilerContext context, ModuleID moduleID, BArrayType arrayType) {
+        super(context, TypeDescKind.ARRAY, moduleID, arrayType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 /**
@@ -33,8 +34,8 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
 
     private TypeSymbol detail;
 
-    public BallerinaErrorTypeSymbol(ModuleID moduleID, BErrorType errorType) {
-        super(TypeDescKind.ERROR, moduleID, errorType);
+    public BallerinaErrorTypeSymbol(CompilerContext context, ModuleID moduleID, BErrorType errorType) {
+        super(context, TypeDescKind.ERROR, moduleID, errorType);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -46,7 +46,8 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
     @Override
     public TypeSymbol detailTypeDescriptor() {
         if (this.detail == null) {
-            this.detail = TypesFactory.getTypeDescriptor(((BErrorType) this.getBType()).getDetailType());
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.detail = typesFactory.getTypeDescriptor(((BErrorType) this.getBType()).getDetailType());
         }
         return this.detail;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -106,7 +106,7 @@ public class BallerinaFieldSymbol implements FieldSymbol {
      */
     @Override
     public String signature() {
-        StringBuilder signature = new StringBuilder(this.typeDescriptor.signature() + " " + this.name());
+        StringBuilder signature = new StringBuilder(this.typeDescriptor().signature() + " " + this.name());
         if (this.isOptional()) {
             signature.append("?");
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.Optional;
@@ -35,11 +36,12 @@ public class BallerinaFieldSymbol implements FieldSymbol {
 
     private final Documentation docAttachment;
     private final BField bField;
-    private final TypeSymbol typeDescriptor;
+    private final CompilerContext context;
+    private TypeSymbol typeDescriptor;
 
-    public BallerinaFieldSymbol(BField bField) {
+    public BallerinaFieldSymbol(CompilerContext context, BField bField) {
+        this.context = context;
         this.bField = bField;
-        this.typeDescriptor = TypesFactory.getTypeDescriptor(bField.getType());
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
     }
 
@@ -69,7 +71,12 @@ public class BallerinaFieldSymbol implements FieldSymbol {
      */
     @Override
     public TypeSymbol typeDescriptor() {
-        return TypesFactory.getTypeDescriptor(this.bField.getType());
+        if (this.typeDescriptor == null) {
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.typeDescriptor = typesFactory.getTypeDescriptor(this.bField.type);
+        }
+
+        return this.typeDescriptor;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -80,8 +80,10 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     @Override
     public Optional<TypeSymbol> returnTypeDescriptor() {
         if (returnType == null) {
-            this.returnType = TypesFactory.getTypeDescriptor(this.typeSymbol.returnType);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.returnType = typesFactory.getTypeDescriptor(this.typeSymbol.returnType);
         }
+
         return Optional.ofNullable(this.returnType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -59,21 +59,26 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     @Override
     public List<ParameterSymbol> parameters() {
         if (this.requiredParams == null) {
+            SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+
             this.requiredParams = this.typeSymbol.params.stream()
                     .map(symbol -> {
                         ParameterKind parameterKind = symbol.defaultableParam ? DEFAULTABLE : REQUIRED;
-                        return SymbolFactory.createBallerinaParameter(symbol, parameterKind);
+                        return symbolFactory.createBallerinaParameter(symbol, parameterKind);
                     })
                     .collect(Collectors.collectingAndThen(toList(), Collections::unmodifiableList));
         }
+
         return this.requiredParams;
     }
 
     @Override
     public Optional<ParameterSymbol> restParam() {
         if (restParam == null) {
-            this.restParam = SymbolFactory.createBallerinaParameter(typeSymbol.restParam, REST);
+            SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+            this.restParam = symbolFactory.createBallerinaParameter(typeSymbol.restParam, REST);
         }
+
         return Optional.ofNullable(this.restParam);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Collections;
 import java.util.List;
@@ -49,8 +50,9 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     private TypeSymbol returnType;
     private final BInvokableTypeSymbol typeSymbol;
 
-    public BallerinaFunctionTypeSymbol(ModuleID moduleID, BInvokableTypeSymbol invokableSymbol) {
-        super(TypeDescKind.FUNCTION, moduleID, invokableSymbol.type);
+    public BallerinaFunctionTypeSymbol(CompilerContext context, ModuleID moduleID,
+                                       BInvokableTypeSymbol invokableSymbol) {
+        super(context, TypeDescKind.FUNCTION, moduleID, invokableSymbol.type);
         this.typeSymbol = invokableSymbol;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Optional;
 
@@ -34,8 +35,8 @@ public class BallerinaFutureTypeSymbol extends AbstractTypeSymbol implements Fut
 
     private TypeSymbol memberTypeDesc;
 
-    public BallerinaFutureTypeSymbol(ModuleID moduleID, BFutureType futureType) {
-        super(TypeDescKind.FUTURE, moduleID, futureType);
+    public BallerinaFutureTypeSymbol(CompilerContext context, ModuleID moduleID, BFutureType futureType) {
+        super(context, TypeDescKind.FUTURE, moduleID, futureType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
@@ -42,8 +42,10 @@ public class BallerinaFutureTypeSymbol extends AbstractTypeSymbol implements Fut
     @Override
     public Optional<TypeSymbol> typeParameter() {
         if (this.memberTypeDesc == null) {
-            this.memberTypeDesc = TypesFactory.getTypeDescriptor(((BFutureType) this.getBType()).constraint);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.memberTypeDesc = typesFactory.getTypeDescriptor(((BFutureType) this.getBType()).constraint);
         }
+
         return Optional.ofNullable(this.memberTypeDesc);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Optional;
 
@@ -34,8 +35,8 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
 
     private TypeSymbol memberTypeDesc;
 
-    public BallerinaMapTypeSymbol(ModuleID moduleID, BMapType mapType) {
-        super(TypeDescKind.MAP, moduleID, mapType);
+    public BallerinaMapTypeSymbol(CompilerContext context, ModuleID moduleID, BMapType mapType) {
+        super(context, TypeDescKind.MAP, moduleID, mapType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -42,8 +42,10 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
     @Override
     public Optional<TypeSymbol> typeParameter() {
         if (this.memberTypeDesc == null) {
-            this.memberTypeDesc = TypesFactory.getTypeDescriptor(((BMapType) this.getBType()).constraint);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.memberTypeDesc = typesFactory.getTypeDescriptor(((BMapType) this.getBType()).constraint);
         }
+
         return Optional.ofNullable(this.memberTypeDesc);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -30,6 +30,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.Scope.ScopeEntry;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -49,6 +50,7 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.is
  */
 public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
+    private final CompilerContext context;
     private BPackageSymbol packageSymbol;
     private List<TypeDefinitionSymbol> typeDefs;
     private List<FunctionSymbol> functions;
@@ -56,8 +58,9 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
     private List<TypeDefinitionSymbol> listeners;
     private List<Symbol> allSymbols;
 
-    protected BallerinaModule(String name, PackageID moduleID, BPackageSymbol packageSymbol) {
+    protected BallerinaModule(CompilerContext context, String name, PackageID moduleID, BPackageSymbol packageSymbol) {
         super(name, moduleID, SymbolKind.MODULE, packageSymbol);
+        this.context = context;
         this.packageSymbol = packageSymbol;
     }
 
@@ -72,15 +75,18 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             return functions;
         }
 
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
         List<FunctionSymbol> functions = new ArrayList<>();
+
         for (Map.Entry<Name, ScopeEntry> entry : this.packageSymbol.scope.entries.entrySet()) {
             ScopeEntry scopeEntry = entry.getValue();
+
             if (scopeEntry.symbol != null
                     && scopeEntry.symbol.kind == org.ballerinalang.model.symbols.SymbolKind.FUNCTION
                     && isFlagOn(scopeEntry.symbol.flags, Flags.PUBLIC)
                     && scopeEntry.symbol.origin == COMPILED_SOURCE) {
                 String funcName = scopeEntry.symbol.getName().getValue();
-                functions.add(SymbolFactory.createFunctionSymbol((BInvokableSymbol) scopeEntry.symbol, funcName));
+                functions.add(symbolFactory.createFunctionSymbol((BInvokableSymbol) scopeEntry.symbol, funcName));
             }
         }
 
@@ -116,13 +122,16 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             return this.constants;
         }
 
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
         List<ConstantSymbol> constants = new ArrayList<>();
+
         for (Map.Entry<Name, ScopeEntry> entry : this.packageSymbol.scope.entries.entrySet()) {
             ScopeEntry scopeEntry = entry.getValue();
+
             if (scopeEntry.symbol instanceof BConstantSymbol &&
                     (scopeEntry.symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
                 String constName = scopeEntry.symbol.getName().getValue();
-                constants.add(SymbolFactory.createConstantSymbol((BConstantSymbol) scopeEntry.symbol, constName));
+                constants.add(symbolFactory.createConstantSymbol((BConstantSymbol) scopeEntry.symbol, constName));
             }
         }
 
@@ -159,15 +168,18 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
     @Override
     public List<Symbol> allSymbols() {
         if (this.allSymbols == null) {
+            SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
             List<Symbol> symbols = new ArrayList<>();
+
             for (Map.Entry<Name, ScopeEntry> entry : this.packageSymbol.scope.entries.entrySet()) {
                 ScopeEntry scopeEntry = entry.getValue();
                 if (!isFlagOn(scopeEntry.symbol.flags, Flags.PUBLIC) || scopeEntry.symbol.origin != COMPILED_SOURCE) {
                     continue;
                 }
-                symbols.add(SymbolFactory.getBCompiledSymbol(scopeEntry.symbol,
-                        scopeEntry.symbol.getName().getValue()));
+                symbols.add(
+                        symbolFactory.getBCompiledSymbol(scopeEntry.symbol, scopeEntry.symbol.getName().getValue()));
             }
+
             this.allSymbols = Collections.unmodifiableList(symbols);
         }
 
@@ -181,8 +193,12 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
      */
     public static class ModuleSymbolBuilder extends SymbolBuilder<ModuleSymbolBuilder> {
 
-        public ModuleSymbolBuilder(String name, PackageID moduleID, BPackageSymbol packageSymbol) {
+        private final CompilerContext context;
+
+        public ModuleSymbolBuilder(CompilerContext context, String name,
+                                   PackageID moduleID, BPackageSymbol packageSymbol) {
             super(name, moduleID, SymbolKind.MODULE, packageSymbol);
+            this.context = context;
         }
 
         /**
@@ -193,7 +209,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             if (this.bSymbol == null) {
                 throw new AssertionError("Package Symbol cannot be null");
             }
-            return new BallerinaModule(this.name, this.moduleID, (BPackageSymbol) this.bSymbol);
+            return new BallerinaModule(this.context, this.name, this.moduleID, (BPackageSymbol) this.bSymbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
@@ -20,6 +20,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.NilTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 /**
  * Represents the nil type descriptor.
@@ -28,8 +29,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
  */
 public class BallerinaNilTypeSymbol extends AbstractTypeSymbol implements NilTypeSymbol {
 
-    public BallerinaNilTypeSymbol(ModuleID moduleID, BNilType nilType) {
-        super(TypeDescKind.NIL, moduleID, nilType);
+    public BallerinaNilTypeSymbol(CompilerContext context, ModuleID moduleID, BNilType nilType) {
+        super(context, TypeDescKind.NIL, moduleID, nilType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -76,7 +76,7 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
         if (this.objectFields == null) {
             this.objectFields = new ArrayList<>();
             for (BField field : ((BObjectType) this.getBType()).fields.values()) {
-                this.objectFields.add(new BallerinaFieldSymbol(field));
+                this.objectFields.add(new BallerinaFieldSymbol(this.context, field));
             }
         }
         return objectFields;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -18,10 +18,7 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
-import io.ballerina.compiler.api.symbols.FieldSymbol;
-import io.ballerina.compiler.api.symbols.MethodSymbol;
-import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
-import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.*;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
@@ -29,10 +26,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.StringJoiner;
+import java.util.*;
 
 /**
  * Represents an object type descriptor.
@@ -90,12 +84,14 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     // TODO: Rename to method declarations
     public List<MethodSymbol> methods() {
         if (this.methods == null) {
-            this.methods = new ArrayList<>();
-            for (BAttachedFunction attachedFunc : ((BObjectTypeSymbol) ((BObjectType) this
-                    .getBType()).tsymbol).attachedFuncs) {
-                this.methods
-                        .add(SymbolFactory.createMethodSymbol(attachedFunc.symbol, attachedFunc.funcName.getValue()));
+            SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+            List<MethodSymbol> methods = new ArrayList<>();
+
+            for (BAttachedFunction attachedFunc : ((BObjectTypeSymbol) this.getBType().tsymbol).attachedFuncs) {
+                methods.add(symbolFactory.createMethodSymbol(attachedFunc.symbol, attachedFunc.funcName.getValue()));
             }
+
+            this.methods = Collections.unmodifiableList(methods);
         }
 
         return this.methods;
@@ -104,10 +100,13 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     @Override
     public Optional<MethodSymbol> initMethod() {
         if (this.initFunction == null) {
-            BAttachedFunction initFunction =
-                    ((BObjectTypeSymbol) ((BObjectType) this.getBType()).tsymbol).initializerFunc;
-            this.initFunction = initFunction == null ? null
-                    : SymbolFactory.createMethodSymbol(initFunction.symbol, initFunction.funcName.getValue());
+            BAttachedFunction initFunction = ((BObjectTypeSymbol) this.getBType().tsymbol).initializerFunc;
+
+            if (initFunction != null) {
+                SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+                this.initFunction = symbolFactory.createMethodSymbol(initFunction.symbol,
+                                                                     initFunction.funcName.getValue());
+            }
         }
 
         return Optional.ofNullable(this.initFunction);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -46,8 +47,8 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     private List<MethodSymbol> methods;
     private MethodSymbol initFunction;
 
-    public BallerinaObjectTypeSymbol(ModuleID moduleID, BObjectType objectType) {
-        super(TypeDescKind.OBJECT, moduleID, objectType);
+    public BallerinaObjectTypeSymbol(CompilerContext context, ModuleID moduleID, BObjectType objectType) {
+        super(context, TypeDescKind.OBJECT, moduleID, objectType);
         // TODO: Fix this
         // objectTypeReference = null;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -18,7 +18,10 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
-import io.ballerina.compiler.api.symbols.*;
+import io.ballerina.compiler.api.symbols.FieldSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
@@ -26,7 +29,11 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.StringJoiner;
 
 /**
  * Represents an object type descriptor.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -57,7 +57,7 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
         if (this.fieldSymbols == null) {
             this.fieldSymbols = new ArrayList<>();
             for (BField field : ((BRecordType) this.getBType()).fields.values()) {
-                this.fieldSymbols.add(new BallerinaFieldSymbol(field));
+                this.fieldSymbols.add(new BallerinaFieldSymbol(this.context, field));
             }
         }
 
@@ -77,8 +77,10 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
     @Override
     public Optional<TypeSymbol> restTypeDescriptor() {
         if (this.restTypeDesc == null) {
-            this.restTypeDesc = TypesFactory.getTypeDescriptor(((BRecordType) this.getBType()).restFieldType);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.restTypeDesc = typesFactory.getTypeDescriptor(((BRecordType) this.getBType()).restFieldType);
         }
+
         return Optional.ofNullable(this.restTypeDesc);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,12 +37,13 @@ import java.util.StringJoiner;
  * @since 2.0.0
  */
 public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements RecordTypeSymbol {
+
     private List<FieldSymbol> fieldSymbols;
     private final boolean isInclusive;
     private TypeSymbol restTypeDesc;
 
-    public BallerinaRecordTypeSymbol(ModuleID moduleID, BRecordType recordType) {
-        super(TypeDescKind.RECORD, moduleID, recordType);
+    public BallerinaRecordTypeSymbol(CompilerContext context, ModuleID moduleID, BRecordType recordType) {
+        super(context, TypeDescKind.RECORD, moduleID, recordType);
         this.isInclusive = !recordType.sealed;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSimpleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSimpleTypeSymbol.java
@@ -20,18 +20,19 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.SimpleTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 /**
  * Represents the built-in simple type descriptor.
- * 
+ *
  * @since 2.0.0
  */
 public class BallerinaSimpleTypeSymbol extends AbstractTypeSymbol implements SimpleTypeSymbol {
 
     private String typeName;
 
-    public BallerinaSimpleTypeSymbol(ModuleID moduleID, BType bType) {
-        super(TypesFactory.getTypeDescKind(bType.getKind()), moduleID, bType);
+    public BallerinaSimpleTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType) {
+        super(context, TypesFactory.getTypeDescKind(bType.getKind()), moduleID, bType);
         this.typeName = bType.getKind().typeName();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.symbols.SingletonTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 /**
  * Represents a singleton type descriptor.
@@ -31,8 +32,9 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
 
     private String typeName;
 
-    public BallerinaSingletonTypeSymbol(ModuleID moduleID, BLangExpression shape, BType bType) {
-        super(TypeDescKind.SINGLETON, moduleID, bType);
+    public BallerinaSingletonTypeSymbol(CompilerContext context, ModuleID moduleID, BLangExpression shape,
+                                        BType bType) {
+        super(context, TypeDescKind.SINGLETON, moduleID, bType);
         this.typeName = shape.toString();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.StringJoiner;
 
@@ -44,8 +45,10 @@ public class BallerinaStreamTypeSymbol extends AbstractTypeSymbol implements Str
     @Override
     public List<TypeSymbol> typeParameters() {
         if (this.typeParameters == null) {
-            this.typeParameters = new ArrayList<>();
-            typeParameters.add(TypesFactory.getTypeDescriptor(((BStreamType) this.getBType()).constraint));
+            List<TypeSymbol> typeParams = new ArrayList<>();
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            typeParams.add(typesFactory.getTypeDescriptor(((BStreamType) this.getBType()).constraint));
+            this.typeParameters = Collections.unmodifiableList(typeParams);
         }
 
         return this.typeParameters;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,8 +37,8 @@ public class BallerinaStreamTypeSymbol extends AbstractTypeSymbol implements Str
 
     private List<TypeSymbol> typeParameters;
 
-    public BallerinaStreamTypeSymbol(ModuleID moduleID, BStreamType streamType) {
-        super(TypeDescKind.STREAM, moduleID, streamType);
+    public BallerinaStreamTypeSymbol(CompilerContext context, ModuleID moduleID, BStreamType streamType) {
+        super(context, TypeDescKind.STREAM, moduleID, streamType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -23,6 +23,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,8 +40,8 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
     private List<TypeSymbol> memberTypes;
     private TypeSymbol restTypeDesc;
 
-    public BallerinaTupleTypeSymbol(ModuleID moduleID, BTupleType tupleType) {
-        super(TypeDescKind.TUPLE, moduleID, tupleType);
+    public BallerinaTupleTypeSymbol(CompilerContext context, ModuleID moduleID, BTupleType tupleType) {
+        super(context, TypeDescKind.TUPLE, moduleID, tupleType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -26,6 +26,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -47,10 +48,14 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
     @Override
     public List<TypeSymbol> memberTypeDescriptors() {
         if (this.memberTypes == null) {
-            this.memberTypes = new ArrayList<>();
+            List<TypeSymbol> types = new ArrayList<>();
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+
             for (BType type : ((BTupleType) this.getBType()).tupleTypes) {
-                this.memberTypes.add(TypesFactory.getTypeDescriptor(type));
+                types.add(typesFactory.getTypeDescriptor(type));
             }
+
+            this.memberTypes = Collections.unmodifiableList(types);
         }
 
         return this.memberTypes;
@@ -59,7 +64,8 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
     @Override
     public Optional<TypeSymbol> restTypeDescriptor() {
         if (this.restTypeDesc == null) {
-            this.restTypeDesc = TypesFactory.getTypeDescriptor(((BTupleType) this.getBType()).restType);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.restTypeDesc = typesFactory.getTypeDescriptor(((BTupleType) this.getBType()).restType);
         }
 
         return Optional.ofNullable(this.restTypeDesc);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
@@ -42,7 +42,8 @@ public class BallerinaTypeDescTypeSymbol extends AbstractTypeSymbol implements T
     @Override
     public Optional<TypeSymbol> typeParameter() {
         if (this.typeParameter == null) {
-            this.typeParameter = TypesFactory.getTypeDescriptor(((BTypedescType) this.getBType()).constraint);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.typeParameter = typesFactory.getTypeDescriptor(((BTypedescType) this.getBType()).constraint);
         }
 
         return Optional.ofNullable(this.typeParameter);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeDescTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Optional;
 
@@ -34,8 +35,8 @@ public class BallerinaTypeDescTypeSymbol extends AbstractTypeSymbol implements T
 
     private TypeSymbol typeParameter;
 
-    public BallerinaTypeDescTypeSymbol(ModuleID moduleID, BTypedescType typedescType) {
-        super(TypeDescKind.TYPEDESC, moduleID, typedescType);
+    public BallerinaTypeDescTypeSymbol(CompilerContext context, ModuleID moduleID, BTypedescType typedescType) {
+        super(context, TypeDescKind.TYPEDESC, moduleID, typedescType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -45,8 +45,10 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public TypeSymbol typeDescriptor() {
         if (this.typeDescriptorImpl == null) {
-            this.typeDescriptorImpl = TypesFactory.getTypeDescriptor(this.getBType(), true);
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.typeDescriptorImpl = typesFactory.getTypeDescriptor(this.getBType(), true);
         }
+
         return this.typeDescriptorImpl;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 /**
@@ -35,8 +36,9 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     private final String definitionName;
     private TypeSymbol typeDescriptorImpl;
 
-    public BallerinaTypeReferenceTypeSymbol(ModuleID moduleID, BType bType, String definitionName) {
-        super(TypeDescKind.TYPE_REFERENCE, moduleID, bType);
+    public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
+                                            String definitionName) {
+        super(context, TypeDescKind.TYPE_REFERENCE, moduleID, bType);
         this.definitionName = definitionName;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -56,8 +56,10 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             List<TypeSymbol> members = new ArrayList<>();
 
             if (this.getBType().tag == TypeTags.UNION) {
+                TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+
                 for (BType memberType : ((BUnionType) this.getBType()).getMemberTypes()) {
-                    members.add(TypesFactory.getTypeDescriptor(memberType));
+                    members.add(typesFactory.getTypeDescriptor(memberType));
                 }
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import java.util.ArrayList;
@@ -41,12 +42,12 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
 
     private List<TypeSymbol> memberTypes;
 
-    public BallerinaUnionTypeSymbol(ModuleID moduleID, BUnionType unionType) {
-        super(TypeDescKind.UNION, moduleID, unionType);
+    public BallerinaUnionTypeSymbol(CompilerContext context, ModuleID moduleID, BUnionType unionType) {
+        super(context, TypeDescKind.UNION, moduleID, unionType);
     }
 
-    public BallerinaUnionTypeSymbol(ModuleID moduleID, BFiniteType finiteType) {
-        super(TypeDescKind.UNION, moduleID, finiteType);
+    public BallerinaUnionTypeSymbol(CompilerContext context, ModuleID moduleID, BFiniteType finiteType) {
+        super(context, TypeDescKind.UNION, moduleID, finiteType);
     }
 
     @Override
@@ -60,7 +61,7 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
                 }
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
-                    members.add(new BallerinaSingletonTypeSymbol(moduleID(), value, value.type));
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID(), value, value.type));
                 }
             }
 

--- a/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSModuleCompiler.java
+++ b/language-server/modules/langserver-compiler/src/main/java/org/ballerinalang/langserver/compiler/LSModuleCompiler.java
@@ -170,10 +170,11 @@ public class LSModuleCompiler {
         if (packages.isEmpty()) {
             throw new CompilationFailedException("Couldn't find any compiled artifact!");
         }
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(compilerContext);
         Optional<BLangPackage> currentPackage = filterCurrentPackage(packages, context);
         currentPackage.ifPresent(bLangPackage -> {
             context.put(DocumentServiceKeys.CURRENT_BLANG_PACKAGE_CONTEXT_KEY, bLangPackage);
-            context.put(DocumentServiceKeys.CURRENT_MODULE_KEY, SymbolFactory.createModuleSymbol(bLangPackage.symbol,
+            context.put(DocumentServiceKeys.CURRENT_MODULE_KEY, symbolFactory.createModuleSymbol(bLangPackage.symbol,
                     bLangPackage.symbol.name.getValue()));
             context.put(DocumentServiceKeys.CURRENT_PACKAGE_ID_KEY, bLangPackage.packageID);
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
@@ -38,12 +38,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.AttachPoints;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.stream.Collectors;
 
 /**
@@ -92,7 +87,7 @@ public class LSAnnotationCache {
             CompilerContext context = LSContextManager.getInstance().getBuiltInPackagesCompilerContext();
             new Thread(() -> {
                 Map<String, BPackageSymbol> packages = loadPackagesMap(context);
-                loadAnnotations(new ArrayList<>(packages.values()));
+                loadAnnotations(new ArrayList<>(packages.values()), context);
             }).start();
         }
     }
@@ -116,7 +111,7 @@ public class LSAnnotationCache {
                             && !importPackage.symbol.pkgID.getName().getValue().equals("runtime")) {
                         Optional<BPackageSymbol> pkgSymbol = LSPackageLoader.getPackageSymbolById(compilerCtx,
                                 importPackage.symbol.pkgID);
-                        pkgSymbol.ifPresent(LSAnnotationCache::loadAnnotationsFromPackage);
+                        pkgSymbol.ifPresent(bPackageSymbol -> loadAnnotationsFromPackage(bPackageSymbol, compilerCtx));
                     }
                 });
         switch (attachmentPoint) {
@@ -223,8 +218,9 @@ public class LSAnnotationCache {
      * Load annotations from the package.
      *
      * @param bPackageSymbol BLang Package Symbol to load annotations
+     * @param context        The compiler context used to compile the modules
      */
-    private static void loadAnnotationsFromPackage(BPackageSymbol bPackageSymbol) {
+    private static void loadAnnotationsFromPackage(BPackageSymbol bPackageSymbol, CompilerContext context) {
         List<Scope.ScopeEntry> scopeEntries = extractAnnotationDefinitions(bPackageSymbol.scope.entries);
 
         scopeEntries.forEach(annotationEntry -> {
@@ -234,61 +230,61 @@ public class LSAnnotationCache {
                 int attachPoints = ((BAnnotationSymbol) annotationEntry.symbol).maskedPoints;
 
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.TYPE)) {
-                    addAttachment(annotationSymbol, typeAnnotations);
-                    addAttachment(annotationSymbol, objectAnnotations);
+                    addAttachment(annotationSymbol, typeAnnotations, context);
+                    addAttachment(annotationSymbol, objectAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.OBJECT)) {
-                    addAttachment(annotationSymbol, objectAnnotations);
+                    addAttachment(annotationSymbol, objectAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.FUNCTION)) {
-                    addAttachment(annotationSymbol, functionAnnotations);
-                    addAttachment(annotationSymbol, objectMethodAnnotations);
-                    addAttachment(annotationSymbol, resourceAnnotations);
+                    addAttachment(annotationSymbol, functionAnnotations, context);
+                    addAttachment(annotationSymbol, objectMethodAnnotations, context);
+                    addAttachment(annotationSymbol, resourceAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.OBJECT_METHOD)) {
-                    addAttachment(annotationSymbol, objectMethodAnnotations);
+                    addAttachment(annotationSymbol, objectMethodAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.RESOURCE)) {
-                    addAttachment(annotationSymbol, resourceAnnotations);
+                    addAttachment(annotationSymbol, resourceAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.PARAMETER)) {
-                    addAttachment(annotationSymbol, parameterAnnotations);
+                    addAttachment(annotationSymbol, parameterAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.RETURN)) {
-                    addAttachment(annotationSymbol, returnAnnotations);
+                    addAttachment(annotationSymbol, returnAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.SERVICE)) {
-                    addAttachment(annotationSymbol, serviceAnnotations);
+                    addAttachment(annotationSymbol, serviceAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.LISTENER)) {
-                    addAttachment(annotationSymbol, listenerAnnotations);
+                    addAttachment(annotationSymbol, listenerAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.ANNOTATION)) {
-                    addAttachment(annotationSymbol, annotationAnnotations);
+                    addAttachment(annotationSymbol, annotationAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.EXTERNAL)) {
-                    addAttachment(annotationSymbol, externalAnnotations);
+                    addAttachment(annotationSymbol, externalAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.VAR)) {
-                    addAttachment(annotationSymbol, varAnnotations);
+                    addAttachment(annotationSymbol, varAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.CONST)) {
-                    addAttachment(annotationSymbol, constAnnotations);
+                    addAttachment(annotationSymbol, constAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.WORKER)) {
-                    addAttachment(annotationSymbol, workerAnnotations);
+                    addAttachment(annotationSymbol, workerAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.FIELD)) {
-                    addAttachment(annotationSymbol, fieldAnnotations);
+                    addAttachment(annotationSymbol, fieldAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.OBJECT_FIELD)) {
-                    addAttachment(annotationSymbol, objectFieldAnnotations);
+                    addAttachment(annotationSymbol, objectFieldAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.RECORD_FIELD)) {
-                    addAttachment(annotationSymbol, recordFieldAnnotations);
+                    addAttachment(annotationSymbol, recordFieldAnnotations, context);
                 }
                 if (Symbols.isAttachPointPresent(attachPoints, AttachPoints.CLASS)) {
-                    addAttachment(annotationSymbol, classAnnotations);
+                    addAttachment(annotationSymbol, classAnnotations, context);
                 }
             }
         });
@@ -331,13 +327,14 @@ public class LSAnnotationCache {
         return staticPackages;
     }
 
-    private static void loadAnnotations(List<BPackageSymbol> packageList) {
-        packageList.forEach(LSAnnotationCache::loadAnnotationsFromPackage);
+    private static void loadAnnotations(List<BPackageSymbol> packageList, CompilerContext context) {
+        packageList.forEach(bPackageSymbol -> loadAnnotationsFromPackage(bPackageSymbol, context));
     }
 
-    private static void addAttachment(BAnnotationSymbol bAnnotationSymbol,
-                                      Map<ModuleID, List<AnnotationSymbol>> map) {
-        AnnotationSymbol annotationSymbol = SymbolFactory.createAnnotationSymbol(bAnnotationSymbol);
+    private static void addAttachment(BAnnotationSymbol bAnnotationSymbol, Map<ModuleID, List<AnnotationSymbol>> map,
+                                      CompilerContext context) {
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(context);
+        AnnotationSymbol annotationSymbol = symbolFactory.createAnnotationSymbol(bAnnotationSymbol);
         // TODO: Check the map contains is valid
         if (map.containsKey(annotationSymbol.moduleID())) {
             map.get(annotationSymbol.moduleID()).add(annotationSymbol);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
@@ -38,7 +38,12 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.AttachPoints;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**


### PR DESCRIPTION
## Purpose
This PR is to convert the `TypesFactory` and `SymbolFactory` to per-context instances so that they can have access to the symbol table. This is a prerequisite for #25929.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
