### PR TITLE
Mandate the project path as the first arg in run command

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/BuildCommand.java
@@ -129,8 +129,8 @@ public class BuildCommand implements BLauncherCmd {
     @CommandLine.Option(names = "--debug", description = "run tests in remote debugging mode")
     private String debugPort;
 
-    private static final String buildCmd = "ballerina build [-o <output>] [--sourceroot] [--offline] [--skip-tests]\n" +
-            "                    [--skip-lock] {<ballerina-file | module-name> | -a | --all} [--] [(--key=value)...]";
+    private static final String buildCmd = "ballerina build [-o <output>] [--offline] [--skip-tests]\n" +
+            "                    [--skip-lock] [<ballerina-file | project-name>] [--] [(--key=value)...]";
 
     @CommandLine.Option(names = "--test-report", description = "enable test report generation")
     private Boolean testReport;

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -30,8 +30,6 @@ import io.ballerina.projects.BuildOptionsBuilder;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.SingleFileProject;
-import io.ballerina.projects.util.ProjectConstants;
-import io.ballerina.runtime.api.constants.RuntimeConstants;
 import org.ballerinalang.tool.BLauncherCmd;
 import picocli.CommandLine;
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/RunCommand.java
@@ -80,6 +80,9 @@ public class RunCommand implements BLauncherCmd {
             "when run is used with a source file or a module.")
     private boolean observabilityIncluded;
 
+    private static final String runCmd = "ballerina run {<ballerina-file | project-name> | <executable-jar>} " +
+            "[--] [(--key=value)...]";
+
     public RunCommand() {
         this.outStream = System.err;
         this.errStream = System.err;
@@ -107,14 +110,12 @@ public class RunCommand implements BLauncherCmd {
 
         String[] args;
         if (this.argList == null) {
-            args = new String[0];
-            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
-        } else if (this.argList.get(0).startsWith(RuntimeConstants.BALLERINA_ARGS_INIT_PREFIX)) {
-            args = argList.toArray(new String[0]);
-            this.projectPath = Paths.get(System.getProperty(ProjectConstants.USER_DIR));
+            CommandUtil.printError(this.errStream, "no project path provided.", runCmd, false);
+            CommandUtil.exitError(this.exitWhenFinish);
+            return;
         } else {
             args = argList.subList(1, argList.size()).toArray(new String[0]);
-            this.projectPath = Paths.get(argList.get(0));
+            this.projectPath = Paths.get(argList.get(0)).toAbsolutePath().normalize();
         }
 
         // load project
@@ -173,8 +174,8 @@ public class RunCommand implements BLauncherCmd {
 
     @Override
     public void printUsage(StringBuilder out) {
-        out.append("  ballerina run [--offline]\n" +
-                "                {<balfile> | executable-jar} [(--key=value)...] "
+        out.append("  ballerina run {<balfile> | <project-path> | executable-jar}[--offline]\n" +
+                "                 [(--key=value)...] "
                 + "[--] [args...] \n");
     }
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
@@ -61,18 +61,6 @@ public class RunCommandTest extends BaseCommandTest {
         Files.delete(tempFile);
     }
 
-    @Test(description = "Run non .bal file")
-    public void testRunNonBalFile() throws IOException {
-        Path nonBalFilePath = this.testResources.resolve("non-bal-file").resolve("hello_world.txt");
-        RunCommand runCommand = new RunCommand(nonBalFilePath, printStream, false);
-        new CommandLine(runCommand).parse(nonBalFilePath.toString());
-        runCommand.execute();
-
-        String buildLog = readOutput(true);
-        Assert.assertTrue(buildLog.replaceAll("\r", "")
-                .contains("Invalid Ballerina source file(.bal): " + nonBalFilePath.toString()));
-    }
-
     @Test(description = "Run non existing bal file")
     public void testRunNonExistingBalFile() throws IOException {
         // valid source root path
@@ -115,26 +103,8 @@ public class RunCommandTest extends BaseCommandTest {
         }
     }
 
-    @Test(description = "Run a valid ballerina file", enabled = false)
-    public void testRunValidBalProject() throws IOException {
-        Path projectPath = this.testResources.resolve("validRunProject");
-
-        System.setProperty("user.dir", projectPath.toString());
-        Path tempFile = projectPath.resolve("temp.txt");
-        // set valid source root
-        RunCommand runCommand = new RunCommand(projectPath, printStream, false);
-        // name of the file as argument
-        new CommandLine(runCommand).parse(tempFile.toString());
-
-        Assert.assertFalse(tempFile.toFile().exists());
-        runCommand.execute();
-        Assert.assertTrue(tempFile.toFile().exists());
-
-        Files.delete(tempFile);
-    }
-
     @Test(description = "Run a valid ballerina file from a different directory")
-    public void testRunValidBalProjectFromDifferentDirectory() throws IOException {
+    public void testRunValidBalProject() throws IOException {
         Path projectPath = this.testResources.resolve("validRunProject");
 
         Path tempFile = projectPath.resolve("temp.txt");

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BaloFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/BaloFiles.java
@@ -182,20 +182,21 @@ public class BaloFiles {
     }
 
     private static void extractPlatformLibraries(FileSystem zipFileSystem, PackageJson packageJson, Path balrPath) {
-        if (packageJson.getPlatformDependencies() != null) {
-            packageJson.getPlatformDependencies().forEach(dependency -> {
-                Path libPath = balrPath.getParent().resolve(dependency.getPath());
-                if (!Files.exists(libPath)) {
-                    try {
-                        Files.createDirectories(libPath.getParent());
-                        Files.copy(zipFileSystem.getPath(dependency.getPath()), libPath);
-                    } catch (IOException e) {
-                        throw new ProjectException("Failed to extract platform dependency:" + libPath.getFileName(), e);
-                    }
-                }
-                dependency.setPath(libPath.toString());
-            });
+        if (packageJson.getPlatformDependencies() == null) {
+            return;
         }
+        packageJson.getPlatformDependencies().forEach(dependency -> {
+            Path libPath = balrPath.getParent().resolve(dependency.getPath());
+            if (!Files.exists(libPath)) {
+                try {
+                    Files.createDirectories(libPath.getParent());
+                    Files.copy(zipFileSystem.getPath(dependency.getPath()), libPath);
+                } catch (IOException e) {
+                    throw new ProjectException("Failed to extract platform dependency:" + libPath.getFileName(), e);
+                }
+            }
+            dependency.setPath(libPath.toString());
+        });
     }
 
     private static PackageManifest getPackageManifest(PackageJson packageJson) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ProjectFiles.java
@@ -195,8 +195,18 @@ public class ProjectFiles {
 
         // Check if it is inside a project
         Path projectRoot = ProjectUtils.findProjectRoot(filePath);
-        if (projectRoot != null) {
-            throw new ProjectException("The source file '" + filePath + "' belongs to a Ballerina package.");
+        if (null != projectRoot) {
+            if (projectRoot.equals(Optional.of(filePath.getParent()).get().toAbsolutePath())) {
+                throw new ProjectException("The source file '" + filePath + "' belongs to a Ballerina package.");
+            }
+            // Check if it is inside a module
+            Path modulesRoot = projectRoot.resolve(ProjectConstants.MODULES_ROOT);
+            Path parent = filePath.getParent();
+            if (parent != null) {
+                if (modulesRoot.equals(Optional.of(parent.getParent()).get().toAbsolutePath())) {
+                    throw new ProjectException("The source file '" + filePath + "' belongs to a Ballerina package.");
+                }
+            }
         }
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/launch/Launcher.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/launch/Launcher.java
@@ -107,6 +107,8 @@ public abstract class Launcher {
         // Adds file name, only if single file debugging.
         if (balFile != null) {
             command.add(balFile);
+        } else if (!testDebugging) {
+            command.add(".");
         }
 
         boolean networkLogs = false;

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestSingleFileProject.java
@@ -61,6 +61,27 @@ public class TestSingleFileProject {
 
     }
 
+    @Test (description = "tests loading a valid standalone Ballerina file")
+    public void testLoadSingleFileInProject() {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject").resolve("util").resolve("file-util.bal");
+        SingleFileProject project = null;
+        try {
+            project = SingleFileProject.load(projectPath);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        // 2) Load the package
+        Package currentPackage = project.currentPackage();
+        // 3) Load the default module
+        Module defaultModule = currentPackage.getDefaultModule();
+        Assert.assertEquals(defaultModule.documentIds().size(), 1);
+
+        Collection<ModuleId> moduleIds = currentPackage.moduleIds();
+        Assert.assertEquals(moduleIds.size(), 1);
+        Assert.assertEquals(moduleIds.iterator().next(), currentPackage.getDefaultModule().moduleId());
+
+    }
+
     @Test (description = "tests loading an invalid standalone Ballerina file")
     public void testLoadSingleFileNegative() {
         Path projectPath = RESOURCE_DIRECTORY.resolve("myproject").resolve("modules").resolve("services")

--- a/project-api/project-api-test/src/test/resources/myproject/util/file-util.bal
+++ b/project-api/project-api-test/src/test/resources/myproject/util/file-util.bal
@@ -1,0 +1,2 @@
+public function foo() {
+}

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/remote/BallerinaRunRemoteDebugTest.java
@@ -51,7 +51,7 @@ public class BallerinaRunRemoteDebugTest extends BaseTestCase {
         int port = findFreePort();
         String msg = "Listening for transport dt_socket at address: " + port;
         LogLeecher clientLeecher = new LogLeecher(msg);
-        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port)}, null,
+        balClient.debugMain("run", new String[]{"--debug", String.valueOf(port), "."}, null,
                 new String[]{}, new LogLeecher[]{clientLeecher}, projectPath, 10);
         clientLeecher.waitForText(20000);
     }


### PR DESCRIPTION
## Purpose
> Mandate the project path as the first arg in run command
> Allow loading a bal file in a project that doesnt belong to a project
> Refactor extractPlatformLibraries method to handle null

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
