### PR TITLE
Rename getType() -> type()

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -66,7 +66,7 @@ public interface SemanticModel {
      * @param range    the text range of the expression
      * @return the type of the expression
      */
-    Optional<TypeSymbol> getType(String fileName, LineRange range);
+    Optional<TypeSymbol> type(String fileName, LineRange range);
 
     /**
      * Get the diagnostics within the given text Span.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -153,7 +153,7 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public Optional<TypeSymbol> getType(String fileName, LineRange range) {
+    public Optional<TypeSymbol> type(String fileName, LineRange range) {
         BLangCompilationUnit compilationUnit = getCompilationUnit(fileName);
         NodeFinder nodeFinder = new NodeFinder();
         BLangNode node = nodeFinder.lookup(compilationUnit, range);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
@@ -61,7 +61,7 @@ public class CodeActionRouter {
         if (nodeTypeAndNode.isPresent()) {
             CodeActionNodeType nodeType = nodeTypeAndNode.get().getLeft();
             NonTerminalNode matchedNode = nodeTypeAndNode.get().getRight();
-            TypeSymbol matchedTypeSymbol = semanticModel.getType(relPath, matchedNode.lineRange()).orElse(null);
+            TypeSymbol matchedTypeSymbol = semanticModel.type(relPath, matchedNode.lineRange()).orElse(null);
             PositionDetails posDetails = PositionDetailsImpl.from(matchedNode, null, matchedTypeSymbol);
             ctx.setPositionDetails(posDetails);
             codeActionProvidersHolder.getActiveNodeBasedProviders(nodeType).forEach(provider -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -458,7 +458,7 @@ public class CodeActionUtil {
             matchedNode = cursorNode;
             matchedSymbol = null;
         }
-        matchedExprTypeSymbol = semanticModel.getType(relPath, largestExpressionNode(cursorNode, range).lineRange());
+        matchedExprTypeSymbol = semanticModel.type(relPath, largestExpressionNode(cursorNode, range).lineRange());
         return PositionDetailsImpl.from(matchedNode, matchedSymbol, matchedExprTypeSymbol.orElse(null));
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -314,6 +314,6 @@ public class ExpressionTypeTest {
     private TypeSymbol getExprType(int sLine, int sCol, int eLine, int eCol) {
         LinePosition start = LinePosition.from(sLine, sCol);
         LinePosition end = LinePosition.from(eLine, eCol);
-        return model.getType("expressions_test.bal", LineRange.from("expressions_test.bal", start, end)).get();
+        return model.type("expressions_test.bal", LineRange.from("expressions_test.bal", start, end)).get();
     }
 }


### PR DESCRIPTION
## Purpose
This PR renames the `getType()` API to `type()` to be consistent with the rest of the APIs in `SemanticModel`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
