### PR TITLE
Refactor BIRVarToJVMIndexMap

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCastGen.java
@@ -24,16 +24,12 @@ import org.wso2.ballerinalang.compiler.bir.codegen.internal.BIRVarToJVMIndexMap;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.LabelGenerator;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JType;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
-import org.wso2.ballerinalang.compiler.bir.model.VarKind;
-import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BUnionType;
-import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
 import static org.objectweb.asm.Opcodes.ALOAD;
@@ -115,7 +111,6 @@ public class JvmCastGen {
 
     static void generatePlatformCheckCast(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, BType sourceType,
                                           BType targetType) {
-
         if (sourceType.tag == JTypeTags.JTYPE) {
             // If a target type is bir type, then we can guarantee source type is a jvm type, hence the cast
             generateJToBCheckCast(mv, indexMap, (JType) sourceType, targetType);
@@ -401,7 +396,6 @@ public class JvmCastGen {
 
     private static void generateJToBCheckCast(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, JType sourceType,
                                               BType targetType) {
-
         if (TypeTags.isIntegerTypeTag(targetType.tag)) {
             generateCheckCastJToBInt(mv, sourceType);
             return;
@@ -596,12 +590,10 @@ public class JvmCastGen {
 
     private static void generateCheckCastJToBUnionType(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, JType sourceType,
                                                        BUnionType targetType) {
-
         generateJCastToBAny(mv, indexMap, sourceType, targetType);
     }
 
     private static void generateCheckCastJToBAnyData(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, JType sourceType) {
-
         if (!(sourceType.jTag == JTypeTags.JREF || sourceType.jTag == JTypeTags.JARRAY)) {
             // if value types, then ad box instruction
             generateJCastToBAny(mv, indexMap, sourceType, symbolTable.anydataType);
@@ -625,7 +617,6 @@ public class JvmCastGen {
 
     private static void generateJCastToBAny(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, JType sourceType,
                                             BType targetType) {
-
         switch (sourceType.jTag) {
             case JTypeTags.JBOOLEAN:
                 mv.visitMethodInsn(INVOKESTATIC, BOOLEAN_VALUE, VALUE_OF_METHOD, String.format("(Z)L%s;",
@@ -684,9 +675,7 @@ public class JvmCastGen {
                 mv.visitTypeInsn(INSTANCEOF, REF_VALUE);
                 mv.visitJumpInsn(IFNE, afterHandle);
 
-                BIRVariableDcl retJObjectVarDcl = new BIRVariableDcl(null, symbolTable.anyType,
-                        new Name("$_ret_jobject_val_$"), VarScope.FUNCTION, VarKind.LOCAL, "");
-                int returnJObjectVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(retJObjectVarDcl);
+                int returnJObjectVarRefIndex = indexMap.addIfNotExists("$_ret_jobject_val_$", symbolTable.anyType);
                 mv.visitVarInsn(ASTORE, returnJObjectVarRefIndex);
                 mv.visitTypeInsn(NEW, HANDLE_VALUE);
                 mv.visitInsn(DUP);
@@ -723,7 +712,6 @@ public class JvmCastGen {
     }
 
     private static void generateCheckCastJToBJSON(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, JType sourceType) {
-
         if (sourceType.jTag == JTypeTags.JREF || sourceType.jTag == JTypeTags.JARRAY) {
             return;
         }
@@ -734,7 +722,6 @@ public class JvmCastGen {
 
     private static void generateCheckCastJToBReadOnly(MethodVisitor mv, BIRVarToJVMIndexMap indexMap,
                                                       JType sourceType) {
-
         if (sourceType.jTag == JTypeTags.JREF || sourceType.jTag == JTypeTags.JARRAY) {
             return;
         }
@@ -753,7 +740,6 @@ public class JvmCastGen {
     }
 
     static void generateCheckCast(MethodVisitor mv, BType sourceType, BType targetType, BIRVarToJVMIndexMap indexMap) {
-
         if (TypeTags.isXMLTypeTag(sourceType.tag) && targetType.tag == TypeTags.MAP) {
             generateXMLToAttributesMap(mv);
             return;
@@ -1130,7 +1116,6 @@ public class JvmCastGen {
     }
 
     private static void generateCheckCastToString(MethodVisitor mv, BType sourceType, BIRVarToJVMIndexMap indexMap) {
-
         if (TypeTags.isStringTypeTag(sourceType.tag)) {
             return;
         } else if (TypeTags.isIntegerTypeTag(sourceType.tag)) {
@@ -1170,17 +1155,13 @@ public class JvmCastGen {
     }
 
     private static void generateNonBMPStringValue(MethodVisitor mv, BIRVarToJVMIndexMap indexMap) {
-
-        BIRVariableDcl strVar = new BIRVariableDcl(null, symbolTable.anyType,
-                new Name("str"), VarScope.FUNCTION, VarKind.LOCAL, "");
-        int tmpVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(strVar);
-
+        int tmpVarIndex = indexMap.addIfNotExists("str", symbolTable.anyType);
         mv.visitVarInsn(ASTORE, tmpVarIndex);
         mv.visitTypeInsn(NEW, BMP_STRING_VALUE);
         mv.visitInsn(DUP);
         mv.visitVarInsn(ALOAD, tmpVarIndex);
         mv.visitMethodInsn(INVOKESPECIAL, BMP_STRING_VALUE, JVM_INIT_METHOD,
-                String.format("(L%s;)V", STRING_VALUE), false);
+                           String.format("(L%s;)V", STRING_VALUE), false);
     }
 
     private static void generateCheckCastToChar(MethodVisitor mv, BType sourceType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmErrorGen.java
@@ -68,7 +68,6 @@ public class JvmErrorGen {
     }
 
     void genPanic(BIRTerminator.Panic panicTerm) {
-
         BIRNode.BIRVariableDcl varDcl = panicTerm.errorOp.variableDcl;
         int errorIndex = this.getJVMIndexOfVarRef(varDcl);
         jvmInstructionGen.generateVarLoad(this.mv, varDcl, errorIndex);
@@ -92,7 +91,7 @@ public class JvmErrorGen {
         if (currentEE instanceof JErrorEntry) {
             JErrorEntry jCurrentEE = ((JErrorEntry) currentEE);
             BIRNode.BIRVariableDcl retVarDcl = currentEE.errorOp.variableDcl;
-            int retIndex = this.indexMap.addToMapIfNotFoundAndGetIndex(retVarDcl);
+            int retIndex = this.indexMap.addIfNotExists(retVarDcl.name.value, retVarDcl.type);
             boolean exeptionExist = false;
             for (CatchIns catchIns : jCurrentEE.catchIns) {
                 if (ERROR_VALUE.equals(catchIns.errorClass)) {
@@ -135,7 +134,7 @@ public class JvmErrorGen {
         this.mv.visitLabel(errorValueLabel);
 
         BIRNode.BIRVariableDcl varDcl = currentEE.errorOp.variableDcl;
-        int lhsIndex = this.indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
+        int lhsIndex = this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
         jvmInstructionGen.generateVarStore(this.mv, varDcl, lhsIndex);
         this.mv.visitJumpInsn(GOTO, jumpLabel);
         this.mv.visitLabel(otherErrorLabel);
@@ -146,6 +145,6 @@ public class JvmErrorGen {
     }
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
-        return this.indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
+        return this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -196,7 +196,6 @@ public class JvmInstructionGen {
 
     public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, BIRNode.BIRPackage currentPackage,
                              JvmPackageGen jvmPackageGen) {
-
         this.mv = mv;
         this.indexMap = indexMap;
         this.currentPackage = currentPackage;
@@ -243,7 +242,7 @@ public class JvmInstructionGen {
         }
     }
 
-    private static void generateJVarLoad(MethodVisitor mv, JType jType, String currentPackageName, int valueIndex) {
+    private static void generateJVarLoad(MethodVisitor mv, JType jType, int valueIndex) {
 
         switch (jType.jTag) {
             case JTypeTags.JBYTE:
@@ -280,7 +279,7 @@ public class JvmInstructionGen {
         }
     }
 
-    private static void generateJVarStore(MethodVisitor mv, JType jType, String currentPackageName, int valueIndex) {
+    private static void generateJVarStore(MethodVisitor mv, JType jType, int valueIndex) {
 
         switch (jType.jTag) {
             case JTypeTags.JBYTE:
@@ -506,7 +505,7 @@ public class JvmInstructionGen {
                 mv.visitVarInsn(ALOAD, valueIndex);
                 break;
             case JTypeTags.JTYPE:
-                generateJVarLoad(mv, (JType) bType, currentPackageName, valueIndex);
+                generateJVarLoad(mv, (JType) bType, valueIndex);
                 break;
             default:
                 throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
@@ -578,7 +577,7 @@ public class JvmInstructionGen {
                 mv.visitVarInsn(ASTORE, valueIndex);
                 break;
             case JTypeTags.JTYPE:
-                generateJVarStore(mv, (JType) bType, currentPackageName, valueIndex);
+                generateJVarStore(mv, (JType) bType, valueIndex);
                 break;
             default:
                 throw new BLangCompilerException(JvmConstants.TYPE_NOT_SUPPORTED_MESSAGE +
@@ -609,7 +608,6 @@ public class JvmInstructionGen {
     }
 
     void generatePlatformIns(JInstruction ins) {
-
         if (ins.jKind == JInsKind.JCAST) {
             JCast castIns = (JCast) ins;
             BType targetType = castIns.targetType;
@@ -620,7 +618,6 @@ public class JvmInstructionGen {
     }
 
     void generateMoveIns(BIRNonTerminator.Move moveIns) {
-
         this.loadVar(moveIns.rhsOp.variableDcl);
         this.storeToVar(moveIns.lhsOp.variableDcl);
     }
@@ -1224,8 +1221,7 @@ public class JvmInstructionGen {
     }
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
-
-        return this.indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
+        return this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
     }
 
     void generateMapNewIns(BIRNonTerminator.NewStructure mapNewIns, int localVarOffset) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -131,11 +131,9 @@ public class JvmPackageGen {
     public final SymbolTable symbolTable;
     public final PackageCache packageCache;
     private final MethodGen methodGen;
-    private final ModuleStopMethodGen moduleStopMethodGen;
     private final FrameClassGen frameClassGen;
     private final InitMethodGen initMethodGen;
     private final ConfigMethodGen configMethodGen;
-    private final MainMethodGen mainMethodGen;
     private final LambdaGen lambdaGen;
     private final Map<String, BIRFunctionWrapper> birFunctionMap;
     private final Map<String, String> externClassMap;
@@ -153,10 +151,8 @@ public class JvmPackageGen {
         this.dlog = dlog;
         methodGen = new MethodGen(this);
         initMethodGen = new InitMethodGen(symbolTable);
-        mainMethodGen = new MainMethodGen(symbolTable);
         configMethodGen = new ConfigMethodGen();
         lambdaGen = new LambdaGen(this);
-        moduleStopMethodGen = new ModuleStopMethodGen(symbolTable);
         frameClassGen = new FrameClassGen();
         typeBuilder = new ResolvedTypeBuilder();
 
@@ -488,7 +484,7 @@ public class JvmPackageGen {
 
                 serviceEPAvailable = listenerDeclarationFound(module.globalVars)
                         || isServiceDefAvailable(module.typeDefs);
-
+                MainMethodGen mainMethodGen = new MainMethodGen(symbolTable);
                 mainMethodGen.generateMainMethod(mainFunc, cw, module, moduleClass, serviceEPAvailable,
                                                  asyncDataCollector);
                 if (mainFunc != null) {
@@ -499,8 +495,8 @@ public class JvmPackageGen {
                 generateLockForVariable(cw);
                 generateCreateTypesMethod(cw, module.typeDefs, moduleInitClass, symbolTable);
                 initMethodGen.generateModuleInitializer(cw, module, moduleInitClass);
-                moduleStopMethodGen.generateExecutionStopMethod(cw, moduleInitClass, module, moduleImports,
-                                                                asyncDataCollector);
+                new ModuleStopMethodGen(symbolTable).generateExecutionStopMethod(cw, moduleInitClass, module,
+                                                                                 moduleImports, asyncDataCollector);
             } else {
                 cw.visit(V1_8, ACC_PUBLIC + ACC_SUPER, moduleClass, null, OBJECT, null);
                 JvmCodeGenUtil.generateDefaultConstructor(cw, OBJECT);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -559,7 +559,7 @@ public class JvmTerminatorGen {
         }
         if (callIns.varArgExist) {
             BIROperand arg = callIns.args.get(argIndex);
-            int localVarIndex = this.indexMap.addToMapIfNotFoundAndGetIndex(arg.variableDcl);
+            int localVarIndex = this.indexMap.addIfNotExists(arg.variableDcl.name.value, arg.variableDcl.type);
             genVarArg(this.mv, this.indexMap, arg.variableDcl.type, callIns.varArgType, localVarIndex, symbolTable);
         }
 
@@ -1257,8 +1257,7 @@ public class JvmTerminatorGen {
     }
 
     private int getJVMIndexOfVarRef(BIRNode.BIRVariableDcl varDcl) {
-
-        return this.indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
+        return this.indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
     }
 
     private void loadVar(BIRNode.BIRVariableDcl varDcl) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -29,9 +29,6 @@ import org.wso2.ballerinalang.compiler.bir.codegen.internal.BIRVarToJVMIndexMap;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.ScheduleFunctionInfo;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
-import org.wso2.ballerinalang.compiler.bir.model.VarKind;
-import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
@@ -62,7 +59,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.NamedNode;
 import org.wso2.ballerinalang.compiler.semantics.model.types.TypeFlags;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
-import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
@@ -424,7 +420,7 @@ public class JvmTypeGen {
         for (NamedNode node : nodes) {
             if (node != null) {
                 labels.add(i, new Label());
-                String name = node.getName().value;;
+                String name = node.getName().value;
                 hashCodes[i] = name.hashCode();
                 i += 1;
             }
@@ -482,7 +478,7 @@ public class JvmTypeGen {
         for (BIRTypeDefinition optionalTypeDef : typeDefs) {
             BType bType = optionalTypeDef.type;
             if (bType.tag == TypeTags.OBJECT &&
-                    Symbols.isFlagOn(((BObjectType) bType).tsymbol.flags, Flags.CLASS)) {
+                    Symbols.isFlagOn(bType.tsymbol.flags, Flags.CLASS)) {
                 objectTypeDefs.add(i, optionalTypeDef);
                 i += 1;
             }
@@ -564,30 +560,12 @@ public class JvmTypeGen {
 
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
 
-        BIRVariableDcl selfVar = new BIRVariableDcl(symbolTable.anyType, new Name("self"), VarScope.FUNCTION,
-                VarKind.ARG);
-
-        BIRVariableDcl var1 = new BIRVariableDcl(symbolTable.stringType, new Name("var1"), VarScope.FUNCTION,
-                VarKind.ARG);
-
-        BIRVariableDcl scheduler = new BIRVariableDcl(symbolTable.anyType, new Name("scheduler"), VarScope.FUNCTION,
-                VarKind.ARG);
-
-        BIRVariableDcl parent = new BIRVariableDcl(symbolTable.anyType, new Name("parent"), VarScope.FUNCTION,
-                VarKind.ARG);
-
-        BIRVariableDcl properties = new BIRVariableDcl(symbolTable.anyType, new Name("properties"), VarScope.FUNCTION,
-                VarKind.ARG);
-
-        BIRVariableDcl args = new BIRVariableDcl(symbolTable.anyType, new Name("args"), VarScope.FUNCTION, VarKind.ARG);
-
-        indexMap.addToMapIfNotFoundAndGetIndex(selfVar);
-
-        int var1Index = indexMap.addToMapIfNotFoundAndGetIndex(var1);
-        int schedulerIndex = indexMap.addToMapIfNotFoundAndGetIndex(scheduler);
-        int parentIndex = indexMap.addToMapIfNotFoundAndGetIndex(parent);
-        int propertiesIndex = indexMap.addToMapIfNotFoundAndGetIndex(properties);
-        int argsIndex = indexMap.addToMapIfNotFoundAndGetIndex(args);
+        indexMap.addIfNotExists("self", symbolTable.anyType);
+        int var1Index = indexMap.addIfNotExists("var1", symbolTable.stringType);
+        int schedulerIndex = indexMap.addIfNotExists("scheduler", symbolTable.anyType);
+        int parentIndex = indexMap.addIfNotExists("parent", symbolTable.anyType);
+        int propertiesIndex = indexMap.addIfNotExists("properties", symbolTable.anyType);
+        int argsIndex = indexMap.addIfNotExists("args", symbolTable.anyType);
 
         mv.visitCode();
 
@@ -615,14 +593,9 @@ public class JvmTypeGen {
             mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, String.format("(L%s;)V", OBJECT_TYPE_IMPL),
                                false);
 
-            BIRVariableDcl tempVar = new BIRVariableDcl(optionalTypeDef.type, new Name("tempVar"), VarScope.FUNCTION,
-                                                        VarKind.LOCAL);
-
-            int tempVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(tempVar);
+            int tempVarIndex = indexMap.addIfNotExists("tempVar", optionalTypeDef.type);
             mv.visitVarInsn(ASTORE, tempVarIndex);
-            BIRVariableDcl strandVar = new BIRVariableDcl(symbolTable.anyType, new Name("strandVar"), VarScope.FUNCTION,
-                    VarKind.LOCAL);
-            int strandVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(strandVar);
+            int strandVarIndex = indexMap.addIfNotExists("strandVar", symbolTable.anyType);
 
             mv.visitVarInsn(ALOAD, parentIndex);
             Label parentNonNullLabel = new Label();
@@ -659,10 +632,7 @@ public class JvmTypeGen {
             String methodDesc = String.format("(L%s;L%s;[L%s;)L%s;", STRAND_CLASS, STRING_VALUE, OBJECT, OBJECT);
             mv.visitMethodInsn(INVOKEINTERFACE, B_OBJECT, "call", methodDesc, true);
 
-            BIRVariableDcl tempResult = new BIRVariableDcl(symbolTable.anyType, new Name("tempResult"),
-                    VarScope.FUNCTION, VarKind.LOCAL);
-
-            int tempResultIndex = indexMap.addToMapIfNotFoundAndGetIndex(tempResult);
+            int tempResultIndex = indexMap.addIfNotExists("tempResult", symbolTable.anyType);
             mv.visitVarInsn(ASTORE, tempResultIndex);
             mv.visitVarInsn(ALOAD, tempResultIndex);
             mv.visitTypeInsn(INSTANCEOF, BERROR);
@@ -998,10 +968,8 @@ public class JvmTypeGen {
             }
             // create and load attached function
             createObjectAttachedFunction(mv, attachedFunc, objType);
-            BIRVariableDcl attachedFuncVar = new BIRVariableDcl(symbolTable.anyType,
-                    new Name(toNameString(objType) + attachedFunc.funcName.value), VarScope.FUNCTION,
-                    VarKind.LOCAL);
-            int attachedFunctionVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(attachedFuncVar);
+            int attachedFunctionVarIndex = indexMap.addIfNotExists(toNameString(objType) + attachedFunc.funcName.value,
+                                                                   symbolTable.anyType);
             mv.visitVarInsn(ASTORE, attachedFunctionVarIndex);
 
             mv.visitInsn(DUP);
@@ -1029,10 +997,8 @@ public class JvmTypeGen {
 
         mv.visitInsn(DUP);
         createObjectAttachedFunction(mv, initFunction, objType);
-        BType anyType = symbolTable.anyType;
-        BIRVariableDcl attachedFuncVar = new BIRVariableDcl(anyType,
-                new Name(objType.name + initFunction.funcName.value), VarScope.FUNCTION, VarKind.LOCAL);
-        int attachedFunctionVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(attachedFuncVar);
+        int attachedFunctionVarIndex = indexMap.addIfNotExists(objType.name + initFunction.funcName.value,
+                                                               symbolTable.anyType);
         mv.visitVarInsn(ASTORE, attachedFunctionVarIndex);
         mv.visitVarInsn(ALOAD, attachedFunctionVarIndex);
         mv.visitInsn(DUP);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/BIRVarToJVMIndexMap.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/internal/BIRVarToJVMIndexMap.java
@@ -19,7 +19,6 @@ package org.wso2.ballerinalang.compiler.bir.codegen.internal;
 
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JType;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JTypeTags;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
@@ -45,13 +44,8 @@ public class BIRVarToJVMIndexMap {
 
     private final Map<String, Integer> jvmLocalVarIndexMap = new HashMap<>();
 
-    private void add(BIRNode.BIRVariableDcl varDcl) {
-
-        String varRefName = this.getVarRefName(varDcl);
+    private void add(String varRefName, BType bType) {
         this.jvmLocalVarIndexMap.put(varRefName, this.localVarIndex);
-
-        BType bType = varDcl.type;
-
         if (TypeTags.isIntegerTypeTag(bType.tag) || bType.tag == TypeTags.FLOAT) {
             this.localVarIndex = this.localVarIndex + 2;
         } else if (bType.tag == JTypeTags.JTYPE) {
@@ -66,18 +60,14 @@ public class BIRVarToJVMIndexMap {
         }
     }
 
-    private String getVarRefName(BIRNode.BIRVariableDcl varDcl) {
-
-        return varDcl.name.value;
+    public int addIfNotExists(String varRefName, BType bType) {
+        if (!(this.jvmLocalVarIndexMap.containsKey(varRefName))) {
+            this.add(varRefName, bType);
+        }
+        return get(varRefName);
     }
 
-    public int addToMapIfNotFoundAndGetIndex(BIRNode.BIRVariableDcl varDcl) {
-
-        String varRefName = this.getVarRefName(varDcl);
-        if (!(this.jvmLocalVarIndexMap.containsKey(varRefName))) {
-            this.add(varDcl);
-        }
-
+    public int get(String varRefName) {
         Integer index = this.jvmLocalVarIndexMap.get(varRefName);
         return index != null ? index : -1;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -131,11 +131,8 @@ public class InteropMethodGen {
                                          String moduleClassName,
                                          AsyncDataCollector asyncDataCollector) {
 
-        // Create a local variable for the strand
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
-        BIRVariableDcl strandVarDcl = new BIRVariableDcl(jvmPackageGen.symbolTable.stringType, new Name("$_strand_$"),
-                null, VarKind.ARG);
-        indexMap.addToMapIfNotFoundAndGetIndex(strandVarDcl);
+        indexMap.addIfNotExists("$_strand_$", jvmPackageGen.symbolTable.stringType);
 
         // Generate method desc
         BIRFunction birFunc = jFieldFuncWrapper.func;
@@ -168,7 +165,7 @@ public class InteropMethodGen {
             if (birLocalVarOptional instanceof BIRNode.BIRFunctionParameter) {
                 BIRNode.BIRFunctionParameter functionParameter = (BIRNode.BIRFunctionParameter) birLocalVarOptional;
                 birFuncParams.add(functionParameter);
-                indexMap.addToMapIfNotFoundAndGetIndex(functionParameter);
+                indexMap.addIfNotExists(functionParameter.name.value, functionParameter.type);
             }
         }
 
@@ -186,7 +183,7 @@ public class InteropMethodGen {
 
             // The following boolean parameter indicates the existence of a default value
             BIRNode.BIRFunctionParameter isDefaultValueExist = birFuncParams.get(birFuncParamIndex + 1);
-            mv.visitVarInsn(ILOAD, indexMap.addToMapIfNotFoundAndGetIndex(isDefaultValueExist));
+            mv.visitVarInsn(ILOAD, indexMap.addIfNotExists(isDefaultValueExist.name.value, isDefaultValueExist.type));
 
             // Gen the if not equal logic
             Label paramNextLabel = labelGen.getLabel(birFuncParam.name.value + "next");
@@ -206,7 +203,8 @@ public class InteropMethodGen {
 
         // Load receiver which is the 0th parameter in the birFunc
         if (!jField.isStatic()) {
-            int receiverLocalVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(birFuncParams.get(0));
+            BIRNode.BIRVariableDcl var = birFuncParams.get(0);
+            int receiverLocalVarIndex = indexMap.addIfNotExists(var.name.value, var.type);
             mv.visitVarInsn(ALOAD, receiverLocalVarIndex);
             mv.visitMethodInsn(INVOKEVIRTUAL, HANDLE_VALUE, GET_VALUE_METHOD, "()Ljava/lang/Object;", false);
             mv.visitTypeInsn(CHECKCAST, jField.getDeclaringClassName());
@@ -233,7 +231,7 @@ public class InteropMethodGen {
         birFuncParamIndex = jField.isStatic() ? 0 : 2;
         if (birFuncParamIndex < birFuncParams.size()) {
             BIRNode.BIRFunctionParameter birFuncParam = birFuncParams.get(birFuncParamIndex);
-            int paramLocalVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(birFuncParam);
+            int paramLocalVarIndex = indexMap.addIfNotExists(birFuncParam.name.value, birFuncParam.type);
             loadMethodParamToStackInInteropFunction(mv, birFuncParam, jFieldType,
                                                     paramLocalVarIndex, instGen);
         }
@@ -254,15 +252,14 @@ public class InteropMethodGen {
 
         // Handle return type
         BIRVariableDcl retVarDcl = new BIRVariableDcl(retType, new Name("$_ret_var_$"), null, VarKind.LOCAL);
-        int returnVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(retVarDcl);
+        int returnVarRefIndex = indexMap.addIfNotExists(retVarDcl.name.value, retType);
 
         if (retType.tag == TypeTags.NIL) {
             mv.visitInsn(ACONST_NULL);
         } else if (retType.tag == TypeTags.HANDLE) {
             // Here the corresponding Java method parameter type is 'jvm:RefType'. This has been verified before
-            BIRVariableDcl retJObjectVarDcl = new BIRVariableDcl(jvmPackageGen.symbolTable.anyType,
-                    new Name("$_ret_jobject_var_$"), null, VarKind.LOCAL);
-            int returnJObjectVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(retJObjectVarDcl);
+            int returnJObjectVarRefIndex = indexMap.addIfNotExists("$_ret_jobject_var_$",
+                                                                   jvmPackageGen.symbolTable.anyType);
             mv.visitVarInsn(ASTORE, returnJObjectVarRefIndex);
             mv.visitTypeInsn(NEW, HANDLE_VALUE);
             mv.visitInsn(DUP);
@@ -590,17 +587,9 @@ public class InteropMethodGen {
             throw new BLangCompilerException(String.format("invalid type for var-arg: %s", jvmType));
         }
 
-        BIRVariableDcl varArgsLen = new BIRVariableDcl(symbolTable.intType, new Name("$varArgsLen"), null,
-                VarKind.TEMP);
-
-        BIRVariableDcl index = new BIRVariableDcl(symbolTable.intType, new Name("$index"), null, VarKind.TEMP);
-
-        BIRVariableDcl valueArray = new BIRVariableDcl(symbolTable.anyType, new Name("$valueArray"), null,
-                VarKind.TEMP);
-
-        int varArgsLenVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(varArgsLen);
-        int indexVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(index);
-        int valueArrayIndex = indexMap.addToMapIfNotFoundAndGetIndex(valueArray);
+        int varArgsLenVarIndex = indexMap.addIfNotExists("$varArgsLen", symbolTable.intType);
+        int indexVarIndex = indexMap.addIfNotExists("$index", symbolTable.intType);
+        int valueArrayIndex = indexMap.addIfNotExists("$valueArray", symbolTable.anyType);
 
         // get the number of var args provided
         mv.visitVarInsn(ALOAD, varArgIndex);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -48,12 +48,10 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator.Return;
 import org.wso2.ballerinalang.compiler.bir.model.BirScope;
 import org.wso2.ballerinalang.compiler.bir.model.InstructionKind;
 import org.wso2.ballerinalang.compiler.bir.model.VarKind;
-import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
-import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -158,9 +156,7 @@ public class MethodGen {
                                    BType attachedType, AsyncDataCollector asyncDataCollector) {
 
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
-        BIRVariableDcl strandVar = new BIRVariableDcl(symbolTable.stringType, new Name(STRAND), VarScope.FUNCTION,
-                                                      VarKind.ARG);
-        indexMap.addToMapIfNotFoundAndGetIndex(strandVar);
+        indexMap.addIfNotExists(STRAND, symbolTable.stringType);
 
         // generate method desc
         int access = Opcodes.ACC_PUBLIC;
@@ -168,9 +164,7 @@ public class MethodGen {
         if (attachedType != null) {
             localVarOffset = 1;
             // add the self as the first local var
-            BIRVariableDcl selfVar = new BIRVariableDcl(symbolTable.anyType, new Name("self"), VarScope.FUNCTION,
-                                                        VarKind.ARG);
-            indexMap.addToMapIfNotFoundAndGetIndex(selfVar);
+            indexMap.addIfNotExists("self", symbolTable.anyType);
         } else {
             localVarOffset = 0;
             access += ACC_STATIC;
@@ -268,7 +262,7 @@ public class MethodGen {
     }
 
     private void visitModuleStartFunction(BIRPackage module, String funcName, MethodVisitor mv) {
-        if (!isModuleStartFunction(module, funcName)) {
+        if (!isModuleStartFunction(funcName)) {
             return;
         }
         mv.visitInsn(ICONST_1);
@@ -304,7 +298,7 @@ public class MethodGen {
         localVars.sort(new FunctionParamComparator());
         for (int i = 1; i < localVars.size(); i++) {
             BIRVariableDcl localVar = localVars.get(i);
-            int index = indexMap.addToMapIfNotFoundAndGetIndex(localVar);
+            int index = indexMap.addIfNotExists(localVar.name.value, localVar.type);
             if (localVar.kind != VarKind.ARG) {
                 BType bType = localVar.type;
                 genDefaultValue(mv, bType, index);
@@ -314,7 +308,7 @@ public class MethodGen {
 
     private int getReturnVarRefIndex(BIRFunction func, BIRVarToJVMIndexMap indexMap, BType retType, MethodVisitor mv) {
         BIRVariableDcl varDcl = func.localVars.get(0);
-        int returnVarRefIndex = indexMap.addToMapIfNotFoundAndGetIndex(varDcl);
+        int returnVarRefIndex = indexMap.addIfNotExists(varDcl.name.value, varDcl.type);
         genDefaultValue(mv, retType, returnVarRefIndex);
         return returnVarRefIndex;
     }
@@ -409,9 +403,7 @@ public class MethodGen {
     }
 
     private int getStateVarIndex(BIRVarToJVMIndexMap indexMap, MethodVisitor mv) {
-        BIRVariableDcl stateVar = new BIRVariableDcl(symbolTable.stringType, //should  be javaInt
-                                                     new Name(STATE), null, VarKind.TEMP);
-        int stateVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(stateVar);
+        int stateVarIndex = indexMap.addIfNotExists(STATE, symbolTable.stringType);
         mv.visitInsn(ICONST_0);
         mv.visitVarInsn(ISTORE, stateVarIndex);
         return stateVarIndex;
@@ -496,12 +488,12 @@ public class MethodGen {
     private void processTerminator(MethodVisitor mv, BIRFunction func, BIRPackage module, String funcName,
                                    BIRTerminator terminator) {
         JvmCodeGenUtil.generateDiagnosticPos(terminator.pos, mv);
-        if ((MethodGenUtils.isModuleInitFunction(module, func) || isModuleTestInitFunction(module, func)) &&
+        if ((MethodGenUtils.isModuleInitFunction(func) || isModuleTestInitFunction(func)) &&
                 terminator instanceof Return) {
             generateAnnotLoad(mv, module.typeDefs, JvmCodeGenUtil.getPackageName(module));
         }
         //set module start success to true for $_init class
-        if (isModuleStartFunction(module, funcName) && terminator.kind == InstructionKind.RETURN) {
+        if (isModuleStartFunction(funcName) && terminator.kind == InstructionKind.RETURN) {
             mv.visitInsn(ICONST_1);
             mv.visitFieldInsn(PUTSTATIC,
                               JvmCodeGenUtil.getModuleLevelClassName(module, MODULE_INIT_CLASS_NAME),
@@ -509,7 +501,7 @@ public class MethodGen {
         }
     }
 
-    private boolean isModuleTestInitFunction(BIRPackage module, BIRFunction func) {
+    private boolean isModuleTestInitFunction(BIRFunction func) {
         return func.name.value.equals(
                 MethodGenUtils
                         .encodeModuleSpecialFuncName(".<testinit>"));
@@ -546,7 +538,7 @@ public class MethodGen {
         JvmTypeGen.loadType(mv, typeDefinition.type);
     }
 
-    private boolean isModuleStartFunction(BIRPackage module, String functionName) {
+    private boolean isModuleStartFunction(String functionName) {
         return functionName
                 .equals(MethodGenUtils.encodeModuleSpecialFuncName(MethodGenUtils.START_FUNCTION_SUFFIX));
     }
@@ -568,8 +560,8 @@ public class MethodGen {
     private void generateFrameClassFieldLoad(List<BIRVariableDcl> localVars, MethodVisitor mv,
                                              BIRVarToJVMIndexMap indexMap, String frameName) {
         for (BIRVariableDcl localVar : localVars) {
-            int index = indexMap.addToMapIfNotFoundAndGetIndex(localVar);
             BType bType = localVar.type;
+            int index = indexMap.addIfNotExists(localVar.name.value, bType);
             mv.visitInsn(DUP);
 
             if (TypeTags.isIntegerTypeTag(bType.tag)) {
@@ -726,10 +718,10 @@ public class MethodGen {
     private void generateFrameClassFieldUpdate(List<BIRVariableDcl> localVars, MethodVisitor mv,
                                                BIRVarToJVMIndexMap indexMap, String frameName) {
         for (BIRVariableDcl localVar : localVars) {
-            int index = indexMap.addToMapIfNotFoundAndGetIndex(localVar);
+            BType bType = localVar.type;
+            int index = indexMap.addIfNotExists(localVar.name.value, bType);
             mv.visitInsn(DUP);
 
-            BType bType = localVar.type;
             if (TypeTags.isIntegerTypeTag(bType.tag)) {
                 mv.visitVarInsn(LLOAD, index);
                 mv.visitFieldInsn(PUTFIELD, frameName, localVar.name.value.replace("%", "_"), "J");
@@ -893,8 +885,7 @@ public class MethodGen {
     }
 
     private void generateGetFrame(BIRVarToJVMIndexMap indexMap, int localVarOffset, MethodVisitor mv) {
-        BIRVariableDcl frameVar = new BIRVariableDcl(symbolTable.stringType, new Name("frame"), null, VarKind.TEMP);
-        int frameVarIndex = indexMap.addToMapIfNotFoundAndGetIndex(frameVar);
+        int frameVarIndex = indexMap.addIfNotExists("frame", symbolTable.stringType);
         mv.visitVarInsn(ASTORE, frameVarIndex);
         mv.visitVarInsn(ALOAD, localVarOffset);
         mv.visitFieldInsn(GETFIELD, STRAND_CLASS, MethodGenUtils.FRAMES, "[Ljava/lang/Object;");
@@ -936,7 +927,8 @@ public class MethodGen {
             String metaVarName = localVar.metaVarName;
             if (isCompilerAddedVars(metaVarName)) {
                 mv.visitLocalVariable(metaVarName, getJVMTypeSign(localVar.type), null,
-                                      startLabel, endLabel, indexMap.addToMapIfNotFoundAndGetIndex(localVar));
+                                      startLabel, endLabel,
+                                      indexMap.addIfNotExists(localVar.name.value, localVar.type));
             }
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGenUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGenUtils.java
@@ -29,10 +29,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BServiceType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 
-import static org.objectweb.asm.Opcodes.ALOAD;
-import static org.objectweb.asm.Opcodes.ANEWARRAY;
 import static org.objectweb.asm.Opcodes.ARETURN;
-import static org.objectweb.asm.Opcodes.BIPUSH;
 import static org.objectweb.asm.Opcodes.GETSTATIC;
 import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_FUNCTION_POINTER;
@@ -59,25 +56,19 @@ public class MethodGenUtils {
 
     static boolean hasInitFunction(BIRNode.BIRPackage pkg) {
         for (BIRNode.BIRFunction func : pkg.functions) {
-            if (func != null && isModuleInitFunction(pkg, func)) {
+            if (func != null && isModuleInitFunction(func)) {
                 return true;
             }
         }
         return false;
     }
 
-    static boolean isModuleInitFunction(BIRNode.BIRPackage module, BIRNode.BIRFunction func) {
+    static boolean isModuleInitFunction(BIRNode.BIRFunction func) {
         return func.name.value.equals(encodeModuleSpecialFuncName(INIT_FUNCTION_SUFFIX));
     }
 
     static PackageID packageToModuleId(BIRNode.BIRPackage mod) {
         return new PackageID(mod.org, mod.name, mod.version);
-    }
-
-    static void genArgs(MethodVisitor mv, int schedulerVarIndex) {
-        mv.visitVarInsn(ALOAD, schedulerVarIndex);
-        mv.visitIntInsn(BIPUSH, 1);
-        mv.visitTypeInsn(ANEWARRAY, OBJECT);
     }
 
     static void submitToScheduler(MethodVisitor mv, String moduleClassName,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ModuleStopMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ModuleStopMethodGen.java
@@ -29,11 +29,8 @@ import org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.AsyncDataCollector;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.BIRVarToJVMIndexMap;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
-import org.wso2.ballerinalang.compiler.bir.model.VarKind;
-import org.wso2.ballerinalang.compiler.bir.model.VarScope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BNilType;
-import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.List;
 
@@ -81,26 +78,24 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.THROWABLE
  * @since 2.0.0
  */
 public class ModuleStopMethodGen {
+    public static final String SCHEDULER_VAR = "schedulerVar";
+    public static final String FUTURE_VAR = "futureVar";
+    public static final String ARR_VAR = "arrVar";
     private final SymbolTable symbolTable;
+    private final BIRVarToJVMIndexMap indexMap;
 
     public ModuleStopMethodGen(SymbolTable symbolTable) {
         this.symbolTable = symbolTable;
+        indexMap = new BIRVarToJVMIndexMap(1);
     }
 
     public void generateExecutionStopMethod(ClassWriter cw, String initClass, BIRNode.BIRPackage module,
-                                     List<PackageID> imprtMods, AsyncDataCollector asyncDataCollector) {
+                                            List<PackageID> imprtMods, AsyncDataCollector asyncDataCollector) {
         MethodVisitor mv = cw.visitMethod(Opcodes.ACC_PUBLIC + ACC_STATIC, MODULE_STOP,
                                           String.format("(L%s;)V", JvmConstants.LISTENER_REGISTRY_CLASS), null, null);
         mv.visitCode();
 
-        BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap(1);
-
-        BIRNode.BIRVariableDcl argsVar = new BIRNode.BIRVariableDcl(symbolTable.anyType, new Name("schedulerVar"),
-                                                                    VarScope.FUNCTION, VarKind.ARG);
-        int schedulerIndex = indexMap.addToMapIfNotFoundAndGetIndex(argsVar);
-        BIRNode.BIRVariableDcl futureVar = new BIRNode.BIRVariableDcl(symbolTable.anyType, new Name("futureVar"),
-                                                                      VarScope.FUNCTION, VarKind.ARG);
-        int futureIndex = indexMap.addToMapIfNotFoundAndGetIndex(futureVar);
+        int schedulerIndex = indexMap.addIfNotExists(SCHEDULER_VAR, symbolTable.anyType);
         // Create a scheduler. A new scheduler is used here, to make the stop function to not to
         // depend/wait on whatever is being running on the background. eg: a busy loop in the main.
         mv.visitTypeInsn(NEW, SCHEDULER);
@@ -114,18 +109,15 @@ public class ModuleStopMethodGen {
         String moduleInitClass = getModuleInitClassName(currentModId);
         String fullFuncName = MethodGenUtils.calculateLambdaStopFuncName(currentModId);
         String lambdaName = generateStopDynamicListenerLambdaBody(cw);
-        generateCallStopDynamicListenersLambda(mv, lambdaName, moduleInitClass, futureIndex, asyncDataCollector,
-                                               schedulerIndex, indexMap);
-        scheduleStopLambda(mv, initClass, fullFuncName, schedulerIndex, futureIndex, moduleInitClass,
-                           asyncDataCollector);
+        generateCallStopDynamicListenersLambda(mv, lambdaName, moduleInitClass, asyncDataCollector);
+        scheduleStopLambda(mv, initClass, fullFuncName, moduleInitClass, asyncDataCollector);
         int i = imprtMods.size() - 1;
         while (i >= 0) {
             PackageID id = imprtMods.get(i);
             i -= 1;
             fullFuncName = MethodGenUtils.calculateLambdaStopFuncName(id);
             moduleInitClass = getModuleInitClassName(id);
-            scheduleStopLambda(mv, initClass, fullFuncName, schedulerIndex, futureIndex, moduleInitClass,
-                               asyncDataCollector);
+            scheduleStopLambda(mv, initClass, fullFuncName, moduleInitClass, asyncDataCollector);
         }
         mv.visitInsn(RETURN);
         mv.visitMaxs(0, 0);
@@ -142,13 +134,10 @@ public class ModuleStopMethodGen {
     }
 
     private void generateCallStopDynamicListenersLambda(MethodVisitor mv, String lambdaName, String moduleInitClass,
-                                                        int futureIndex, AsyncDataCollector asyncDataCollector,
-                                                        int schedulerVarIndex, BIRVarToJVMIndexMap indexMap) {
-        BIRNode.BIRVariableDcl arrVar = new BIRNode.BIRVariableDcl(symbolTable.anyType, new Name("arrVar"),
-                                                                   VarScope.FUNCTION, VarKind.ARG);
-        int arrIndex = indexMap.addToMapIfNotFoundAndGetIndex(arrVar);
-        addListenerRegistryAsParameter(mv, schedulerVarIndex, arrIndex);
-        generateMethodBody(mv, moduleInitClass, lambdaName, futureIndex, asyncDataCollector, schedulerVarIndex);
+                                                        AsyncDataCollector asyncDataCollector) {
+        addListenerRegistryAsParameter(mv);
+        int futureIndex = indexMap.addIfNotExists(FUTURE_VAR, symbolTable.anyType);
+        generateMethodBody(mv, moduleInitClass, lambdaName, asyncDataCollector);
 
         // handle any runtime errors
         Label labelIf = new Label();
@@ -178,7 +167,8 @@ public class ModuleStopMethodGen {
         MethodGenUtils.visitReturn(mv);
     }
 
-    private void addListenerRegistryAsParameter(MethodVisitor mv, int schedulerIndex, int arrIndex) {
+    private void addListenerRegistryAsParameter(MethodVisitor mv) {
+        int arrIndex = indexMap.addIfNotExists(ARR_VAR, symbolTable.anyType);
         mv.visitIntInsn(BIPUSH, 2);
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
         mv.visitVarInsn(ASTORE, arrIndex);
@@ -186,25 +176,26 @@ public class ModuleStopMethodGen {
         mv.visitInsn(ICONST_1);
         mv.visitVarInsn(ALOAD, 0);
         mv.visitInsn(AASTORE);
-        mv.visitVarInsn(ALOAD, schedulerIndex);
+        mv.visitVarInsn(ALOAD, indexMap.get(SCHEDULER_VAR));
         mv.visitVarInsn(ALOAD, arrIndex);
     }
 
-    private void scheduleStopLambda(MethodVisitor mv, String initClass, String stopFuncName,
-                                    int schedulerIndex, int futureIndex, String moduleClass,
+    private void scheduleStopLambda(MethodVisitor mv, String initClass, String stopFuncName, String moduleClass,
                                     AsyncDataCollector asyncDataCollector) {
         Label labelIf = createIfLabel(mv, moduleClass);
-        MethodGenUtils.genArgs(mv, schedulerIndex);
+        mv.visitVarInsn(ALOAD, indexMap.get(SCHEDULER_VAR));
+        mv.visitIntInsn(BIPUSH, 1);
+        mv.visitTypeInsn(ANEWARRAY, OBJECT);
 
         // create FP value
-        generateMethodBody(mv, initClass, stopFuncName, futureIndex, asyncDataCollector, schedulerIndex);
+        generateMethodBody(mv, initClass, stopFuncName, asyncDataCollector);
 
         // handle any runtime errors
-        genHandleRuntimeErrors(mv, futureIndex, moduleClass, labelIf);
+        genHandleRuntimeErrors(mv, moduleClass, labelIf);
     }
 
-    private void generateMethodBody(MethodVisitor mv, String initClass, String stopFuncName, int futureIndex,
-                                    AsyncDataCollector asyncDataCollector, int schedulerIndex) {
+    private void generateMethodBody(MethodVisitor mv, String initClass, String stopFuncName,
+                                    AsyncDataCollector asyncDataCollector) {
         // create FP value
         JvmCodeGenUtil.createFunctionPointer(mv, initClass, stopFuncName);
 
@@ -212,6 +203,7 @@ public class ModuleStopMethodGen {
         mv.visitInsn(ACONST_NULL);
         JvmTypeGen.loadType(mv, new BNilType());
         MethodGenUtils.submitToScheduler(mv, initClass, "stop", asyncDataCollector);
+        int futureIndex = indexMap.get(FUTURE_VAR);
         mv.visitVarInsn(ASTORE, futureIndex);
 
         mv.visitVarInsn(ALOAD, futureIndex);
@@ -220,14 +212,15 @@ public class ModuleStopMethodGen {
         mv.visitIntInsn(BIPUSH, 100);
         mv.visitTypeInsn(ANEWARRAY, OBJECT);
         mv.visitFieldInsn(PUTFIELD, STRAND_CLASS, MethodGenUtils.FRAMES, String.format("[L%s;", OBJECT));
-
+        int schedulerIndex = indexMap.get(SCHEDULER_VAR);
         mv.visitVarInsn(ALOAD, schedulerIndex);
         mv.visitMethodInsn(INVOKEVIRTUAL, SCHEDULER, SCHEDULER_START_METHOD, "()V", false);
 
     }
 
 
-    private void genHandleRuntimeErrors(MethodVisitor mv, int futureIndex, String moduleClass, Label labelIf) {
+    private void genHandleRuntimeErrors(MethodVisitor mv, String moduleClass, Label labelIf) {
+        int futureIndex = indexMap.get(FUTURE_VAR);
         mv.visitVarInsn(ALOAD, futureIndex);
         mv.visitFieldInsn(GETFIELD, FUTURE_VALUE, PANIC_FIELD, String.format("L%s;", THROWABLE));
         mv.visitJumpInsn(IFNULL, labelIf);


### PR DESCRIPTION
# Purpose
> To refactor BIRVarToJVMIndexMap

## Approach
> The BIRVarToJVMIndexMap had used BIRNode.BIRVariableDcl as the input while only the type and the name are actually required. This refactors the class to only use these.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
