### PR TITLE
Add an API to get type inclusions of record/object types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -83,6 +84,11 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         }
 
         return Optional.ofNullable(this.initMethod);
+    }
+
+    @Override
+    public List<TypeSymbol> typeInclusions() {
+        return this.typeDescriptor.typeInclusions();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -20,6 +20,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BRecordType;
@@ -40,6 +41,7 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
     private List<FieldSymbol> fieldSymbols;
     private final boolean isInclusive;
     private TypeSymbol restTypeDesc;
+    private List<TypeReferenceTypeSymbol> typeInclusions;
 
     public BallerinaRecordTypeSymbol(CompilerContext context, ModuleID moduleID, BRecordType recordType) {
         super(context, TypeDescKind.RECORD, moduleID, recordType);
@@ -81,6 +83,12 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
         }
 
         return Optional.ofNullable(this.restTypeDesc);
+    }
+
+    @Override
+    public List<TypeSymbol> typeInclusions() {
+
+        return null;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
@@ -47,6 +47,13 @@ public interface ObjectTypeSymbol extends TypeSymbol {
     List<MethodSymbol> methods();
 
     /**
+     * Gets a list of included types. An included type is always a subtype of object.
+     *
+     * @return The list of included object types
+     */
+    List<TypeSymbol> typeInclusions();
+
+    /**
      * Represents the object type qualifier.
      *
      * @since 2.0.0

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/RecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/RecordTypeSymbol.java
@@ -46,4 +46,11 @@ public interface RecordTypeSymbol extends TypeSymbol {
      * @return {@link Optional} rest type descriptor
      */
     Optional<TypeSymbol> restTypeDescriptor();
+
+    /**
+     * Gets a list of included types. An included type is always a named record type.
+     *
+     * @return The list of included record types
+     */
+    List<TypeSymbol> typeInclusions();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1036,13 +1036,16 @@ public class BIRPackageSymbolEnter {
                         boolean isNative = Symbols.isFlagOn(recordInitFuncFlags, Flags.NATIVE);
                         BInvokableSymbol recordInitFuncSymbol =
                                 Symbols.createFunctionSymbol(recordInitFuncFlags,
-                                        initFuncName, env.pkgSymbol.pkgID, recordInitFuncType,
-                                        env.pkgSymbol, isNative, symTable.builtinPos, COMPILED_SOURCE);
+                                                             initFuncName, env.pkgSymbol.pkgID, recordInitFuncType,
+                                                             env.pkgSymbol, isNative, symTable.builtinPos,
+                                                             COMPILED_SOURCE);
                         recordInitFuncSymbol.retType = recordInitFuncType.retType;
                         recordSymbol.initializerFunc = new BAttachedFunction(initFuncName, recordInitFuncSymbol,
                                                                              recordInitFuncType, symTable.builtinPos);
                         recordSymbol.scope.define(initFuncName, recordInitFuncSymbol);
                     }
+
+                    recordType.typeInclusions = readTypeInclusions();
 
 //                    setDocumentation(varSymbol, attrData); // TODO fix
 
@@ -1324,6 +1327,7 @@ public class BIRPackageSymbolEnter {
                         ignoreAttachedFunc();
                     }
 
+                    objectType.typeInclusions = readTypeInclusions();
                     objectType.typeIdSet = readTypeIdSet(inputStream);
 
                     Object poppedObjType = compositeStack.pop();
@@ -1400,6 +1404,16 @@ public class BIRPackageSymbolEnter {
             // TODO: check
             inputStream.readLong();
             readTypeFromCp();
+        }
+
+        private List<BType> readTypeInclusions() throws IOException {
+            int nTypeInclusions = inputStream.readInt();
+            List<BType> typeInclusions = new ArrayList<>();
+            for (int i = 0; i < nTypeInclusions; i++) {
+                BType inclusion = readTypeFromCp();
+                typeInclusions.add(inclusion);
+            }
+            return typeInclusions;
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -337,6 +337,8 @@ public class BIRTypeWriter implements TypeVisitor {
         buff.writeInt(addStringCPEntry(initializerFunc.funcName.value));
         buff.writeLong(initializerFunc.symbol.flags);
         writeTypeCpIndex(initializerFunc.type);
+
+        writeTypeInclusions(bRecordType.typeInclusions);
     }
 
     @Override
@@ -396,6 +398,8 @@ public class BIRTypeWriter implements TypeVisitor {
         for (BAttachedFunction attachedFunc : attachedFuncs) {
             writeAttachFunction(attachedFunc);
         }
+
+        writeTypeInclusions(bObjectType.typeInclusions);
     }
 
     private void writeAttachFunction(BAttachedFunction attachedFunc) {
@@ -513,5 +517,12 @@ public class BIRTypeWriter implements TypeVisitor {
         int length = byteBuf.nioBuffer().limit();
         buff.writeInt(length);
         buff.writeBytes(byteBuf.nioBuffer().array(), 0, length);
+    }
+
+    private void writeTypeInclusions(List<BType> inclusions) {
+        buff.writeInt(inclusions.size());
+        for (BType inclusion : inclusions) {
+            writeTypeCpIndex(inclusion);
+        }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2027,6 +2027,13 @@ public class SymbolEnter extends BLangNodeVisitor {
                 .map(field -> new BField(names.fromIdNode(field.name), field.pos, field.symbol))
                 .collect(getFieldCollector());
 
+        List<BType> list = new ArrayList<>();
+        for (BLangType tRef : structureTypeNode.typeRefs) {
+            BType type = tRef.type;
+            list.add(type);
+        }
+        structureType.typeInclusions = list;
+
         // Resolve and add the fields of the referenced types to this object.
         resolveReferencedFields(structureTypeNode, typeDefEnv);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStructureType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BStructureType.java
@@ -23,7 +23,9 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 /**
  * {@code BStructureType} represents structure type in Ballerina.
@@ -35,15 +37,18 @@ public abstract class BStructureType extends BType {
     private static final String DOLLAR = "$";
 
     public LinkedHashMap<String, BField> fields;
+    public List<BType> typeInclusions;
 
     public BStructureType(int tag, BTypeSymbol tSymbol) {
         super(tag, tSymbol);
         this.fields = new LinkedHashMap<>();
+        this.typeInclusions = new ArrayList<>();
     }
 
     public BStructureType(int tag, BTypeSymbol tSymbol, long flags) {
         super(tag, tSymbol, flags);
         this.fields = new LinkedHashMap<>();
+        this.typeInclusions = new ArrayList<>();
     }
 
     public LinkedHashMap<String, BField> getFields() {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -110,3 +110,44 @@ type Person record {
   readonly string name;
   int age;
 };
+
+type Employee record {|
+    *Person;
+    string designation;
+|};
+
+type Foo record {
+    int a;
+};
+
+type Bar record {|
+    string b;
+|};
+
+type Baz record {|
+    *Foo;
+    float c;
+    *Bar;
+|};
+
+type FooObj object {
+    int a;
+
+    function getA() returns int;
+};
+
+type BarObj object {
+    string b;
+
+    function getB() returns string;
+};
+
+type BazObj object {
+    *FooObj;
+    *BarObj;
+};
+
+class EmployeeObj {
+    *PersonObj;
+    string designation;
+}


### PR DESCRIPTION
## Purpose
This PR adds an API to the type symbols for records and objects to easily access the type inclusions.

Fix #26432

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
