### PR TITLE
Add string-literal parsing support in service-decl

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -6708,7 +6708,7 @@ public class BallerinaParser extends AbstractParser {
      * Parse service declaration.
      * <p>
      * <code>
-     * service-decl := metadata `service` [type-descriptor] [absolute-resource-path]
+     * service-decl := metadata `service` [type-descriptor] [absolute-resource-path | string-literal]
      * `on` expression-list object-constructor-block
      * <br/>
      * absolute-resource-path := "/" | ("/" identifier)+
@@ -6725,7 +6725,7 @@ public class BallerinaParser extends AbstractParser {
      * @return Parsed node
      */
     private STNode parseServiceDecl(STNode metadata, STNode qualNodeList, STNode serviceKeyword, STNode serviceType) {
-        STNode resourcePath = parseOptionalAbsolutePath();
+        STNode resourcePath = parseOptionalAbsolutePathOrStringLiteral();
         STNode onKeyword = parseOnKeyword();
         STNode expressionList = parseListeners();
         STNode openBrace = parseOpenBrace();
@@ -6764,20 +6764,23 @@ public class BallerinaParser extends AbstractParser {
     }
 
     /**
-     * Parse optional absolute resource path.
+     * Parse optional absolute resource path or string literal.
      *
      * @return Parsed node
      */
-    private STNode parseOptionalAbsolutePath() {
+    private STNode parseOptionalAbsolutePathOrStringLiteral() {
         STToken nextToken = peek();
         switch (nextToken.kind) {
             case SLASH_TOKEN:
                 return parseAbsoluteResourcePath();
+            case STRING_LITERAL_TOKEN:
+                STToken stringLiteralToken = consume();
+                return parseBasicLiteral(stringLiteralToken);
             case ON_KEYWORD:
                 return STNodeFactory.createEmptyNodeList();
             default:
                 recover(nextToken, ParserRuleContext.OPTIONAL_ABSOLUTE_PATH);
-                return parseOptionalAbsolutePath();
+                return parseOptionalAbsolutePathOrStringLiteral();
         }
     }
 

--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParserErrorHandler.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParserErrorHandler.java
@@ -661,7 +661,8 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
             { ParserRuleContext.TYPE_DESC_IN_SERVICE, ParserRuleContext.OPTIONAL_ABSOLUTE_PATH };
 
     private static final ParserRuleContext[] OPTIONAL_ABSOLUTE_PATH =
-            { ParserRuleContext.ABSOLUTE_RESOURCE_PATH, ParserRuleContext.ON_KEYWORD };
+            { ParserRuleContext.ABSOLUTE_RESOURCE_PATH, ParserRuleContext.STRING_LITERAL_TOKEN,
+                    ParserRuleContext.ON_KEYWORD };
 
     private static final ParserRuleContext[] ABSOLUTE_RESOURCE_PATH_START =
             { ParserRuleContext.SLASH, ParserRuleContext.ABSOLUTE_PATH_SINGLE_SLASH };
@@ -2564,8 +2565,11 @@ public class BallerinaParserErrorHandler extends AbstractParserErrorHandler {
             case COLON:
                 return getNextRuleForColon();
             case STRING_LITERAL_TOKEN:
-                // We assume string literal is specifically used only in the mapping constructor key.
-                return ParserRuleContext.COLON;
+                parentCtx = getParentContext();
+                if (parentCtx == ParserRuleContext.SERVICE_DECL) {
+                    return ParserRuleContext.ON_KEYWORD;
+                }
+                return ParserRuleContext.COLON; // mapping constructor key
             case COMPUTED_FIELD_NAME:
                 return ParserRuleContext.OPEN_BRACKET;
             case LISTENERS_LIST:

--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/declarations/ServiceDeclarationTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/syntax/declarations/ServiceDeclarationTest.java
@@ -53,6 +53,11 @@ public class ServiceDeclarationTest extends AbstractDeclarationTest {
         test("service-decl/service_decl_source_18.bal", "service-decl/service_decl_assert_18.json");
     }
 
+    @Test
+    public void testServiceDeclStringLiteral() {
+        testFile("service-decl/service_decl_source_19.bal", "service-decl/service_decl_assert_19.json");
+    }
+
     // Valid service function syntax tests
 
     @Test

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_19.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_19.json
@@ -1,0 +1,227 @@
+{
+  "kind": "MODULE_PART",
+  "children": [
+    {
+      "kind": "LIST",
+      "children": []
+    },
+    {
+      "kind": "LIST",
+      "children": [
+        {
+          "kind": "SERVICE_DECLARATION",
+          "children": [
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "SERVICE_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "SINGLETON_TYPE_DESC",
+              "children": [
+                {
+                  "kind": "STRING_LITERAL",
+                  "children": [
+                    {
+                      "kind": "STRING_LITERAL_TOKEN",
+                      "value": "sample.demo.foo",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "ON_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "LIST",
+              "children": [
+                {
+                  "kind": "SIMPLE_NAME_REFERENCE",
+                  "children": [
+                    {
+                      "kind": "IDENTIFIER_TOKEN",
+                      "value": "listner1",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "OPEN_BRACE_TOKEN",
+              "trailingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ]
+            },
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "CLOSE_BRACE_TOKEN",
+              "leadingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ],
+              "trailingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "kind": "SERVICE_DECLARATION",
+          "children": [
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "SERVICE_KEYWORD",
+              "leadingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ],
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "SIMPLE_NAME_REFERENCE",
+              "children": [
+                {
+                  "kind": "IDENTIFIER_TOKEN",
+                  "value": "serviceType",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "STRING_LITERAL",
+              "children": [
+                {
+                  "kind": "STRING_LITERAL_TOKEN",
+                  "value": "sample.demo.foo",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "ON_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "LIST",
+              "children": [
+                {
+                  "kind": "SIMPLE_NAME_REFERENCE",
+                  "children": [
+                    {
+                      "kind": "IDENTIFIER_TOKEN",
+                      "value": "listner1",
+                      "trailingMinutiae": [
+                        {
+                          "kind": "WHITESPACE_MINUTIAE",
+                          "value": " "
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "OPEN_BRACE_TOKEN",
+              "trailingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ]
+            },
+            {
+              "kind": "LIST",
+              "children": []
+            },
+            {
+              "kind": "CLOSE_BRACE_TOKEN",
+              "leadingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ],
+              "trailingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "kind": "EOF_TOKEN"
+    }
+  ]
+}

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_source_19.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_source_19.bal
@@ -1,0 +1,7 @@
+service "sample.demo.foo" on listner1 {
+
+}
+
+service serviceType "sample.demo.foo" on listner1 {
+
+}


### PR DESCRIPTION
## Purpose
$subject.

Fixes #27221

## Approach
N/A

## Samples
```bal
service "sample.demo.bar" on listner1 {

}

service foo "sample.demo.bar" on listner1 {

}
```

## Remarks
Old syntax:
`service-decl := metadata service [type-descriptor] [absolute-resource-path] on  .....`

New syntax:
`service-decl := metadata service [type-descriptor] [absolute-resource-path | string-literal] on .....`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Parser Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [x] Added necessary documentation  
  - [x] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
