### PR TITLE
Make the inbound response length limits configurable

### DIFF
--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -38,7 +38,7 @@ dependencies {
     dist 'org.wso2.carbon:org.wso2.carbon.core:5.1.0'
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'
     dist 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
-    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.15'
+    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.17'
     dist 'org.bouncycastle:bcprov-jdk15on:1.61'
     dist 'org.bouncycastle:bcpkix-jdk15on:1.61'
 

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -96,7 +96,7 @@ dependencies {
         implementation 'org.wso2.carbon.messaging:org.wso2.carbon.messaging:2.3.7'
         implementation 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'
         implementation 'org.wso2.orbit.org.yaml:snakeyaml:1.26.0.wso2v1'
-        implementation 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.15'
+        implementation 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.17'
         implementation 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
         implementation 'org.wso2.staxon:staxon-core:1.2.0.wso2v2'
         implementation 'org.quartz-scheduler:quartz:2.3.1'

--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -21,8 +21,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.15"
-    path = "./lib/org.wso2.transport.http.netty-6.3.15.jar"
+    version = "6.3.17"
+    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
     groupId = "org.wso2.transport.http"
     modules = ["grpc"]
 

--- a/stdlib/http/src/main/ballerina/Ballerina.toml
+++ b/stdlib/http/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.15"
-    path = "./lib/org.wso2.transport.http.netty-6.3.15.jar"
+    version = "6.3.17"
+    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
     groupId = "org.wso2.transport.http"
     modules = ["http"]
 

--- a/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
@@ -260,10 +260,18 @@ public type ClientConfiguration record {|
 # + keepAlive - Specifies whether to reuse a connection for multiple requests
 # + chunking - The chunking behaviour of the request
 # + proxy - Proxy server related options
+# + maxStatusLineLength - Maximum allowed length for response status line(`HTTP/1.0 200 OK`). Exceeding this limit will
+#                          result in an error response
+# + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in an error response
+# + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there is no
+#                       restriction `maxEntityBodySize`, On the Exceeding this limit will result in an error response
 public type ClientHttp1Settings record {|
     KeepAlive keepAlive = KEEPALIVE_AUTO;
     Chunking chunking = CHUNKING_AUTO;
     ProxyConfig? proxy = ();
+    int maxStatusLineLength = 4096;
+    int maxHeaderSize = 8192;
+    int maxEntityBodySize = -1;
 |};
 
 function createSimpleHttpClient(HttpClient caller, PoolConfiguration globalPoolConfig) = @java:Method {

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -224,7 +224,7 @@ public type ListenerConfiguration record {|
 # + maxUriLength - Maximum allowed length for a URI. Exceeding this limit will result in a
 #                  `414 - URI Too Long` response.
 # + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in a
-#                   `413 - Payload Too Large` response.
+#                   `431 - Request Header Fields Too Large` response.
 # + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there
 #                       is no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a
 #                       `413 - Payload Too Large` response.

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -316,9 +316,10 @@ public class HttpConstants {
     public static final String ENDPOINT_CONFIG_CHUNKING = "chunking";
     public static final String ENDPOINT_CONFIG_VERSION = "httpVersion";
     public static final String ENDPOINT_REQUEST_LIMITS = "requestLimits";
-    public static final String REQUEST_LIMITS_MAXIMUM_URL_LENGTH = "maxUriLength";
-    public static final String REQUEST_LIMITS_MAXIMUM_HEADER_SIZE = "maxHeaderSize";
-    public static final String REQUEST_LIMITS_MAXIMUM_ENTITY_BODY_SIZE = "maxEntityBodySize";
+    public static final String MAX_URI_LENGTH = "maxUriLength";
+    public static final String MAX_STATUS_LINE_LENGTH = "maxStatusLineLength";
+    public static final String MAX_HEADER_SIZE = "maxHeaderSize";
+    public static final String MAX_ENTITY_BODY_SIZE = "maxEntityBodySize";
     public static final String ENDPOINT_CONFIG_PIPELINING = "pipelining";
     public static final String ENABLE_PIPELINING = "enable";
     public static final String PIPELINING_REQUEST_LIMIT = "maxPipelinedRequests";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -1530,7 +1530,8 @@ public class HttpUtil {
         return listenerConfiguration;
     }
 
-    public static void setInboundMgsSizeValidationConfig(long maxInitialLineLength, long maxHeaderSize, long maxEntityBodySize,
+    public static void setInboundMgsSizeValidationConfig(long maxInitialLineLength, long maxHeaderSize,
+                                                         long maxEntityBodySize,
                                                          InboundMsgSizeValidationConfig sizeValidationConfig) {
         if (maxInitialLineLength >= 0) {
             sizeValidationConfig.setMaxInitialLineLength(Math.toIntExact(maxInitialLineLength));

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -71,11 +71,11 @@ import org.wso2.transport.http.netty.contract.HttpResponseFuture;
 import org.wso2.transport.http.netty.contract.HttpWsConnectorFactory;
 import org.wso2.transport.http.netty.contract.config.ChunkConfig;
 import org.wso2.transport.http.netty.contract.config.ForwardedExtensionConfig;
+import org.wso2.transport.http.netty.contract.config.InboundMsgSizeValidationConfig;
 import org.wso2.transport.http.netty.contract.config.KeepAliveConfig;
 import org.wso2.transport.http.netty.contract.config.ListenerConfiguration;
 import org.wso2.transport.http.netty.contract.config.Parameter;
 import org.wso2.transport.http.netty.contract.config.ProxyServerConfiguration;
-import org.wso2.transport.http.netty.contract.config.RequestSizeValidationConfig;
 import org.wso2.transport.http.netty.contract.config.SenderConfiguration;
 import org.wso2.transport.http.netty.contract.config.SslConfiguration;
 import org.wso2.transport.http.netty.contract.exceptions.ClientConnectorException;
@@ -516,7 +516,7 @@ public class HttpUtil {
                                      IO_PACKAGE_ID, DETAIL_RECORD_TYPE_NAME);
             return createHttpError("Something wrong with the connection", HttpErrorType.GENERIC_CLIENT_ERROR, cause);
         } else {
-            return createHttpError(throwable.getMessage());
+            return createHttpError(throwable.getMessage(), HttpErrorType.GENERIC_CLIENT_ERROR);
         }
     }
 
@@ -761,8 +761,9 @@ public class HttpUtil {
         inboundResponse.addNativeData(TRANSPORT_MESSAGE, inboundResponseMsg);
         int statusCode = inboundResponseMsg.getHttpStatusCode();
         inboundResponse.set(RESPONSE_STATUS_CODE_FIELD, (long) statusCode);
-        inboundResponse.set(RESPONSE_REASON_PHRASE_FIELD,
-                HttpResponseStatus.valueOf(statusCode).reasonPhrase());
+
+        String reasonPhrase = inboundResponseMsg.getReasonPhrase();
+        inboundResponse.set(RESPONSE_REASON_PHRASE_FIELD, reasonPhrase);
 
         if (inboundResponseMsg.getHeader(HttpHeaderNames.SERVER.toString()) != null) {
             inboundResponse.set(HttpConstants.RESPONSE_SERVER_FIELD,
@@ -1479,7 +1480,11 @@ public class HttpUtil {
             String keepAlive = http1Settings.getStringValue(HttpConstants.ENDPOINT_CONFIG_KEEP_ALIVE);
             listenerConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAlive));
             // Set Request validation limits.
-            setRequestSizeValidationConfig(http1Settings, listenerConfiguration);
+            setInboundMgsSizeValidationConfig(
+                    http1Settings.getIntValue(HttpConstants.MAX_URI_LENGTH),
+                    http1Settings.getIntValue(HttpConstants.MAX_HEADER_SIZE),
+                    http1Settings.getIntValue(HttpConstants.MAX_ENTITY_BODY_SIZE),
+                    listenerConfiguration.getMsgSizeValidationConfig());
         }
 
         if (host == null || host.trim().isEmpty()) {
@@ -1525,29 +1530,24 @@ public class HttpUtil {
         return listenerConfiguration;
     }
 
-    private static void setRequestSizeValidationConfig(MapValue http1Settings,
-                                                     ListenerConfiguration listenerConfiguration) {
-        long maxUriLength = http1Settings.getIntValue(HttpConstants.REQUEST_LIMITS_MAXIMUM_URL_LENGTH);
-        long maxHeaderSize = http1Settings.getIntValue(HttpConstants.REQUEST_LIMITS_MAXIMUM_HEADER_SIZE);
-        long maxEntityBodySize = http1Settings.getIntValue(HttpConstants.REQUEST_LIMITS_MAXIMUM_ENTITY_BODY_SIZE);
-        RequestSizeValidationConfig requestSizeValidationConfig = listenerConfiguration
-                .getRequestSizeValidationConfig();
-
-        if (maxUriLength >= 0) {
-            requestSizeValidationConfig.setMaxUriLength(Math.toIntExact(maxUriLength));
+    public static void setInboundMgsSizeValidationConfig(long maxInitialLineLength, long maxHeaderSize, long maxEntityBodySize,
+                                                         InboundMsgSizeValidationConfig sizeValidationConfig) {
+        if (maxInitialLineLength >= 0) {
+            sizeValidationConfig.setMaxInitialLineLength(Math.toIntExact(maxInitialLineLength));
         } else {
-            throw new BallerinaConnectorException("Invalid configuration found for maxUriLength : " + maxUriLength);
+            throw new BallerinaConnectorException(
+                    "Invalid configuration found for max initial line length : " + maxInitialLineLength);
         }
 
         if (maxHeaderSize >= 0) {
-            requestSizeValidationConfig.setMaxHeaderSize(Math.toIntExact(maxHeaderSize));
+            sizeValidationConfig.setMaxHeaderSize(Math.toIntExact(maxHeaderSize));
         } else {
             throw new BallerinaConnectorException("Invalid configuration found for maxHeaderSize : " + maxHeaderSize);
         }
 
         if (maxEntityBodySize != -1) {
             if (maxEntityBodySize >= 0) {
-                requestSizeValidationConfig.setMaxEntityBodySize(maxEntityBodySize);
+                sizeValidationConfig.setMaxEntityBodySize(maxEntityBodySize);
             } else {
                 throw new BallerinaConnectorException(
                         "Invalid configuration found for maxEntityBodySize : " + maxEntityBodySize);

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -86,6 +86,12 @@ public class CreateSimpleHttpClient {
             senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
             String keepAliveConfig = http1Settings.getStringValue(HttpConstants.CLIENT_EP_IS_KEEP_ALIVE);
             senderConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAliveConfig));
+            // Set Response validation limits.
+            HttpUtil.setInboundMgsSizeValidationConfig(
+                    http1Settings.getIntValue(HttpConstants.MAX_STATUS_LINE_LENGTH),
+                    http1Settings.getIntValue(HttpConstants.MAX_HEADER_SIZE),
+                    http1Settings.getIntValue(HttpConstants.MAX_ENTITY_BODY_SIZE),
+                    senderConfiguration.getMsgSizeValidationConfig());
         }
         try {
             populateSenderConfigurations(senderConfiguration, clientEndpointConfig, scheme);

--- a/stdlib/mime/src/main/ballerina/Ballerina.toml
+++ b/stdlib/mime/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.15"
-    path = "./lib/org.wso2.transport.http.netty-6.3.15.jar"
+    version = "6.3.17"
+    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
     groupId = "org.wso2.transport.http"
     modules = ["mime"]
 

--- a/stdlib/websub/src/main/ballerina/Ballerina.toml
+++ b/stdlib/websub/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.15"
-    path = "./lib/org.wso2.transport.http.netty-6.3.15.jar"
+    version = "6.3.17"
+    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
     groupId = "org.wso2.transport.http"
     modules = ["web-sub"]
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -40,7 +40,7 @@ public class HttpBaseTest extends BaseTest {
                 9102, 9103, 9104, 9105, 9106, 9107, 9108, 9109, 9110, 9111, 9112, 9113, 9114, 9115, 9116, 9117, 9118,
                 9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225, 9226, 9227, 9228, 9229, 9230, 9231, 9232, 9233,
                 9234, 9235, 9236, 9237, 9238, 9239, 9240, 9241, 9242, 9243, 9244, 9245, 9246, 9247, 9248, 9249, 9250,
-                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260};
+                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260, 9261, 9262, 9263, 9264 };
         String balFile = Paths.get("src", "test", "resources", "http").toAbsolutePath().toString();
         String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
                                                                    "private.key").toAbsolutePath().toString());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/RequestLimitsConfigurationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/RequestLimitsConfigurationTest.java
@@ -81,7 +81,7 @@ public class RequestLimitsConfigurationTest extends HttpBaseTest {
 
     @Test(description = "Tests the behaviour when header size is greater than the configured threshold")
     public void testInvalidHeaderLength() {
-        String expectedMessage = "413 Request Entity Too Large";
+        String expectedMessage = "431 Request Header Fields Too Large";
         HttpClient httpClient = new HttpClient(TEST_HOST, 9236);
         FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
                                             "/lowRequestHeaderLimit/invalidHeaderSize");

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/ResponseLimitsConfigurationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/ResponseLimitsConfigurationTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.test.service.http.configuration;
+
+import org.ballerinalang.test.service.http.HttpBaseTest;
+import org.ballerinalang.test.util.HttpClientRequest;
+import org.ballerinalang.test.util.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test case for services with inbound response Limit configurations.
+ *
+ * @since 1.2.11
+ */
+@Test(groups = "http-test")
+public class ResponseLimitsConfigurationTest extends HttpBaseTest {
+
+    private static final String X_TEST_TYPE = "x-test-type";
+    private static final String ERROR = "error";
+    private static final String SUCCESS = "success";
+
+    @Test(description = "Test when status line length is less than the configured maxStatusLineLength threshold")
+    public void testValidStatusLineLength() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, SUCCESS);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/statusline"), headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "Hello World!!!", "Message content mismatched");
+        Assert.assertEquals(response.getResponseMessage(), "HELLO", "Phrase content mismatched");
+    }
+
+    @Test(description = "Test when status line length is greater than the configured maxStatusLineLength threshold")
+    public void testInvalidStatusLineLength() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, ERROR);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/statusline"), headers);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "error {ballerina/http}GenericClientError message=Response max " +
+                "status line length exceeds: An HTTP line is larger than 1024 bytes.", "Message content mismatched");
+    }
+
+    @Test(description = "Test when header size is less than the configured maxHeaderSize threshold")
+    public void testValidHeaderLength() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, SUCCESS);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/header"), headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "Hello World!!!", "Message content mismatched");
+        Assert.assertEquals(response.getHeaders().get("x-header"), "Validated", "Header content mismatched");
+    }
+
+    @Test(description = "Test when header size is greater than the configured maxHeaderSize threshold")
+    public void testInvalidHeaderLength() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, ERROR);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261,"responseLimit/header"), headers);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "error {ballerina/http}GenericClientError message=Response max " +
+                "header size exceeds: HTTP header is larger than 1024 bytes.", "Header content mismatched");
+        Assert.assertNull(response.getHeaders().get("x-header"), "Message content mismatched");
+    }
+
+    @Test(description = "Test when entityBody size is less than the configured maxEntityBodySize threshold")
+    public void testValidEntityBodyLength() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, SUCCESS);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/entitybody"), headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "Small payload", "Message content mismatched");
+    }
+
+    @Test(description = "Test when entityBody size is greater than the configured maxEntityBodySize threshold")
+    public void testInvalidEntityBodyLength() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, ERROR);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/entitybody"), headers);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "error {ballerina/http}GenericClientError message=Response max " +
+                                    "entity body size exceeds: Entity body is larger than 1024 bytes. ",
+                            "Message content mismatched");
+    }
+}

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/ResponseLimitsConfigurationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/ResponseLimitsConfigurationTest.java
@@ -78,7 +78,7 @@ public class ResponseLimitsConfigurationTest extends HttpBaseTest {
         Map<String, String> headers = new HashMap<>();
         headers.put(X_TEST_TYPE, ERROR);
         HttpResponse response = HttpClientRequest.doGet(
-                serverInstance.getServiceURLHttp(9261,"responseLimit/header"), headers);
+                serverInstance.getServiceURLHttp(9261, "responseLimit/header"), headers);
         Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
         Assert.assertEquals(response.getData(), "error {ballerina/http}GenericClientError message=Response max " +
                 "header size exceeds: HTTP header is larger than 1024 bytes.", "Header content mismatched");

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/48_inbound_response_limits.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/48_inbound_response_limits.bal
@@ -1,0 +1,135 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/http;
+import ballerina/log;
+
+http:ClientConfiguration statusLineLimitConfig = {
+    http1Settings: {
+        maxStatusLineLength: 1024
+    }
+};
+
+http:ClientConfiguration headerLimitConfig = {
+    http1Settings: {
+        maxHeaderSize: 1024
+    }
+};
+
+http:ClientConfiguration  entityBodyLimitConfig = {
+    http1Settings: {
+        maxEntityBodySize: 1024
+    }
+};
+
+http:Client statusLimitClient = new("http://localhost:9262/backend/statustest", statusLineLimitConfig);
+http:Client headerLimitClient = new("http://localhost:9263/backend/headertest", headerLimitConfig);
+http:Client entityBodyLimitClient = new("http://localhost:9264/backend/entitybodytest", entityBodyLimitConfig);
+
+
+@http:ServiceConfig {basePath:"/responseLimit"}
+service passthruLimitService on new http:Listener(9261) {
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/{clientType}"
+    }
+    resource function testStatusline(http:Caller caller, http:Request req, string clientType) {
+        http:Client clientEP = entityBodyLimitClient;
+        if (clientType == "statusline") {
+            clientEP = statusLimitClient;
+        } else if (clientType == "header") {
+            clientEP = headerLimitClient;
+        }
+
+        var clientResponse = clientEP->forward("/", <@untainted>req);
+        if (clientResponse is http:Response) {
+            var result = caller->respond(<@untainted>clientResponse);
+            if (result is error) {
+                log:printError("Error sending passthru response", result);
+            }
+        } else {
+            http:Response res = new;
+            res.statusCode = 500;
+            res.setPayload(clientResponse.toString());
+            var result = caller->respond(res);
+            if (result is error) {
+                log:printError("Error sending error response", result);
+            }
+        }
+    }
+}
+
+@http:ServiceConfig {basePath:"/backend"}
+service statusBackendService on new http:Listener(9262) {
+
+    resource function statustest(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        string testType = req.getHeader("x-test-type");
+        if (testType == "error") {
+            res.reasonPhrase = getStringLengthOf(1200);
+        } else {
+            res.reasonPhrase = "HELLO";
+        }
+        res.setTextPayload("Hello World!!!");
+        sendResponse(caller, res);
+    }
+
+}
+@http:ServiceConfig {basePath:"/backend"}
+service headertBackendService on new http:Listener(9263) {
+    resource function headertest(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        string testType = req.getHeader("x-test-type");
+        if (testType == "error") {
+            res.setHeader("x-header", getStringLengthOf(2048));
+        } else {
+            res.setHeader("x-header", "Validated");
+        }
+        res.setTextPayload("Hello World!!!");
+        sendResponse(caller, res);
+    }
+}
+@http:ServiceConfig {basePath:"/backend"}
+service entitybodyBackendService on new http:Listener(9264) {
+    resource function entitybodytest(http:Caller caller, http:Request req) {
+        http:Response res = new;
+        string testType = req.getHeader("x-test-type");
+        if (testType == "error") {
+            res.setTextPayload(getStringLengthOf(2048));
+        } else {
+            res.setTextPayload("Small payload");
+        }
+        sendResponse(caller, res);
+    }
+}
+
+function getStringLengthOf(int length) returns string {
+    string builder = "";
+    int i = 0;
+    while (i < length) {
+        builder = builder + "a";
+        i = i + 1;
+    }
+    return builder;
+}
+
+function sendResponse(http:Caller caller, http:Response res) {
+    var result = caller->respond(res);
+    if (result is error) {
+        log:printError("Error sending backend response", result);
+    }
+}

--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -37,6 +37,7 @@
             <class name="org.ballerinalang.test.service.http.HttpBaseTest"/>
             <class name="org.ballerinalang.test.service.http.configuration.AcceptEncodingHeaderTestCase"/>
             <class name="org.ballerinalang.test.service.http.configuration.RequestLimitsConfigurationTest"/>
+            <class name="org.ballerinalang.test.service.http.configuration.ResponseLimitsConfigurationTest"/>
             <class name="org.ballerinalang.test.service.http.sample.HttpHeaderTestCases"/>
             <class name="org.ballerinalang.test.service.http.sample.RedirectTestCase"/>
             <class name="org.ballerinalang.test.service.http.sample.RoutingServiceSampleTestCase"/>


### PR DESCRIPTION
## Purpose
> Add response status line, header, and entity body validation configs
```ballerina
public type ClientHttp1Settings record {|
    //...
    int maxStatusLineLength = 4096;
    int maxHeaderSize = 8192;
    int maxEntityBodySize = -1;
|};
```
> Change inbound request header length validation error status code to `431 Request Header Fields Too Large`

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/27251

## Approach
> Override Client codec with input values and plug validation handers to channel pipeline

## Samples
```ballerina
http:Client clientEP = new ("http://localhost:9092/hello", config = {
    http1Settings : {
        maxStatusLineLength : 1024,
        maxHeaderSize : 4096,
        maxEntityBodySize: 8192
        }
    }
);
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
