### PR TITLE
Change exception handling behavior to throw an exception when writing JSON to Jar fails

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -511,14 +511,16 @@ public class JBallerinaBackend extends CompilerBackend {
             assembleExecutableJar(executableFilePath, manifest, jarLibraryPaths);
 
             // TODO: Move to a compiler extension once Compiler revamp is complete
-            ObservabilitySymbolCollector observabilitySymbolCollector
-                    = ObserverbilitySymbolCollectorRunner.getInstance(compilerContext);
-            for (ModuleId moduleId : packageContext.moduleIds()) {
-                ModuleContext moduleContext = packageContext.moduleContext(moduleId);
-                BLangPackage bLangPackage = moduleContext.bLangPackage();
-                observabilitySymbolCollector.process(bLangPackage);
+            if (packageContext.compilationOptions().observabilityIncluded()) {
+                ObservabilitySymbolCollector observabilitySymbolCollector
+                        = ObserverbilitySymbolCollectorRunner.getInstance(compilerContext);
+                for (ModuleId moduleId : packageContext.moduleIds()) {
+                    ModuleContext moduleContext = packageContext.moduleContext(moduleId);
+                    BLangPackage bLangPackage = moduleContext.bLangPackage();
+                    observabilitySymbolCollector.process(bLangPackage);
+                }
+                observabilitySymbolCollector.writeCollectedSymbols(executableFilePath);
             }
-            observabilitySymbolCollector.writeCollectedSymbols(executableFilePath);
         } catch (IOException e) {
             throw new ProjectException("error while creating the executable jar file for package: " +
                     this.packageContext.packageName(), e);

--- a/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
+++ b/misc/observerability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.observability.anaylze;
 
 import com.google.gson.JsonElement;
+import io.ballerina.projects.ProjectException;
 import org.ballerinalang.langserver.compiler.common.modal.SymbolMetaInfo;
 import org.ballerinalang.langserver.compiler.format.JSONGenerationException;
 import org.ballerinalang.langserver.compiler.format.TextDocumentFormatUtil;
@@ -151,7 +152,7 @@ public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolC
             JsonElement jsonAST = TextDocumentFormatUtil.generateJSON(cUnit, new HashMap<>(), visibleEPsByNode);
             cUnitASTHolder.setAst(jsonAST);
         } catch (JSONGenerationException e) {
-            out.println("ballerina: error while generating json AST for " + cUnit.name + ". " + e.getMessage());
+            throw new ProjectException("failed to generate json AST for " + cUnit.name, e);
         }
         return cUnitASTHolder;
     }


### PR DESCRIPTION
## Purpose
> Change exception handling behavior to throw an exception when writing JSON to Jar fails. Currently this causes a Null Pointer exception at a later time.

## Approach
> Change exception handling behavior to throw an exception when writing JSON to Jar fails. Currently this causes a Null Pointer exception at a later time.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
