### PR TITLE
Add missing type descriptors

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.api.impl;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Diagnostic;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -30,6 +30,7 @@ import io.ballerina.compiler.api.impl.symbols.BallerinaTypeDefinitionSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaVariableSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaWorkerSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaXMLNSSymbol;
+import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -266,7 +266,7 @@ public class SymbolFactory {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
 
-        return symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(typeSymbol.type)).build();
+        return symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(typeSymbol.type, true)).build();
     }
 
     public BallerinaClassSymbol createClassSymbol(BClassSymbol classSymbol, String name) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/TypesFactory.java
@@ -181,12 +181,8 @@ public class TypesFactory {
                 }
 
                 return new BallerinaUnionTypeSymbol(this.context, moduleID, finiteType);
-            case OTHER:
-                if (bType instanceof BInvokableType) {
-                    return new BallerinaFunctionTypeSymbol(this.context, moduleID,
-                                                           (BInvokableTypeSymbol) bType.tsymbol);
-                }
-                // fall through
+            case FUNCTION:
+                return new BallerinaFunctionTypeSymbol(this.context, moduleID, (BInvokableTypeSymbol) bType.tsymbol);
             default:
                 return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/TypesFactory.java
@@ -18,21 +18,28 @@
 package io.ballerina.compiler.api.impl;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.symbols.BallerinaAnyTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaAnydataTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaArrayTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaErrorTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaFunctionTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaFutureTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaHandleTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaJSONTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaMapTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaNilTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaObjectTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaReadonlyTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaRecordTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaSimpleTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaSingletonTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaStreamTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaTableTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaTupleTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaTypeDescTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaUnionTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaXMLTypeSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -40,20 +47,27 @@ import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BArrayType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BReadonlyType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -116,6 +130,20 @@ public class TypesFactory {
         }
 
         switch (bType.getKind()) {
+            case ANY:
+                return new BallerinaAnyTypeSymbol(this.context, moduleID, (BAnyType) bType);
+            case ANYDATA:
+                return new BallerinaAnydataTypeSymbol(this.context, moduleID, (BAnydataType) bType);
+            case HANDLE:
+                return new BallerinaHandleTypeSymbol(this.context, moduleID, (BHandleType) bType);
+            case JSON:
+                return new BallerinaJSONTypeSymbol(this.context, moduleID, (BJSONType) bType);
+            case READONLY:
+                return new BallerinaReadonlyTypeSymbol(this.context, moduleID, (BReadonlyType) bType);
+            case TABLE:
+                return new BallerinaTableTypeSymbol(this.context, moduleID, (BTableType) bType);
+            case XML:
+                return new BallerinaXMLTypeSymbol(this.context, moduleID, (BXMLType) bType);
             case OBJECT:
                 ObjectTypeSymbol objType = new BallerinaObjectTypeSymbol(this.context, moduleID, (BObjectType) bType);
                 if (Symbols.isFlagOn(bType.tsymbol.flags, Flags.CLASS)) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.AnyTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+/**
+ * Represents the any type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaAnyTypeSymbol extends AbstractTypeSymbol implements AnyTypeSymbol {
+
+    public BallerinaAnyTypeSymbol(CompilerContext context, ModuleID moduleID, BAnyType anyType) {
+        super(context, TypeDescKind.ANY, moduleID, anyType);
+    }
+
+    @Override
+    public String signature() {
+        return "any";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.AnydataTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+/**
+ * Represents the anydata type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaAnydataTypeSymbol extends AbstractTypeSymbol implements AnydataTypeSymbol {
+
+    public BallerinaAnydataTypeSymbol(CompilerContext context, ModuleID moduleID, BAnydataType anydataType) {
+        super(context, TypeDescKind.ANYDATA, moduleID, anydataType);
+    }
+
+    @Override
+    public String signature() {
+        return "anydata";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -17,7 +17,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -18,7 +18,6 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.HandleTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+/**
+ * Represents the handle type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaHandleTypeSymbol extends AbstractTypeSymbol implements HandleTypeSymbol {
+
+    public BallerinaHandleTypeSymbol(CompilerContext context, ModuleID moduleID, BHandleType handleType) {
+        super(context, TypeDescKind.HANDLE, moduleID, handleType);
+    }
+
+    @Override
+    public String signature() {
+        return "handle";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.JSONTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+/**
+ * Represents the json type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaJSONTypeSymbol extends AbstractTypeSymbol implements JSONTypeSymbol {
+
+    public BallerinaJSONTypeSymbol(CompilerContext context, ModuleID moduleID, BJSONType jsonType) {
+        super(context, TypeDescKind.JSON, moduleID, jsonType);
+    }
+
+    @Override
+    public String signature() {
+        return "json";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -51,6 +51,6 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
     @Override
     public String signature() {
         Optional<TypeSymbol> memberTypeDescriptor = this.typeParameter();
-        return memberTypeDescriptor.map(typeDescriptor -> "map<" + typeDescriptor.signature() + ">").orElse("map<>");
+        return memberTypeDescriptor.map(typeDescriptor -> "map<" + typeDescriptor.signature() + ">").orElse("map");
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.ReadonlyTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BReadonlyType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+/**
+ * Represents the readonly type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaReadonlyTypeSymbol extends AbstractTypeSymbol implements ReadonlyTypeSymbol {
+
+    public BallerinaReadonlyTypeSymbol(CompilerContext context, ModuleID moduleID, BReadonlyType readonlyType) {
+        super(context, TypeDescKind.READONLY, moduleID, readonlyType);
+    }
+
+    @Override
+    public String signature() {
+        return "readonly";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSimpleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSimpleTypeSymbol.java
@@ -28,11 +28,21 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  */
 public class BallerinaSimpleTypeSymbol extends AbstractTypeSymbol implements SimpleTypeSymbol {
 
-    private String typeName;
+    private final String typeName;
 
     public BallerinaSimpleTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType) {
         super(context, TypesFactory.getTypeDescKind(bType.getKind()), moduleID, bType);
         this.typeName = bType.getKind().typeName();
+    }
+
+    public BallerinaSimpleTypeSymbol(CompilerContext context, ModuleID moduleID, String name, BType bType) {
+        super(context, TypesFactory.getTypeDescKind(bType.getKind()), moduleID, bType);
+        this.typeName = name;
+    }
+
+    @Override
+    public String name() {
+        return this.typeName;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSimpleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSimpleTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.SimpleTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -21,12 +21,10 @@ import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.StringJoiner;
+import java.util.Optional;
 
 /**
  * Represents an stream type descriptor.
@@ -35,34 +33,47 @@ import java.util.StringJoiner;
  */
 public class BallerinaStreamTypeSymbol extends AbstractTypeSymbol implements StreamTypeSymbol {
 
-    private List<TypeSymbol> typeParameters;
+    private TypeSymbol typeParameter;
+    private TypeSymbol completionValueTypeParameter;
+    private String signature;
 
     public BallerinaStreamTypeSymbol(CompilerContext context, ModuleID moduleID, BStreamType streamType) {
         super(context, TypeDescKind.STREAM, moduleID, streamType);
     }
 
     @Override
-    public List<TypeSymbol> typeParameters() {
-        if (this.typeParameters == null) {
-            List<TypeSymbol> typeParams = new ArrayList<>();
+    public TypeSymbol typeParameter() {
+        if (this.typeParameter == null) {
             TypesFactory typesFactory = TypesFactory.getInstance(this.context);
-            typeParams.add(typesFactory.getTypeDescriptor(((BStreamType) this.getBType()).constraint));
-            this.typeParameters = Collections.unmodifiableList(typeParams);
+            this.typeParameter = typesFactory.getTypeDescriptor(((BStreamType) this.getBType()).constraint);
         }
 
-        return this.typeParameters;
+        return this.typeParameter;
+    }
+
+    @Override
+    public Optional<TypeSymbol> completionValueTypeParameter() {
+        if (this.completionValueTypeParameter == null) {
+            BType completionType = ((BStreamType) this.getBType()).error;
+
+            if (completionType != null) {
+                TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+                this.completionValueTypeParameter = typesFactory.getTypeDescriptor(completionType);
+            }
+        }
+
+        return Optional.ofNullable(this.completionValueTypeParameter);
     }
 
     @Override
     public String signature() {
-        String memberSignature;
-        if (this.typeParameters().isEmpty()) {
-            memberSignature = "()";
-        } else {
-            StringJoiner joiner = new StringJoiner(", ");
-            this.typeParameters().forEach(typeDescriptor -> joiner.add(typeDescriptor.signature()));
-            memberSignature = joiner.toString();
+        if (this.signature == null) {
+            StringBuilder sigBuilder = new StringBuilder("stream<");
+            sigBuilder.append(this.typeParameter().signature());
+            this.completionValueTypeParameter().ifPresent(t -> sigBuilder.append(", ").append(t.signature()));
+            sigBuilder.append('>');
+            this.signature = sigBuilder.toString();
         }
-        return "stream<" + memberSignature + ">";
+        return this.signature;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -37,6 +38,7 @@ public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements Tabl
 
     private TypeSymbol rowTypeParameter;
     private TypeSymbol keyConstraintTypeParameter;
+    private List<String> keySpecifiers;
 
     public BallerinaTableTypeSymbol(CompilerContext context, ModuleID moduleID, BTableType tableType) {
         super(context, TypeDescKind.TABLE, moduleID, tableType);
@@ -65,7 +67,17 @@ public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements Tabl
 
     @Override
     public List<String> keySpecifiers() {
-        return Collections.emptyList();
+        if (this.keySpecifiers == null) {
+            List<String> specifiers = ((BTableType) this.getBType()).fieldNameList;
+
+            if (specifiers == null) {
+                specifiers = new ArrayList<>();
+            }
+
+            this.keySpecifiers = Collections.unmodifiableList(specifiers);
+        }
+
+        return this.keySpecifiers;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -18,7 +18,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TableTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TableTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -38,20 +39,28 @@ public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements Tabl
     private TypeSymbol rowTypeParameter;
     private TypeSymbol keyConstraintTypeParameter;
 
-    public BallerinaTableTypeSymbol(CompilerContext context, ModuleID moduleID, TypeSymbol rowTypeParameter,
-                                    TypeSymbol keyConstraintTypeParameter, BTableType tableType) {
+    public BallerinaTableTypeSymbol(CompilerContext context, ModuleID moduleID, BTableType tableType) {
         super(context, TypeDescKind.TABLE, moduleID, tableType);
-        this.rowTypeParameter = rowTypeParameter;
-        this.keyConstraintTypeParameter = keyConstraintTypeParameter;
     }
 
     @Override
     public TypeSymbol rowTypeParameter() {
+        if (this.rowTypeParameter == null) {
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.rowTypeParameter = typesFactory.getTypeDescriptor(((BTableType) this.getBType()).constraint);
+        }
+
         return this.rowTypeParameter;
     }
 
     @Override
     public Optional<TypeSymbol> keyConstraintTypeParameter() {
+        if (this.rowTypeParameter == null) {
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.keyConstraintTypeParameter = typesFactory.getTypeDescriptor(
+                    ((BTableType) this.getBType()).keyTypeConstraint);
+        }
+
         return Optional.ofNullable(this.keyConstraintTypeParameter);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.TableTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Represents a table type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements TableTypeSymbol {
+
+    private TypeSymbol rowTypeParameter;
+    private TypeSymbol keyConstraintTypeParameter;
+
+    public BallerinaTableTypeSymbol(CompilerContext context, ModuleID moduleID, TypeSymbol rowTypeParameter,
+                                    TypeSymbol keyConstraintTypeParameter, BTableType tableType) {
+        super(context, TypeDescKind.TABLE, moduleID, tableType);
+        this.rowTypeParameter = rowTypeParameter;
+        this.keyConstraintTypeParameter = keyConstraintTypeParameter;
+    }
+
+    @Override
+    public TypeSymbol rowTypeParameter() {
+        return this.rowTypeParameter;
+    }
+
+    @Override
+    public Optional<TypeSymbol> keyConstraintTypeParameter() {
+        return Optional.ofNullable(this.keyConstraintTypeParameter);
+    }
+
+    @Override
+    public List<String> keySpecifiers() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String signature() {
+        // TODO: Implement the correct signature
+        return "table";
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeDescTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -17,7 +17,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
@@ -35,14 +36,17 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
 
     private TypeSymbol typeParameter;
 
-    public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, TypeSymbol typeParameter,
-                                  BXMLType xmlType) {
+    public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLType xmlType) {
         super(context, TypeDescKind.XML, moduleID, xmlType);
-        this.typeParameter = typeParameter;
     }
 
     @Override
     public Optional<TypeSymbol> typeParameter() {
+        if (this.typeParameter == null) {
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.typeParameter = typesFactory.getTypeDescriptor(((BXMLType) this.getBType()).constraint);
+        }
+
         return Optional.ofNullable(this.typeParameter);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.Optional;
+
+/**
+ * Represents an xml type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTypeSymbol {
+
+    private TypeSymbol typeParameter;
+
+    public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, TypeSymbol typeParameter,
+                                  BXMLType xmlType) {
+        super(context, TypeDescKind.XML, moduleID, xmlType);
+        this.typeParameter = typeParameter;
+    }
+
+    @Override
+    public Optional<TypeSymbol> typeParameter() {
+        return Optional.ofNullable(this.typeParameter);
+    }
+
+    @Override
+    public String signature() {
+        Optional<TypeSymbol> memberTypeDescriptor = this.typeParameter();
+        return memberTypeDescriptor.map(typeDescriptor -> "xml<" + typeDescriptor.signature() + ">").orElse("xml");
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -21,6 +21,8 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
@@ -34,9 +36,15 @@ import java.util.Optional;
 public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTypeSymbol {
 
     private TypeSymbol typeParameter;
+    private String typeName;
 
     public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLType xmlType) {
         super(context, TypeDescKind.XML, moduleID, xmlType);
+    }
+
+    public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType xmlSubType) {
+        super(context, TypeDescKind.XML, moduleID, xmlSubType);
+        this.typeName = xmlSubType.name.getValue();
     }
 
     @Override
@@ -50,8 +58,23 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
     }
 
     @Override
+    public String name() {
+        if (this.typeName == null) {
+            BXMLType xmlType = (BXMLType) this.getBType();
+            SymbolTable symbolTable = SymbolTable.getInstance(this.context);
+
+            if (xmlType == symbolTable.xmlType || this.typeParameter().isEmpty()) {
+                this.typeName = "xml";
+            } else {
+                this.typeName = "xml<" + this.typeParameter().get().name() + ">";
+            }
+        }
+
+        return this.typeName;
+    }
+
+    @Override
     public String signature() {
-        Optional<TypeSymbol> memberTypeDescriptor = this.typeParameter();
-        return memberTypeDescriptor.map(typeDescriptor -> "xml<" + typeDescriptor.signature() + ">").orElse("xml");
+        return name();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -18,7 +18,6 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.TypesFactory;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -134,6 +134,9 @@ public class TypesFactory {
             case TABLE:
                 return new BallerinaTableTypeSymbol(this.context, moduleID, (BTableType) bType);
             case XML:
+                if (bType instanceof BXMLSubType) {
+                    return new BallerinaXMLTypeSymbol(this.context, moduleID, (BXMLSubType) bType);
+                }
                 return new BallerinaXMLTypeSymbol(this.context, moduleID, (BXMLType) bType);
             case OBJECT:
                 ObjectTypeSymbol objType = new BallerinaObjectTypeSymbol(this.context, moduleID, (BObjectType) bType);
@@ -194,7 +197,7 @@ public class TypesFactory {
 
         final TypeKind kind = bType.getKind();
         return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel
-                || bType instanceof BIntSubType || bType instanceof BStringSubType;
+                || bType instanceof BIntSubType || bType instanceof BStringSubType || bType instanceof BXMLSubType;
     }
 
     public static TypeDescKind getTypeDescKind(TypeKind bTypeKind) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -33,6 +33,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
@@ -108,6 +109,11 @@ public class TypesFactory {
         }
 
         switch (bType.getKind()) {
+            case INT:
+                if (bType instanceof BIntSubType) {
+                    return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType.name.getValue(), bType);
+                }
+                return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType);
             case ANY:
                 return new BallerinaAnyTypeSymbol(this.context, moduleID, (BAnyType) bType);
             case ANYDATA:
@@ -176,7 +182,7 @@ public class TypesFactory {
         }
 
         final TypeKind kind = bType.getKind();
-        return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel;
+        return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel || bType instanceof BIntSubType;
     }
 
     public static TypeDescKind getTypeDescKind(TypeKind bTypeKind) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -41,11 +41,13 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BReadonlyType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BStreamType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BStringSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTupleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -113,7 +115,12 @@ public class TypesFactory {
                 if (bType instanceof BIntSubType) {
                     return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType.name.getValue(), bType);
                 }
-                return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType);
+                return createSimpleTypedesc(moduleID, bType);
+            case STRING:
+                if (bType instanceof BStringSubType) {
+                    return new BallerinaSimpleTypeSymbol(this.context, moduleID, bType.name.getValue(), bType);
+                }
+                return createSimpleTypedesc(moduleID, bType);
             case ANY:
                 return new BallerinaAnyTypeSymbol(this.context, moduleID, (BAnyType) bType);
             case ANYDATA:
@@ -172,6 +179,10 @@ public class TypesFactory {
         }
     }
 
+    private BallerinaSimpleTypeSymbol createSimpleTypedesc(ModuleID moduleID, BType internalType) {
+        return new BallerinaSimpleTypeSymbol(this.context, moduleID, internalType);
+    }
+
     private static boolean isTypeReference(BType bType, boolean rawTypeOnly) {
         if (rawTypeOnly || bType.tsymbol == null) {
             return false;
@@ -182,7 +193,8 @@ public class TypesFactory {
         }
 
         final TypeKind kind = bType.getKind();
-        return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel || bType instanceof BIntSubType;
+        return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel
+                || bType instanceof BIntSubType || bType instanceof BStringSubType;
     }
 
     public static TypeDescKind getTypeDescKind(TypeKind bTypeKind) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -6,40 +6,19 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
-package io.ballerina.compiler.api.impl;
+package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.symbols.BallerinaAnyTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaAnydataTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaArrayTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaErrorTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaFunctionTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaFutureTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaHandleTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaJSONTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaMapTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaNilTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaObjectTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaReadonlyTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaRecordTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaSimpleTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaSingletonTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaStreamTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaTableTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaTupleTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaTypeDescTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaUnionTypeSymbol;
-import io.ballerina.compiler.api.impl.symbols.BallerinaXMLTypeSymbol;
+import io.ballerina.compiler.api.impl.BallerinaModuleID;
+import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -54,7 +33,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BErrorType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
-import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnyTypeSymbol.java
@@ -14,36 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
-import java.util.Optional;
-
 /**
- * Represents the table type descriptor.
+ * Represents the any type descriptor.
  *
  * @since 2.0.0
  */
-public interface TableTypeSymbol extends TypeSymbol {
-
-    /**
-     * Get the row type parameter.
-     *
-     * @return {@link TypeSymbol}
-     */
-    TypeSymbol rowTypeParameter();
-
-    /**
-     * Get the key type constraint.
-     *
-     * @return {@link Optional} type descriptor
-     */
-    Optional<TypeSymbol> keyConstraintTypeParameter();
-
-    /**
-     * Get the list of key specifiers.
-     *
-     * @return {@link List} of key names
-     */
-    List<String> keySpecifiers();
+public interface AnyTypeSymbol extends TypeSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnydataTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnydataTypeSymbol.java
@@ -14,36 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
-import java.util.Optional;
-
 /**
- * Represents the table type descriptor.
+ * Represents the anydata type descriptor.
  *
  * @since 2.0.0
  */
-public interface TableTypeSymbol extends TypeSymbol {
-
-    /**
-     * Get the row type parameter.
-     *
-     * @return {@link TypeSymbol}
-     */
-    TypeSymbol rowTypeParameter();
-
-    /**
-     * Get the key type constraint.
-     *
-     * @return {@link Optional} type descriptor
-     */
-    Optional<TypeSymbol> keyConstraintTypeParameter();
-
-    /**
-     * Get the list of key specifiers.
-     *
-     * @return {@link List} of key names
-     */
-    List<String> keySpecifiers();
+public interface AnydataTypeSymbol extends TypeSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/HandleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/HandleTypeSymbol.java
@@ -14,36 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
-import java.util.Optional;
-
 /**
- * Represents the table type descriptor.
+ * Represents the handle type descriptor.
  *
  * @since 2.0.0
  */
-public interface TableTypeSymbol extends TypeSymbol {
-
-    /**
-     * Get the row type parameter.
-     *
-     * @return {@link TypeSymbol}
-     */
-    TypeSymbol rowTypeParameter();
-
-    /**
-     * Get the key type constraint.
-     *
-     * @return {@link Optional} type descriptor
-     */
-    Optional<TypeSymbol> keyConstraintTypeParameter();
-
-    /**
-     * Get the list of key specifiers.
-     *
-     * @return {@link List} of key names
-     */
-    List<String> keySpecifiers();
+public interface HandleTypeSymbol extends TypeSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/JSONTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/JSONTypeSymbol.java
@@ -14,36 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
-import java.util.Optional;
-
 /**
- * Represents the table type descriptor.
+ * Represents the json type descriptor.
  *
  * @since 2.0.0
  */
-public interface TableTypeSymbol extends TypeSymbol {
-
-    /**
-     * Get the row type parameter.
-     *
-     * @return {@link TypeSymbol}
-     */
-    TypeSymbol rowTypeParameter();
-
-    /**
-     * Get the key type constraint.
-     *
-     * @return {@link Optional} type descriptor
-     */
-    Optional<TypeSymbol> keyConstraintTypeParameter();
-
-    /**
-     * Get the list of key specifiers.
-     *
-     * @return {@link List} of key names
-     */
-    List<String> keySpecifiers();
+public interface JSONTypeSymbol extends TypeSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ReadonlyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ReadonlyTypeSymbol.java
@@ -14,36 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
-import java.util.Optional;
-
 /**
- * Represents the table type descriptor.
+ * Represents the readonly type descriptor.
  *
  * @since 2.0.0
  */
-public interface TableTypeSymbol extends TypeSymbol {
-
-    /**
-     * Get the row type parameter.
-     *
-     * @return {@link TypeSymbol}
-     */
-    TypeSymbol rowTypeParameter();
-
-    /**
-     * Get the key type constraint.
-     *
-     * @return {@link Optional} type descriptor
-     */
-    Optional<TypeSymbol> keyConstraintTypeParameter();
-
-    /**
-     * Get the list of key specifiers.
-     *
-     * @return {@link List} of key names
-     */
-    List<String> keySpecifiers();
+public interface ReadonlyTypeSymbol extends TypeSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/StreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/StreamTypeSymbol.java
@@ -16,7 +16,7 @@
  */
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents an stream type descriptor.
@@ -26,9 +26,17 @@ import java.util.List;
 public interface StreamTypeSymbol extends TypeSymbol {
 
     /**
-     * Get the type parameters.
+     * Gets the type of the values of this stream.
      *
-     * @return {@link List} of types
+     * @return The type of the values
      */
-    List<TypeSymbol> typeParameters();
+    TypeSymbol typeParameter();
+
+    /**
+     * Gets the type of the completion value of the stream. Absence of a type descriptor is the same as the type being
+     * ().
+     *
+     * @return The type of the completion value
+     */
+    Optional<TypeSymbol> completionValueTypeParameter();
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDescKind.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDescKind.java
@@ -50,8 +50,9 @@ public enum TypeDescKind {
     HANDLE("handle"),
     TABLE("table"),
     SINGLETON("singleton"),
+    READONLY("readonly"),
     NEVER("never");
-    
+
     
     private final String name;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLTypeSymbol.java
@@ -14,36 +14,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
- * Represents the table type descriptor.
+ * Represents an xml type descriptor.
  *
  * @since 2.0.0
  */
-public interface TableTypeSymbol extends TypeSymbol {
+public interface XMLTypeSymbol extends TypeSymbol {
 
     /**
-     * Get the row type parameter.
+     * Get the type descriptor of the type parameter.
      *
-     * @return {@link TypeSymbol}
+     * @return The type parameter
      */
-    TypeSymbol rowTypeParameter();
-
-    /**
-     * Get the key type constraint.
-     *
-     * @return {@link Optional} type descriptor
-     */
-    Optional<TypeSymbol> keyConstraintTypeParameter();
-
-    /**
-     * Get the list of key specifiers.
-     *
-     * @return {@link List} of key names
-     */
-    List<String> keySpecifiers();
+    Optional<TypeSymbol> typeParameter();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BInvokableType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BInvokableType.java
@@ -57,6 +57,10 @@ public class BInvokableType extends BType implements InvokableType {
         return retType;
     }
 
+    @Override
+    public TypeKind getKind() {
+        return TypeKind.FUNCTION;
+    }
 
     @Override
     public <T, R> R accept(BTypeVisitor<T, R> visitor, T t) {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/remote_action_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/remote_action_config1.json
@@ -6,13 +6,13 @@
   "source": "statement_context/source/remote_action_source1.bal",
   "items": [
     {
-      "label": "post(string path, string|xml|json|byte[] message, string targetType)(ballerina/module1:0.1.0:Response)",
+      "label": "post(string path, string|xml<>|json|byte[] message, string targetType)(ballerina/module1:0.1.0:Response)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `ballerina/module1:0.1.0:Response`   \n- The response for the request  \n  \n"
+          "value": "**Package:** _ballerina/module1:0.1.0_  \n  \nThe `Client.post()` function can be used to send HTTP POST requests to HTTP endpoints.\n  \n**Params**  \n- `string` path: Resource path  \n- `string|xml<>|json|byte[]` message: An HTTP outbound request message or any payload of type `string`, `xml`, `json`, `byte[]`  \n- `string` targetType: Specifies the target type(Defaultable)  \n  \n**Returns** `ballerina/module1:0.1.0:Response`   \n- The response for the request  \n  \n"
         }
       },
       "insertText": "post(${1})",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -291,25 +291,26 @@ public class TypedescriptorTest {
     public Object[][] getTypesPos() {
         return new Object[][]{
                 {64, 9, JSON},
-                {69, 13, READONLY},
-                {71, 8, ANY},
-                {72, 12, ANYDATA},
+                {68, 13, READONLY},
+                {70, 8, ANY},
+                {71, 12, ANYDATA},
         };
     }
 
     @Test(dataProvider = "XMLPosProvider")
-    public void testXML(int line, int column, TypeDescKind kind) {
+    public void testXML(int line, int column, TypeDescKind kind, String name) {
         VariableSymbol symbol = (VariableSymbol) getSymbol(line, column);
         TypeSymbol type = symbol.typeDescriptor();
         assertEquals(type.typeKind(), XML);
         assertEquals(((XMLTypeSymbol) type).typeParameter().get().typeKind(), kind);
+        assertEquals(type.name(), name);
     }
 
     @DataProvider(name = "XMLPosProvider")
     public Object[][] getXMLTypePos() {
         return new Object[][]{
-                {66, 8, UNION},
-//                {67, 17, XML}, TODO: https://github.com/ballerina-platform/ballerina-lang/issues/26787
+                {66, 8, UNION, "xml"},
+                {91, 22, TYPE_REFERENCE, "xml<Element>"},
         };
     }
 
@@ -330,9 +331,37 @@ public class TypedescriptorTest {
     @DataProvider(name = "TablePosProvider")
     public Object[][] getTableTypePos() {
         return new Object[][]{
-                {74, 28, TYPE_REFERENCE, "Person", List.of("name"), null},
-                {75, 18, TYPE_REFERENCE, "Person", Collections.emptyList(), null},
-                {76, 27, TYPE_REFERENCE, "Person", Collections.emptyList(), INT}
+                {73, 28, TYPE_REFERENCE, "Person", List.of("name"), null},
+                {74, 18, TYPE_REFERENCE, "Person", Collections.emptyList(), null},
+                {75, 27, TYPE_REFERENCE, "Person", Collections.emptyList(), INT}
+        };
+    }
+
+    @Test(dataProvider = "BuiltinTypePosProvider")
+    public void testBuiltinSubtypes(int line, int column, TypeDescKind kind, String name) {
+        Symbol symbol = getSymbol(line, column);
+        TypeSymbol typeRef = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(typeRef.typeKind(), TYPE_REFERENCE);
+
+        TypeSymbol type = ((TypeReferenceTypeSymbol) typeRef).typeDescriptor();
+        assertEquals(type.typeKind(), kind);
+        assertEquals(type.name(), name);
+    }
+
+    @DataProvider(name = "BuiltinTypePosProvider")
+    public Object[][] getBuiltinTypePos() {
+        return new Object[][]{
+                {77, 20, INT, "Unsigned32"},
+                {78, 18, INT, "Signed32"},
+                {79, 19, INT, "Unsigned8"},
+                {80, 17, INT, "Signed8"},
+                {81, 20, INT, "Unsigned16"},
+                {82, 18, INT, "Signed16"},
+                {84, 17, STRING, "Char"},
+                {86, 17, XML, "Element"},
+                {87, 31, XML, "ProcessingInstruction"},
+                {88, 17, XML, "Comment"},
+                {89, 14, XML, "Text"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -316,7 +316,7 @@ public class TypedescriptorTest {
 
     @Test(dataProvider = "TablePosProvider")
     public void testTable(int line, int column, TypeDescKind rowTypeKind, String rowTypeName,
-                          List<String> keySpecifiers, TypeDescKind keyConstraintTypeKind) {
+                          List<String> keySpecifiers, TypeDescKind keyConstraintTypeKind, String signature) {
         VariableSymbol symbol = (VariableSymbol) getSymbol(line, column);
         TypeSymbol type = symbol.typeDescriptor();
         assertEquals(type.typeKind(), TABLE);
@@ -326,14 +326,15 @@ public class TypedescriptorTest {
         assertEquals(tableType.rowTypeParameter().name(), rowTypeName);
         assertEquals(tableType.keySpecifiers(), keySpecifiers);
         tableType.keyConstraintTypeParameter().ifPresent(t -> assertEquals(t.typeKind(), keyConstraintTypeKind));
+        assertEquals(type.signature(), signature);
     }
 
     @DataProvider(name = "TablePosProvider")
     public Object[][] getTableTypePos() {
         return new Object[][]{
-                {73, 28, TYPE_REFERENCE, "Person", List.of("name"), null},
-                {74, 18, TYPE_REFERENCE, "Person", Collections.emptyList(), null},
-                {75, 27, TYPE_REFERENCE, "Person", Collections.emptyList(), INT}
+                {73, 28, TYPE_REFERENCE, "Person", List.of("name"), null, "table<Person> key(name)"},
+                {74, 18, TYPE_REFERENCE, "Person", Collections.emptyList(), null, "table<Person>"},
+                {75, 30, TYPE_REFERENCE, "Person", Collections.emptyList(), STRING, "table<Person> key<string>"}
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -180,9 +180,7 @@ public class TypedescriptorTest {
     @Test
     public void testRecordType() {
         Symbol symbol = getSymbol(18, 5);
-        TypeReferenceTypeSymbol typeRef =
-                (TypeReferenceTypeSymbol) ((TypeDefinitionSymbol) symbol).typeDescriptor();
-        RecordTypeSymbol type = (RecordTypeSymbol) typeRef.typeDescriptor();
+        RecordTypeSymbol type = (RecordTypeSymbol) ((TypeDefinitionSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), RECORD);
         assertFalse(type.inclusive());
         assertFalse(type.restTypeDescriptor().isPresent());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -32,6 +32,7 @@ import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.StreamTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TableTypeSymbol;
 import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
@@ -60,6 +61,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.ANY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
@@ -70,6 +72,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.READONLY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.SINGLETON;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
@@ -81,6 +84,7 @@ import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.compile;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -363,6 +367,31 @@ public class TypedescriptorTest {
                 {87, 31, XML, "ProcessingInstruction"},
                 {88, 17, XML, "Comment"},
                 {89, 14, XML, "Text"},
+        };
+    }
+
+    @Test(dataProvider = "StreamTypePosProvider")
+    public void testStreamType(int line, int column, TypeDescKind typeParamKind, TypeDescKind completionValueTypeKind) {
+        Symbol symbol = getSymbol(line, column);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), STREAM);
+
+        StreamTypeSymbol streamType = (StreamTypeSymbol) type;
+        assertEquals(streamType.typeParameter().typeKind(), typeParamKind);
+
+        if (streamType.completionValueTypeParameter().isPresent()) {
+            assertEquals(streamType.completionValueTypeParameter().get().typeKind(), completionValueTypeKind);
+        } else {
+            assertNull(completionValueTypeKind);
+        }
+    }
+
+    @DataProvider(name = "StreamTypePosProvider")
+    public Object[][] getStreamTypePos() {
+        return new Object[][]{
+                {93, 19, TYPE_REFERENCE, null},
+                {94, 23, TYPE_REFERENCE, NIL},
+                {95, 45, RECORD, ERROR}
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -90,6 +90,10 @@ function test() {
     'xml:Text txt = xml `hello text`;
 
     xml<'xml:Element> greet3 = xml `<greet>Ciao!</greet>`;
+
+    stream<Person> st1;
+    stream<Person, ()> st2;
+    stream<record {| string name; |}, error> st3;
 }
 
 type Number int|float|decimal;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -73,7 +73,7 @@ function test() {
 
     table<Person> key(name) tab = table [];
     table<Person> tab2 = table [];
-    table<Person> key<int> tab3 = table [];
+    table<Person> key<string> tab3 = table key(name) [];
 
     'int:Unsigned32 uInt32 = 1000;
     'int:Signed32 sInt32 = -1000;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -65,7 +65,6 @@ function test() {
     json j = {name: "Pubudu"};
 
     xml greet1 = xml `<greet>Hello</greet>`;
-    'xml:Element greet2 = xml `<greet>Hola!</greet>`;
 
     readonly ro = 12;
 
@@ -75,6 +74,22 @@ function test() {
     table<Person> key(name) tab = table [];
     table<Person> tab2 = table [];
     table<Person> key<int> tab3 = table [];
+
+    'int:Unsigned32 uInt32 = 1000;
+    'int:Signed32 sInt32 = -1000;
+    'int:Unsigned8 uInt8 = 10;
+    'int:Signed8 sInt8 = -10;
+    'int:Unsigned16 uInt16 = 100;
+    'int:Signed16 sInt16 = -100;
+
+    'string:Char ch = "A";
+
+    'xml:Element greet2 = xml `<greet>Hola!</greet>`;
+    'xml:ProcessingInstruction pi = xml `<?xml-stylesheet type="text/xsl" href="style.xsl"?>`;
+    'xml:Comment comment = xml `<!-- hello from comment -->`;
+    'xml:Text txt = xml `hello text`;
+
+    xml<'xml:Element> greet3 = xml `<greet>Ciao!</greet>`;
 }
 
 type Number int|float|decimal;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -61,6 +61,20 @@ function test() {
     Digit d = 1;
 
     Format fmt = DEFAULT;
+
+    json j = {name: "Pubudu"};
+
+    xml greet1 = xml `<greet>Hello</greet>`;
+    'xml:Element greet2 = xml `<greet>Hola!</greet>`;
+
+    readonly ro = 12;
+
+    any a = "Hello World!";
+    anydata ad = 1234;
+
+    table<Person> key(name) tab = table [];
+    table<Person> tab2 = table [];
+    table<Person> key<int> tab3 = table [];
 }
 
 type Number int|float|decimal;
@@ -72,3 +86,8 @@ public type Format DEFAULT|CSV|TDF;
 public const DEFAULT = "default";
 public const CSV = "csv";
 public const TDF = "tdf";
+
+type Person record {
+  readonly string name;
+  int age;
+};


### PR DESCRIPTION
## Purpose
- Add the following missing typedescs: `any`, `anydata`, `json`, `handle`, `table`, `xml` and `readonly`. 
- Add support for all the builtin sub types defined in the lang lib.
- Fix/Implement type signatures of constrained types.

Fix #26757 
Fix #26260

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
