### PR TITLE
Fix a null pointer exception when updating the Ballerina.toml

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
@@ -119,7 +119,7 @@ public class BindgenMvnResolver {
         try (FileWriterWithEncoding fileWriter = new FileWriterWithEncoding(tomlFile, StandardCharsets.UTF_8, true)) {
             PackageManifest.Platform platform = BallerinaTomlProcessor.parseAsPackageManifest(tomlFile.toPath())
                     .platform("java11");
-            if (platform.dependencies() != null) {
+            if (platform != null && platform.dependencies() != null) {
                 for (Map<String, Object> library : platform.dependencies()) {
                     if (library.get("path") == null &&
                             library.get("groupId") != null && library.get("groupId").equals(groupId) &&


### PR DESCRIPTION
## Purpose
Fixes the following null pointer exception happening when the `Ballerina.toml` file is updated using the bindgen maven resolver.
```
[2020-11-25 16:56:18,186] SEVERE {b7a.log.crash} - null 
java.lang.NullPointerException
	at org.ballerinalang.bindgen.utils.BindgenMvnResolver.populateBallerinaToml(BindgenMvnResolver.java:122)
	at org.ballerinalang.bindgen.utils.BindgenMvnResolver.handleDependency(BindgenMvnResolver.java:112)
	at org.ballerinalang.bindgen.utils.BindgenMvnResolver.mavenResolver(BindgenMvnResolver.java:71)
	at org.ballerinalang.bindgen.command.BindingsGenerator.generateJavaBindings(BindingsGenerator.java:98)
	at org.ballerinalang.bindgen.command.BindgenCommand.execute(BindgenCommand.java:155)
	at java.base/java.util.Optional.ifPresent(Unknown Source)
	at org.ballerinalang.tool.Main.main(Main.java:57)
```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
