### PR TITLE
Fix TypeConverter error

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -355,7 +355,7 @@ public class TypeConverter {
             } else {
                 if (targetFieldTypes.containsKey(fieldName)) {
                     if (getConvertibleTypes(valueEntry.getValue(), targetFieldTypes.get(fieldName),
-                            unresolvedValues).size() != 1) {
+                            unresolvedValues).size() == 0) {
                         return false;
                     }
                 } else if (!targetType.sealed) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -245,6 +245,9 @@ public class TypeConverter {
         switch (targetTypeTag) {
             case TypeTags.UNION_TAG:
                 for (Type memType : ((BUnionType) targetType).getMemberTypes()) {
+                    if (checkIsType(inputValue, memType)) {
+                        return List.of(memType);
+                    }
                     convertibleTypes.addAll(getConvertibleTypes(inputValue, memType, unresolvedValues));
                 }
                 break;
@@ -265,6 +268,15 @@ public class TypeConverter {
                 }
         }
         return convertibleTypes;
+    }
+
+    private static boolean checkIsType(Object value, Type targetType) {
+        Type valueType = TypeChecker.getType(value);
+        if (valueType.equals(targetType)) {
+            return true;
+        }
+
+        return false;
     }
 
     public static List<Type> getConvertibleTypesFromJson(Object value, Type targetType,
@@ -355,7 +367,7 @@ public class TypeConverter {
             } else {
                 if (targetFieldTypes.containsKey(fieldName)) {
                     if (getConvertibleTypes(valueEntry.getValue(), targetFieldTypes.get(fieldName),
-                            unresolvedValues).size() == 0) {
+                            unresolvedValues).size() != 1) {
                         return false;
                     }
                 } else if (!targetType.sealed) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeConverter.java
@@ -245,7 +245,7 @@ public class TypeConverter {
         switch (targetTypeTag) {
             case TypeTags.UNION_TAG:
                 for (Type memType : ((BUnionType) targetType).getMemberTypes()) {
-                    if (checkIsType(inputValue, memType)) {
+                    if (TypeChecker.getType(inputValue) == memType) {
                         return List.of(memType);
                     }
                     convertibleTypes.addAll(getConvertibleTypes(inputValue, memType, unresolvedValues));
@@ -268,15 +268,6 @@ public class TypeConverter {
                 }
         }
         return convertibleTypes;
-    }
-
-    private static boolean checkIsType(Object value, Type targetType) {
-        Type valueType = TypeChecker.getType(value);
-        if (valueType.equals(targetType)) {
-            return true;
-        }
-
-        return false;
     }
 
     public static List<Type> getConvertibleTypesFromJson(Object value, Type targetType,

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -332,7 +332,8 @@ public class LangLibValueTest {
                 { "testFromJsonWithTypeIntArray" },
                 { "testFromJsonWithTypeArrayNegative" },
                 { "testFromJsonWithTypeTable" },
-                { "tesFromJsonWithTypeMapWithDecimal" }
+                { "tesFromJsonWithTypeMapWithDecimal" },
+                { "testConvertJsonToAmbiguousType" }
         };
     }
 

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -331,7 +331,8 @@ public class LangLibValueTest {
                 { "testFromJsonWithTypeArrayNegative" },
                 { "testFromJsonWithTypeIntArray" },
                 { "testFromJsonWithTypeArrayNegative" },
-                { "testFromJsonWithTypeTable" }
+                { "testFromJsonWithTypeTable" },
+                { "tesFromJsonWithTypeMapWithDecimal" }
         };
     }
 

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1281,8 +1281,8 @@ type OpenRecordWithUnionTarget record {|
 
 function tesFromJsonWithTypeMapWithDecimal() {
     map<json> mp = {
-            name: "foo",
-            factor: 1.23d
+        name: "foo",
+        factor: 1.23d
     };
     var or = mp.fromJsonWithType(OpenRecordWithUnionTarget);
 
@@ -1293,4 +1293,22 @@ function tesFromJsonWithTypeMapWithDecimal() {
     OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
     assertEquality(castedValue["factor"], mp["factor"]);
     assertEquality(castedValue["name"], mp["name"]);
+}
+
+public type Maps record {|int i; int...;|}|record {|int i?;|};
+
+public type Value record {|
+    Maps value;
+|};
+
+public function testConvertJsonToAmbiguousType() {
+    json j = {"value": <map<int>> {i: 1}};
+    Value|error res = j.cloneWithType(Value);
+
+    if res is error {
+        assertEquality("'map<json>' value cannot be converted to 'Value'", res.detail()["message"]);
+        return;
+    }
+
+    panic error("Invalid respone.", message = "Expected error");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -1274,3 +1274,23 @@ function testEnsureTypeNegative() {
     assertEquality("error(\"{ballerina}TypeCastError\",message=\"incompatible types: '()' cannot be cast to 'int'\")", e5.toString());
     assertEquality("error(\"{ballerina/lang.map}KeyNotFound\",message=\"Key 'children' not found in JSON mapping\")", e6.toString());
 }
+
+type OpenRecordWithUnionTarget record {|
+    string|decimal...;
+|};
+
+function tesFromJsonWithTypeMapWithDecimal() {
+    map<json> mp = {
+            name: "foo",
+            factor: 1.23d
+    };
+    var or = mp.fromJsonWithType(OpenRecordWithUnionTarget);
+
+    if (or is error) {
+        panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
+    }
+
+    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
+    assertEquality(castedValue["factor"], mp["factor"]);
+    assertEquality(castedValue["name"], mp["name"]);
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
@@ -135,7 +135,7 @@ public class NativeConversionWithStampTypesTest {
     }
 
     @Test
-    void testConvertUnion() {
-        BRunUtil.invoke(compileResult, "testConvertUnion");
+    void testConvertToUnionWithActualType() {
+        BRunUtil.invoke(compileResult, "testConvertToUnionWithActualType");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
@@ -133,4 +133,9 @@ public class NativeConversionWithStampTypesTest {
     public void testConvertMapJsonWithDecimalUnionTarget() {
         BRunUtil.invoke(compileResult, "testConvertMapJsonWithDecimalUnionTarget");
     }
+
+    @Test
+    public void testConvertMapJsonWithFromJsonWithType() {
+        BRunUtil.invoke(compileResult, "testConvertMapJsonWithDecimalUnionTarget");
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/conversion/NativeConversionWithStampTypesTest.java
@@ -135,7 +135,7 @@ public class NativeConversionWithStampTypesTest {
     }
 
     @Test
-    public void testConvertMapJsonWithFromJsonWithType() {
-        BRunUtil.invoke(compileResult, "testConvertMapJsonWithDecimalUnionTarget");
+    void testConvertUnion() {
+        BRunUtil.invoke(compileResult, "testConvertUnion");
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -104,6 +104,18 @@ function testConvertMapJsonWithDecimalUnionTarget() {
     assert(castedValue["name"], mp["name"]);
 }
 
+function testConvertMapJsonWithFromJsonWithType() {
+    var or = mp.fromJsonWithType(OpenRecordWithUnionTarget);
+
+    if (or is error) {
+        panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
+    }
+
+    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
+    assert(castedValue["factor"], mp["factor"]);
+    assert(castedValue["name"], mp["name"]);
+}
+
 function assert(anydata actual, anydata expected) {
     if (expected != actual) {
         typedesc<anydata> expT = typeof expected;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -78,7 +78,7 @@ type OpenRecordWithUnionTarget record {|
 map<json> mp = {
         name: "foo",
         factor: 1.23d
-    };
+};
 
 function testConvertMapJsonWithDecimalToOpenRecord() {
     var or = mp.cloneWithType(OpenRecord);
@@ -104,16 +104,23 @@ function testConvertMapJsonWithDecimalUnionTarget() {
     assert(castedValue["name"], mp["name"]);
 }
 
-function testConvertMapJsonWithFromJsonWithType() {
-    var or = mp.fromJsonWithType(OpenRecordWithUnionTarget);
+public type Scalar int|string|float|boolean;
 
-    if (or is error) {
-        panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
+public type Argument record {|
+    Scalar value;
+|};
+
+public function testConvertUnion() {
+    json expectedJson = { "value": 132 };
+
+    Argument expected = { "value": 132 };
+    var actual = expectedJson.cloneWithType(Argument);
+
+    if (actual is error) {
+        panic error("`cloneWithType` returned an error.");
+    } else {
+        assert(actual, expected);
     }
-
-    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
-    assert(castedValue["factor"], mp["factor"]);
-    assert(castedValue["name"], mp["name"]);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -76,8 +76,8 @@ type OpenRecordWithUnionTarget record {|
 |};
 
 map<json> mp = {
-        name: "foo",
-        factor: 1.23d
+    name: "foo",
+    factor: 1.23d
 };
 
 function testConvertMapJsonWithDecimalToOpenRecord() {
@@ -110,17 +110,17 @@ public type Argument record {|
     Scalar value;
 |};
 
-public function testConvertUnion() {
-    json expectedJson = { "value": 132 };
+public function testConvertToUnionWithActualType() {
+    json expectedJson = {"value": 132};
 
-    Argument expected = { "value": 132 };
+    Argument expected = {"value": 132};
     var actual = expectedJson.cloneWithType(Argument);
 
     if (actual is error) {
         panic error("`cloneWithType` returned an error.");
-    } else {
-        assert(actual, expected);
     }
+
+    assert(actual, expected);
 }
 
 function assert(anydata actual, anydata expected) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -123,10 +123,10 @@ public function testConvertToUnionWithActualType() {
     assert(actual, expected);
 }
 
-function assert(anydata actual, anydata expected) {
+function assert(anydata|error actual, anydata|error expected) {
     if (expected != actual) {
-        typedesc<anydata> expT = typeof expected;
-        typedesc<anydata> actT = typeof actual;
+        typedesc<anydata|error> expT = typeof expected;
+        typedesc<anydata|error> actT = typeof actual;
         string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
                             + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
 


### PR DESCRIPTION
## Purpose
> $title
When a converting to a record, if a union type is present and the value was convertible to multiple options of the union type converter assumed this is an error.

Also added test cases to check json with decimal using `fromJsonWithType` langlib function

Fixes #27549

## Approach


## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
