### PR TITLE
Extend semantic API to support test sources in a module

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -41,6 +41,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
@@ -50,6 +51,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Stream;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.COMPILED_SOURCE;
@@ -270,7 +272,13 @@ public class BallerinaSemanticModel implements SemanticModel {
     }
 
     private BLangCompilationUnit getCompilationUnit(String srcFile) {
-        return bLangPackage.compUnits.stream()
+        List<BLangCompilationUnit> testSrcs = new ArrayList<>();
+        for (BLangTestablePackage pkg : bLangPackage.testablePkgs) {
+            testSrcs.addAll(pkg.compUnits);
+        }
+
+        Stream<BLangCompilationUnit> units = Stream.concat(bLangPackage.compUnits.stream(), testSrcs.stream());
+        return units
                 .filter(unit -> unit.name.equals(srcFile))
                 .findFirst()
                 .get();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -35,6 +35,7 @@ import org.wso2.ballerinalang.compiler.semantics.analyzer.SymbolResolver;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -56,6 +57,7 @@ import java.util.stream.Stream;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.COMPILED_SOURCE;
 import static org.ballerinalang.model.symbols.SymbolOrigin.SOURCE;
+import static org.ballerinalang.model.tree.SourceKind.REGULAR_SOURCE;
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.ANNOTATION;
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.PACKAGE;
 
@@ -68,17 +70,12 @@ public class BallerinaSemanticModel implements SemanticModel {
 
     private final BLangPackage bLangPackage;
     private final CompilerContext compilerContext;
-    private final EnvironmentResolver envResolver;
     private final SymbolFactory symbolFactory;
     private final TypesFactory typesFactory;
 
     public BallerinaSemanticModel(BLangPackage bLangPackage, CompilerContext context) {
         this.compilerContext = context;
         this.bLangPackage = bLangPackage;
-
-        SymbolTable symbolTable = SymbolTable.getInstance(context);
-        SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(bLangPackage.symbol);
-        this.envResolver = new EnvironmentResolver(pkgEnv);
         this.symbolFactory = SymbolFactory.getInstance(context);
         this.typesFactory = TypesFactory.getInstance(context);
     }
@@ -88,16 +85,21 @@ public class BallerinaSemanticModel implements SemanticModel {
      */
     @Override
     public List<Symbol> visibleSymbols(String fileName, LinePosition linePosition) {
-        List<Symbol> compiledSymbols = new ArrayList<>();
-        SymbolResolver symbolResolver = SymbolResolver.getInstance(this.compilerContext);
         BLangCompilationUnit compilationUnit = getCompilationUnit(fileName);
+        BPackageSymbol moduleSymbol = getModuleSymbol(compilationUnit);
+        SymbolTable symbolTable = SymbolTable.getInstance(this.compilerContext);
+        SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(moduleSymbol);
+        EnvironmentResolver envResolver = new EnvironmentResolver(pkgEnv);
+
+        SymbolResolver symbolResolver = SymbolResolver.getInstance(this.compilerContext);
         Map<Name, List<Scope.ScopeEntry>> scopeSymbols =
-                symbolResolver.getAllVisibleInScopeSymbols(this.envResolver.lookUp(compilationUnit, linePosition));
+                symbolResolver.getAllVisibleInScopeSymbols(envResolver.lookUp(compilationUnit, linePosition));
 
         Location cursorPos = new BLangDiagnosticLocation(compilationUnit.name,
-                                                    linePosition.line(), linePosition.line(),
-                                                    linePosition.offset(), linePosition.offset());
+                                                         linePosition.line(), linePosition.line(),
+                                                         linePosition.offset(), linePosition.offset());
 
+        List<Symbol> compiledSymbols = new ArrayList<>();
         for (Map.Entry<Name, List<Scope.ScopeEntry>> entry : scopeSymbols.entrySet()) {
             Name name = entry.getKey();
             List<Scope.ScopeEntry> scopeEntries = entry.getValue();
@@ -295,6 +297,11 @@ public class BallerinaSemanticModel implements SemanticModel {
         }
 
         return ((BallerinaSymbol) symbol).getInternalSymbol();
+    }
+
+    private BPackageSymbol getModuleSymbol(BLangCompilationUnit compilationUnit) {
+        return compilationUnit.getSourceKind() == REGULAR_SOURCE ? bLangPackage.symbol :
+                bLangPackage.getTestablePkg().symbol;
     }
 
     private boolean withinRange(LineRange range, LineRange specifiedRange) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -395,11 +395,8 @@ class NodeFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangExpressionStmt exprStmtNode) {
-        if (setEnclosingNode(exprStmtNode.expr, exprStmtNode.pos)) {
-            return;
-        }
-
         lookupNode(exprStmtNode.expr);
+        setEnclosingNode(exprStmtNode.expr, exprStmtNode.pos);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -43,6 +43,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTableKeySpecifier;
 import org.wso2.ballerinalang.compiler.tree.BLangTableKeyTypeConstraint;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
@@ -153,6 +154,7 @@ import org.wso2.ballerinalang.compiler.tree.types.BLangTupleTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUnionTypeNode;
 import org.wso2.ballerinalang.compiler.tree.types.BLangUserDefinedType;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -167,7 +169,14 @@ class NodeFinder extends BaseVisitor {
     private BLangNode enclosingContainer;
 
     BLangNode lookup(BLangPackage module, LineRange range) {
-        return lookupTopLevelNodes(module.topLevelNodes, range);
+        List<TopLevelNode> topLevelNodes = new ArrayList<>(module.topLevelNodes);
+        BLangTestablePackage tests = module.getTestablePkg();
+
+        if (tests != null) {
+            topLevelNodes.addAll(tests.topLevelNodes);
+        }
+
+        return lookupTopLevelNodes(topLevelNodes, range);
     }
 
     BLangNode lookup(BLangCompilationUnit unit, LineRange range) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -41,6 +41,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangService;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTableKeySpecifier;
 import org.wso2.ballerinalang.compiler.tree.BLangTableKeyTypeConstraint;
+import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
@@ -219,6 +220,10 @@ public class ReferenceFinder extends BaseVisitor {
         find(pkgNode.functions.stream()
                      .filter(f -> !f.flagSet.contains(Flag.LAMBDA))
                      .collect(Collectors.toList()));
+
+        if (!(pkgNode instanceof BLangTestablePackage)) {
+            find(pkgNode.getTestablePkg());
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -254,6 +254,7 @@ class SymbolFinder extends BaseVisitor {
             return;
         }
 
+        lookupNodes(funcNode.annAttachments);
         lookupNodes(funcNode.requiredParams);
         lookupNode(funcNode.restParam);
         lookupNode(funcNode.returnTypeNode);
@@ -665,7 +666,7 @@ class SymbolFinder extends BaseVisitor {
             return;
         }
 
-        lookupNodes(invocationExpr.requiredArgs);
+        lookupNodes(invocationExpr.argExprs);
         lookupNodes(invocationExpr.restArgs);
         lookupNode(invocationExpr.expr);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
@@ -28,6 +28,7 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextDocuments;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.tree.SourceKind;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.parser.BLangNodeTransformer;
 import org.wso2.ballerinalang.compiler.parser.NodeCloner;
@@ -97,7 +98,7 @@ class DocumentContext {
         return this.textDocument;
     }
 
-    BLangCompilationUnit compilationUnit(CompilerContext compilerContext, PackageID pkgID) {
+    BLangCompilationUnit compilationUnit(CompilerContext compilerContext, PackageID pkgID, SourceKind sourceKind) {
         nodeCloner = NodeCloner.getInstance(compilerContext);
         if (compilationUnit != null) {
             return nodeCloner.clone(compilationUnit);
@@ -108,6 +109,7 @@ class DocumentContext {
         reportSyntaxDiagnostics(pkgID, syntaxTree, dlog);
         BLangNodeTransformer bLangNodeTransformer = new BLangNodeTransformer(compilerContext, pkgID, this.name);
         compilationUnit = (BLangCompilationUnit) bLangNodeTransformer.accept(syntaxTree.rootNode()).get(0);
+        compilationUnit.setSourceKind(sourceKind);
         return nodeCloner.clone(compilationUnit);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -49,6 +49,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import static org.ballerinalang.compiler.CompilerOptionName.SKIP_TESTS;
+import static org.ballerinalang.model.tree.SourceKind.REGULAR_SOURCE;
+import static org.ballerinalang.model.tree.SourceKind.TEST_SOURCE;
 
 /**
  * Maintains the internal state of a {@code Module} instance.
@@ -219,7 +221,7 @@ class ModuleContext {
         testablePkg.pos = new BLangDiagnosticLocation(this.moduleName().toString(), 1, 1, 1, 1);
         pkgNode.addTestablePkg(testablePkg);
         for (DocumentContext documentContext : testDocContextMap.values()) {
-            testablePkg.addCompilationUnit(documentContext.compilationUnit(compilerContext, pkgId));
+            testablePkg.addCompilationUnit(documentContext.compilationUnit(compilerContext, pkgId, TEST_SOURCE));
         }
     }
 
@@ -325,7 +327,8 @@ class ModuleContext {
 
         // Parse source files
         for (DocumentContext documentContext : moduleContext.srcDocContextMap.values()) {
-            pkgNode.addCompilationUnit(documentContext.compilationUnit(compilerContext, moduleCompilationId));
+            pkgNode.addCompilationUnit(documentContext.compilationUnit(compilerContext, moduleCompilationId,
+                                                                       REGULAR_SOURCE));
         }
 
         // Parse test source files if --skip-tests option is set to false

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/CompilationUnitNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/CompilationUnitNode.java
@@ -33,5 +33,8 @@ public interface CompilationUnitNode extends Node {
     void setName(String name);
     
     String getName();
-    
+
+    void setSourceKind(SourceKind kind);
+
+    SourceKind getSourceKind();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/SourceKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/SourceKind.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.model.tree;
+
+/**
+ * An enum for representing the types source files.
+ *
+ * @since 2.0.0
+ */
+public enum SourceKind {
+    /**
+     * Represents a regular Ballerina source file.
+     */
+    REGULAR_SOURCE,
+    /**
+     * Represents a Ballerina source file in the tests directory of a module.
+     */
+    TEST_SOURCE
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -391,6 +391,7 @@ public class NodeCloner extends BLangNodeVisitor {
         source.cloneRef = clone;
         clone.name = source.name;
         clone.setPackageID(source.getPackageID());
+        clone.setSourceKind(source.getSourceKind());
         for (TopLevelNode node : source.topLevelNodes) {
             clone.topLevelNodes.add(clone(node));
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangCompilationUnit.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangCompilationUnit.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.tree;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.CompilationUnitNode;
 import org.ballerinalang.model.tree.NodeKind;
+import org.ballerinalang.model.tree.SourceKind;
 import org.ballerinalang.model.tree.TopLevelNode;
 
 import java.util.ArrayList;
@@ -38,6 +39,7 @@ public class BLangCompilationUnit extends BLangNode implements CompilationUnitNo
 
     public List<TopLevelNode> topLevelNodes;
     private PackageID packageID;
+    private SourceKind sourceKind;
 
     public BLangCompilationUnit() {
         this.topLevelNodes = new ArrayList<>();
@@ -75,7 +77,17 @@ public class BLangCompilationUnit extends BLangNode implements CompilationUnitNo
     public NodeKind getKind() {
         return NodeKind.COMPILATION_UNIT;
     }
-    
+
+    @Override
+    public void setSourceKind(SourceKind kind) {
+        this.sourceKind = kind;
+    }
+
+    @Override
+    public SourceKind getSourceKind() {
+        return this.sourceKind;
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
@@ -233,7 +233,7 @@ public class BLangPackage extends BLangNode implements PackageNode {
      * @return testable package
      */
     public BLangTestablePackage getTestablePkg() {
-        return testablePkgs.stream().findAny().get();
+        return testablePkgs.stream().findAny().orElse(null);
     }
 
     /**

--- a/tests/ballerina-compiler-api-test/build.gradle
+++ b/tests/ballerina-compiler-api-test/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 
     testCompile 'org.testng:testng'
     testCompile project(path: ':ballerina-test-utils', configuration: 'shadow')
+    distributionBalo project(path: ':testerina:testerina-core', configuration: 'distributionBalo')
 }
 
 description = 'Ballerina - Compiler API'

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -19,7 +19,10 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.tools.text.LineRange;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -28,6 +31,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertList;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getSymbolNames;
 import static io.ballerina.tools.text.LinePosition.from;
@@ -90,5 +95,20 @@ public class TestSourcesTest {
         };
     }
 
+    @Test(dataProvider = "ExprPosProvider")
+    public void testType(int sLine, int sCol, int eLine, int eCol, TypeDescKind expKind) {
+        LineRange exprRange = LineRange.from("tests/test1.bal", from(sLine, sCol), from(eLine, eCol));
+        Optional<TypeSymbol> type = model.type("tests/test1.bal", exprRange);
 
+        assertEquals(type.get().typeKind(), expKind);
+    }
+
+    @DataProvider(name = "ExprPosProvider")
+    public Object[][] getExprPos() {
+        return new Object[][]{
+                {20, 22, 20, 24, FLOAT},
+                {20, 26, 20, 30, FLOAT},
+                {26, 22, 26, 25, INT},
+        };
+    }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * Test cases for the positions of symbols.
+ *
+ * @since 2.0.0
+ */
+public class TestSourcesTest {
+
+    private SemanticModel model;
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getSemanticModelOf("test-src/test-project", "baz");
+    }
+
+    @Test(dataProvider = "PositionProvider")
+    public void testSymbolPositions(int sLine, int sCol, String expSymbolName) {
+        Optional<Symbol> symbol = model.symbol("tests/test1.bal", from(sLine, sCol));
+
+        if (symbol.isEmpty()) {
+            assertNull(expSymbolName);
+        }
+
+        assertEquals(symbol.get().name(), expSymbolName);
+    }
+
+    @DataProvider(name = "PositionProvider")
+    public Object[][] getPositions() {
+        return new Object[][]{
+                {18, 7, "Config"},
+                {20, 9, "assertEquals"},
+                {20, 22, "PI"},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
@@ -83,6 +83,10 @@ public abstract class FindAllReferencesTest {
         return new BLangDiagnosticLocation(getFileName(), line, line, startCol, endCol);
     }
 
+    protected Location location(int line, int startCol, int endCol, String fileName) {
+        return new BLangDiagnosticLocation(fileName, line, line, startCol, endCol);
+    }
+
     private void assertLocations(List<Location> locations, List<Location> expLocations) {
         assertEquals(locations.size(), expLocations.size());
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
@@ -26,12 +26,12 @@ import org.testng.annotations.Test;
 import java.util.List;
 
 /**
- * Test cases for the finding all references of a symbol across multiple files in the module.
+ * Test cases for the finding all references of a symbol across a module, in tests.
  *
  * @since 2.0.0
  */
 @Test
-public class FindRefsAcrossFilesTest extends FindAllReferencesTest {
+public class FindRefsInTestsTest extends FindAllReferencesTest {
 
     @BeforeClass
     public void setup() {
@@ -41,21 +41,18 @@ public class FindRefsAcrossFilesTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {22, 42, List.of(location(18, 6, 10, "constants.bal"),
-                                 location(22, 42, 46, getFileName()))
+                {25, 14, List.of(location(16, 16, 19, "functions.bal"),
+                                 location(25, 14, 17, getFileName()))
                 },
-                {22, 56, List.of(location(16, 12, 18, "type_defs.bal"),
-                                 location(22, 56, 62, getFileName()))
-                },
-                {16, 16, List.of(location(16, 16, 19, getFileName()),
-                                 location(25, 14, 17, "tests/test1.bal"))
+                {20, 22, List.of(location(16, 13, 15, "constants.bal"),
+                                 location(20, 22, 24, getFileName()))
                 },
         };
     }
 
     @Override
     public String getFileName() {
-        return "functions.bal";
+        return "tests/test1.bal";
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/test-project/modules/baz/tests/test1.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/test-project/modules/baz/tests/test1.bal
@@ -1,0 +1,28 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Config {}
+function testConstUse() {
+    test:assertEquals(PI, 3.14);
+}
+
+@test:Config {}
+function testAdd() {
+    int sum = add(10, 20);
+    test:assertEquals(sum, 30);
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -42,6 +42,7 @@
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInExprsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInLambdasTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInServiceDeclTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInTestsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInWorkersTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.XMLRefsTest" />
         </classes>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -28,6 +28,7 @@
             <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest" />
             <class name="io.ballerina.semantic.api.test.SymbolBIRTest" />
             <class name="io.ballerina.semantic.api.test.SymbolFlagToQualifierMappingTest" />
+            <class name="io.ballerina.semantic.api.test.TestSourcesTest" />
             <class name="io.ballerina.semantic.api.test.SymbolLookupTest" />
             <class name="io.ballerina.semantic.api.test.SymbolPositionTest" />
             <class name="io.ballerina.semantic.api.test.TypedescriptorTest" />


### PR DESCRIPTION
## Purpose
This PR extends the APIs provided by the semantic API to take source files in the `tests` directory of a module in to consideration.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
