### PR TITLE
Add missing rt jar to dependencies when generating the testable jar

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -147,6 +147,13 @@ public class CodeGenerator {
         Set<Path> moduleDependencies = getPlatformDependencyPaths(moduleId, compilerBackend, null);
         Set<Path> testDependencies = getPlatformDependencyPaths(moduleId, compilerBackend, "testOnly");
         testDependencies.addAll(moduleDependencies);
+
+        // Add runtime library
+        Path runtimeJar = compilerBackend.runtimeLibrary().path();
+        // We check if the runtime jar exist to support bootstrap
+        if (Files.exists(runtimeJar)) {
+            testDependencies.add(runtimeJar);
+        }
         return generate(bLangTestablePackage.symbol, testDependencies);
     }
 


### PR DESCRIPTION
## Purpose
> Add missing rt jar to dependencies when generating the testable jar

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
