### PR TITLE
Add an API to check type compatibility in type symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -100,6 +100,12 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         return this.langLibFunctions;
     }
 
+    @Override
+    public boolean assignableTo(TypeSymbol targetType) {
+        Types types = Types.getInstance(this.context);
+        return types.isAssignable(this.bType, ((AbstractTypeSymbol) targetType).bType);
+    }
+
     /**
      * Get the BType.
      *

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -103,7 +103,7 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     @Override
     public boolean assignableTo(TypeSymbol targetType) {
         Types types = Types.getInstance(this.context);
-        return types.isAssignable(this.bType, ((AbstractTypeSymbol) targetType).bType);
+        return types.isAssignable(this.bType, getTargetBType(targetType));
     }
 
     /**
@@ -130,6 +130,14 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         }
 
         return filteredFunctions;
+    }
+
+    private BType getTargetBType(TypeSymbol typeSymbol) {
+        if (typeSymbol.kind() == SymbolKind.TYPE) {
+            return ((AbstractTypeSymbol) typeSymbol).getBType();
+        }
+
+        return ((BallerinaClassSymbol) typeSymbol).getBType();
     }
 
     private Documentation getDocAttachment(BType bType) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -28,6 +28,7 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -111,6 +112,12 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public List<FunctionSymbol> langLibMethods() {
         return this.typeDescriptor.langLibMethods();
+    }
+
+    @Override
+    public boolean assignableTo(TypeSymbol targetType) {
+        Types types = Types.getInstance(this.context);
+        return types.isAssignable(this.internalSymbol.type, ((AbstractTypeSymbol) targetType).getBType());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -32,6 +32,7 @@ import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -117,7 +118,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public boolean assignableTo(TypeSymbol targetType) {
         Types types = Types.getInstance(this.context);
-        return types.isAssignable(this.internalSymbol.type, ((AbstractTypeSymbol) targetType).getBType());
+        return types.isAssignable(this.internalSymbol.type, getTargetBType(targetType));
     }
 
     @Override
@@ -128,6 +129,18 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public List<Qualifier> qualifiers() {
         return this.qualifiers;
+    }
+
+    BType getBType() {
+        return this.internalSymbol.type;
+    }
+
+    private BType getTargetBType(TypeSymbol typeSymbol) {
+        if (typeSymbol.kind() == SymbolKind.TYPE) {
+            return ((AbstractTypeSymbol) typeSymbol).getBType();
+        }
+
+        return ((BallerinaClassSymbol) typeSymbol).getBType();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
@@ -54,4 +54,12 @@ public interface TypeSymbol extends Symbol {
      * @return {@link List} of lang library functions of the type
      */
     List<FunctionSymbol> langLibMethods();
+
+    /**
+     * Checks whether a value of this type can be assigned to a variable of the specified type.
+     *
+     * @param targetType The type with which compatibility is checked
+     * @return Returns true if this type is assignable to the specified type
+     */
+    boolean assignableTo(TypeSymbol targetType);
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeAssignabilityTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeAssignabilityTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for class symbols.
+ *
+ * @since 2.0.0
+ */
+public class TypeAssignabilityTest {
+
+    private SemanticModel model;
+    private final String fileName = "type_assignability_test.bal";
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/type_assignability_test.bal");
+    }
+
+    @Test(dataProvider = "ClassPosProvider")
+    public void testAssignabilityForClasses(int sourceLine, int sourceCol, int targetLine, int targetCol) {
+        ClassSymbol srcSymbol = (ClassSymbol) model.symbol(fileName, from(sourceLine, sourceCol)).get();
+        ClassSymbol targetSymbol = (ClassSymbol) model.symbol(fileName, from(targetLine, targetCol)).get();
+
+        assertTrue(srcSymbol.assignableTo(targetSymbol));
+    }
+
+    @DataProvider(name = "ClassPosProvider")
+    public Object[][] getClassPos() {
+        return new Object[][]{
+                {16, 6, 30, 6},
+                {30, 6, 16, 6},
+        };
+    }
+
+    @Test
+    public void testAssignabilityForClassesAndObjects() {
+        ClassSymbol srcSymbol = (ClassSymbol) model.symbol(fileName, from(30, 6)).get();
+        TypeDefinitionSymbol targetSymbol = (TypeDefinitionSymbol) model.symbol(fileName, from(39, 5)).get();
+
+        assertTrue(srcSymbol.assignableTo(targetSymbol.typeDescriptor()));
+    }
+
+    @Test(dataProvider = "TypeDefPosProvider")
+    public void testAssignabilityForTypeDefs(int sourceLine, int sourceCol, int targetLine, int targetCol,
+                                             boolean assignable) {
+        TypeDefinitionSymbol srcSymbol =
+                (TypeDefinitionSymbol) model.symbol(fileName, from(sourceLine, sourceCol)).get();
+        TypeDefinitionSymbol targetSymbol =
+                (TypeDefinitionSymbol) model.symbol(fileName, from(targetLine, targetCol)).get();
+
+        assertEquals(srcSymbol.typeDescriptor().assignableTo(targetSymbol.typeDescriptor()), assignable);
+    }
+
+    @DataProvider(name = "TypeDefPosProvider")
+    public Object[][] getTypeDefPos() {
+        return new Object[][]{
+                {52, 6, 46, 6, true},
+                {58, 6, 60, 6, false},
+                {60, 6, 58, 6, true},
+        };
+    }
+
+    @Test(dataProvider = "VarPosProvider")
+    public void testAssignabilityForVars(int sourceLine, int sourceCol, int targetLine, int targetCol,
+                                         boolean assignable) {
+        VariableSymbol srcSymbol = (VariableSymbol) model.symbol(fileName, from(sourceLine, sourceCol)).get();
+        VariableSymbol targetSymbol = (VariableSymbol) model.symbol(fileName, from(targetLine, targetCol)).get();
+
+        assertEquals(srcSymbol.typeDescriptor().assignableTo(targetSymbol.typeDescriptor()), assignable);
+    }
+
+    @DataProvider(name = "VarPosProvider")
+    public Object[][] getVarPos() {
+        return new Object[][]{
+                {63, 21, 64, 15, false},
+                {64, 15, 63, 21, true},
+                {66, 20, 67, 20, true},
+                {67, 20, 66, 20, false},
+                {69, 17, 70, 20, false},
+                {70, 20, 69, 17, true},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type_assignability_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type_assignability_test.bal
@@ -1,0 +1,72 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class Person1 {
+    string fname;
+    string lname;
+
+    public function init(string fname, string lname) {
+        self.fname = fname;
+        self.lname = lname;
+    }
+
+    public function getFullName() returns string {
+        return self.fname + " " + self.lname;
+    }
+}
+
+class Person2 {
+    string fname = "John";
+    string lname = "Doe";
+
+    public function getFullName() returns string {
+        return self.fname + " " + self.lname;
+    }
+}
+
+type PersonObj {
+    string fname;
+    string lname;
+
+    public function getFullName() returns string;
+};
+
+type Person record {|
+    string name;
+    int age;
+    anydata...;
+|};
+
+type Employee record {|
+    string name;
+    int age;
+    string designation;
+|};
+
+type Error1 error<record { string message?; error cause?; }>;
+
+type Error2 error<record { string message?; error cause?; int code; }>;
+
+function test() {
+    int|string|float x;
+    int|string y;
+
+    'int:Unsigned16 a;
+    'int:Unsigned32 b;
+
+    map<anydata> m1;
+    map<int|string> m2;
+}


### PR DESCRIPTION
## Purpose
This PR basically adds a public API to access the type checking capabilities provided in `Types`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
