### PR TITLE
Implement API for getting the lang lib functions allowed by method call expr

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.impl;
+
+import io.ballerina.compiler.api.impl.symbols.BallerinaFunctionSymbol.FunctionSymbolBuilder;
+import io.ballerina.compiler.api.impl.symbols.BallerinaMethodSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.SymbolKind;
+import org.wso2.ballerinalang.compiler.semantics.model.Scope;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
+import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.Name;
+import org.wso2.ballerinalang.compiler.util.Names;
+import org.wso2.ballerinalang.util.Flags;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+
+
+/**
+ * A class to hold the lang library function info required for types.
+ *
+ * @since 2.0.0
+ */
+class LangLibrary {
+
+    private static final CompilerContext.Key<LangLibrary> LANG_LIB_KEY = new CompilerContext.Key<>();
+    private static final String LANG_VALUE = "value";
+
+    private final Map<String, Map<String, BInvokableSymbol>> langLibMethods;
+    private final Map<String, List<MethodSymbol>> wrappedLangLibMethods;
+
+    private LangLibrary(CompilerContext context) {
+        context.put(LANG_LIB_KEY, this);
+
+        SymbolTable symbolTable = SymbolTable.getInstance(context);
+        Map<String, BPackageSymbol> langLibs = new HashMap<>();
+        wrappedLangLibMethods = new HashMap<>();
+
+        for (Map.Entry<BPackageSymbol, SymbolEnv> entry : symbolTable.pkgEnvMap.entrySet()) {
+            BPackageSymbol module = entry.getKey();
+            PackageID moduleID = module.pkgID;
+
+            if (Names.BALLERINA_ORG.equals(moduleID.orgName) &&
+                    (moduleID.nameComps.size() == 2 && Names.LANG.equals(moduleID.nameComps.get(0)))) {
+                langLibs.put(moduleID.nameComps.get(1).value, module);
+            }
+        }
+
+        langLibMethods = getLangLibMethods(langLibs);
+    }
+
+    public static LangLibrary getInstance(CompilerContext context) {
+        LangLibrary langLib = context.get(LANG_LIB_KEY);
+        if (langLib == null) {
+            langLib = new LangLibrary(context);
+        }
+
+        return langLib;
+    }
+
+    /**
+     * Given a type descriptor kind, return the list of lang library functions that can be called using a method call
+     * expr, on an expression of that type.
+     *
+     * @param typeDescKind A type descriptor kind
+     * @return The associated list of lang library functions
+     */
+    public List<MethodSymbol> getMethods(TypeDescKind typeDescKind) {
+        String langLibName = getAssociatedLangLibName(typeDescKind);
+
+        if (wrappedLangLibMethods.containsKey(langLibName)) {
+            return wrappedLangLibMethods.get(langLibName);
+        }
+
+        Map<String, BInvokableSymbol> methods = langLibMethods.get(langLibName);
+
+        List<MethodSymbol> wrappedMethods = new ArrayList<>();
+        wrappedLangLibMethods.put(langLibName, wrappedMethods);
+        populateMethodList(wrappedMethods, methods);
+
+        // Add the common functions in lang.value to types which have an associated lang library.
+        if (!LANG_VALUE.equals(langLibName)) {
+            populateMethodList(wrappedMethods, langLibMethods.get(LANG_VALUE));
+        }
+
+        return wrappedMethods;
+    }
+
+    // Private Methods
+
+    private void populateMethodList(List<MethodSymbol> list, Map<String, BInvokableSymbol> langLib) {
+        for (Map.Entry<String, BInvokableSymbol> entry : langLib.entrySet()) {
+            MethodSymbol method = createMethodSymbol(entry.getValue());
+            list.add(method);
+        }
+    }
+
+    private MethodSymbol createMethodSymbol(BInvokableSymbol internalSymbol) {
+        Set<Qualifier> qualifiers = Qualifiers.getMethodQualifiers(internalSymbol.flags);
+        FunctionSymbolBuilder funcBuilder = new FunctionSymbolBuilder(internalSymbol.name.value, internalSymbol.pkgID,
+                                                                      internalSymbol);
+
+        FunctionSymbol funcSymbol = funcBuilder.withQualifiers(qualifiers).build();
+        return new BallerinaMethodSymbol(funcSymbol);
+    }
+
+    private String getAssociatedLangLibName(TypeDescKind typeDescKind) {
+        switch (typeDescKind) {
+            case INT:
+            case BYTE:
+                return INT.getName();
+            case FLOAT:
+                return FLOAT.getName();
+            case DECIMAL:
+                return DECIMAL.getName();
+            case STRING:
+                return STRING.getName();
+            case BOOLEAN:
+                return BOOLEAN.getName();
+            case ARRAY:
+            case TUPLE:
+                return ARRAY.getName();
+            case STREAM:
+                return STREAM.getName();
+            case OBJECT:
+                return OBJECT.getName();
+            case RECORD:
+            case MAP:
+                return MAP.getName();
+            case ERROR:
+                return ERROR.getName();
+            case FUTURE:
+                return FUTURE.getName();
+            case TYPEDESC:
+                return TYPEDESC.getName();
+            case XML:
+                return XML.getName();
+            case TABLE:
+                return TABLE.getName();
+            default:
+                return "value";
+        }
+    }
+
+    private static Map<String, Map<String, BInvokableSymbol>> getLangLibMethods(Map<String, BPackageSymbol> langLibs) {
+        Map<String, Map<String, BInvokableSymbol>> langLibMethods = new HashMap<>();
+
+        for (Map.Entry<String, BPackageSymbol> entry : langLibs.entrySet()) {
+            String key = entry.getKey();
+            BPackageSymbol value = entry.getValue();
+
+            Map<String, BInvokableSymbol> methods = new HashMap<>();
+
+            for (Map.Entry<Name, Scope.ScopeEntry> nameScopeEntry : value.scope.entries.entrySet()) {
+                BSymbol symbol = nameScopeEntry.getValue().symbol;
+
+                if (symbol.kind != SymbolKind.FUNCTION) {
+                    continue;
+                }
+
+                BInvokableSymbol invSymbol = (BInvokableSymbol) symbol;
+
+                if (Symbols.isFlagOn(invSymbol.flags, Flags.PUBLIC) && !invSymbol.params.isEmpty() &&
+                        key.compareToIgnoreCase(invSymbol.params.get(0).type.getKind().name()) == 0) {
+                    methods.put(invSymbol.name.value, invSymbol);
+                }
+            }
+
+            langLibMethods.put(key, methods);
+        }
+
+        populateLangValueLibrary(langLibs, langLibMethods);
+        return langLibMethods;
+    }
+
+    private static void populateLangValueLibrary(Map<String, BPackageSymbol> langLibs,
+                                                 Map<String, Map<String, BInvokableSymbol>> langLibMethods) {
+        BPackageSymbol langValue = langLibs.get(LANG_VALUE);
+        Map<String, BInvokableSymbol> methods = new HashMap<>();
+
+        for (Map.Entry<Name, Scope.ScopeEntry> nameScopeEntry : langValue.scope.entries.entrySet()) {
+            BSymbol symbol = nameScopeEntry.getValue().symbol;
+
+            if (symbol.kind != SymbolKind.FUNCTION || !Symbols.isFlagOn(symbol.flags, Flags.LANG_LIB)) {
+                continue;
+            }
+
+            methods.put(symbol.name.value, (BInvokableSymbol) symbol);
+        }
+
+        langLibMethods.put(LANG_VALUE, methods);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
@@ -40,19 +40,8 @@ import java.util.List;
 import java.util.Map;
 
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
 
 
 /**
@@ -82,7 +71,7 @@ public class LangLibrary {
             PackageID moduleID = module.pkgID;
 
             if (Names.BALLERINA_ORG.equals(moduleID.orgName) &&
-                    (moduleID.nameComps.size() == 2 && Names.LANG.equals(moduleID.nameComps.get(0)))) {
+                    (moduleID.nameComps.size() >= 2 && Names.LANG.equals(moduleID.nameComps.get(0)))) {
                 langLibs.put(moduleID.nameComps.get(1).value, module);
             }
         }
@@ -141,34 +130,24 @@ public class LangLibrary {
             case INT:
             case BYTE:
                 return INT.getName();
-            case FLOAT:
-                return FLOAT.getName();
-            case DECIMAL:
-                return DECIMAL.getName();
-            case STRING:
-                return STRING.getName();
-            case BOOLEAN:
-                return BOOLEAN.getName();
             case ARRAY:
             case TUPLE:
                 return ARRAY.getName();
-            case STREAM:
-                return STREAM.getName();
-            case OBJECT:
-                return OBJECT.getName();
             case RECORD:
             case MAP:
                 return MAP.getName();
+            case FLOAT:
+            case DECIMAL:
+            case STRING:
+            case BOOLEAN:
+            case STREAM:
+            case OBJECT:
             case ERROR:
-                return ERROR.getName();
             case FUTURE:
-                return FUTURE.getName();
             case TYPEDESC:
-                return TYPEDESC.getName();
             case XML:
-                return XML.getName();
             case TABLE:
-                return TABLE.getName();
+                return typeDescKind.getName();
             default:
                 return "value";
         }
@@ -178,12 +157,12 @@ public class LangLibrary {
         Map<String, Map<String, BInvokableSymbol>> langLibMethods = new HashMap<>();
 
         for (Map.Entry<String, BPackageSymbol> entry : langLibs.entrySet()) {
-            String key = entry.getKey();
-            BPackageSymbol value = entry.getValue();
+            String moduleName = entry.getKey();
+            BPackageSymbol moduleSymbol = entry.getValue();
 
             Map<String, BInvokableSymbol> methods = new HashMap<>();
 
-            for (Map.Entry<Name, Scope.ScopeEntry> nameScopeEntry : value.scope.entries.entrySet()) {
+            for (Map.Entry<Name, Scope.ScopeEntry> nameScopeEntry : moduleSymbol.scope.entries.entrySet()) {
                 BSymbol symbol = nameScopeEntry.getValue().symbol;
 
                 if (symbol.kind != SymbolKind.FUNCTION) {
@@ -193,12 +172,12 @@ public class LangLibrary {
                 BInvokableSymbol invSymbol = (BInvokableSymbol) symbol;
 
                 if (Symbols.isFlagOn(invSymbol.flags, Flags.PUBLIC) && !invSymbol.params.isEmpty() &&
-                        key.compareToIgnoreCase(invSymbol.params.get(0).type.getKind().name()) == 0) {
+                        moduleName.compareToIgnoreCase(invSymbol.params.get(0).type.getKind().name()) == 0) {
                     methods.put(invSymbol.name.value, invSymbol);
                 }
             }
 
-            langLibMethods.put(key, methods);
+            langLibMethods.put(moduleName, methods);
         }
 
         populateLangValueLibrary(langLibs, langLibMethods);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/Qualifiers.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/Qualifiers.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.impl;
+
+import io.ballerina.compiler.api.symbols.Qualifier;
+import org.wso2.ballerinalang.util.Flags;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.isFlagOn;
+
+/**
+ * Util class for mapping internal symbol flags to relevant public qualifiers.
+ *
+ * @since 2.0.0
+ */
+public class Qualifiers {
+
+    public static Set<Qualifier> getMethodQualifiers(int flags) {
+        Set<Qualifier> qualifiers = new HashSet<>();
+
+        if (isFlagOn(flags, Flags.PUBLIC)) {
+            qualifiers.add(Qualifier.PUBLIC);
+        }
+        if (isFlagOn(flags, Flags.PRIVATE)) {
+            qualifiers.add(Qualifier.PRIVATE);
+        }
+        if (isFlagOn(flags, Flags.ISOLATED)) {
+            qualifiers.add(Qualifier.ISOLATED);
+        }
+        if (isFlagOn(flags, Flags.REMOTE)) {
+            qualifiers.add(Qualifier.REMOTE);
+        }
+        return qualifiers;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -18,7 +18,7 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.Documentation;
-import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -84,7 +84,7 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     }
 
     @Override
-    public List<MethodSymbol> builtinMethods() {
+    public List<FunctionSymbol> langLibMethods() {
         return new ArrayList<>();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.api.impl.symbols;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -104,7 +105,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     }
 
     @Override
-    public List<MethodSymbol> builtinMethods() {
+    public List<FunctionSymbol> langLibMethods() {
         return new ArrayList<>();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -33,7 +33,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -106,7 +105,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
 
     @Override
     public List<FunctionSymbol> langLibMethods() {
-        return new ArrayList<>();
+        return this.typeDescriptor.langLibMethods();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -107,13 +107,15 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
             return this;
         }
 
+        public FunctionSymbolBuilder withQualifiers(Set<Qualifier> qualifiers) {
+            this.qualifiers.addAll(qualifiers);
+            return this;
+        }
+
         @Override
         public BallerinaFunctionSymbol build() {
-            return new BallerinaFunctionSymbol(this.name,
-                    this.moduleID,
-                    this.qualifiers,
-                    this.typeDescriptor,
-                    (BInvokableSymbol) this.bSymbol);
+            return new BallerinaFunctionSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
+                                               (BInvokableSymbol) this.bSymbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -17,12 +17,15 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
+
+import java.util.List;
 
 /**
  * Represents a TypeReference type descriptor.
@@ -49,6 +52,11 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         }
 
         return this.typeDescriptorImpl;
+    }
+
+    @Override
+    public List<FunctionSymbol> langLibMethods() {
+        return this.typeDescriptor().langLibMethods();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDescKind.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDescKind.java
@@ -41,7 +41,7 @@ public enum TypeDescKind {
     TUPLE("tuple"),
     STREAM("stream"),
     FUTURE("future"),
-    TYPEDESC("typeDesc"),
+    TYPEDESC("typedesc"),
     TYPE_REFERENCE("typeReference"),
     UNION("union"),
     INTERSECTION("intersection"),

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
@@ -49,9 +49,9 @@ public interface TypeSymbol extends Symbol {
     String signature();
 
     /**
-     * List of members that are visible to a value of this type.
-     * 
-     * @return {@link List} of visible member symbols
+     * List of lang library functions that can be called using a method call expression.
+     *
+     * @return {@link List} of lang library functions of the type
      */
-    List<MethodSymbol> builtinMethods();
+    List<FunctionSymbol> langLibMethods();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/VariableAssignmentRequiredCodeActionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/VariableAssignmentRequiredCodeActionProvider.java
@@ -299,7 +299,7 @@ public class VariableAssignmentRequiredCodeActionProvider extends AbstractCodeAc
         }
 
         @Override
-        public List<MethodSymbol> builtinMethods() {
+        public List<FunctionSymbol> langLibMethods() {
             return Collections.emptyList();
         }
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -197,7 +197,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
             return Optional.empty();
         }
         TypeSymbol rawType = CommonUtil.getRawType(fieldTypeDesc.get());
-        List<MethodSymbol> visibleMethods = rawType.builtinMethods();
+        List<MethodSymbol> visibleMethods = rawType.langLibMethods();
         if (rawType.typeKind() == TypeDescKind.OBJECT) {
             visibleMethods.addAll(((ObjectTypeSymbol) rawType).methods());
         }
@@ -250,7 +250,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
             default:
                 break;
         }
-        completionItems.addAll(this.getCompletionItemList(typeDescriptor.builtinMethods(), context));
+        completionItems.addAll(this.getCompletionItemList(typeDescriptor.langLibMethods(), context));
 
         return completionItems;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
-import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -197,11 +196,11 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
             return Optional.empty();
         }
         TypeSymbol rawType = CommonUtil.getRawType(fieldTypeDesc.get());
-        List<MethodSymbol> visibleMethods = rawType.langLibMethods();
+        List<FunctionSymbol> visibleMethods = rawType.langLibMethods();
         if (rawType.typeKind() == TypeDescKind.OBJECT) {
             visibleMethods.addAll(((ObjectTypeSymbol) rawType).methods());
         }
-        Optional<MethodSymbol> filteredMethod = visibleMethods.stream()
+        Optional<FunctionSymbol> filteredMethod = visibleMethods.stream()
                 .filter(methodSymbol -> methodSymbol.name().equals(methodName))
                 .findFirst();
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -489,7 +489,7 @@ public class SignatureHelpUtil {
             return Optional.empty();
         }
 
-        List<MethodSymbol> visibleMethods = fieldTypeDesc.get().builtinMethods();
+        List<MethodSymbol> visibleMethods = fieldTypeDesc.get().langLibMethods();
         if (CommonUtil.getRawType(fieldTypeDesc.get()).typeKind() == TypeDescKind.OBJECT) {
             visibleMethods.addAll(((ObjectTypeSymbol) CommonUtil.getRawType(fieldTypeDesc.get())).methods());
         }
@@ -510,7 +510,7 @@ public class SignatureHelpUtil {
             ObjectTypeSymbol objTypeDesc = (ObjectTypeSymbol) CommonUtil.getRawType(typeDescriptor);
             functionSymbols.addAll(objTypeDesc.methods());
         }
-        functionSymbols.addAll(typeDescriptor.builtinMethods());
+        functionSymbols.addAll(typeDescriptor.langLibMethods());
 
         return functionSymbols;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -18,7 +18,6 @@ package org.ballerinalang.langserver.signature;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
-import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
@@ -489,11 +488,11 @@ public class SignatureHelpUtil {
             return Optional.empty();
         }
 
-        List<MethodSymbol> visibleMethods = fieldTypeDesc.get().langLibMethods();
+        List<FunctionSymbol> visibleMethods = fieldTypeDesc.get().langLibMethods();
         if (CommonUtil.getRawType(fieldTypeDesc.get()).typeKind() == TypeDescKind.OBJECT) {
             visibleMethods.addAll(((ObjectTypeSymbol) CommonUtil.getRawType(fieldTypeDesc.get())).methods());
         }
-        Optional<MethodSymbol> filteredMethod = visibleMethods.stream()
+        Optional<FunctionSymbol> filteredMethod = visibleMethods.stream()
                 .filter(methodSymbol -> methodSymbol.name().equals(methodName))
                 .findFirst();
 

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
@@ -16,6 +16,345 @@
       "detail": "int",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function () func, any|error initial)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeIfHasKey(string k)(any|error|())",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error|()`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+        }
+      },
+      "insertText": "removeIfHasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()( object {function () returns {| any|error value |}|()})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ` object {function () returns {| any|error value |}|()}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,any|error]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()(any|error[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `any|error[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
+        }
+      },
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(TYPEDESC<anydata> t)(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `TYPEDESC<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
+        }
+      },
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
@@ -16,6 +16,345 @@
       "detail": "int",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function () func, any|error initial)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeIfHasKey(string k)(any|error|())",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error|()`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+        }
+      },
+      "insertText": "removeIfHasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()( object {function () returns {| any|error value |}|()})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ` object {function () returns {| any|error value |}|()}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,any|error]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()(any|error[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `any|error[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
+        }
+      },
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(TYPEDESC<anydata> t)(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `TYPEDESC<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
+        }
+      },
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
@@ -22,6 +22,345 @@
       "detail": "int",
       "insertText": "optionalInt",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function () func, any|error initial)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeIfHasKey(string k)(any|error|())",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error|()`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+        }
+      },
+      "insertText": "removeIfHasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()( object {function () returns {| any|error value |}|()})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ` object {function () returns {| any|error value |}|()}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,any|error]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()(any|error[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `any|error[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
+        }
+      },
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(TYPEDESC<anydata> t)(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `TYPEDESC<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
+        }
+      },
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config4.json
@@ -4,5 +4,302 @@
     "character": 11
   },
   "source": "expression_context/source/field_access_ctx_source4.bal",
-  "items": []
+  "items": [
+    {
+      "label": "forEach(function () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nApplies a function to each item in an xml sequence.\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each item in `x`  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns number of xml items in `x`.\n  \n  \n  \n**Returns** `int`   \n- number of XML items in `x`  \n  \n"
+        }
+      },
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "filter(function () func)(xml<>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nSelects the items from an xml sequence for which a function returns true.\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each item to test whether it should be selected  \n  \n**Returns** `xml<>`   \n- new xml sequence containing items in `x` for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()( object {function () returns {| xml<>|string value |}|()})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** ` object {function () returns {| xml<>|string value |}|()}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "strip()(xml<>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nStrips the insignificant parts of the an xml value.\nComment items, processing instruction items are considered insignificant.\nAfter removal of comments and processing instructions, the text is grouped into\nthe biggest possible chunks (i.e. only elements cause division into multiple chunks)\nand a chunk is considered insignificant if the entire chunk is whitespace.\n  \n  \n  \n**Returns** `xml<>`   \n- `x` with insignificant parts removed  \n  \n"
+        }
+      },
+      "insertText": "strip()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "slice(int startIndex, int endIndex)(xml<>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
+        }
+      },
+      "insertText": "slice(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "children()(xml<>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns the children of elements in an xml value.\nWhen `x` is of type Element, it is equivalent to `getChildren`.  \n  \n  \n**Returns** `xml<>`   \n- xml sequence containing the children of each element x concatenated in order  \nThis is equivalent to `elements(x).map(getChildren)`.  \n  \n"
+        }
+      },
+      "insertText": "children()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(int i)(xml<>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns the item of `x` with index `i`.\nThis differs from `x[i]` in that it panics if\n`x` does not have an item with index `i`.\n  \n**Params**  \n- `int` i: the index  \n  \n**Returns** `xml<>`   \n- the item with index `i` in `x`  \n  \n"
+        }
+      },
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "elements(string|() nm)(xml<Element>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nSelects elements from an xml value.\nIf `nm` is `()`, selects all elements;\notherwise, selects only elements whose expanded name is `nm`.\n  \n**Params**  \n- `string|()` nm: the expanded name of the elements to be selected, or `()` for all elements(Defaultable)  \n  \n**Returns** `xml<Element>`   \n- an xml sequence consisting of all the element items in `x` whose expanded name is `nm`,  \n or, if `nm` is `()`, all element items in `x`  \n  \n"
+        }
+      },
+      "insertText": "elements(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "elementChildren(string|() nm)(xml<Element>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nSelects element children of an xml value  \n**Params**  \n- `string|()` nm: the expanded name of the elements to be selected, or `()` for all elements(Defaultable)  \n  \n**Returns** `xml<Element>`   \n- an xml sequence consisting of child elements of elements in `x`; if `nm`  \n is `()`, returns a sequence of all such elements;  \n otherwise, include only elements whose expanded name is `nm`  \nThis is equivalent to `children(x).elements(nm)`.  \n  \n"
+        }
+      },
+      "insertText": "elementChildren(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "map(function () func)(xml<xml<>>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or `item`  \n  \n**Returns** `xml<xml<>>`   \n- new xml value containing result of applying `func` to each child or `item`  \n  \n"
+        }
+      },
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(TYPEDESC<anydata> t)(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `TYPEDESC<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
+        }
+      },
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
@@ -16,6 +16,345 @@
       "detail": "int",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function () func, any|error initial)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeIfHasKey(string k)(any|error|())",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error|()`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+        }
+      },
+      "insertText": "removeIfHasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()( object {function () returns {| any|error value |}|()})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ` object {function () returns {| any|error value |}|()}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,any|error]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()(any|error[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `any|error[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
+        }
+      },
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(TYPEDESC<anydata> t)(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `TYPEDESC<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
+        }
+      },
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config6.json
@@ -23,6 +23,49 @@
       },
       "insertText": "testMethod()",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
@@ -16,6 +16,345 @@
       "detail": "string",
       "insertText": "testField2",
       "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "reduce(function () func, any|error initial)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
+        }
+      },
+      "insertText": "reduce(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "hasKey(string k)(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "hasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "forEach(function () func)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "forEach(${1});",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "keys()(string[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
+        }
+      },
+      "insertText": "keys()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "length()(int)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
+        }
+      },
+      "insertText": "length()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "remove(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
+        }
+      },
+      "insertText": "remove(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "filter(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
+        }
+      },
+      "insertText": "filter(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "removeIfHasKey(string k)(any|error|())",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error|()`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
+        }
+      },
+      "insertText": "removeIfHasKey(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "iterator()( object {function () returns {| any|error value |}|()})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** ` object {function () returns {| any|error value |}|()}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "entries()(map<[string,any|error]>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string,any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
+        }
+      },
+      "insertText": "entries()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "removeAll()",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n  \n  \n**Returns** `()`   \n  \n"
+        }
+      },
+      "insertText": "removeAll();",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "get(string k)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
+        }
+      },
+      "insertText": "get(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toArray()(any|error[])",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `any|error[]`   \n- an array whose members are the members of `m`  \n  \n"
+        }
+      },
+      "insertText": "toArray()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map(function () func)(map<any|error>)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
+        }
+      },
+      "insertText": "map(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneWithType(TYPEDESC<anydata> t)(anydata|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `TYPEDESC<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
+        }
+      },
+      "insertText": "cloneWithType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "cloneReadOnly()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJson()(json)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
+        }
+      },
+      "insertText": "toJson()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "isReadOnly()(boolean)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
+        }
+      },
+      "insertText": "isReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(anydata)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(TYPEDESC<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `TYPEDESC<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toJsonString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
+        }
+      },
+      "insertText": "toJsonString()",
+      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -1,0 +1,349 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import org.ballerinalang.test.util.CompileResult;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.compile;
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for the functions returned from the langLibMethods() method in a type.
+ *
+ * @since 2.0.0
+ */
+public class LangLibFunctionTest {
+
+    private static List<String> valueLangLib = List.of("clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
+                                                       "toString", "toBalString", "toJson", "toJsonString",
+                                                       "fromJsonString", "fromJsonFloatString", "fromJsonDecimalString",
+                                                       "fromJsonWithType", "fromJsonStringWithType", "mergeJson");
+    private SemanticModel model;
+
+    @BeforeClass
+    public void setup() {
+        CompilerContext context = new CompilerContext();
+        CompileResult result = compile("test-src/langlib_test.bal", context);
+        BLangPackage pkg = (BLangPackage) result.getAST();
+        model = new BallerinaSemanticModel(pkg, context);
+    }
+
+    @Test
+    public void testIntLangLib() {
+        Symbol symbol = getSymbol(43, 8);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), INT);
+
+        List<String> expFunctions = List.of("abs", "max", "min", "toHexString", "clone", "cloneReadOnly",
+                                            "cloneWithType", "isReadOnly", "toString", "toBalString", "toJson",
+                                            "toJsonString", "fromJsonWithType", "mergeJson", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testFloatLangLib() {
+        Symbol symbol = getSymbol(16, 7);
+        TypeSymbol type = ((ConstantSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), FLOAT);
+
+        List<String> expFunctions = List.of("isFinite", "isInfinite", "isNaN", "abs", "round", "floor", "ceiling",
+                                            "sqrt", "cbrt", "pow", "log", "log10", "exp", "sin", "cos", "tan", "asin",
+                                            "acos", "atan", "atan2", "sinh", "cosh", "tanh", "toHexString", "toBitsInt",
+                                            "clone", "cloneReadOnly", "cloneWithType", "isReadOnly", "toString",
+                                            "toBalString", "toJson", "toJsonString", "fromJsonWithType", "mergeJson",
+                                            "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testDecimalLangLib() {
+        Symbol symbol = getSymbol(58, 12);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), DECIMAL);
+
+        List<String> expFunctions = List.of("abs", "max", "min", "round", "floor", "ceiling", "clone", "cloneReadOnly",
+                                            "cloneWithType", "isReadOnly", "toString", "toBalString", "toJson",
+                                            "toJsonString", "fromJsonWithType", "mergeJson", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testStringLangLib() {
+        Symbol symbol = getSymbol(19, 11);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), STRING);
+
+        List<String> expFunctions = List.of("length", "iterator", "getCodePoint", "substring", "codePointCompare",
+                                            "join", "indexOf", "lastIndexOf", "startsWith", "endsWith", "toLowerAscii",
+                                            "toUpperAscii", "equalsIgnoreCaseAscii", "trim", "toBytes",
+                                            "toCodePointInts", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
+                                            "toString", "toBalString", "fromBalString", "toJson", "toJsonString",
+                                            "fromJsonWithType", "mergeJson", "ensureType", "fromJsonString",
+                                            "fromJsonFloatString", "fromJsonDecimalString", "fromJsonStringWithType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testFutureLangLib() {
+        Symbol symbol = getSymbol(45, 16);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), FUTURE);
+
+        List<String> expFunctions = List.of("cancel", "toString", "toBalString", "ensureType");
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testArrayLangLib() {
+        Symbol symbol = getSymbol(47, 18);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), ARRAY);
+
+        List<String> expFunctions = List.of("length", "iterator", "enumerate", "map", "forEach", "filter", "reduce",
+                                            "slice", "remove", "removeAll", "setLength", "indexOf", "lastIndexOf",
+                                            "reverse", "sort", "pop", "push", "shift", "unshift", "toString",
+                                            "toBalString", "toStream", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testMapLangLib() {
+        Symbol symbol = getSymbol(49, 16);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), MAP);
+
+        List<String> expFunctions = List.of("length", "iterator", "get", "entries", "map", "forEach", "filter",
+                                            "reduce", "removeIfHasKey", "remove", "removeAll", "hasKey", "keys",
+                                            "toArray", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
+                                            "toString", "toBalString", "toJson", "toJsonString", "fromJsonWithType",
+                                            "mergeJson", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test(dataProvider = "XMLInfoProvider")
+    public void testXMLLangLib(int line, int column, List<String> expFunctions) {
+        Symbol symbol = getSymbol(67, 8);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), XML);
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @DataProvider(name = "XMLInfoProvider")
+    public Object[][] getXMLInfo() {
+        List<String> expFunctions = List.of("length", "iterator", "forEach", "map", "filter", "get", "slice", "strip",
+                                            "elements", "children", "elementChildren", "clone", "cloneReadOnly",
+                                            "cloneWithType", "isReadOnly", "toString", "toBalString", "toJson",
+                                            "toJsonString", "ensureType");
+
+//        List<String> additionalFuncs = List.of("getName", "setName", "getChildren", "setChildren", "getAttributes");
+
+        return new Object[][]{
+                {67, 8, expFunctions},
+//                {68, 17, Stream.concat(expFunctions.stream(), additionalFuncs.stream()).collect(Collectors.toList())}
+        };
+    }
+
+    @Test
+    public void testValueLangLib() {
+        Symbol symbol = getSymbol(38, 9);
+        FunctionTypeSymbol type = ((FunctionSymbol) symbol).typeDescriptor();
+        assertEquals(type.returnTypeDescriptor().get().typeKind(), NIL);
+
+        List<String> expFunctions = List.of("clone", "cloneReadOnly", "cloneWithType", "isReadOnly", "toString",
+                                            "toBalString", "toJson", "toJsonString", "fromJsonWithType", "mergeJson",
+                                            "ensureType");
+
+        assertLangLibList(type.returnTypeDescriptor().get().langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testObjectLangLib() {
+        Symbol symbol = getSymbol(28, 6);
+        ClassSymbol clazz = ((ClassSymbol) symbol);
+        assertEquals(clazz.typeKind(), OBJECT);
+
+        List<String> expFunctions = List.of("toString", "toBalString", "ensureType");
+        assertLangLibList(clazz.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testRecordLangLib() {
+        Symbol symbol = getSymbol(18, 5);
+        TypeSymbol type = ((TypeDefinitionSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), RECORD);
+
+        List<String> expFunctions = List.of("length", "iterator", "get", "entries", "map", "forEach", "filter",
+                                            "reduce", "removeIfHasKey", "remove", "removeAll", "hasKey", "keys",
+                                            "toArray", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
+                                            "toString", "toBalString", "toJson", "toJsonString", "fromJsonWithType",
+                                            "mergeJson", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test(enabled = false)
+    public void testTupleLangLib() {
+        Symbol symbol = getSymbol(51, 28);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), TUPLE);
+
+        List<String> expFunctions = List.of("length", "iterator", "enumerate", "map", "forEach", "filter", "reduce",
+                                            "slice", "remove", "removeAll", "setLength", "indexOf", "lastIndexOf",
+                                            "reverse", "sort", "pop", "push", "shift", "unshift", "toStream", "clone",
+                                            "cloneReadOnly", "cloneWithType", "isReadOnly", "toString", "toBalString",
+                                            "toJson", "toJsonString", "fromJsonWithType", "mergeJson", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testTypedescLangLib() {
+        Symbol symbol = getSymbol(53, 22);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), TYPEDESC);
+
+        List<String> expFunctions = List.of("toString", "toBalString", "ensureType");
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testUnionType() {
+        Symbol symbol = getSymbol(56, 21);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), UNION);
+
+        List<String> expFunctions = List.of("clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
+                                            "toString", "toBalString", "toJson", "toJsonString",
+                                            "fromJsonWithType", "mergeJson", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testErrorLangLib() {
+        Symbol symbol = getSymbol(60, 10);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), ERROR);
+
+        List<String> expFunctions = List.of("message", "cause", "detail", "stackTrace", "toString", "toBalString",
+                                            "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test
+    public void testStreamLangLib() {
+        Symbol symbol = getSymbol(62, 22);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), STREAM);
+
+        List<String> expFunctions = List.of("filter", "next", "map", "reduce", "forEach", "iterator", "close",
+                                            "toString", "toBalString", "ensureType");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @Test(dataProvider = "TableInfoProvider")
+    public void testTableLangLib(int line, int column, List<String> expFunctions) {
+        Symbol symbol = getSymbol(line, column);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), TABLE);
+        assertLangLibList(type.langLibMethods(), expFunctions);
+    }
+
+    @DataProvider(name = "TableInfoProvider")
+    public Object[][] getTableInfo() {
+        List<String> expFunctions = List.of("length", "put", "add", "removeAll", "toArray", "map", "reduce", "forEach",
+                                            "iterator", "toString", "toBalString", "clone", "cloneReadOnly",
+                                            "cloneWithType", "isReadOnly", "toJson", "toJsonString", "ensureType");
+
+        List<String> additionalFuncs = List.of("get", "remove", "removeIfHasKey", "filter", "hasKey", "keys");
+
+        return new Object[][]{
+                {64, 22, expFunctions},
+                {65, 32, Stream.concat(expFunctions.stream(), additionalFuncs.stream()).collect(Collectors.toList())}
+        };
+    }
+
+    private Symbol getSymbol(int line, int column) {
+        return model.symbol("langlib_test.bal", from(line, column)).get();
+    }
+
+    private void assertLangLibList(List<FunctionSymbol> langLib, List<String> expFunctions) {
+        Set<String> langLibSet = langLib.stream().map(FunctionSymbol::name).collect(Collectors.toSet());
+
+        for (String expFunction : expFunctions) {
+            assertTrue(langLibSet.contains(expFunction), "Expected function '" + expFunction + "' not found");
+        }
+
+        assertEquals(langLibSet.size(), expFunctions.size(),
+                     "Found additional functions: " + getAdditionalFunctions(langLibSet, expFunctions).toString());
+    }
+
+    private Set<String> getAdditionalFunctions(Set<String> langLibSet, List<String> expFunctions) {
+        Set<String> copy = new HashSet<>(langLibSet);
+        copy.removeAll(expFunctions);
+        return copy;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
@@ -1,0 +1,70 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const PI = 3.14;
+
+type PathConfig record {|
+    string path;
+|};
+
+public const annotation PathConfig Path on source const;
+
+function foo(int x, float y = 12.34, int... rest) returns int {
+    return 0;
+}
+
+class PersonObj {
+    string name;
+
+    function init(string name) {
+        self.name = name;
+    }
+
+    function getName() returns string => self.name;
+}
+
+function bar() {
+    decimal sum = 10.1 + 20.3;
+}
+
+function test() {
+    int x = foo(10, 3.4, 10);
+
+    future<int> f1 = start foo(20, 4.5);
+
+    PersonObj[] arr = [];
+
+    map<string> m1 = {};
+
+    [int, string, float...] tup = [];
+
+    typedesc<anydata> td = int;
+    typedesc td2 = string;
+
+    int|string|float union = 10;
+
+    decimal d = 34.5;
+
+    error e = error("Invalid Literal", foo = "bar");
+
+    stream<PersonObj> st = arr.toStream();
+
+    table<PathConfig> tbl;
+    table<PathConfig> key(path) tbl2;
+
+    xml xm = xml `<Greeting>Hello</Greeting>`;
+    'xml:Element xm2 = xml `<Greeting>Hola</Greeting>`;
+}


### PR DESCRIPTION
## Purpose
This PR adds the lang lib functions which can be called using a method call expression to the relevant types. An API is provided to then retrieve a list of its associated lang lib functions.

Fix #25929
Fix #26392

## Remarks
This is to be merged after PR #26758

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
