### PR TITLE
Add support to collect AST from single files for Observability

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -195,9 +195,14 @@ public class ObserveUtils {
         } else {
             String className = typeDef.getClass().getCanonicalName();
             String[] classNameSplit = className.split("\\.");
-            int lastIndexOfDollar = classNameSplit[3].lastIndexOf('$');
-            newObContext.setObjectName(classNameSplit[0] + "/" + classNameSplit[1] + "/"
-                    + classNameSplit[3].substring(lastIndexOfDollar + 1));
+            if (classNameSplit.length == 4) {   // Object from a project module
+                int lastIndexOfDollar = classNameSplit[3].lastIndexOf('$');
+                newObContext.setObjectName(classNameSplit[0] + "/" + classNameSplit[1] + "/"
+                        + classNameSplit[3].substring(lastIndexOfDollar + 1));
+            } else {    // Object from a single file (anonymous module)
+                int lastIndexOfDollar = className.lastIndexOf('$');
+                newObContext.setObjectName(className.substring(lastIndexOfDollar + 1));
+            }
         }
         newObContext.setFunctionName(functionName.getValue());
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -19,6 +19,8 @@
 package io.ballerina.runtime.observability;
 
 import io.ballerina.runtime.api.Environment;
+import io.ballerina.runtime.api.Module;
+import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
@@ -193,16 +195,9 @@ public class ObserveUtils {
         if (typeDef == null) {
             newObContext.setObjectName(StringUtils.EMPTY);
         } else {
-            String className = typeDef.getClass().getCanonicalName();
-            String[] classNameSplit = className.split("\\.");
-            if (classNameSplit.length == 4) {   // Object from a project module
-                int lastIndexOfDollar = classNameSplit[3].lastIndexOf('$');
-                newObContext.setObjectName(classNameSplit[0] + "/" + classNameSplit[1] + "/"
-                        + classNameSplit[3].substring(lastIndexOfDollar + 1));
-            } else {    // Object from a single file (anonymous module)
-                int lastIndexOfDollar = className.lastIndexOf('$');
-                newObContext.setObjectName(className.substring(lastIndexOfDollar + 1));
-            }
+            ObjectType type = typeDef.getType();
+            Module module = type.getPackage();
+            newObContext.setObjectName(module.getOrg() + "/" + module.getName() + "/" + type.getName());
         }
         newObContext.setFunctionName(functionName.getValue());
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/BuildCommand.java
@@ -422,7 +422,7 @@ public class BuildCommand implements BLauncherCmd {
                 .addTask(new CreateBaloTask(), isSingleFileBuild)   // create the BALOs for modules (projects only)
                 .addTask(new CreateJarTask())   // create the jar
                 .addTask(new CopyResourcesTask(), isSingleFileBuild)
-                .addTask(new CopyObservabilitySymbolsTask(), isSingleFileBuild)
+                .addTask(new CopyObservabilitySymbolsTask())
                 .addTask(new RunTestsTask(testReport, coverage, args), this.skipTests || isSingleFileBuild) // run tests
                                                                                                 // (projects only)
                 .addTask(new CreateExecutableTask(), this.compile)  // create the executable.jar

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/cmd/RunCommand.java
@@ -288,7 +288,7 @@ public class RunCommand implements BLauncherCmd {
                 .addTask(new CreateBaloTask(), isSingleFileBuild)   // create the balos for modules(projects only)
                 .addTask(new CreateJarTask())   // create the jar
                 .addTask(new CopyResourcesTask(), isSingleFileBuild)
-                .addTask(new CopyObservabilitySymbolsTask(), isSingleFileBuild)
+                .addTask(new CopyObservabilitySymbolsTask())
                 .addTask(new PrintExecutablePathTask(), isSingleFileBuild)   // print the location of the executable
                 .addTask(new PrintRunningExecutableTask(!isSingleFileBuild))   // print running executables
                 .addTask(new RunExecutableTask(programArgs))

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -145,6 +145,10 @@ public class CodeGenerator {
 
     private void generate(BPackageSymbol packageSymbol, Set<Path> moduleDependencies) {
 
+        // Desugar BIR to include the observations
+        JvmObservabilityGen jvmObservabilityGen = new JvmObservabilityGen(packageCache, symbolTable);
+        jvmObservabilityGen.instrumentPackage(packageSymbol.bir);
+
         dlog.setCurrentPackageId(packageSymbol.pkgID);
         final JvmPackageGen jvmPackageGen = new JvmPackageGen(symbolTable, packageCache, dlog);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -117,21 +117,21 @@ class JvmObservabilityGen {
 
     private final Map<Object, BIROperand> compileTimeConstants;
 
-    JvmObservabilityGen(JvmPackageGen pkgGen) {
-        compileTimeConstants = new HashMap<>();
-        packageCache = pkgGen.packageCache;
-        symbolTable = pkgGen.symbolTable;
-        lambdaIndex = 0;
-        desugaredBBIndex = 0;
-        constantIndex = 0;
+    JvmObservabilityGen(PackageCache packageCache, SymbolTable symbolTable) {
+        this.compileTimeConstants = new HashMap<>();
+        this.packageCache = packageCache;
+        this.symbolTable = symbolTable;
+        this.lambdaIndex = 0;
+        this.desugaredBBIndex = 0;
+        this.constantIndex = 0;
     }
 
     /**
-     * Rewrite all observable functions in a package.
+     * Instrument the package by rewriting the BIR to add relevant Observability related instructions.
      *
      * @param pkg The package to instrument
      */
-    void rewriteObservableFunctions(BIRPackage pkg) {
+    void instrumentPackage(BIRPackage pkg) {
         for (int i = 0; i < pkg.functions.size(); i++) {
             BIRFunction func = pkg.functions.get(i);
             rewriteAsyncInvocations(func, null, pkg);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -115,7 +115,7 @@ class JvmObservabilityGen {
     private int desugaredBBIndex;
     private int constantIndex;
 
-    private Map<Object, BIROperand> compileTimeConstants;
+    private final Map<Object, BIROperand> compileTimeConstants;
 
     JvmObservabilityGen(JvmPackageGen pkgGen) {
         compileTimeConstants = new HashMap<>();
@@ -863,11 +863,7 @@ class JvmObservabilityGen {
      */
     private String cleanUpServiceName(String serviceName) {
         if (serviceName.contains(SERVICE_IDENTIFIER)) {
-            if (serviceName.contains(ANONYMOUS_SERVICE_IDENTIFIER)) {
-                return serviceName.replace(SERVICE_IDENTIFIER, "_");
-            } else {
-                return serviceName.substring(0, serviceName.lastIndexOf(SERVICE_IDENTIFIER));
-            }
+            return serviceName.substring(0, serviceName.indexOf(SERVICE_IDENTIFIER));
         }
         return serviceName;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -418,10 +418,6 @@ public class JvmPackageGen {
             }
         }
 
-        // Desugar BIR to include the observations
-        JvmObservabilityGen jvmObservabilityGen = new JvmObservabilityGen(this);
-        jvmObservabilityGen.rewriteObservableFunctions(module);
-
         String moduleInitClass = JvmCodeGenUtil
                 .getModuleLevelClassName(module.org.value, module.name.value, module.version.value,
                         MODULE_INIT_CLASS_NAME);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class ConcurrencyTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "05_concurrency.bal";
     private static final String SERVICE_NAME = "testServiceFour";
-    private static final String BASE_URL = "http://localhost:9094";
+    private static final String BASE_URL = "http://localhost:9095";
 
     @DataProvider(name = "async-call-data-provider")
     public Object[][] getAsyncCallData() {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
 public class CustomTracingTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "06_custom_trace_spans.bal";
     private static final String SERVICE_NAME = "testServiceFive";
-    private static final String BASE_URL = "http://localhost:9095";
+    private static final String BASE_URL = "http://localhost:9096";
 
     @Test
     public void testAddCustomSpanToSystemTrace() throws Exception {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -19,11 +19,14 @@
 package org.ballerinalang.test.observability.tracing;
 
 import org.ballerina.testobserve.tracing.extension.BMockSpan;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -38,13 +41,13 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "01_main_function.bal";
 
     @Test
-    public void testSimpleResourceCall() throws Exception {
-        final String span1Position = FILE_NAME + ":17:1";
-        final String span2Position = FILE_NAME + ":18:5";
+    public void testMainMethod() throws Exception {
+        final String span1Position = FILE_NAME + ":19:1";
+        final String span2Position = FILE_NAME + ":20:5";
         final String span3Position = COMMONS_FILE_NAME + ":37:9";
-        final String span4Position = FILE_NAME + ":22:15";
-        final String span5Position = FILE_NAME + ":30:21";
-        final String span6Position = FILE_NAME + ":36:16";
+        final String span4Position = FILE_NAME + ":24:15";
+        final String span5Position = FILE_NAME + ":32:21";
+        final String span6Position = FILE_NAME + ":38:16";
 
         List<BMockSpan> spans = this.getFinishedSpans("Unknown Service");
         Assert.assertEquals(spans.stream()
@@ -162,6 +165,70 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("connector_name", "ballerina-test/testservices/MockClient"),
                     new AbstractMap.SimpleEntry<>("action", "callWithErrorReturn"),
                     new AbstractMap.SimpleEntry<>("error", "true")
+            ));
+        });
+    }
+
+    @Test
+    public void testProgrammaticallyStartedService() throws Exception {
+        final String serviceName = "$anonService$_0";
+        final String resourceName = "resourceOne";
+        final String resourceFunctionPosition = "01_main_function.bal:45:9";
+        final String callerResponsePosition = "01_main_function.bal:51:24";
+
+        HttpResponse httpResponse = HttpClientRequest.doPost(
+                "http://localhost:9091/" + serviceName + "/" + resourceName, "15", Collections.emptyMap());
+        Assert.assertEquals(httpResponse.getResponseCode(), 200);
+        Assert.assertEquals(httpResponse.getData(), "Sum of numbers: 120");
+        Thread.sleep(1000);
+
+        List<BMockSpan> spans = this.getFinishedSpans(serviceName, resourceName);
+        Assert.assertEquals(spans.stream()
+                        .map(span -> span.getTags().get("src.position"))
+                        .collect(Collectors.toSet()),
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, callerResponsePosition)));
+        Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
+
+        Optional<BMockSpan> span1 = spans.stream()
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
+                .findFirst();
+        Assert.assertTrue(span1.isPresent());
+        long traceId = span1.get().getTraceId();
+        span1.ifPresent(span -> {
+            Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
+                    && mockSpan.getSpanId() == span.getParentId()));
+            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getTags(), toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
+                    new AbstractMap.SimpleEntry<>("src.module", MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.entry_point.resource", "true"),
+                    new AbstractMap.SimpleEntry<>("http.url", "/" + serviceName + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
+                    new AbstractMap.SimpleEntry<>("protocol", "http"),
+                    new AbstractMap.SimpleEntry<>("service", serviceName),
+                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("connector_name", SERVER_CONNECTOR_NAME)
+            ));
+        });
+
+        Optional<BMockSpan> span2 = spans.stream()
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), callerResponsePosition))
+                .findFirst();
+        Assert.assertTrue(span2.isPresent());
+        span2.ifPresent(span -> {
+            Assert.assertEquals(span.getTraceId(), traceId);
+            Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
+            Assert.assertEquals(span.getOperationName(), "ballerina/testobserve/Caller:respond");
+            Assert.assertEquals(span.getTags(), toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
+                    new AbstractMap.SimpleEntry<>("src.module", MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", callerResponsePosition),
+                    new AbstractMap.SimpleEntry<>("src.remote", "true"),
+                    new AbstractMap.SimpleEntry<>("service", serviceName),
+                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("connector_name", "ballerina/testobserve/Caller"),
+                    new AbstractMap.SimpleEntry<>("action", "respond")
             ));
         });
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "04_observability_annotation.bal";
     private static final String SERVICE_NAME = "testServiceThree";
-    private static final String BASE_URL = "http://localhost:9093";
+    private static final String BASE_URL = "http://localhost:9094";
 
     @Test
     public void testObservableFunction() throws Exception {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class RemoteCallTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "03_remote_call.bal";
     private static final String SERVICE_NAME = "testServiceTwo";
-    private static final String BASE_URL = "http://localhost:9092";
+    private static final String BASE_URL = "http://localhost:9093";
 
     @Test
     public void testNestedRemoteCalls() throws Exception {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class ResourceFunctionTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "02_resource_function.bal";
     private static final String SERVICE_NAME = "testServiceOne";
-    private static final String BASE_URL = "http://localhost:9091";
+    private static final String BASE_URL = "http://localhost:9092";
 
     @DataProvider(name = "success-response-data-provider")
     public Object[][] getSuccessResponseData() {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/01_main_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/01_main_function.bal
@@ -14,7 +14,9 @@
 // specific language governing permissions and limitations
 // under the License.
 
-public function main() {
+import ballerina/testobserve;
+
+public function main() returns error? {
     testClient->callAnotherRemoteFunction();
 
     var a = 63;
@@ -38,4 +40,18 @@ public function main() {
         error e = error("Expected error not found");
         panic e;
     }
+
+    service testServiceInMain = service {
+        resource function resourceOne(testobserve:Caller caller, string body) {
+            int numberCount = checkpanic 'int:fromString(body);
+            var sum = 0;
+            foreach var i in 1 ... numberCount {
+                sum = sum + i;
+            }
+            checkpanic caller->respond("Sum of numbers: " + sum.toString());
+        }
+    };
+    var testObserveListener = new testobserve:Listener(9091);
+    check testObserveListener.__attach(testServiceInMain);
+    check testObserveListener.__start();
 }

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/02_resource_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/02_resource_function.bal
@@ -16,7 +16,7 @@
 
 import ballerina/testobserve;
 
-service testServiceOne on new testobserve:Listener(9091) {
+service testServiceOne on new testobserve:Listener(9092) {
     # Resource function for testing whether no return functions are instrumented properly.
     resource function resourceOne(testobserve:Caller caller, string body) {
         int numberCount = checkpanic 'int:fromString(body);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/03_remote_call.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/03_remote_call.bal
@@ -16,7 +16,7 @@
 
 import ballerina/testobserve;
 
-service testServiceTwo on new testobserve:Listener(9092) {
+service testServiceTwo on new testobserve:Listener(9093) {
     # Resource function for testing remote call which calls another remote call
     resource function resourceOne(testobserve:Caller caller) {
         testClient->callAnotherRemoteFunction();

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/04_observability_annotation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/04_observability_annotation.bal
@@ -16,7 +16,7 @@
 
 import ballerina/testobserve;
 
-service testServiceThree on new testobserve:Listener(9093) {
+service testServiceThree on new testobserve:Listener(9094) {
     # Resource function for testing function call with observable annotation
     resource function resourceOne(testobserve:Caller caller) {
         var sum = calculateSumWithObservability(10, 51);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/05_concurrency.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/05_concurrency.bal
@@ -16,7 +16,7 @@
 
 import ballerina/testobserve;
 
-service testServiceFour on new testobserve:Listener(9094) {
+service testServiceFour on new testobserve:Listener(9095) {
     # Resource function for testing async remote call wait
     resource function resourceOne(testobserve:Caller caller) {
         future<int> futureSum = start testClient->calculateSum(6, 17);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/06_custom_trace_spans.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing/src/testservices/06_custom_trace_spans.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import ballerina/observe;
 
-service testServiceFive on new testobserve:Listener(9095) {
+service testServiceFive on new testobserve:Listener(9096) {
     resource function resourceOne(testobserve:Caller caller) {
         var customSpanOneId = checkpanic observe:startSpan("customSpanOne");
         _ = checkpanic observe:addTagToSpan("resource", "resourceOne", customSpanOneId);

--- a/tests/observability-test-utils/src/main/ballerina/src/testobserve/listener_endpoint.bal
+++ b/tests/observability-test-utils/src/main/ballerina/src/testobserve/listener_endpoint.bal
@@ -25,7 +25,7 @@ public class Listener {
         externInitEndpoint(self, port);
     }
 
-    public isolated function __attach(service s, string? name) returns error? {
+    public isolated function __attach(service s, string? name = ()) returns error? {
         return externAttach(self, s);
     }
 


### PR DESCRIPTION
## Purpose
> Add support to collect AST from single files for Observability

## Approach
> The tasks for collecting the AST had been enabled for single files & the relevant problems related to it had been fixed.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
