### PR TITLE
Exclude certain api docs

### DIFF
--- a/gradle/ballerinaLangLibBuild.gradle
+++ b/gradle/ballerinaLangLibBuild.gradle
@@ -66,7 +66,8 @@ class BallerinaLangLibBuildTask extends JavaExec {
         args << distCache
         args << pkgName
         args << skipBootstrap
-
+        args << "lang.__internal,lang.annotations"
+        
         super.setArgs(args)
         super.exec()
     }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -512,7 +512,8 @@ public class Generator {
         if (docLines != null) {
             for (Node docLine : docLines.documentationLines()) {
                 if (docLine instanceof MarkdownDocumentationLineNode) {
-                    doc += getDocString(((MarkdownDocumentationLineNode) docLine).documentElements());
+                    doc += !((MarkdownDocumentationLineNode) docLine).documentElements().isEmpty() ?
+                            getDocString(((MarkdownDocumentationLineNode) docLine).documentElements()) : "\n";
                 } else {
                     break;
                 }

--- a/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/BuildLangLib.java
+++ b/misc/lib-creator/src/main/java/org/ballerinalang/stdlib/utils/BuildLangLib.java
@@ -43,7 +43,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 
@@ -69,6 +72,7 @@ public class BuildLangLib {
             if (args.length >= 4 && args[3].equals("true")) {
                 skipBootstrap = true;
             }
+            String docFilter = args.length > 4 ? args[4] : "";
             System.setProperty(ProjectConstants.BALLERINA_HOME, distCache.toString());
             out.println("Building langlib ...");
             out.println("Project Dir: " + projectDir);
@@ -133,9 +137,12 @@ public class BuildLangLib {
             Files.copy(generatedJarFilePath, targetJarFilePath);
 
             //Generate docs
-            out.println("Generating docs...");
-            BallerinaDocGenerator.generateAPIDocs(project, targetPath.resolve(ProjectConstants.TARGET_API_DOC_DIRECTORY)
-                    .toString());
+            Set<String> docsToFilter = new HashSet<>(Arrays.asList(docFilter.split(",")));
+            if (!docsToFilter.contains(pkg.packageName().toString())) {
+                out.println("Generating docs...");
+                BallerinaDocGenerator.generateAPIDocs(project, targetPath.resolve(
+                        ProjectConstants.TARGET_API_DOC_DIRECTORY).toString());
+            }
 
         } catch (Exception e) {
             out.println("Unknown error building : " + projectDir.toString());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
@@ -39,12 +39,9 @@ public class MultilineDocsTest {
     private Function multilineDocsFunction;
     private Function multilineDocsDeprecatedFunction;
 
-    private final String firstLine = "<p>Returns a formatted string using the specified format string and arguments. "
-            + "Following format specifiers are allowed.</p>\n";
-    private final String deprecatedFirstLine = "Returns a formatted string using the specified format string and "
-            + "arguments. Following format specifiers are allowed.\n";
-
-    private final String otherLines = "<p>b - boolean</p>\n"
+    private final String lines = "<p>Returns a formatted string using the specified format string and arguments. "
+            + "Following format specifiers are allowed.</p>\n"
+            + "<p>b - boolean</p>\n"
             + "<p>B - boolean (ALL_CAPS)</p>\n"
             + "<p>d - int</p>\n"
             + "<p>f - float</p>\n"
@@ -52,7 +49,7 @@ public class MultilineDocsTest {
             + "<p>X - HEX (ALL_CAPS)</p>\n"
             + "<p>s - string (This specifier is applicable for any of the supported types in Ballerina.\n"
             + "These values will be converted to their string representation.)</p>\n"
-            + "<pre><code class=\"language-ballerina\"> "
+            + "<pre><code class=\"language-ballerina\">"
             + "string s8 = io:sprintf(&quot;%s scored %d for %s and has an average of %.2f.&quot;, name, marks, "
             + "subjects[0], average);\n"
             + "</code></pre>\n";
@@ -77,14 +74,10 @@ public class MultilineDocsTest {
         }
     }
 
-    @Test(enabled = false, description = "Test multiline documentation")
+    @Test(description = "Test multiline documentation")
     public void testMultilineDocs() {
         Assert.assertNotNull(multilineDocsFunction);
-        Assert.assertEquals(multilineDocsFunction.description, firstLine + otherLines);
+        Assert.assertEquals(multilineDocsFunction.description, lines);
     }
 
-    @Test(enabled = false, description = "Test multiline documentation with @deprecated annotation")
-    public void testMultilineDocsWithDeprecation() {
-        Assert.assertEquals(multilineDocsDeprecatedFunction.description, deprecatedFirstLine + otherLines);
-    }
 }


### PR DESCRIPTION
## Purpose
>- Disable lang.annotations and lang.__internal api docs being geenrated.
>- Fix MultilineDocsTest 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
