### PR TITLE
[Testerina] Get coverage report tools from external zip

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -62,12 +62,14 @@ import java.util.StringJoiner;
 
 import static io.ballerina.cli.utils.DebugUtils.getDebugArgs;
 import static io.ballerina.cli.utils.DebugUtils.isInDebugMode;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.COVERAGE_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.FILE_PROTOCOL;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.REPORT_DATA_PLACEHOLDER;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.REPORT_ZIP_NAME;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.RERUN_TEST_JSON_FILE;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.RESULTS_HTML_FILE;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.RESULTS_JSON_FILE;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.TOOLS_DIR_NAME;
 import static org.ballerinalang.tool.LauncherUtils.createLauncherException;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_BRE;
@@ -308,7 +310,7 @@ public class RunTestsTask implements Task {
             try (Writer writer = new OutputStreamWriter(new FileOutputStream(jsonFile), StandardCharsets.UTF_8)) {
                 writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
                 out.println("\t" + Paths.get("").toAbsolutePath().
-                        relativize(Paths.get(jsonFile.getAbsolutePath())) + "\n");
+                        relativize(Paths.get(jsonFile.getCanonicalPath())) + "\n");
             } catch (IOException e) {
                 throw LauncherUtils.createLauncherException("couldn't read data from the Json file : " + e.toString());
             }
@@ -334,8 +336,11 @@ public class RunTestsTask implements Task {
                     throw createLauncherException("couldn't read data from the Json file : " + e.toString());
                 }
             } else {
+                String reportToolsPath = "<" + BALLERINA_HOME + ">" + File.separator + BALLERINA_HOME_LIB +
+                        File.separator + TOOLS_DIR_NAME + File.separator + COVERAGE_DIR + File.separator +
+                        REPORT_ZIP_NAME;
                 out.println("warning: Could not find the required HTML report tools for code coverage at "
-                    + Paths.get("").toAbsolutePath().relativize(reportZipPath));
+                    + reportToolsPath);
             }
         }
     }

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunTestsTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunTestsTask.java
@@ -328,7 +328,8 @@ public class RunTestsTask implements Task {
         File jsonFile = new File(jsonPath.resolve(RESULTS_JSON_FILE).toString());
         try (Writer writer = new OutputStreamWriter(new FileOutputStream(jsonFile), StandardCharsets.UTF_8)) {
             writer.write(new String(json.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
-            out.println("\t" + Paths.get("").toAbsolutePath().relativize(jsonFile.toPath()) + "\n");
+            out.println("\t" + Paths.get("").toAbsolutePath().relativize(Paths.get(jsonFile.getCanonicalPath())) +
+                    "\n");
         } catch (IOException e) {
             throw LauncherUtils.createLauncherException("couldn't read data from the Json file : " + e.toString());
         }
@@ -354,8 +355,10 @@ public class RunTestsTask implements Task {
                 throw LauncherUtils.createLauncherException("couldn't read data from the Json file : " + e.toString());
             }
         } else {
+            String reportToolsPath = "<" + BALLERINA_HOME + ">" + File.separator + BALLERINA_HOME_LIB +
+                    File.separator + TOOLS_DIR_NAME + File.separator + COVERAGE_DIR + File.separator + REPORT_ZIP_NAME;
             out.println("warning: Could not find the required HTML report tools for code coverage at "
-                    + Paths.get("").toAbsolutePath().relativize(reportZipPath));
+                    + reportToolsPath);
         }
     }
 

--- a/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunTestsTask.java
+++ b/cli/ballerina-packerina/src/main/java/org/ballerinalang/packerina/task/RunTestsTask.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.util.RepoUtils;
 
 import java.io.BufferedReader;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -58,6 +59,7 @@ import java.util.List;
 
 import static org.ballerinalang.packerina.utils.DebugUtils.getDebugArgs;
 import static org.ballerinalang.packerina.utils.DebugUtils.isInDebugMode;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.COVERAGE_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.DOT;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.FILE_PROTOCOL;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.REPORT_DATA_PLACEHOLDER;
@@ -67,6 +69,7 @@ import static org.ballerinalang.test.runtime.util.TesterinaConstants.RERUN_TEST_
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.RESULTS_HTML_FILE;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.RESULTS_JSON_FILE;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.TEST_RUNTIME_JAR_PREFIX;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.TOOLS_DIR_NAME;
 import static org.ballerinalang.tool.LauncherUtils.createLauncherException;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME_BRE;
@@ -329,24 +332,30 @@ public class RunTestsTask implements Task {
         } catch (IOException e) {
             throw LauncherUtils.createLauncherException("couldn't read data from the Json file : " + e.toString());
         }
-
-        String content;
-        try {
-            CodeCoverageUtils.unzipReportResources(getClass().getClassLoader().getResourceAsStream(REPORT_ZIP_NAME),
-                    jsonPath.resolve(REPORT_DIR_NAME).toFile());
-
-            content = new String(Files.readAllBytes(jsonPath.resolve(REPORT_DIR_NAME).resolve(RESULTS_HTML_FILE)),
-                    StandardCharsets.UTF_8);
-            content = content.replace(REPORT_DATA_PLACEHOLDER, json);
-        } catch (IOException e) {
-            throw LauncherUtils.createLauncherException("error occurred while preparing test report: " + e.toString());
-        }
-        File htmlFile = new File(jsonPath.resolve(REPORT_DIR_NAME).resolve(RESULTS_HTML_FILE).toString());
-        try (Writer writer = new OutputStreamWriter(new FileOutputStream(htmlFile), StandardCharsets.UTF_8)) {
-            writer.write(new String(content.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
-            out.println("\tView the test report at: " + FILE_PROTOCOL + htmlFile.getAbsolutePath());
-        } catch (IOException e) {
-            throw LauncherUtils.createLauncherException("couldn't read data from the Json file : " + e.toString());
+        Path reportZipPath = Paths.get(System.getProperty(BALLERINA_HOME)).resolve(BALLERINA_HOME_LIB).
+                resolve(TOOLS_DIR_NAME).resolve(COVERAGE_DIR).resolve(REPORT_ZIP_NAME);
+        if (Files.exists(reportZipPath)) {
+            String content;
+            try {
+                CodeCoverageUtils.unzipReportResources(new FileInputStream(reportZipPath.toFile()),
+                        jsonPath.resolve(REPORT_DIR_NAME).toFile());
+                content = new String(Files.readAllBytes(jsonPath.resolve(REPORT_DIR_NAME).resolve(RESULTS_HTML_FILE)),
+                        StandardCharsets.UTF_8);
+                content = content.replace(REPORT_DATA_PLACEHOLDER, json);
+            } catch (IOException e) {
+                throw LauncherUtils.createLauncherException("error occurred while preparing test report: " +
+                        e.toString());
+            }
+            File htmlFile = new File(jsonPath.resolve(REPORT_DIR_NAME).resolve(RESULTS_HTML_FILE).toString());
+            try (Writer writer = new OutputStreamWriter(new FileOutputStream(htmlFile), StandardCharsets.UTF_8)) {
+                writer.write(new String(content.getBytes(StandardCharsets.UTF_8), StandardCharsets.UTF_8));
+                out.println("\tView the test report at: " + FILE_PROTOCOL + htmlFile.getAbsolutePath());
+            } catch (IOException e) {
+                throw LauncherUtils.createLauncherException("couldn't read data from the Json file : " + e.toString());
+            }
+        } else {
+            out.println("warning: Could not find the required HTML report tools for code coverage at "
+                    + Paths.get("").toAbsolutePath().relativize(reportZipPath));
         }
     }
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
@@ -51,6 +51,7 @@ public class TesterinaConstants {
     public static final String RESULTS_JSON_FILE = "test_results.json";
     public static final String RERUN_TEST_JSON_FILE = "rerun_test.json";
     public static final String RESULTS_HTML_FILE = "index.html";
+    public static final String TOOLS_DIR_NAME = "tools";
     public static final String REPORT_DIR_NAME = "report";
     public static final String REPORT_ZIP_NAME = REPORT_DIR_NAME + ".zip";
     public static final String REPORT_DATA_PLACEHOLDER = "__data__";

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/TestReportTest.java
@@ -54,6 +54,15 @@ public class TestReportTest extends BaseTestCase {
     }
 
     @Test ()
+    public void testWarningForReportTools() throws BallerinaTestException, IOException {
+        String msg = "warning: Could not find the required HTML report tools for code coverage";
+        LogLeecher clientLeecher = new LogLeecher(msg);
+        balClient.runMain("test", new String[]{"--code-coverage"}, null, new String[]{},
+                new LogLeecher[]{clientLeecher}, projectPath);
+        clientLeecher.waitForText(60000);
+    }
+
+    @Test ()
     public void testWithCoverage() throws BallerinaTestException, IOException {
         runCommand(true);
         validateStatuses();

--- a/tests/testerina-integration-test/src/test/resources/testng.xml
+++ b/tests/testerina-integration-test/src/test/resources/testng.xml
@@ -39,7 +39,7 @@ under the License.
 <!--            <class name="org.ballerinalang.testerina.test.DisableTestsTestCase" />-->
 <!--            <class name="org.ballerinalang.testerina.test.MockTest" />-->
 <!--            <class name="org.ballerinalang.testerina.test.ServicesTest" />-->
-<!--            <class name="org.ballerinalang.testerina.test.TestReportTest" />-->
+            <class name="org.ballerinalang.testerina.test.TestReportTest" />
 <!--            <class name="org.ballerinalang.testerina.test.PathVerificationTest" />-->
 <!--            <class name="org.ballerinalang.testerina.test.RerunFailedTest"/>-->
 <!--            <class name="org.ballerinalang.testerina.test.ImportTest" />-->


### PR DESCRIPTION
## Purpose
Get coverage report tools from external zip
Expects the report.zip to be added to the path "<BALLERINA_HOME>/lib/tools/coverage/report.zip"

To support removing the npm builds for report tools https://github.com/ballerina-platform/ballerina-lang/issues/26549

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
TODO: Add test case to verify the warning for unavailability of external zip

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
