### PR TITLE
Fix decimal to anydata cast error when using cloneWithType

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -824,6 +824,10 @@ public class TypeConverter {
             return PredefinedTypes.TYPE_BYTE;
         }
 
+        if (checkIsLikeType(value, PredefinedTypes.TYPE_DECIMAL)) {
+            return PredefinedTypes.TYPE_DECIMAL;
+        }
+
         Type anydataArrayType = new BArrayType(type);
         if (checkIsLikeType(value, anydataArrayType)) {
             return anydataArrayType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
@@ -128,4 +128,9 @@ public class NativeConversionWithStampTypesTest {
     public void testConvertMapJsonWithDecimalToOpenRecord() {
         BRunUtil.invoke(compileResult, "testConvertMapJsonWithDecimalToOpenRecord");
     }
+
+    @Test
+    public void testConvertMapJsonWithDecimalUnionTarget() {
+        BRunUtil.invoke(compileResult, "testConvertMapJsonWithDecimalUnionTarget");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
@@ -123,4 +123,9 @@ public class NativeConversionWithStampTypesTest {
         Assert.assertEquals(originalMap.get("school").toString(), "ABC College");
         Assert.assertEquals(convertedMap.get("school").stringValue(), "ABC College");
     }
+
+    @Test
+    public void testConvertMapJsonWithDecimalToOpenRecord() {
+        BRunUtil.invoke(compileResult, "testConvertMapJsonWithDecimalToOpenRecord");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -71,19 +71,35 @@ type OpenRecord record {
 
 };
 
-function testConvertMapJsonWithDecimalToOpenRecord() {
-    map<json> mp = {
+type OpenRecordWithUnionTarget record {|
+    string|decimal...;
+|};
+
+map<json> mp = {
         name: "foo",
         factor: 1.23d
     };
 
+function testConvertMapJsonWithDecimalToOpenRecord() {
     var or = mp.cloneWithType(OpenRecord);
 
-    if(or is error) {
+    if (or is error) {
         panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
     }
 
     OpenRecord castedValue = <OpenRecord>or;
+    assert(castedValue["factor"], mp["factor"]);
+    assert(castedValue["name"], mp["name"]);
+}
+
+function testConvertMapJsonWithDecimalUnionTarget() {
+    var or = mp.cloneWithType(OpenRecordWithUnionTarget);
+
+    if (or is error) {
+        panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
+    }
+
+    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
     assert(castedValue["factor"], mp["factor"]);
     assert(castedValue["name"], mp["name"]);
 }
@@ -94,7 +110,7 @@ function assert(anydata actual, anydata expected) {
         typedesc<anydata> actT = typeof actual;
         string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
                             + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
-        error e = error(reason);
-        panic e;
+
+        panic error(reason);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -66,3 +66,35 @@ function testConvertStampTupleToMap() returns [[string, Employee], [string, Empl
     tupleValue[0] = "Vinod";
     return [tupleValue, returnValue];
 }
+
+type OpenRecord record {
+
+};
+
+function testConvertMapJsonWithDecimalToOpenRecord() {
+    map<json> mp = {
+        name: "foo",
+        factor: 1.23d
+    };
+
+    var or = mp.cloneWithType(OpenRecord);
+
+    if(or is error) {
+        panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
+    }
+
+    OpenRecord castedValue = <OpenRecord>or;
+    assert(castedValue["factor"], mp["factor"]);
+    assert(castedValue["name"], mp["name"]);
+}
+
+function assert(anydata actual, anydata expected) {
+    if (expected != actual) {
+        typedesc<anydata> expT = typeof expected;
+        typedesc<anydata> actT = typeof actual;
+        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
+                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        error e = error(reason);
+        panic e;
+    }
+}


### PR DESCRIPTION
## Purpose
> $title. An error was generated.

Fixes #26624 

## Approach
> `resolveMatchingTypeForUnion` method didn't have a check for decimal type. Added the check.

## Samples
>
```
type OpenRecord record {

};

public function main() {
    map<json> mp = {
        name: "foo",
        factor: 1.23d
    };

    var e = mp.cloneWithType(OpenRecord);

    if (e is error) {
       panic("cloneWithTypeFail");
    }
}
```

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
