### PR TITLE
Update file list created by init new commands and improve cli messages

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/CommandUtil.java
@@ -58,7 +58,6 @@ public class CommandUtil {
     public static final String GITIGNORE = "gitignore";
     public static final String NEW_CMD_DEFAULTS = "new_cmd_defaults";
     public static final String CREATE_CMD_TEMPLATES = "create_cmd_templates";
-    public static final String PACKAGE_MD_DEFAULTS = "package_md_defaults";
     private static FileSystem jarFs;
     private static Map<String, String> env;
 
@@ -125,15 +124,8 @@ public class CommandUtil {
             URISyntaxException {
         // We will be creating following in the project directory
         // - Ballerina.toml
-        // - Package.md
-        // - Module.md
         // - main.bal
-        // - resources
-        // - tests
-        //      - main_test.bal
-        //      - resources/
         // - .gitignore       <- git ignore file
-        String templateMD = template + "_template.md";
         initProject(path, packageName);
         applyTemplate(path, template);
         if (template.equalsIgnoreCase("lib")) {
@@ -142,16 +134,9 @@ public class CommandUtil {
                     StandardCopyOption.REPLACE_EXISTING);
         }
         Path gitignore = path.resolve(ProjectConstants.GITIGNORE_FILE_NAME);
-        Path packageMD = path.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME);
-
         Files.createFile(gitignore);
-        Files.createFile(packageMD);
-
         String defaultGitignore = FileUtils.readFileAsString(NEW_CMD_DEFAULTS + "/" + GITIGNORE);
-        String defaultPackageMD = FileUtils.readFileAsString(PACKAGE_MD_DEFAULTS + "/" + templateMD);
-
         Files.write(gitignore, defaultGitignore.getBytes(StandardCharsets.UTF_8));
-        Files.write(packageMD, defaultPackageMD.getBytes(StandardCharsets.UTF_8));
     }
 
     /**

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/InitCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/InitCommand.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static io.ballerina.cli.cmd.Constants.INIT_COMMAND;
+import static io.ballerina.projects.util.ProjectUtils.guessPkgName;
 
 
 /**
@@ -150,7 +151,7 @@ public class InitCommand implements BLauncherCmd {
             errStream.println("error: Error occurred while initializing project : " + e.getMessage());
             return;
         }
-        errStream.println("Ballerina project initialised ");
+        errStream.println("Created new Ballerina package '" + guessPkgName(packageName) + "'.");
         errStream.println();
     }
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/NewCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/NewCommand.java
@@ -33,6 +33,7 @@ import java.nio.file.Paths;
 import java.util.List;
 
 import static io.ballerina.cli.cmd.Constants.NEW_COMMAND;
+import static io.ballerina.projects.util.ProjectUtils.guessPkgName;
 
 /**
  * New command for creating a ballerina project.
@@ -151,11 +152,9 @@ public class NewCommand implements BLauncherCmd {
             errStream.println("error: Error occurred while creating project : " + e.getMessage());
             return;
         }
-        errStream.println("Created new Ballerina project at " + userDir.relativize(path));
+        errStream.println("Created new Ballerina package '" + guessPkgName(packageName)
+                + "' at " + userDir.relativize(path) + ".");
         errStream.println();
-        errStream.println("Next:");
-        errStream.println("    Move into the project directory and use `ballerina add <module-name>` to");
-        errStream.println("    add a new Ballerina module.");
     }
 
     @Override

--- a/cli/ballerina-cli/src/main/resources/create_cmd_templates/lib/lib.bal
+++ b/cli/ballerina-cli/src/main/resources/create_cmd_templates/lib/lib.bal
@@ -1,7 +1,5 @@
 import ballerina/io;
 
-# Prints `Hello World`.
-
 public function hello() {
     io:println("Hello World!");
 }

--- a/cli/ballerina-cli/src/main/resources/create_cmd_templates/main/main.bal
+++ b/cli/ballerina-cli/src/main/resources/create_cmd_templates/main/main.bal
@@ -1,7 +1,5 @@
 import ballerina/io;
 
-# Prints `Hello World`.
-
 public function main() {
     io:println("Hello World!");
 }

--- a/cli/ballerina-cli/src/main/resources/new_cmd_defaults/manifest.toml
+++ b/cli/ballerina-cli/src/main/resources/new_cmd_defaults/manifest.toml
@@ -1,7 +1,7 @@
 [package]
-org= "ORG_NAME"
-name= "PKG_NAME"
-version= "0.1.0"
+org = "ORG_NAME"
+name = "PKG_NAME"
+version = "0.1.0"
 
 [build-options]
-observabilityIncluded=true
+observabilityIncluded = true

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/InitCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/InitCommandTest.java
@@ -55,7 +55,7 @@ public class InitCommandTest extends BaseCommandTest {
         Path resourcePath = projectPath.resolve(ProjectConstants.RESOURCE_DIR_NAME);
         Assert.assertFalse(Files.exists(resourcePath));
 
-        Assert.assertTrue(readOutput().contains("Ballerina project initialised "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test init command with main template")
@@ -84,7 +84,7 @@ public class InitCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
         Assert.assertTrue(Files.exists(packageDir.resolve("main.bal")));
 
-        Assert.assertTrue(readOutput().contains("Ballerina project initialised "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test init command with service template")
@@ -111,10 +111,9 @@ public class InitCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
         Assert.assertTrue(Files.isDirectory(packageDir));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve("service.bal")));
 
-        Assert.assertTrue(readOutput().contains("Ballerina project initialised "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test init command with lib template")
@@ -141,10 +140,9 @@ public class InitCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
         Assert.assertTrue(Files.isDirectory(packageDir));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve("myproject.bal")));
 
-        Assert.assertTrue(readOutput().contains("Ballerina project initialised "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test init command with invalid template")

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/NewCommandTest.java
@@ -60,7 +60,7 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
         Assert.assertTrue(Files.exists(packageDir.resolve("main.bal")));
 
-        Assert.assertTrue(readOutput().contains("Created new Ballerina project at "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test new command with main template")
@@ -79,7 +79,7 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
         Assert.assertTrue(Files.exists(packageDir.resolve("main.bal")));
 
-        Assert.assertTrue(readOutput().contains("Created new Ballerina project at "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test new command with service template")
@@ -105,10 +105,9 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
         Assert.assertTrue(Files.isDirectory(packageDir));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve("service.bal")));
 
-        Assert.assertTrue(readOutput().contains("Created new Ballerina project at "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test new command with lib template")
@@ -134,10 +133,9 @@ public class NewCommandTest extends BaseCommandTest {
         Assert.assertTrue(Files.exists(packageDir));
         Assert.assertTrue(Files.isDirectory(packageDir));
         Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.BALLERINA_TOML)));
-        Assert.assertTrue(Files.exists(packageDir.resolve(ProjectConstants.PACKAGE_MD_FILE_NAME)));
         Assert.assertTrue(Files.exists(packageDir.resolve("lib_sample.bal")));
 
-        Assert.assertTrue(readOutput().contains("Created new Ballerina project at "));
+        Assert.assertTrue(readOutput().contains("Created new Ballerina package"));
     }
 
     @Test(description = "Test new command with invalid project name", dataProvider = "invalidProjectNames")


### PR DESCRIPTION
## Purpose
> Update file list created by init new commands and improve cli messages

This contains the following changes:

- New command message example: Created new Ballerina package 'test_foo' at test-foo.
- Init command message example : Created new Ballerina package 'test_foo'.
- Formatting in Ballerina.toml
- Removed Package.md from new and init commands
- Removed the comment from helloworld bal templates

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
