### PR TITLE
Fix initialising token updater for every cli command

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -48,7 +48,6 @@ import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_
         description = "download the module source and binaries from a remote repository")
 public class PullCommand implements BLauncherCmd {
     private PrintStream errStream;
-    private CentralAPIClient client;
 
     @CommandLine.Parameters
     private List<String> argList;
@@ -61,12 +60,6 @@ public class PullCommand implements BLauncherCmd {
 
     public PullCommand() {
         this.errStream = System.err;
-        this.client = new CentralAPIClient();
-    }
-
-    public PullCommand(PrintStream errStream, CentralAPIClient client) {
-        this.errStream = errStream;
-        this.client = client;
     }
 
     @Override
@@ -129,8 +122,8 @@ public class PullCommand implements BLauncherCmd {
 
         for (String supportedPlatform : SUPPORTED_PLATFORMS) {
             try {
-                this.client
-                        .pullPackage(orgName, packageName, version, packagePathInBaloCache, supportedPlatform, false);
+                CentralAPIClient client = new CentralAPIClient();
+                client.pullPackage(orgName, packageName, version, packagePathInBaloCache, supportedPlatform, false);
             } catch (Exception e) {
                 errStream.println("unexpected error occurred while pulling package:" + e.getMessage());
                 // Exit status, zero for OK, non-zero for error


### PR DESCRIPTION
## Purpose
> Since the central client has initialized in the constructor of push command, for every command token update got started. Moved central client initialization to member method to fix the issue.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
