### PR TITLE
Fix skipping of runtime args in commands for build projects

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -26,6 +26,7 @@ import io.ballerina.cli.task.CreateTargetDirTask;
 import io.ballerina.cli.task.RunTestsTask;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
@@ -206,6 +207,13 @@ public class BuildCommand implements BLauncherCmd {
                 CommandUtil.exitError(this.exitWhenFinish);
                 return;
             }
+        }
+
+        // Skip code coverage for single bal files if option is set
+        if (project.kind().equals(ProjectKind.SINGLE_FILE_PROJECT) && coverage) {
+            coverage = false;
+            this.outStream.println("Code coverage is not yet supported with single bal files. Ignoring the flag " +
+                    "and continuing the test run...");
         }
 
         CompilerContext compilerContext = project.projectEnvironmentContext().getService(CompilerContext.class);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -29,6 +29,7 @@ import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.runtime.internal.launch.LaunchUtils;
 import org.ballerinalang.compiler.CompilerPhase;
@@ -69,7 +70,7 @@ public class BuildCommand implements BLauncherCmd {
     private boolean skipCopyLibsFromDist;
 
     public BuildCommand() {
-        this.projectPath = Paths.get(System.getProperty("user.dir"));
+        this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         this.outStream = System.out;
         this.errStream = System.err;
         this.exitWhenFinish = true;
@@ -154,10 +155,10 @@ public class BuildCommand implements BLauncherCmd {
         String[] args;
         if (this.argList == null) {
             args = new String[0];
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
+            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
             args = argList.toArray(new String[0]);
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
+            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
             this.projectPath = Paths.get(argList.get(0));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -28,6 +28,7 @@ import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.runtime.internal.launch.LaunchUtils;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.tool.BLauncherCmd;
@@ -152,8 +153,13 @@ public class BuildCommand implements BLauncherCmd {
         String[] args;
         if (this.argList == null) {
             args = new String[0];
+            this.projectPath = Paths.get(System.getProperty("user.dir"));
+        } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
+            args = argList.toArray(new String[0]);
+            this.projectPath = Paths.get(System.getProperty("user.dir"));
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
+            this.projectPath = Paths.get(argList.get(0));
         }
 
         String[] userArgs = LaunchUtils.getUserArgs(args, new HashMap<>());
@@ -162,11 +168,6 @@ public class BuildCommand implements BLauncherCmd {
             CommandUtil.printError(this.errStream, "too many arguments.", buildCmd, false);
             CommandUtil.exitError(this.exitWhenFinish);
             return;
-        }
-        if (argList == null) {
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
-        } else {
-            this.projectPath = Paths.get(argList.get(0));
         }
 
         // load project

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -272,7 +272,7 @@ public class CommandUtil {
                     .resolve(pkg.packageOrg().toString())
                     .resolve(pkg.packageName().toString())
                     .resolve(pkg.packageVersion().toString()));
-            return packageJarCacheDir.resolve(ProjectUtils.getJarName(pkg) + BLANG_COMPILED_JAR_EXT);
+            return packageJarCacheDir.resolve(ProjectUtils.getJarFileName(pkg) + BLANG_COMPILED_JAR_EXT);
         } catch (IOException e) {
             throw new BLangCompilerException("error resolving bir_cache dir for package: " + pkg.packageName());
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -28,6 +28,7 @@ import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.runtime.api.constants.RuntimeConstants;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.tool.BLauncherCmd;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -114,8 +115,13 @@ public class RunCommand implements BLauncherCmd {
         String[] args;
         if (this.argList == null) {
             args = new String[0];
+            this.projectPath = Paths.get(System.getProperty("user.dir"));
+        } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
+            args = argList.toArray(new String[0]);
+            this.projectPath = Paths.get(System.getProperty("user.dir"));
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
+            this.projectPath = Paths.get(argList.get(0));
         }
 
 
@@ -129,12 +135,6 @@ public class RunCommand implements BLauncherCmd {
         options.put(SKIP_TESTS, Boolean.toString(true));
         options.put(TEST_ENABLED, Boolean.toString(false));
         options.put(EXPERIMENTAL_FEATURES_ENABLED, Boolean.toString(this.experimentalFlag));
-
-        if (argList == null) {
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
-        } else {
-            this.projectPath = Paths.get(argList.get(0));
-        }
 
         // load project
         Project project;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -28,6 +28,7 @@ import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.tool.BLauncherCmd;
@@ -115,10 +116,10 @@ public class RunCommand implements BLauncherCmd {
         String[] args;
         if (this.argList == null) {
             args = new String[0];
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
+            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
             args = argList.toArray(new String[0]);
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
+            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
             this.projectPath = Paths.get(argList.get(0));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -29,6 +29,7 @@ import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.runtime.internal.launch.LaunchUtils;
 import org.ballerinalang.compiler.CompilerPhase;
@@ -66,7 +67,7 @@ public class TestCommand implements BLauncherCmd {
     private boolean exitWhenFinish;
 
     public TestCommand() {
-        this.projectPath = Paths.get(System.getProperty("user.dir"));
+        this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         this.outStream = System.out;
         this.errStream = System.err;
         this.exitWhenFinish = true;
@@ -146,10 +147,10 @@ public class TestCommand implements BLauncherCmd {
         String[] args;
         if (this.argList == null) {
             args = new String[0];
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
+            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
             args = argList.toArray(new String[0]);
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
+            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
             this.projectPath = Paths.get(argList.get(0));

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -28,6 +28,7 @@ import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
+import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.runtime.internal.launch.LaunchUtils;
 import org.ballerinalang.compiler.CompilerPhase;
 import org.ballerinalang.tool.BLauncherCmd;
@@ -144,8 +145,13 @@ public class TestCommand implements BLauncherCmd {
         String[] args;
         if (this.argList == null) {
             args = new String[0];
+            this.projectPath = Paths.get(System.getProperty("user.dir"));
+        } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
+            args = argList.toArray(new String[0]);
+            this.projectPath = Paths.get(System.getProperty("user.dir"));
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
+            this.projectPath = Paths.get(argList.get(0));
         }
 
         String[] userArgs = LaunchUtils.getUserArgs(args, new HashMap<>());
@@ -154,11 +160,6 @@ public class TestCommand implements BLauncherCmd {
             CommandUtil.printError(this.errStream, "too many arguments.", testCmd, false);
             CommandUtil.exitError(this.exitWhenFinish);
             return;
-        }
-        if (argList == null) {
-            this.projectPath = Paths.get(System.getProperty("user.dir"));
-        } else {
-            this.projectPath = Paths.get(argList.get(0));
         }
 
         // load project

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -26,6 +26,7 @@ import io.ballerina.cli.task.ListTestGroupsTask;
 import io.ballerina.cli.task.RunTestsTask;
 import io.ballerina.cli.utils.FileUtils;
 import io.ballerina.projects.Project;
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
@@ -182,6 +183,13 @@ public class TestCommand implements BLauncherCmd {
                 CommandUtil.exitError(this.exitWhenFinish);
                 return;
             }
+        }
+
+        // Skip code coverage for single bal files if option is set
+        if (project.kind().equals(ProjectKind.SINGLE_FILE_PROJECT) && coverage) {
+            coverage = false;
+            this.outStream.println("Code coverage is not yet supported with single bal files. Ignoring the flag " +
+                    "and continuing the test run...");
         }
 
         CompilerContext compilerContext = project.projectEnvironmentContext().getService(CompilerContext.class);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
@@ -24,6 +24,7 @@ import io.ballerina.projects.JdkVersion;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.PackageCompilation;
 import io.ballerina.projects.Project;
+import org.ballerinalang.tool.RuntimePanicException;
 import org.wso2.ballerinalang.util.Lists;
 
 import java.io.File;
@@ -37,6 +38,7 @@ import java.util.StringJoiner;
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.MODULE_INIT_CLASS_NAME;
+import static org.ballerinalang.tool.LauncherUtils.createLauncherException;
 
 /**
  * Task for running the executable.
@@ -99,8 +101,12 @@ public class RunExecutableTask implements Task {
             ProcessBuilder pb = new ProcessBuilder(commands).inheritIO();
             Process process = pb.start();
             process.waitFor();
+            int exitValue = process.exitValue();
+            if (exitValue != 0) {
+                throw new RuntimePanicException(exitValue);
+            }
         } catch (IOException | InterruptedException e) {
-            throw new RuntimeException("Error occurred while running the executable ", e.getCause());
+            throw createLauncherException("Error occurred while running the executable ", e.getCause());
         }
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -292,7 +292,7 @@ public class RunTestsTask implements Task {
             // Set projectName in test report
             String projectName;
             if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
-                projectName = ProjectUtils.getJarName(project.currentPackage().getDefaultModule())
+                projectName = ProjectUtils.getJarFileName(project.currentPackage().getDefaultModule())
                         + ProjectConstants.BLANG_SOURCE_EXT;
             } else {
                 projectName = project.currentPackage().packageName().toString();

--- a/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/Main.java
+++ b/cli/ballerina-tool/src/main/java/org/ballerinalang/tool/Main.java
@@ -99,9 +99,12 @@ public class Main {
             }
 
             // set stop at positional to run command
-            cmdParser.getSubcommands().get("run").setUnmatchedArgumentsAllowed(true).setStopAtPositional(true);
-            cmdParser.getSubcommands().get("build").setUnmatchedArgumentsAllowed(true).setStopAtPositional(true);
-            cmdParser.getSubcommands().get("test").setUnmatchedArgumentsAllowed(true).setStopAtPositional(true);
+            cmdParser.getSubcommands().get("run").setStopAtPositional(true)
+                    .setUnmatchedOptionsArePositionalParams(true);
+            cmdParser.getSubcommands().get("build").setStopAtPositional(true)
+                    .setUnmatchedOptionsArePositionalParams(true);
+            cmdParser.getSubcommands().get("test").setStopAtPositional(true)
+                    .setUnmatchedOptionsArePositionalParams(true);
 
             // Build Version Command
             VersionCmd versionCmd = new VersionCmd();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
@@ -191,7 +191,7 @@ public class ProjectUtils {
         return org + "-" + pkgName + "-" + platform + "-" + version + BLANG_COMPILED_PKG_BINARY_EXT;
     }
 
-    public static String getJarName(Package pkg) {
+    public static String getJarFileName(Package pkg) {
         // <orgname>-<packagename>-<version>.jar
         return pkg.packageOrg().toString() + "-" + pkg.packageName().toString()
                 + "-" + pkg.packageVersion() + BLANG_COMPILED_JAR_EXT;
@@ -386,7 +386,7 @@ public class ProjectUtils {
      * @param module Module instance
      * @return the name of the thin jar
      */
-    public static String getJarName(Module module) {
+    public static String getJarFileName(Module module) {
         String jarName;
         if (module.packageInstance().packageDescriptor().org().anonymous()) {
             DocumentId documentId = module.documentIds().iterator().next();
@@ -400,7 +400,7 @@ public class ProjectUtils {
                 jarName = moduleName.moduleNamePart();
             }
         }
-        return jarName + BLANG_COMPILED_JAR_EXT;
+        return jarName;
     }
 
     /**


### PR DESCRIPTION
## Purpose
> When the build/run/test command is run for a build project from the project directory with runtime args provided (e.g. `ballerina build --b7a.config.file=/home/user/config.toml`), the args are skipped since it has the same prefix (`"--"`) as the options. This contains the fix for it. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
