### PR TITLE
Enable Semantic API test cases

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilationState.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilationState.java
@@ -51,7 +51,7 @@ enum ModuleCompilationState {
                                           CompilerContext compilerContext,
                                           CompilerBackend compilerBackend) {
             compile(moduleContext, compilerContext);
-            ModuleContext.generateCodeInternal(moduleContext, compilerBackend);
+            ModuleContext.generateCodeInternal(moduleContext, compilerBackend, compilerContext);
             moduleContext.setCompilationState(PLATFORM_LIBRARY_GENERATED);
         }
     },
@@ -80,7 +80,7 @@ enum ModuleCompilationState {
                                           CompilerContext compilerContext,
                                           CompilerBackend compilerBackend) {
             compile(moduleContext, compilerContext);
-            ModuleContext.generateCodeInternal(moduleContext, compilerBackend);
+            ModuleContext.generateCodeInternal(moduleContext, compilerBackend, compilerContext);
             moduleContext.setCompilationState(PLATFORM_LIBRARY_GENERATED);
         }
     },
@@ -106,7 +106,7 @@ enum ModuleCompilationState {
                                           CompilerContext compilerContext,
                                           CompilerBackend compilerBackend) {
             compile(moduleContext, compilerContext);
-            ModuleContext.generateCodeInternal(moduleContext, compilerBackend);
+            ModuleContext.generateCodeInternal(moduleContext, compilerBackend, compilerContext);
             moduleContext.setCompilationState(PLATFORM_LIBRARY_GENERATED);
         }
     },
@@ -129,7 +129,7 @@ enum ModuleCompilationState {
         void generatePlatformSpecificCode(ModuleContext moduleContext,
                                           CompilerContext compilerContext,
                                           CompilerBackend compilerBackend) {
-            ModuleContext.generateCodeInternal(moduleContext, compilerBackend);
+            ModuleContext.generateCodeInternal(moduleContext, compilerBackend, compilerContext);
             moduleContext.setCompilationState(PLATFORM_LIBRARY_GENERATED);
         }
     },

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -149,6 +149,12 @@ public class PackageCompilation {
         }
 
         ModuleContext moduleContext = this.packageContext.moduleContext(moduleId);
+        if (moduleContext.compilationState() != ModuleCompilationState.COMPILED) {
+            throw new IllegalStateException("Semantic model cannot be retrieved when the module is in " +
+                    "compilation state '" + moduleContext.compilationState().name() + "'. " +
+                    "This is an internal error which will be fixed in a later release.");
+        }
+
         return new BallerinaSemanticModel(moduleContext.bLangPackage(), this.compilerContext);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/CompilerPhaseRunner.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/CompilerPhaseRunner.java
@@ -105,7 +105,7 @@ public class CompilerPhaseRunner {
                 && Boolean.parseBoolean(this.options.get(TOOLING_COMPILATION));
     }
 
-    public void compile(BLangPackage pkgNode) {
+    public void performTypeCheckPhases(BLangPackage pkgNode) {
         if (this.stopCompilation(pkgNode, CompilerPhase.TYPE_CHECK)) {
             return;
         }
@@ -146,6 +146,9 @@ public class CompilerPhaseRunner {
         }
 
         annotationProcess(pkgNode);
+    }
+
+    public void performBirGenPhases(BLangPackage pkgNode) {
         if (this.stopCompilation(pkgNode, CompilerPhase.OBSERVABILITY_DATA_GEN)) {
             return;
         }
@@ -163,7 +166,7 @@ public class CompilerPhaseRunner {
         birGen(pkgNode);
     }
 
-    public void compileLangLibs(BLangPackage pkgNode) {
+    public void performLangLibTypeCheckPhases(BLangPackage pkgNode) {
         if (this.stopCompilation(pkgNode, CompilerPhase.TYPE_CHECK)) {
             return;
         }
@@ -184,6 +187,9 @@ public class CompilerPhaseRunner {
         }
 
         taintAnalyze(pkgNode);
+    }
+
+    public void performLangLibBirGenPhases(BLangPackage pkgNode) {
         if (this.stopCompilation(pkgNode, CompilerPhase.DESUGAR)) {
             return;
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -23,9 +23,8 @@ import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.text.LinePosition;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -49,12 +48,11 @@ import static org.testng.Assert.assertTrue;
 public class ClassSymbolTest {
 
     private SemanticModel model;
-    private String fileName = "class_symbols_test.bal";
+    private final String fileName = "class_symbols_test.bal";
 
     @BeforeClass
     public void setup() {
-        CompileResult result = BCompileUtil.compile("test-src/class_symbols_test.bal");
-        model = result.defaultModuleSemanticModel();
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/class_symbols_test.bal");
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DiagnosticsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DiagnosticsTest.java
@@ -18,11 +18,10 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -38,8 +37,8 @@ public class DiagnosticsTest {
 
     @Test
     public void testAllDiagnostics() {
-        CompileResult result = BCompileUtil.compile("test-src/testerrorproject/");
-        SemanticModel model = result.defaultModuleSemanticModel();
+        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/testerrorproject/");
 
         List<Diagnostic> diagnostics = model.diagnostics();
         Object[][] expErrs = getExpectedErrors();
@@ -51,8 +50,8 @@ public class DiagnosticsTest {
 
     @Test
     public void testDiagnosticsInARange() {
-        CompileResult result = BCompileUtil.compile("test-src/testerrorproject/");
-        SemanticModel model = result.defaultModuleSemanticModel();
+        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/testerrorproject/");
 
         LineRange range = LineRange.from("type_checking_errors.bal", LinePosition.from(1, 0),
                                          LinePosition.from(18, 19));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -24,10 +24,9 @@ import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -64,8 +63,7 @@ public class ExpressionTypeTest {
 
     @BeforeClass
     public void setup() {
-        CompileResult result = BCompileUtil.compile("test-src/expressions_test.bal");
-        model = result.defaultModuleSemanticModel();
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/expressions_test.bal");
     }
 
     @Test(dataProvider = "LiteralPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -26,8 +26,7 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -74,8 +73,7 @@ public class LangLibFunctionTest {
 
     @BeforeClass
     public void setup() {
-        CompileResult result = BCompileUtil.compile("test-src/langlib_test.bal");
-        model = result.defaultModuleSemanticModel();
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/langlib_test.bal");
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -19,12 +19,10 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.text.LinePosition;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Optional;
 
@@ -40,8 +38,8 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "BasicsPosProvider")
     public void testBasics(int line, int column, String expSymbolName) {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_at_cursor_basic_test.bal");
-        SemanticModel model = result.defaultModuleSemanticModel();
+        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/symbol_at_cursor_basic_test.bal");
 
         Optional<Symbol> symbol = model.symbol("symbol_at_cursor_basic_test.bal", LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
@@ -92,9 +90,8 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "EnumPosProvider")
     public void testEnum(int line, int column, String expSymbolName) {
-        CompilerContext context = new CompilerContext();
-        CompileResult result = BCompileUtil.compile("test-src/symbol_at_cursor_enum_test.bal");
-        SemanticModel model = result.defaultModuleSemanticModel();
+        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/symbol_at_cursor_enum_test.bal");
 
         Optional<Symbol> symbol = model.symbol("symbol_at_cursor_enum_test.bal", LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
@@ -118,8 +115,8 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "WorkerSymbolPosProvider")
     public void testWorkers(int line, int column, String expSymbolName) {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_lookup_with_workers_test.bal");
-        SemanticModel model = result.defaultModuleSemanticModel();
+        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/symbol_lookup_with_workers_test.bal");
 
         Optional<Symbol> symbol = model.symbol("symbol_lookup_with_workers_test.bal", LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
@@ -22,9 +22,8 @@ import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.text.LinePosition;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -58,8 +57,8 @@ public class SymbolFlagToQualifierMappingTest {
 
     @BeforeClass
     public void setup() {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_flag_to_qualifier_mapping_test.bal");
-        model = result.defaultModuleSemanticModel();
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
+                "test-src/symbol_flag_to_qualifier_mapping_test.bal");
     }
 
     @Test(dataProvider = "QualifierProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -21,14 +21,15 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
 import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -47,17 +48,19 @@ import static org.testng.Assert.assertTrue;
  */
 public class SymbolLookupTest {
 
-    private final Path resourceDir = Paths.get("src/test/resources").toAbsolutePath();
-
     @Test(dataProvider = "PositionProvider1")
     public void testVarSymbolLookup(int line, int column, int expSymbols, List<String> expSymbolNames) {
-        CompileResult result = BCompileUtil.compile("test-src/var_symbol_lookup_test.bal");
-        BLangPackage pkg = (BLangPackage) result.getAST();
+        Project project = BCompileUtil.loadProject("test-src/var_symbol_lookup_test.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
-        SemanticModel model = result.defaultModuleSemanticModel();
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "var_symbol_lookup_test.bal", line, column,
-                                                             moduleID);
+                moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbols);
         for (String symName : expSymbolNames) {
@@ -82,13 +85,17 @@ public class SymbolLookupTest {
 
     @Test(dataProvider = "PositionProvider2")
     public void testVarSymbolLookupInWorkers(int line, int column, int expSymbols, List<String> expSymbolNames) {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_lookup_with_workers_test.bal");
-        BLangPackage pkg = (BLangPackage) result.getAST();
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_workers_test.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
-        SemanticModel model = result.defaultModuleSemanticModel();
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_with_workers_test.bal", line, column,
-                                                             moduleID);
+                moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbols);
         for (String symName : expSymbolNames) {
@@ -113,13 +120,17 @@ public class SymbolLookupTest {
 
     @Test(dataProvider = "PositionProvider3")
     public void testVarSymbolLookupInTypedefs(int line, int column, int expSymbols, List<String> expSymbolNames) {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_lookup_with_typedefs_test.bal");
-        BLangPackage pkg = (BLangPackage) result.getAST();
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_typedefs_test.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
-        SemanticModel model = result.defaultModuleSemanticModel();
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_with_typedefs_test.bal", line,
-                                                             column, moduleID);
+                column, moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbols);
         for (String symName : expSymbolNames) {
@@ -150,13 +161,17 @@ public class SymbolLookupTest {
 
     @Test(dataProvider = "PositionProvider4")
     public void testSymbolLookupForComplexExpressions(int line, int column, List<String> expSymbolNames) {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_lookup_with_exprs_test.bal");
-        BLangPackage pkg = (BLangPackage) result.getAST();
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_exprs_test.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
-        SemanticModel model = result.defaultModuleSemanticModel();
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_with_exprs_test.bal", line, column,
-                                                             moduleID);
+                moduleID);
         assertList(symbolsInFile, expSymbolNames);
     }
 
@@ -176,25 +191,33 @@ public class SymbolLookupTest {
 
     @Test
     public void testSymbolLookupInFollowingLine() {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_lookup_in_assignment.bal");
-        BLangPackage pkg = (BLangPackage) result.getAST();
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_in_assignment.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
-        SemanticModel model = result.defaultModuleSemanticModel();
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_in_assignment.bal", 18, 9,
-                                                             moduleID);
+                moduleID);
         assertList(symbolsInFile, Arrays.asList("test", "v1"));
     }
 
     @Test
     public void testMissingNodeFiltering() {
-        CompileResult result = BCompileUtil.compile("test-src/missing_node_filtering_test.bal");
-        BLangPackage pkg = (BLangPackage) result.getAST();
+        Project project = BCompileUtil.loadProject("test-src/missing_node_filtering_test.bal");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
-        SemanticModel model = result.defaultModuleSemanticModel();
 
         Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "missing_node_filtering_test.bal", 19, 4,
-                                                             moduleID);
+                moduleID);
         assertList(symbolsInFile, Arrays.asList("test", "x"));
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -19,10 +19,9 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -43,8 +42,7 @@ public class SymbolPositionTest {
 
     @BeforeClass
     public void setup() {
-        CompileResult result = BCompileUtil.compile("test-src/symbol_position_test.bal");
-        model = result.defaultModuleSemanticModel();
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/symbol_position_test.bal");
     }
 
     @Test(dataProvider = "PositionProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -43,8 +43,7 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
-import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -95,8 +94,7 @@ public class TypedescriptorTest {
 
     @BeforeClass
     public void setup() {
-        CompileResult result = BCompileUtil.compile("test-src/typedesc_test.bal");
-        model = result.defaultModuleSemanticModel();
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/typedesc_test.bal");
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/WorkspaceSymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/WorkspaceSymbolLookupTest.java
@@ -19,8 +19,11 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.PackageCompilation;
+import io.ballerina.projects.Project;
 import org.ballerinalang.test.BCompileUtil;
-import org.ballerinalang.test.CompileResult;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 
@@ -39,9 +42,13 @@ public class WorkspaceSymbolLookupTest {
 
     @Test
     public void testWSSymbolLookup() {
-        CompileResult result = BCompileUtil.compile("test-src/testproject/");
-        BLangPackage pkg = (BLangPackage) result.getAST();
-        SemanticModel model = result.defaultModuleSemanticModel();
+        Project project = BCompileUtil.loadProject("test-src/testproject/");
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        PackageCompilation packageCompilation = currentPackage.getCompilation();
+        SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+
+        BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
 
         List<Symbol> symbols = model.moduleLevelSymbols();
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -20,19 +20,18 @@ package io.ballerina.semantic.api.test.util;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.model.symbols.SymbolOrigin;
-import org.ballerinalang.test.util.BCompileUtil;
-import org.ballerinalang.test.util.CompileResult;
+import org.ballerinalang.test.BCompileUtil;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
-import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
 
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -52,13 +51,11 @@ import static org.testng.Assert.assertTrue;
  */
 public class SemanticAPITestUtils {
 
-    private static final Path resourceDir = Paths.get("src/test/resources").toAbsolutePath();
-
-    public static CompileResult compile(String path, CompilerContext context) {
-        Path sourcePath = Paths.get(path);
-        String packageName = sourcePath.getFileName().toString();
-        Path sourceRoot = resourceDir.resolve(sourcePath.getParent());
-        return BCompileUtil.compileOnJBallerina(context, sourceRoot.toString(), packageName, false, true, false);
+    public static SemanticModel getDefaultModulesSemanticModel(String sourceFilePath) {
+        Project project = BCompileUtil.loadProject(sourceFilePath);
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        return currentPackage.getCompilation().getSemanticModel(defaultModuleId);
     }
 
     public static void assertList(List<? extends Symbol> actualValues, List<String> expectedValues) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -21,7 +21,7 @@
 <suite name="ballerina-semantic-api-test-suite">
     <test name="semantic-api-test" parallel="false">
         <packages>
-<!--            <package name="io.ballerina.semantic.api.test.*" />-->
+            <package name="io.ballerina.semantic.api.test.*" />
         </packages>
 
         <classes>
@@ -33,6 +33,24 @@
                 <methods>
                     <exclude name="testCheckingExprs"/>
                     <exclude name="testCheckingExprs"/>
+                </methods>
+            </class>
+
+            <class name="io.ballerina.semantic.api.test.SymbolBIRTest">
+                <methods>
+                    <exclude name="testSymbolLookupInBIR"/>
+                </methods>
+            </class>
+
+            <class name="io.ballerina.semantic.api.test.SymbolLookupTest">
+                <methods>
+                    <exclude name="testSymbolLookupForComplexExpressions"/>
+                </methods>
+            </class>
+
+            <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest">
+                <methods>
+                    <exclude name="testBasics"/>
                 </methods>
             </class>
 

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -40,16 +40,20 @@ import static io.ballerina.projects.util.ProjectConstants.DIST_CACHE_DIRECTORY;
  */
 public class BCompileUtil {
 
-    private static Path testSourcesDirectory = Paths.get("src/test/resources").toAbsolutePath().normalize();
-    private static Path testBuildDirectory = Paths.get("build").toAbsolutePath().normalize();
+    private static final Path testSourcesDirectory = Paths.get("src/test/resources").toAbsolutePath().normalize();
+    private static final Path testBuildDirectory = Paths.get("build").toAbsolutePath().normalize();
 
-    public static CompileResult compile(String sourceFilePath) {
+    public static Project loadProject(String sourceFilePath) {
         Path sourcePath = Paths.get(sourceFilePath);
         String sourceFileName = sourcePath.getFileName().toString();
         Path sourceRoot = testSourcesDirectory.resolve(sourcePath.getParent());
 
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
-        Project project = ProjectLoader.loadProject(projectPath);
+        return ProjectLoader.loadProject(projectPath);
+    }
+
+    public static CompileResult compile(String sourceFilePath) {
+        Project project = loadProject(sourceFilePath);
 
         Package currentPackage = project.currentPackage();
         PackageCompilation packageCompilation = currentPackage.getCompilation();


### PR DESCRIPTION
## Purpose
This PR enable the previously disabled Semantic API test cases. I had to delay the desugar and BIR gen phases in order to do this.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
