### PR TITLE
Disable old packerina tests and observability tests

### DIFF
--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -206,17 +206,17 @@
             </run>
         </groups>
         <classes>
-            <class name="org.ballerinalang.test.observability.tracing.TracingBaseTestCase"/>
-            <class name="org.ballerinalang.test.observability.tracing.MainFunctionTestCase"/>
-            <class name="org.ballerinalang.test.observability.tracing.ResourceFunctionTestCase"/>
-            <class name="org.ballerinalang.test.observability.tracing.RemoteCallTestCase"/>
-            <class name="org.ballerinalang.test.observability.tracing.ObservableAnnotationTestCase"/>
-            <class name="org.ballerinalang.test.observability.tracing.ConcurrencyTestCase"/>
-            <class name="org.ballerinalang.test.observability.tracing.CustomTracingTestCase"/>
-            <class name="org.ballerinalang.test.observability.metrics.MetricsTestCase"/>
-<!--            <class name="org.ballerinalang.test.observability.tracing.HttpTracingBaseTest"/>-->
-<!--            <class name="org.ballerinalang.test.observability.tracing.HttpTracingTestCase"/>-->
-<!--            <class name="org.ballerinalang.test.observability.metrics.WebSocketMetricsTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.TracingBaseTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.MainFunctionTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.ResourceFunctionTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.RemoteCallTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.ObservableAnnotationTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.ConcurrencyTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.tracing.CustomTracingTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.observability.metrics.MetricsTestCase"/>-->
+<!--&lt;!&ndash;            <class name="org.ballerinalang.test.observability.tracing.HttpTracingBaseTest"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="org.ballerinalang.test.observability.tracing.HttpTracingTestCase"/>&ndash;&gt;-->
+<!--&lt;!&ndash;            <class name="org.ballerinalang.test.observability.metrics.WebSocketMetricsTestCase"/>&ndash;&gt;-->
         </classes>
     </test>
 
@@ -228,18 +228,18 @@
             </run>
         </groups>
         <classes>
-            <class name="org.ballerinalang.test.packaging.ModulePushTestCase"/>
-            <class name="org.ballerinalang.test.packaging.PackagingNegativeTestCase"/>
-            <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>
-            <class name="org.ballerinalang.test.packaging.LockFileTestCase"/>
-            <class name="org.ballerinalang.test.packaging.NativePackagingTestCase"/>
-            <class name="org.ballerinalang.test.packaging.PathDependencyTestCase"/>
-            <class name="org.ballerinalang.test.packaging.DirectoryTestCase"/>
-            <class name="org.ballerinalang.test.packaging.SpiServicesTestCase"/>
-            <class name="org.ballerinalang.test.packaging.SingleBalFileTestCase"/>
-<!--            <class name="org.ballerinalang.test.packaging.MultipleVersionsModuleTestCase"/>-->
-            <class name="org.ballerinalang.test.packaging.DependencyScopeTestCase"/>
-            <class name="org.ballerinalang.test.packaging.MavenTestCase"/>
+<!--            <class name="org.ballerinalang.test.packaging.ModulePushTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.PackagingNegativeTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.PackagingTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.LockFileTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.NativePackagingTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.PathDependencyTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.DirectoryTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.SpiServicesTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.SingleBalFileTestCase"/>-->
+<!--&lt;!&ndash;            <class name="org.ballerinalang.test.packaging.MultipleVersionsModuleTestCase"/>&ndash;&gt;-->
+<!--            <class name="org.ballerinalang.test.packaging.DependencyScopeTestCase"/>-->
+<!--            <class name="org.ballerinalang.test.packaging.MavenTestCase"/>-->
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Disabling packerina test since they will be invalid with the new project API changes
Disable observability tests which needs to be enabled after master merge. I issue was created to trak this https://github.com/ballerina-platform/ballerina-lang/issues/26910

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
