### PR TITLE
Fix position of AST node for start action

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2890,7 +2890,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             actionInvocation.name = invocation.name;
             actionInvocation.argExprs = invocation.argExprs;
             actionInvocation.flagSet = invocation.flagSet;
-            actionInvocation.pos = invocation.pos;
+            actionInvocation.pos = getPosition(startActionNode);
             invocation = actionInvocation;
         }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -19,6 +19,7 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
 import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.TupleTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -39,6 +40,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.JSON;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
@@ -295,6 +297,13 @@ public class ExpressionTypeTest {
     @Test
     public void testInferredRecordTypeForInvalidExprs() {
         assertType(97, 5, 97, 20, RECORD);
+    }
+
+    @Test
+    public void testStartAction() {
+        TypeSymbol type = getExprType(101, 4, 101, 21);
+        assertEquals(type.typeKind(), FUTURE);
+        assertEquals(((FutureTypeSymbol) type).typeParameter().get().typeKind(), NIL);
     }
 
     private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -98,6 +98,14 @@ function testIneferredRecordType() {
     {"name" : "foo"};
 }
 
+function testStartAction() {
+    start testAsync();
+}
+
+public function testAsync() {
+    // do something
+}
+
 // utils
 
 class PersonObj {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
@@ -46,11 +46,11 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
     @DataProvider(name = "async-call-data-provider")
     public Object[][] getAsyncCallData() {
         return new Object[][] {
-                {"resourceOne", FILE_NAME + ":22:5", FILE_NAME + ":23:39", FILE_NAME + ":29:20",
+                {"resourceOne", FILE_NAME + ":22:5", FILE_NAME + ":23:33", FILE_NAME + ":29:20",
                         MOCK_CLIENT_OBJECT_NAME, "calculateSum", null, null},
-                {"resourceTwo", FILE_NAME + ":33:5", FILE_NAME + ":34:39", FILE_NAME + ":40:20",
+                {"resourceTwo", FILE_NAME + ":33:5", FILE_NAME + ":34:33", FILE_NAME + ":40:20",
                         null, null, null, "calculateSumWithObservability"},
-                {"resourceThree", FILE_NAME + ":44:5", FILE_NAME + ":46:39", FILE_NAME + ":52:20",
+                {"resourceThree", FILE_NAME + ":44:5", FILE_NAME + ":46:33", FILE_NAME + ":52:20",
                         null, null, OBSERVABLE_ADDER_OBJECT_NAME, "getSum"}
         };
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -139,7 +139,7 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_NON_ISOLATED_FUNCTION_CALL_ERROR, 55, 13);
         validateError(result, i++, INVALID_NON_ISOLATED_FUNCTION_CALL_ERROR, 68, 13);
         validateError(result, i++, "worker declaration not allowed in an 'isolated' function", 74, 12);
-        validateError(result, i++, "async invocation not allowed in an 'isolated' function", 80, 28);
+        validateError(result, i++, "async invocation not allowed in an 'isolated' function", 80, 22);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 94, 13);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 101, 22);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 105, 25);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -63,7 +63,7 @@ public class SelectivelyImmutableTypeTest {
                 "'PersonalDetails'", 60, 18);
         validateError(result, index++, "incompatible types: expected '(A|B|(any & readonly))', found 'Obj'", 78, 26);
         validateError(result, index++, "incompatible types: expected 'anydata & readonly', found 'string[]'", 81, 28);
-        validateError(result, index++, "incompatible types: expected 'any & readonly', found 'future'", 83, 30);
+        validateError(result, index++, "incompatible types: expected 'any & readonly', found 'future'", 83, 24);
         validateError(result, index++, "incompatible types: expected '(int[] & readonly)', found 'string[]'",
                       85, 32);
         validateError(result, index++, "incompatible types: expected '(PersonalDetails & readonly)', found " +

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -374,7 +374,7 @@ public class WorkerTest {
         CompileResult result = BCompileUtil.compile("test-src/workers/worker-in-lock.bal");
         int index = 0;
         BAssertUtil.validateError(result, index++, "cannot use a named worker inside a lock statement", 4, 20);
-        BAssertUtil.validateError(result, index++, "cannot use an async call inside a lock statement", 13, 19);
+        BAssertUtil.validateError(result, index++, "cannot use an async call inside a lock statement", 13, 13);
         BAssertUtil.validateError(result, index++, "cannot use a named worker inside a lock statement", 25, 20);
         BAssertUtil.validateError(result, index++, "cannot use a named worker inside a lock statement", 27, 28);
         BAssertUtil.validateError(result, index++, "cannot use a named worker inside a lock statement", 42, 20);


### PR DESCRIPTION
## Purpose
Previously the position of the AST node for the start action was set to the position of the function call expr. This caused the start action node to be ignored when trying to get the type of it through the semantic API.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
