### PR TITLE
Add supported platform header to central client get versions, Change home balo_cache to balo & Pass platform to getBaloName

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PullCommand.java
@@ -122,7 +122,7 @@ public class PullCommand implements BLauncherCmd {
         }
 
         Path packagePathInBaloCache = ProjectUtils.createAndGetHomeReposPath()
-                .resolve(ProjectConstants.BALO_CACHE_DIR_NAME).resolve(orgName).resolve(packageName);
+                .resolve(ProjectConstants.BALO_DIR_NAME).resolve(orgName).resolve(packageName);
         // create directory path in balo cache
         try {
             createDirectories(packagePathInBaloCache);

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateBaloTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/CreateBaloTask.java
@@ -64,7 +64,7 @@ public class CreateBaloTask implements Task {
                 project.currentPackage().packageOrg().toString(),
                 project.currentPackage().packageName().toString(),
                 project.currentPackage().packageVersion().toString(),
-                null);
+                JdkVersion.JAVA_11.code());
         try {
             PackageCompilation packageCompilation = project.currentPackage().getCompilation();
             jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JdkVersion.JAVA_11);

--- a/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
+++ b/cli/central-client/src/main/java/org/ballerinalang/central/client/CentralAPIClient.java
@@ -160,11 +160,12 @@ public class CentralAPIClient {
     /**
      * Get the package versions.
      *
-     * @param orgNamePath     The organization name of the package. (required)
-     * @param packageNamePath The name of the package. (required)
+     * @param orgNamePath       The organization name of the package. (required)
+     * @param packageNamePath   The name of the package. (required)
+     * @param supportedPlatform supported platform. (required)
      * @return PackageJsonSchema
      */
-    public List<String> getPackageVersions(String orgNamePath, String packageNamePath)
+    public List<String> getPackageVersions(String orgNamePath, String packageNamePath, String supportedPlatform)
             throws CentralClientException {
         initializeSsl();
         String url = PACKAGES + "/" + orgNamePath + "/" + packageNamePath;
@@ -172,6 +173,9 @@ public class CentralAPIClient {
         HttpURLConnection conn = createHttpUrlConnection(url);
         conn.setInstanceFollowRedirects(false);
         setRequestMethod(conn, Utils.RequestMethod.GET);
+
+        // Set headers
+        conn.setRequestProperty(BALLERINA_PLATFORM, supportedPlatform);
 
         // status code and meaning
         //// 200 - list of versions

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/FileSystemRepository.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.projects.internal.repositories;
 
+import io.ballerina.projects.JdkVersion;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageVersion;
 import io.ballerina.projects.Project;
@@ -84,7 +85,7 @@ public class FileSystemRepository implements PackageRepository {
         String orgName = resolutionRequest.orgName().value();
         String version = resolutionRequest.version().isPresent() ?
                 resolutionRequest.version().get().toString() : "0.0.0";
-        String baloName = ProjectUtils.getBaloName(orgName, packageName, version, null);
+        String baloName = ProjectUtils.getBaloName(orgName, packageName, version, JdkVersion.JAVA_11.code());
 
         Path baloPath = this.balo.resolve(orgName).resolve(packageName).resolve(version).resolve(baloName);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/repositories/RemotePackageRepository.java
@@ -107,8 +107,10 @@ public class RemotePackageRepository implements PackageRepository {
 
         List<PackageVersion> packageVersions = new ArrayList<>();
         try {
-            for (String version : this.client.getPackageVersions(orgName, packageName)) {
-                packageVersions.add(PackageVersion.from(version));
+            for (String supportedPlatform : SUPPORTED_PLATFORMS) {
+                for (String version : this.client.getPackageVersions(orgName, packageName, supportedPlatform)) {
+                    packageVersions.add(PackageVersion.from(version));
+                }
             }
         } catch (ConnectionErrorException e) {
             // ignore connect to remote repo failure

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -55,7 +55,6 @@ public class ProjectConstants {
     public static final String LIB_DIR = "lib";
 
     public static final String BALO_DIR_NAME = "balo";
-    public static final String BALO_CACHE_DIR_NAME = "balo_cache";
     public static final String BIR_CACHE_DIR_NAME = "bir_cache";
     public static final String JAR_CACHE_DIR_NAME = "jar_cache";
     public static final String JSON_CACHE_DIR_NAME = "json_cache";

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectUtils.java
@@ -18,6 +18,7 @@
 package io.ballerina.projects.util;
 
 import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.JdkVersion;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleName;
 import io.ballerina.projects.Package;
@@ -182,10 +183,9 @@ public class ProjectUtils {
 
     public static String getBaloName(PackageManifest pkgDesc) {
         return ProjectUtils.getBaloName(pkgDesc.org().toString(),
-                pkgDesc.name().toString(),
-                pkgDesc.version().toString(),
-                null
-        );
+                                        pkgDesc.name().toString(),
+                                        pkgDesc.version().toString(),
+                                        JdkVersion.JAVA_11.code());
     }
 
     public static String getBaloName(String org, String pkgName, String version, String platform) {

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
@@ -143,7 +143,8 @@ public class PackageResolutionTests {
         // package_missing_transitive_dep --> package_k --> package_z (this is missing)
         Path baloPath = RESOURCE_DIRECTORY.resolve("balos").resolve("missing_transitive_deps")
                 .resolve("samjs-package_k-any-1.0.0.balo");
-        BCompileUtil.copyBaloToDistRepository(baloPath, "samjs", "package_k", "1.0.0");
+        BCompileUtil.copyBaloToDistRepository(baloPath, "samjs", "package_k", "1.0.0",
+                                              JdkVersion.JAVA_11.code());
 
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_missing_transitive_dep");
         BuildProject buildProject = BuildProject.load(projectDirPath);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -102,7 +102,9 @@ public class BCompileUtil {
         }
 
         Path baloCachePath = baloCachePath(currentPackage.packageOrg().toString(),
-                currentPackage.packageName().toString(), currentPackage.packageVersion().toString());
+                                           currentPackage.packageName().toString(),
+                                           currentPackage.packageVersion().toString(),
+                                           jBallerinaBackend.targetPlatform().code());
         jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALO, baloCachePath);
 
         CompileResult compileResult = new CompileResult(currentPackage, jBallerinaBackend);
@@ -122,8 +124,9 @@ public class BCompileUtil {
     public static void copyBaloToDistRepository(Path srcPath,
                                                 String org,
                                                 String pkgName,
-                                                String version) throws IOException {
-        Path targetPath = baloCachePath(org, pkgName, version);
+                                                String version,
+                                                String platform) throws IOException {
+        Path targetPath = baloCachePath(org, pkgName, version, platform);
         Files.copy(srcPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
     }
 
@@ -151,7 +154,8 @@ public class BCompileUtil {
 
     private static Path baloCachePath(String org,
                                       String pkgName,
-                                      String version) {
+                                      String version,
+                                      String platform) {
         try {
             Path distributionCache = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
             Path baloDirPath = distributionCache.resolve("balo")
@@ -159,7 +163,7 @@ public class BCompileUtil {
                     .resolve(pkgName)
                     .resolve(version);
             Files.createDirectories(baloDirPath);
-            String baloFileName = ProjectUtils.getBaloName(org, pkgName, version, null);
+            String baloFileName = ProjectUtils.getBaloName(org, pkgName, version, platform);
             return baloDirPath.resolve(baloFileName);
         } catch (IOException e) {
             throw new RuntimeException("error while creating the balo distribution cache directory at " +


### PR DESCRIPTION
## Purpose
> Added supported platform header to central client get versions resource
Change user cache `balo_cache` directory to `balo`
Pass platfrom (java11) to `getBaloName` method

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
