### PR TITLE
Fix issues with test coverage

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -155,6 +155,7 @@ public class RunTestsTask implements Task {
         this.out.println();
 
         int result = 0;
+        boolean hasTests = false;
 
         PackageCompilation packageCompilation = project.currentPackage().getCompilation();
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JdkVersion.JAVA_11);
@@ -183,6 +184,10 @@ public class RunTestsTask implements Task {
             } else if (isSingleTestExecution && suite.getTests().isEmpty()) {
                 out.println("\t" + "No tests found with the given name/s");
                 continue;
+            }
+            //Set 'hasTests' flag if there are any tests available in the package
+            if (!hasTests) {
+                hasTests = true;
             }
 
             if (isRerunTestExecution) {
@@ -217,8 +222,10 @@ public class RunTestsTask implements Task {
         }
 
         try {
-            generateCoverage(project);
-            generateHtmlReport(project, this.out, testReport, target);
+            if (hasTests) {
+                generateCoverage(project);
+                generateHtmlReport(project, this.out, testReport, target);
+            }
         } catch (IOException e) {
             throw createLauncherException("error while generating test report :", e);
         }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestReport.java
@@ -77,8 +77,10 @@ public class TestReport {
     }
 
     public void addCoverage(String moduleName, ModuleCoverage coverage) {
-        coverage.setName(moduleName);
-        this.moduleCoverage.add(coverage);
+        if (coverage != null) {
+            coverage.setName(moduleName);
+            this.moduleCoverage.add(coverage);
+        }
     }
 
     public void setOrgName(String orgName) {


### PR DESCRIPTION
## Purpose
Fixes following issues with test coverage

- When no tests available in package, shows following as error message when "--code-coverage" flag is used.

```
$ ballerina test --code-coverage 
.....
error: error while generating test report :java.io.FileNotFoundException: /Users/dilhashanazeer/Desktop/NewProj/target/cache/tests_cache/coverage/ballerina.exec (No such file or directory)

```

- When "--code-coverage" flag is used is used with single bal file, throws a NPE even though it prints "Code coverage is not yet supported with single bal files. Ignoring the flag and continuing the test run..."

```
[2020-11-25 19:05:11,122] SEVERE {b7a.log.crash} - null
java.lang.NullPointerException
        at org.ballerinalang.test.runtime.entity.TestReport.addCoverage(TestReport.java:80)
```

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
