### PR TITLE
Add build options and fix source symbol filtering in semantic model

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -44,6 +44,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.COMPILED_SOURCE;
+import static org.ballerinalang.model.symbols.SymbolOrigin.SOURCE;
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.isFlagOn;
 
 /**
@@ -204,7 +205,8 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
             for (Map.Entry<Name, ScopeEntry> entry : this.packageSymbol.scope.entries.entrySet()) {
                 ScopeEntry scopeEntry = entry.getValue();
-                if (!isFlagOn(scopeEntry.symbol.flags, Flags.PUBLIC) || scopeEntry.symbol.origin != COMPILED_SOURCE) {
+                if (!isFlagOn(scopeEntry.symbol.flags, Flags.PUBLIC)
+                        || (scopeEntry.symbol.origin != COMPILED_SOURCE && scopeEntry.symbol.origin != SOURCE)) {
                     continue;
                 }
                 symbols.add(

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -21,6 +21,8 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.BuildOptions;
+import io.ballerina.projects.BuildOptionsBuilder;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
@@ -205,9 +207,9 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
             Path projectRoot = projectRoot(filePath);
             sourceRootToProject.remove(projectRoot);
             LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CLOSE.getName() +
-                                            "' {project: '" + projectRoot.toUri().toString() +
-                                            "' kind: '" + project.get().kind().name().toLowerCase(Locale.getDefault()) +
-                                            "'} removed}");
+                    "' {project: '" + projectRoot.toUri().toString() +
+                    "' kind: '" + project.get().kind().name().toLowerCase(Locale.getDefault()) +
+                    "'} removed}");
         }
     }
 
@@ -267,14 +269,15 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         ProjectKind projectKind = projectKindAndProjectRootPair.getLeft();
         Path projectRoot = projectKindAndProjectRootPair.getRight();
         Project project;
+        BuildOptions options = new BuildOptionsBuilder().offline(true).build();
         if (projectKind == ProjectKind.BUILD_PROJECT) {
-            project = BuildProject.load(projectRoot);
+            project = BuildProject.load(projectRoot, options);
         } else {
-            project = SingleFileProject.load(projectRoot);
+            project = SingleFileProject.load(projectRoot, options);
         }
         LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_OPEN.getName() +
-                                        "' {project: '" + projectRoot.toUri().toString() + "' kind: '" +
-                                        project.kind().name().toLowerCase(Locale.getDefault()) + "'} created}");
+                "' {project: '" + projectRoot.toUri().toString() + "' kind: '" +
+                project.kind().name().toLowerCase(Locale.getDefault()) + "'} created}");
         return project;
     }
 


### PR DESCRIPTION
## Purpose
1. With this, pass the offline build option to ballerina project loaders,
2. Fix issue with not picking the module symbols in semantic model when the module is within the same project

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
