### PR TITLE
Fix Bindgen tool with Project API and other changes

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     dist 'org.apache.commons:commons-compress:1.18'
     dist 'me.tongfei:progressbar:0.7.4'
     dist 'org.jline:jline:3.11.0'
+    dist 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'
 
     // Following dependencies are required for kraal library
     dist 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindingsGenerator.java
@@ -49,7 +49,6 @@ import static org.ballerinalang.bindgen.utils.BindgenUtils.getClassLoader;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getExistingBindings;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.getUpdatedConstantsList;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.isPublicClass;
-import static org.ballerinalang.bindgen.utils.BindgenUtils.notifyExistingDependencies;
 import static org.ballerinalang.bindgen.utils.BindgenUtils.writeOutputFile;
 
 /**
@@ -206,7 +205,6 @@ public class BindingsGenerator {
         Set<String> names = new HashSet<>(allClasses);
         if (constantsPath.toFile().exists()) {
             getUpdatedConstantsList(constantsPath, names);
-            notifyExistingDependencies(classNames, dependenciesPath.toFile());
         }
         if (!names.isEmpty()) {
             writeOutputFile(names, DEFAULT_TEMPLATE_DIR, CONSTANTS_TEMPLATE_NAME, constantsPath.toString(), true);

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
@@ -17,14 +17,13 @@
  */
 package org.ballerinalang.bindgen.utils;
 
+import io.ballerina.projects.PackageManifest;
 import io.ballerina.projects.internal.BallerinaTomlProcessor;
 import org.apache.commons.io.output.FileWriterWithEncoding;
 import org.ballerinalang.bindgen.exceptions.BindgenException;
 import org.ballerinalang.maven.Dependency;
 import org.ballerinalang.maven.MavenResolver;
 import org.ballerinalang.maven.exceptions.MavenResolverException;
-import org.ballerinalang.toml.model.Library;
-import org.ballerinalang.toml.model.Platform;
 
 import java.io.File;
 import java.io.IOException;
@@ -32,6 +31,7 @@ import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Map;
 import java.util.regex.Pattern;
 
 import static org.ballerinalang.bindgen.command.BindingsGenerator.getOutputPath;
@@ -117,31 +117,30 @@ public class BindgenMvnResolver {
     private static void populateBallerinaToml(String groupId, String artifactId, String version, File tomlFile,
                                               Path projectRoot, String parent) throws BindgenException {
         try (FileWriterWithEncoding fileWriter = new FileWriterWithEncoding(tomlFile, StandardCharsets.UTF_8, true)) {
-            Platform platform = BallerinaTomlProcessor.parse(tomlFile.toPath()).getPlatform();
-            if (platform == null || (platform.target == null && platform.libraries == null)) {
-                fileWriter.write("\n\n[platform]\n");
-                fileWriter.write("target = \"java11\"\n");
-            } else if (platform.getLibraries() != null) {
-                for (Library library : platform.getLibraries()) {
-                    if (library.path == null && library.groupId != null && library.artifactId != null &&
-                            library.version != null && library.groupId.equals(groupId) &&
-                            library.artifactId.equals(artifactId) && library.version.equals(version)) {
+            PackageManifest.Platform platform = BallerinaTomlProcessor.parseAsPackageManifest(tomlFile.toPath())
+                    .platform("java11");
+            if (platform.dependencies() != null) {
+                for (Map<String, Object> library : platform.dependencies()) {
+                    if (library.get("path") == null &&
+                            library.get("groupId") != null && library.get("groupId").equals(groupId) &&
+                            library.get("artifactId") != null && library.get("artifactId").equals(artifactId) &&
+                            library.get("version") != null && library.get("version").equals(version)) {
                         return;
                     }
                 }
             }
             fileWriter.write("\n");
             if (parent != null) {
-                fileWriter.write("    # transitive dependency of " + parent + "\n");
+                fileWriter.write("# transitive dependency of " + parent + "\n");
             }
-            fileWriter.write("    [[platform.libraries]]\n");
+            fileWriter.write("[[platform.java11.dependency]]\n");
             String moduleName = getModuleName(projectRoot, getOutputPath());
             if (moduleName != null) {
-                fileWriter.write("    modules = [\"" + moduleName + "\"]\n");
+                fileWriter.write("modules = [\"" + moduleName + "\"]\n");
             }
-            fileWriter.write("    groupId = \"" + groupId + "\"\n");
-            fileWriter.write("    artifactId = \"" + artifactId + "\"\n");
-            fileWriter.write("    version = \"" + version + "\"\n");
+            fileWriter.write("groupId = \"" + groupId + "\"\n");
+            fileWriter.write("artifactId = \"" + artifactId + "\"\n");
+            fileWriter.write("version = \"" + version + "\"\n");
         } catch (IOException io) {
             throw new BindgenException("Error while updating the Ballerina.toml file.", io);
         }

--- a/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
@@ -8,7 +8,7 @@
 
 {{/unless}}
 import ballerina/java;{{#if importJavaArraysModule}}
-import ballerina/java.arrays as jarrays;{{/if}}
+import ballerina/jarrays;{{/if}}
 
 # Ballerina object mapping for {{#if isInterface}}Java interface{{else}}{{#if isAbstract}}Java abstract class{{else}}Java class{{/if}}{{/if}} `{{className}}`.
 #

--- a/misc/ballerina-bindgen/src/test/resources/mvn-test-resources/Ballerina.toml
+++ b/misc/ballerina-bindgen/src/test/resources/mvn-test-resources/Ballerina.toml
@@ -5,37 +5,34 @@ version= "0.1.0"
 
 [dependencies]
 
-[platform]
-target = "java11"
+[[platform.java11.dependency]]
+modules = ["balModule1"]
+path = "./lib/snakeyaml-1.25.jar"
 
-    [[platform.libraries]]
-    modules = ["balModule1"]
-    path = "./lib/snakeyaml-1.25.jar"
+[[platform.java11.dependency]]
+groupId = "commons-logging"
+artifactId = "commons-logging"
+version = "1.1.1"
 
-    [[platform.libraries]]
-    groupId = "commons-logging"
-    artifactId = "commons-logging"
-    version = "1.1.1"
+[[platform.java11.dependency]]
+groupId = "org.yaml"
+artifactId = "snakeyaml"
+version = "1.25"
 
-    [[platform.libraries]]
-    groupId = "org.yaml"
-    artifactId = "snakeyaml"
-    version = "1.25"
+# transitive dependency of commons-logging:commons-logging:1.1.1
+[[platform.java11.dependency]]
+groupId = "log4j"
+artifactId = "log4j"
+version = "1.2.12"
 
-    # transitive dependency of commons-logging:commons-logging:1.1.1
-    [[platform.libraries]]
-    groupId = "log4j"
-    artifactId = "log4j"
-    version = "1.2.12"
+# transitive dependency of commons-logging:commons-logging:1.1.1
+[[platform.java11.dependency]]
+groupId = "logkit"
+artifactId = "logkit"
+version = "1.0.1"
 
-    # transitive dependency of commons-logging:commons-logging:1.1.1
-    [[platform.libraries]]
-    groupId = "logkit"
-    artifactId = "logkit"
-    version = "1.0.1"
-
-    # transitive dependency of commons-logging:commons-logging:1.1.1
-    [[platform.libraries]]
-    groupId = "avalon-framework"
-    artifactId = "avalon-framework"
-    version = "4.1.3"
+# transitive dependency of commons-logging:commons-logging:1.1.1
+[[platform.java11.dependency]]
+groupId = "avalon-framework"
+artifactId = "avalon-framework"
+version = "4.1.3"

--- a/misc/ballerina-bindgen/src/test/resources/mvn-test-resources/balProject/Ballerina.toml
+++ b/misc/ballerina-bindgen/src/test/resources/mvn-test-resources/balProject/Ballerina.toml
@@ -5,19 +5,16 @@ version= "0.1.0"
 
 [dependencies]
 
-[platform]
-target = "java11"
+[[platform.java11.dependency]]
+modules = ["balModule1"]
+path = "./lib/snakeyaml-1.25.jar"
 
-    [[platform.libraries]]
-    modules = ["balModule1"]
-    path = "./lib/snakeyaml-1.25.jar"
+[[platform.java11.dependency]]
+groupId = "commons-logging"
+artifactId = "commons-logging"
+version = "1.1.1"
 
-    [[platform.libraries]]
-    groupId = "commons-logging"
-    artifactId = "commons-logging"
-    version = "1.1.1"
-
-    [[platform.libraries]]
-    groupId = "org.yaml"
-    artifactId = "snakeyaml"
-    version = "1.25"
+[[platform.java11.dependency]]
+groupId = "org.yaml"
+artifactId = "snakeyaml"
+version = "1.25"


### PR DESCRIPTION
## Purpose
* Adds back the `antlr` jar to the `bre/lib` since it is being used as a transitive dependency by the `com.github.jknack:handlebars` library through the bindgen tool (which was previously removed in https://github.com/ballerina-platform/ballerina-lang/pull/25821).
* Adds some changes addressing the new Project API features.
* Addresses the renaming of `java.arrays` module to `jarrays` (https://github.com/ballerina-platform/module-ballerina-java.arrays/pull/25).

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
