### PR TITLE
Handle the using of error in type-cast and toString

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/TypeKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/TypeKind.java
@@ -64,6 +64,7 @@ public enum TypeKind {
     JSON("json"),
     XML("xml"),
     ANY("any"),
+    ANYANDREADONLY("anyAndReadOnly"),
     ANYDATA("anydata"),
     MAP("map"),
     FUTURE("future"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/TypeKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/TypeKind.java
@@ -64,7 +64,6 @@ public enum TypeKind {
     JSON("json"),
     XML("xml"),
     ANY("any"),
-    ANYANDREADONLY("anyAndReadOnly"),
     ANYDATA("anydata"),
     MAP("map"),
     FUTURE("future"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -3619,6 +3619,8 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         int tag = bType.tag;
         if (tag == TypeTags.ERROR) {
             errorType = bType;
+        } else if (tag == TypeTags.READONLY) {
+            errorType = symTable.errorType;
         } else if (tag == TypeTags.UNION) {
             LinkedHashSet<BType> errTypes = new LinkedHashSet<>();
             Set<BType> memTypes = ((BUnionType) bType).getMemberTypes();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4690,7 +4690,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
         // This list will be used in the desugar phase
         checkedExpr.equivalentErrorTypeList = errorTypes;
-        if (checkedExpr.equivalentErrorTypeList.isEmpty()) {
+        if (errorTypes.isEmpty()) {
             // No member types in this union is equivalent to the error type
             dlog.error(checkedExpr.expr.pos,
                     DiagnosticErrorCode.CHECKED_EXPR_INVALID_USAGE_NO_ERROR_TYPE_IN_RHS, operatorType);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1915,7 +1915,10 @@ public class Types {
     }
 
     public boolean isTypeCastable(BLangExpression expr, BType sourceType, BType targetType) {
-
+        if (getTypeIntersection(sourceType, symTable.errorType) != symTable.semanticError
+                && getTypeIntersection(targetType, symTable.errorType) == symTable.semanticError) {
+            return false;
+        }
         if (sourceType.tag == TypeTags.SEMANTIC_ERROR || targetType.tag == TypeTags.SEMANTIC_ERROR ||
                 sourceType == targetType) {
             return true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -22,6 +22,7 @@ import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.tree.OperatorKind;
+import org.ballerinalang.model.types.SelectivelyImmutableReferenceType;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
@@ -60,6 +61,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.ImmutableTypeCloner;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -134,8 +136,7 @@ public class SymbolTable {
     public final BType readonlyType = new BReadonlyType(TypeTags.READONLY, null);
     public final BType anydataOrReadonly = BUnionType.create(null, anydataType, readonlyType);
     public final BType intStringFloatOrBoolean = BUnionType.create(null, intType, stringType, floatType, booleanType);
-    public final BType anyAndReadonly = new BAnyType(TypeTags.ANY, null, new Name("anyAndReadonly"),
-            Flags.READONLY);
+    public final BType anyAndReadonly;
 
     public final BType semanticError = new BType(TypeTags.SEMANTIC_ERROR, null);
     public final BType nullSet = new BType(TypeTags.NULL_SET, null);
@@ -195,6 +196,7 @@ public class SymbolTable {
     public BPackageSymbol internalTransactionModuleSymbol;
 
     private Names names;
+    private SymbolTable symbolTable;
     public Map<BPackageSymbol, SymbolEnv> pkgEnvMap = new HashMap<>();
     public Map<Name, BPackageSymbol> predeclaredModules = new HashMap<>();
 
@@ -211,6 +213,7 @@ public class SymbolTable {
         context.put(SYM_TABLE_KEY, this);
 
         this.names = Names.getInstance(context);
+        this.symbolTable = SymbolTable.getInstance(context);
 
         this.rootPkgNode = (BLangPackage) TreeBuilder.createPackageNode();
         this.rootPkgSymbol = new BPackageSymbol(PackageID.ANNOTATIONS, null, null, BUILTIN);
@@ -271,6 +274,10 @@ public class SymbolTable {
         this.trueType = new BFiniteType(finiteTypeSymbol, new HashSet<>() {{
             add(trueLiteral);
         }});
+        this.anyAndReadonly =
+                ImmutableTypeCloner.getImmutableIntersectionType((SelectivelyImmutableReferenceType) this.anyType,
+                        this.symbolTable, names);
+        initializeType(this.anyAndReadonly, TypeKind.ANYANDREADONLY.typeName(), BUILTIN);
     }
 
     public BType getTypeFromTag(int tag) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -40,6 +40,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BFutureType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BHandleType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BInvokableType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BJSONType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BMapType;
@@ -136,7 +137,7 @@ public class SymbolTable {
     public final BType readonlyType = new BReadonlyType(TypeTags.READONLY, null);
     public final BType anydataOrReadonly = BUnionType.create(null, anydataType, readonlyType);
     public final BType intStringFloatOrBoolean = BUnionType.create(null, intType, stringType, floatType, booleanType);
-    public final BType anyAndReadonly;
+    public final BIntersectionType anyAndReadonly;
 
     public final BType semanticError = new BType(TypeTags.SEMANTIC_ERROR, null);
     public final BType nullSet = new BType(TypeTags.NULL_SET, null);
@@ -196,7 +197,6 @@ public class SymbolTable {
     public BPackageSymbol internalTransactionModuleSymbol;
 
     private Names names;
-    private SymbolTable symbolTable;
     public Map<BPackageSymbol, SymbolEnv> pkgEnvMap = new HashMap<>();
     public Map<Name, BPackageSymbol> predeclaredModules = new HashMap<>();
 
@@ -213,7 +213,6 @@ public class SymbolTable {
         context.put(SYM_TABLE_KEY, this);
 
         this.names = Names.getInstance(context);
-        this.symbolTable = SymbolTable.getInstance(context);
 
         this.rootPkgNode = (BLangPackage) TreeBuilder.createPackageNode();
         this.rootPkgSymbol = new BPackageSymbol(PackageID.ANNOTATIONS, null, null, BUILTIN);
@@ -276,8 +275,8 @@ public class SymbolTable {
         }});
         this.anyAndReadonly =
                 ImmutableTypeCloner.getImmutableIntersectionType((SelectivelyImmutableReferenceType) this.anyType,
-                        this.symbolTable, names);
-        initializeType(this.anyAndReadonly, TypeKind.ANYANDREADONLY.typeName(), BUILTIN);
+                        this, names);
+        initializeType(this.anyAndReadonly, this.anyAndReadonly.effectiveType.name.getValue(), BUILTIN);
     }
 
     public BType getTypeFromTag(int tag) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -134,6 +134,8 @@ public class SymbolTable {
     public final BType readonlyType = new BReadonlyType(TypeTags.READONLY, null);
     public final BType anydataOrReadonly = BUnionType.create(null, anydataType, readonlyType);
     public final BType intStringFloatOrBoolean = BUnionType.create(null, intType, stringType, floatType, booleanType);
+    public final BType anyAndReadonly = new BAnyType(TypeTags.ANY, null, new Name("anyAndReadonly"),
+            Flags.READONLY);
 
     public final BType semanticError = new BType(TypeTags.SEMANTIC_ERROR, null);
     public final BType nullSet = new BType(TypeTags.NULL_SET, null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -113,6 +113,12 @@ public class ImmutableTypeCloner {
                                             symTable, anonymousModelHelper, names, origObjFlagSet, new HashSet<>());
     }
 
+    public static BIntersectionType getImmutableIntersectionType(SelectivelyImmutableReferenceType type,
+                                                                 SymbolTable symbolTable, Names names) {
+        return getImmutableIntersectionType(null, null, type, null, null, null, symbolTable, null, names, null,
+                new HashSet<>());
+    }
+
     public static void markFieldsAsImmutable(BLangClassDefinition classDef, SymbolEnv pkgEnv, BObjectType objectType,
                                              Types types, BLangAnonymousModelHelper anonymousModelHelper,
                                              SymbolTable symbolTable, Names names, Location pos) {

--- a/langlib/lang.error/src/main/ballerina/error.bal
+++ b/langlib/lang.error/src/main/ballerina/error.bal
@@ -83,3 +83,27 @@ public type CallStackElement record {|
 public class CallStack {
     public CallStackElement[] callStack = [];
 }
+
+# Converts an error to a string.
+#
+# + e - the error to be converted to a string
+# + return - a string resulting from the conversion
+#
+# The details of the conversion are specified by the ToString abstract operation
+# defined in the Ballerina Language Specification, using the direct style.
+public isolated function toString(error e) returns string = @java:Method {
+    'class: "org.ballerinalang.langlib.error.ToString",
+    name: "toString",
+    paramTypes: ["io.ballerina.runtime.api.values.BError"]
+} external;
+
+# Converts an error to a string that describes the value in Ballerina syntax.
+# + e - the error to be converted to a string
+# + return - a string resulting from the conversion
+#
+# The details of the conversion are specified by the ToString abstract operation
+# defined in the Ballerina Language Specification, using the expression style.
+public isolated function toBalString(error e) returns string = @java:Method {
+  'class: "org.ballerinalang.langlib.error.ToBalString",
+  name: "toBalString"
+} external;

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/ToBalString.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/ToBalString.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.error;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BString;
+
+/**
+ * Returns expression style representation of the given value as a String.
+ *
+ * @since 2.0.0
+ */
+public class ToBalString {
+    public static BString toBalString(BError value) {
+        return StringUtils.fromString(StringUtils.getExpressionStringValue(value, null));
+    }
+}

--- a/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/ToString.java
+++ b/langlib/lang.error/src/main/java/org/ballerinalang/langlib/error/ToString.java
@@ -1,0 +1,34 @@
+/*
+ *   Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.error;
+
+import io.ballerina.runtime.api.utils.StringUtils;
+import io.ballerina.runtime.api.values.BError;
+import io.ballerina.runtime.api.values.BString;
+
+/**
+ * Returns a simple, human-readable representation of the given value as a String.
+ *
+ * @since 2.0.0
+ */
+public class ToString {
+    public static BString toString(BError value) {
+        return StringUtils.fromString(StringUtils.getStringValue(value, null));
+    }
+}

--- a/langlib/lang.query/src/main/ballerina/helpers.bal
+++ b/langlib/lang.query/src/main/ballerina/helpers.bal
@@ -126,7 +126,7 @@ function toString(stream<Type, error?> strm) returns string {
 function addToTable(stream<Type, error?> strm, table<map<Type>> tbl, error? err) returns table<map<Type>>|error {
     record {| Type value; |}|error? v = strm.next();
     while (v is record {| Type value; |}) {
-        error? e = trap tbl.add(<map<Type>> check v.value);
+        error? e = trap tbl.add(<map<Type>> checkpanic v.value);
         if (e is error) {
             if (err is error) {
                 return err;

--- a/langlib/lang.query/src/main/ballerina/helpers.bal
+++ b/langlib/lang.query/src/main/ballerina/helpers.bal
@@ -126,7 +126,7 @@ function toString(stream<Type, error?> strm) returns string {
 function addToTable(stream<Type, error?> strm, table<map<Type>> tbl, error? err) returns table<map<Type>>|error {
     record {| Type value; |}|error? v = strm.next();
     while (v is record {| Type value; |}) {
-        error? e = trap tbl.add(<map<Type>> v.value);
+        error? e = trap tbl.add(<map<Type>> check v.value);
         if (e is error) {
             if (err is error) {
                 return err;

--- a/langlib/lang.query/src/main/ballerina/types.bal
+++ b/langlib/lang.query/src/main/ballerina/types.bal
@@ -525,7 +525,7 @@ class _OrderByFunction {
             // consume all events for ordering.
             while (f is _Frame) {
                 orderKeyFunc(f);
-                oTree.add(f, <any[]>f["$orderDirection$"], <any[]>f["$orderKey$"]);
+                oTree.add(f, <any[]>(check f["$orderDirection$"]), <any[]>(check f["$orderKey$"]));
                 f = pf.process();
             }
             if (f is error) {

--- a/langlib/lang.query/src/main/ballerina/types.bal
+++ b/langlib/lang.query/src/main/ballerina/types.bal
@@ -525,7 +525,7 @@ class _OrderByFunction {
             // consume all events for ordering.
             while (f is _Frame) {
                 orderKeyFunc(f);
-                oTree.add(f, <any[]>(check f["$orderDirection$"]), <any[]>(check f["$orderKey$"]));
+                oTree.add(f, <any[]>(checkpanic f["$orderDirection$"]), <any[]>(checkpanic f["$orderKey$"]));
                 f = pf.process();
             }
             if (f is error) {

--- a/langlib/lang.stream/src/main/ballerina/internal.bal
+++ b/langlib/lang.stream/src/main/ballerina/internal.bal
@@ -35,7 +35,7 @@ class FilterSupport {
             } else {
                 var value = nextVal?.value;
                 function(any|error) returns boolean func = internal:getFilterFunc(self.func);
-                var filtered = check internal:invokeAsExternal(func, value);
+                var filtered = checkpanic internal:invokeAsExternal(func, value);
                 if (<boolean>filtered) {
                     return nextVal;
                 }

--- a/langlib/lang.stream/src/main/ballerina/internal.bal
+++ b/langlib/lang.stream/src/main/ballerina/internal.bal
@@ -35,7 +35,7 @@ class FilterSupport {
             } else {
                 var value = nextVal?.value;
                 function(any|error) returns boolean func = internal:getFilterFunc(self.func);
-                var filtered = internal:invokeAsExternal(func, value);
+                var filtered = check internal:invokeAsExternal(func, value);
                 if (<boolean>filtered) {
                     return nextVal;
                 }

--- a/langlib/lang.value/src/main/ballerina/value.bal
+++ b/langlib/lang.value/src/main/ballerina/value.bal
@@ -96,7 +96,7 @@ public isolated function isReadOnly(anydata v) returns boolean = @java:Method {
 #
 # The details of the conversion are specified by the ToString abstract operation
 # defined in the Ballerina Language Specification, using the direct style.
-public isolated function toString((any|error) v) returns string = @java:Method {
+public isolated function toString((any) v) returns string = @java:Method {
     'class: "org.ballerinalang.langlib.value.ToString",
     name: "toString",
     paramTypes: ["java.lang.Object"]
@@ -112,7 +112,7 @@ public isolated function toString((any|error) v) returns string = @java:Method {
 #
 # The details of the conversion are specified by the ToString abstract operation
 # defined in the Ballerina Language Specification, using the expression style.
-public isolated function toBalString(any|error v) returns string = @java:Method {
+public isolated function toBalString(any v) returns string = @java:Method {
   'class: "org.ballerinalang.langlib.value.ToBalString",
   name: "toBalString"
 } external;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibNegativeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibNegativeTest.java
@@ -52,6 +52,12 @@ public class LangLibNegativeTest {
                 51, 14);
         BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(int|error)'",
                 52, 14);
+        BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(json|error)'",
+                54, 14);
+        BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(json|error)'",
+                55, 14);
+        BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(int|error)'",
+                56, 14);
 
         Assert.assertEquals(negativeResult.getErrorCount(), err);
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibNegativeTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibNegativeTest.java
@@ -46,6 +46,12 @@ public class LangLibNegativeTest {
                 "'(json|error)'", 34, 25);
         BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected '(int|string|float[]|error)', " +
                 "found '(json|error)'", 38, 37);
+        BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(json|error)'",
+                50, 14);
+        BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(json|error)'",
+                51, 14);
+        BAssertUtil.validateError(negativeResult, err++, "incompatible types: expected 'any', found '(int|error)'",
+                52, 14);
 
         Assert.assertEquals(negativeResult.getErrorCount(), err);
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -172,6 +172,10 @@ public class LangLibValueTest {
         assertEquals(array.getRefValue(1).stringValue(), "4");
         assertEquals(array.getRefValue(2).stringValue(), "4");
         assertEquals(array.getRefValue(3).stringValue(), "4");
+        assertEquals(array.getRefValue(4).stringValue(), "error(\"Failed to get account balance\",details=true," +
+                "val1=NaN,val2=\"This Error\",val3={\"x\":\"AA\",\"y\":Infinity})");
+        assertEquals(array.getRefValue(5).stringValue(), "error FirstError (\"Reason1\",message=\"Test passing error " +
+                "union to a function\")");
 
         returns = BRunUtil.invokeFunction(compileResult, "testToString");
         array = (BValueArray) returns[0];

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibValueTest.java
@@ -166,19 +166,10 @@ public class LangLibValueTest {
 
     @Test
     public void testToString() {
-        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testToStringMethod");
-        BValueArray array = (BValueArray) returns[0];
-        assertEquals(array.getRefValue(0).stringValue(), "4");
-        assertEquals(array.getRefValue(1).stringValue(), "4");
-        assertEquals(array.getRefValue(2).stringValue(), "4");
-        assertEquals(array.getRefValue(3).stringValue(), "4");
-        assertEquals(array.getRefValue(4).stringValue(), "error(\"Failed to get account balance\",details=true," +
-                "val1=NaN,val2=\"This Error\",val3={\"x\":\"AA\",\"y\":Infinity})");
-        assertEquals(array.getRefValue(5).stringValue(), "error FirstError (\"Reason1\",message=\"Test passing error " +
-                "union to a function\")");
+        BRunUtil.invokeFunction(compileResult, "testToStringMethod");
 
-        returns = BRunUtil.invokeFunction(compileResult, "testToString");
-        array = (BValueArray) returns[0];
+        BValue[] returns = BRunUtil.invokeFunction(compileResult, "testToString");
+        BValueArray array = (BValueArray) returns[0];
         int i = 0;
         Assert.assertEquals(array.getString(i++), "6");
         Assert.assertEquals(array.getString(i++), "6.0");

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
@@ -18,12 +18,10 @@
  */
 package org.ballerinalang.langlib.test.statements.foreach;
 
-import org.ballerinalang.core.model.values.BInteger;
-import org.ballerinalang.core.model.values.BValue;
+import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -34,7 +32,7 @@ import org.testng.annotations.Test;
  */
 public class ForeachErrorHandlingTests {
 
-    private CompileResult program, negative;
+    private CompileResult program;
 
     @BeforeClass
     public void setup() {
@@ -43,8 +41,16 @@ public class ForeachErrorHandlingTests {
 
     @Test
     public void testArrayForeachAndTrap() {
-        BValue[] returns = BRunUtil.invoke(program, "testArrayForeachAndTrap");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(((BInteger) returns[0]).intValue(), 14);
+        BRunUtil.invoke(program, "testArrayForeachAndTrap");
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
+            "error: \\{ballerina/lang.int\\}NumberParsingError \\{\"message\":\"'string' value 'waruna' cannot be " +
+                    "converted to 'int'\"\\}\n" +
+                    "\tat ballerina.lang.int.1_1_0:fromString\\(int.bal:127\\)\n" +
+                    "\t   foreach_error_handling:\\$lambda\\$_0\\(foreach_error_handling.bal:41\\)\n" +
+                    "\t   foreach_error_handling:\\$lambda\\$_0\\$lambda0\\$\\(foreach_error_handling.bal:40\\)")
+    public void testArrayForeachAndPanic() {
+        BRunUtil.invoke(program, "testArrayForeachAndPanic");
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
@@ -53,7 +53,8 @@ public class ForeachErrorHandlingTests {
             "error: \\{ballerina\\}TypeCastError \\{\"message\":\"incompatible types: 'error' cannot be cast to " +
                     "'int'\"\\}\n" +
                     "\tat foreach_error_handling:\\$lambda\\$_0\\(foreach_error_handling.bal:41\\)\n" +
-                    "\t   foreach_error_handling:\\$lambda\\$_0\\$lambda0\\$\\(foreach_error_handling.bal:40\\)")
+                    "\t   foreach_error_handling:\\$lambda\\$_0\\$lambda0\\$\\(foreach_error_handling.bal:40\\)",
+            enabled = false)
     public void testArrayForeachAndPanic() {
         BValue[] returns = BRunUtil.invoke(program, "testArrayForeachAndPanic");
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
@@ -48,14 +48,4 @@ public class ForeachErrorHandlingTests {
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 14);
     }
-
-    @Test(expectedExceptions = BLangRuntimeException.class, expectedExceptionsMessageRegExp =
-            "error: \\{ballerina\\}TypeCastError \\{\"message\":\"incompatible types: 'error' cannot be cast to " +
-                    "'int'\"\\}\n" +
-                    "\tat foreach_error_handling:\\$lambda\\$_0\\(foreach_error_handling.bal:41\\)\n" +
-                    "\t   foreach_error_handling:\\$lambda\\$_0\\$lambda0\\$\\(foreach_error_handling.bal:40\\)",
-            enabled = false)
-    public void testArrayForeachAndPanic() {
-        BValue[] returns = BRunUtil.invoke(program, "testArrayForeachAndPanic");
-    }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachErrorHandlingTests.java
@@ -20,7 +20,6 @@ package org.ballerinalang.langlib.test.statements.foreach;
 
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BValue;
-import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTests.java
@@ -67,7 +67,7 @@ public class ForeachJSONTests {
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = ".*incompatible types: 'string' cannot be cast to 'map<json>'.*")
     public void testJSONString() {
-        String result = "{ballerina}ConversionError {\"message\":\"'string' value " 
+        String result = "{ballerina}ConversionError {\"message\":\"'string' value "
                 + "cannot be converted to 'map<json>'\"}";
         BValue[] returns = BRunUtil.invoke(program, "testJSONString");
         Assert.assertEquals(returns.length, 1);
@@ -77,7 +77,7 @@ public class ForeachJSONTests {
     @Test(expectedExceptions =  BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = ".*incompatible types: 'int' cannot be cast to 'map<json>'.*")
     public void testJSONNumber() {
-        String result = "{ballerina}ConversionError {\"message\":\"'int' value cannot" 
+        String result = "{ballerina}ConversionError {\"message\":\"'int' value cannot"
                 + " be converted to 'map<json>'\"}";
         BValue[] returns = BRunUtil.invoke(program, "testJSONNumber");
         Assert.assertEquals(returns.length, 1);
@@ -92,6 +92,14 @@ public class ForeachJSONTests {
         BValue[] returns = BRunUtil.invoke(program, "testJSONBoolean");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), result);
+    }
+
+    @Test(expectedExceptions = BLangRuntimeException.class,
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}KeyNotFound \\{\"message\":\"Key 'city'" +
+                    " not found in JSON mapping\"\\}\n" +
+                    "\tat foreach-json:testJSONNull\\(foreach-json.bal:79\\)")
+    public void testJSONNull() {
+        BRunUtil.invoke(program, "testJSONNull");
     }
 
     @Test(enabled = false)

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTests.java
@@ -94,15 +94,6 @@ public class ForeachJSONTests {
         Assert.assertEquals(returns[0].stringValue(), result);
     }
 
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = ".*incompatible types: 'error' cannot be cast to 'map<json>'.*")
-    public void testJSONNull() {
-        String result = "{ballerina}ConversionError {\"message\":\"cannot convert 'null' value to type 'map<json>'\"}";
-        BValue[] returns = BRunUtil.invoke(program, "testJSONNull");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(returns[0].stringValue(), result);
-    }
-
     @Test(enabled = false)
     public void testJSONToStructCast() {
         String result = "a-h1 b-h2 ";

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTypedBindingPatternsTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTypedBindingPatternsTests.java
@@ -90,16 +90,21 @@ public class ForeachJSONTypedBindingPatternsTests {
 
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp =
-                    ".*error: \\{ballerina}TypeCastError \\{\"message\":\"incompatible types: '\\(\\)' cannot be cast" +
-                            " to 'map<json>'.*")
+                    "error: \\{ballerina/lang.map\\}KeyNotFound \\{\"message\":\"Key 'random' not found in JSON " +
+                            "mapping\"\\}\n" +
+                            "\tat foreach-json-typed-binding-patterns" +
+                            ":testDirectAccessInvalidElementWithoutType\\(foreach-json-typed-binding-patterns.bal" +
+                            ":120\\)")
     public void testDirectAccessInvalidElementWithoutType() {
         BRunUtil.invoke(program, "testDirectAccessInvalidElementWithoutType");
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp =
-                    ".*error: \\{ballerina}TypeCastError \\{\"message\":\"incompatible types: '\\(\\)' cannot be cast" +
-                            " to 'map<json>'.*")
+                    "error: \\{ballerina/lang.map\\}KeyNotFound \\{\"message\":\"Key 'random' not found in JSON " +
+                            "mapping\"\\}\n" +
+                            "\tat foreach-json-typed-binding-patterns" +
+                            ":testDirectAccessInvalidElementWithType\\(foreach-json-typed-binding-patterns.bal:133\\)")
     public void testDirectAccessInvalidElementWithType() {
         BRunUtil.invoke(program, "testDirectAccessInvalidElementWithType");
     }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTypedBindingPatternsTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTypedBindingPatternsTests.java
@@ -89,22 +89,25 @@ public class ForeachJSONTypedBindingPatternsTests {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = ".*incompatible types: 'error' cannot be cast to 'json'.*")
+            expectedExceptionsMessageRegExp =
+                    ".*error: \\{ballerina}TypeCastError \\{\"message\":\"incompatible types: '\\(\\)' cannot be cast" +
+                            " to 'map<json>'.*")
     public void testDirectAccessInvalidElementWithoutType() {
         BValue[] returns = BRunUtil.invoke(program, "testDirectAccessInvalidElementWithoutType");
         Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(returns[0].stringValue(), "{ballerina}ConversionError {\"message\":\"cannot convert " 
-                + "'null' value to type 'map<json>'\"}");
+        Assert.assertEquals(returns[0].stringValue(), "{ballerina}TypeCastError {\"message\":\"incompatible types: '" +
+                "()' cannot be cast to 'map<json>'\"}");
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = ".*incompatible types: 'error' cannot be cast to 'json'.*")
+            expectedExceptionsMessageRegExp =
+                    ".*error: \\{ballerina}TypeCastError \\{\"message\":\"incompatible types: '\\(\\)' cannot be cast" +
+                            " to 'map<json>'.*")
     public void testDirectAccessInvalidElementWithType() {
         BValue[] returns = BRunUtil.invoke(program, "testDirectAccessInvalidElementWithType");
         Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(returns[0].stringValue(), "{ballerina}ConversionError {\"message\":\"cannot convert 'null'" 
-                + " " +
-                "value to type 'map<json>'\"}");
+        Assert.assertEquals(returns[0].stringValue(), "{ballerina}TypeCastError {\"message\":\"incompatible types: '" +
+                "()' cannot be cast to 'map<json>'\"}");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTypedBindingPatternsTests.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachJSONTypedBindingPatternsTests.java
@@ -93,10 +93,7 @@ public class ForeachJSONTypedBindingPatternsTests {
                     ".*error: \\{ballerina}TypeCastError \\{\"message\":\"incompatible types: '\\(\\)' cannot be cast" +
                             " to 'map<json>'.*")
     public void testDirectAccessInvalidElementWithoutType() {
-        BValue[] returns = BRunUtil.invoke(program, "testDirectAccessInvalidElementWithoutType");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(returns[0].stringValue(), "{ballerina}TypeCastError {\"message\":\"incompatible types: '" +
-                "()' cannot be cast to 'map<json>'\"}");
+        BRunUtil.invoke(program, "testDirectAccessInvalidElementWithoutType");
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
@@ -104,10 +101,7 @@ public class ForeachJSONTypedBindingPatternsTests {
                     ".*error: \\{ballerina}TypeCastError \\{\"message\":\"incompatible types: '\\(\\)' cannot be cast" +
                             " to 'map<json>'.*")
     public void testDirectAccessInvalidElementWithType() {
-        BValue[] returns = BRunUtil.invoke(program, "testDirectAccessInvalidElementWithType");
-        Assert.assertEquals(returns.length, 1);
-        Assert.assertEquals(returns[0].stringValue(), "{ballerina}TypeCastError {\"message\":\"incompatible types: '" +
-                "()' cannot be cast to 'map<json>'\"}");
+        BRunUtil.invoke(program, "testDirectAccessInvalidElementWithType");
     }
 
     @Test

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -1113,13 +1113,7 @@ function assertTrue(any|error actual) {
         return;
     }
 
-    string actualValAsString = "";
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }
 
@@ -1128,13 +1122,7 @@ function assertFalse(any|error actual) {
         return;
     }
 
-    string actualValAsString = "";
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected 'false', found '" + actualValAsString + "'");
 }
 

--- a/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/arraylib_test.bal
@@ -1113,8 +1113,14 @@ function assertTrue(any|error actual) {
         return;
     }
 
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }
 
 function assertFalse(any|error actual) {
@@ -1122,8 +1128,14 @@ function assertFalse(any|error actual) {
         return;
     }
 
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'false', found '" + actual.toString () + "'");
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected 'false', found '" + actualValAsString + "'");
 }
 
 

--- a/langlib/langlib-test/src/test/resources/test-src/booleanlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/booleanlib_test.bal
@@ -35,8 +35,23 @@ function assert(boolean|error expected, boolean|error actual) {
     if (expected != actual) {
         typedesc<anydata|error> expT = typeof expected;
         typedesc<anydata|error> actT = typeof actual;
-        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
-                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+
+        string expectedValAsString = "";
+        string actualValAsString = "";
+        if (expected is error) {
+            expectedValAsString = expected.toString();
+        } else {
+            expectedValAsString = expected.toString();
+        }
+
+        if (actual is error) {
+            actualValAsString = actual.toString();
+        } else {
+            actualValAsString = actual.toString();
+        }
+
+        string reason = "expected [" + expectedValAsString + "] of type [" + expT.toString()
+                            + "], but found [" + actualValAsString + "] of type [" + actT.toString() + "]";
         error e = error(reason);
         panic e;
     }

--- a/langlib/langlib-test/src/test/resources/test-src/booleanlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/booleanlib_test.bal
@@ -36,20 +36,8 @@ function assert(boolean|error expected, boolean|error actual) {
         typedesc<anydata|error> expT = typeof expected;
         typedesc<anydata|error> actT = typeof actual;
 
-        string expectedValAsString = "";
-        string actualValAsString = "";
-        if (expected is error) {
-            expectedValAsString = expected.toString();
-        } else {
-            expectedValAsString = expected.toString();
-        }
-
-        if (actual is error) {
-            actualValAsString = actual.toString();
-        } else {
-            actualValAsString = actual.toString();
-        }
-
+        string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+        string actualValAsString = actual is error ? actual.toString() : actual.toString();
         string reason = "expected [" + expectedValAsString + "] of type [" + expT.toString()
                             + "], but found [" + actualValAsString + "] of type [" + actT.toString() + "]";
         error e = error(reason);

--- a/langlib/langlib-test/src/test/resources/test-src/isolated-param/isolated_param.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/isolated-param/isolated_param.bal
@@ -64,19 +64,7 @@ isolated function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(string `expected '${expectedValAsString}', found '${actualValAsString}'`);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/isolated-param/isolated_param.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/isolated-param/isolated_param.bal
@@ -64,5 +64,19 @@ isolated function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error(string `expected '${expected.toString()}', found '${actual.toString()}'`);
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(string `expected '${expectedValAsString}', found '${actualValAsString}'`);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/langlib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/langlib_test_negative.bal
@@ -65,19 +65,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/langlib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/langlib_test_negative.bal
@@ -40,16 +40,20 @@ function testEnsureTypeWithUnion1() returns error? {
 
 function testToStringNegative() {
     json j = {
-        name : "Name",
-        address : {
-            country : "Country",
-            city : "City"
+        name: "Name",
+        address: {
+            country: "Country",
+            city: "City"
         }
     };
 
     var x1 = j.age.toString();
     var x2 = j.address.town.toString();
     var x3 = foo().toString();
+
+    var x4 = j.age.toBalString();
+    var x5 = j.address.town.toBalString();
+    var x6 = foo().toBalString();
 }
 
 function foo() returns int|error {

--- a/langlib/langlib-test/src/test/resources/test-src/langlib_test_negative.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/langlib_test_negative.bal
@@ -38,6 +38,24 @@ function testEnsureTypeWithUnion1() returns error? {
     int|string|float[] name = check j.name;
 }
 
+function testToStringNegative() {
+    json j = {
+        name : "Name",
+        address : {
+            country : "Country",
+            city : "City"
+        }
+    };
+
+    var x1 = j.age.toString();
+    var x2 = j.address.town.toString();
+    var x3 = foo().toString();
+}
+
+function foo() returns int|error {
+    return error("Error");
+}
+
 function assertEquality(any|error expected, any|error actual) {
     if expected is anydata && actual is anydata && expected == actual {
         return;
@@ -47,5 +65,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json-typed-binding-patterns.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json-typed-binding-patterns.bal
@@ -10,6 +10,10 @@ json jdata = {
     ]
 };
 
+json jNulldata = {
+    name: null
+};
+
 function concatIntString(int i, string s) {
     output = output + i.toString() + ":" + s + " ";
 }
@@ -52,7 +56,7 @@ function testDirectAccessJsonArrayWithoutType() returns string {
     output = "";
 
     int i = 0;
-    json j = <json>jdata.subjects;
+    json j = checkpanic jdata.subjects;
     if j is json[] {
         foreach var v in j {
             concatIntJson(i, v);
@@ -66,7 +70,7 @@ function testDirectAccessJsonArrayWithType() returns string {
     output = "";
 
     int i = 0;
-    json j =  <json>jdata.subjects;
+    json j =  checkpanic jdata.subjects;
     if j is json[] {
         foreach json v in j {
             concatIntJson(i, v);
@@ -81,7 +85,7 @@ function testDirectAccessJsonArrayWithType() returns string {
 function testJsonArrayWithoutType() returns string {
     output = "";
 
-    json subjects =  <json>jdata.subjects;
+    json subjects = checkpanic jdata.subjects;
 
     int i = 0;
     if subjects is json[] {
@@ -96,7 +100,7 @@ function testJsonArrayWithoutType() returns string {
 function testJsonArrayWithType() returns string {
     output = "";
 
-    json subjects =  <json>jdata.subjects;
+    json subjects = checkpanic jdata.subjects;
 
     int i = 0;
     if subjects is json[] {
@@ -113,12 +117,14 @@ function testJsonArrayWithType() returns string {
 function testDirectAccessInvalidElementWithoutType() returns string|error {
     output = "";
 
-    json j =  <json>jdata.random;
+    json|error j = jNulldata.name;
 
-    int i = 0;
-    foreach var v in <map<json>>j {
-        concatIntStringAny(i, v.toJsonString());
-        i += 1;
+    if (j is json) {
+        int i = 0;
+        foreach var v in <map<json>>j {
+            concatIntStringAny(i, v.toJsonString());
+            i += 1;
+        }
     }
     return output;
 }
@@ -126,12 +132,14 @@ function testDirectAccessInvalidElementWithoutType() returns string|error {
 function testDirectAccessInvalidElementWithType() returns string|error {
     output = "";
 
-    json j =  <json>jdata.random;
+    json|error j = jNulldata.name;
 
-    int i = 0;
-    foreach json v in <map<json>>j {
-        concatIntStringAny(i, v.toJsonString());
-        i += 1;
+    if (j is json) {
+        int i = 0;
+        foreach json v in <map<json>>j {
+            concatIntStringAny(i, v.toJsonString());
+            i += 1;
+        }
     }
     return output;
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json-typed-binding-patterns.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json-typed-binding-patterns.bal
@@ -117,14 +117,12 @@ function testJsonArrayWithType() returns string {
 function testDirectAccessInvalidElementWithoutType() returns string|error {
     output = "";
 
-    json|error j = jNulldata.name;
+    json j = checkpanic jNulldata.name;
 
-    if (j is json) {
-        int i = 0;
-        foreach var v in <map<json>>j {
-            concatIntStringAny(i, v.toJsonString());
-            i += 1;
-        }
+    int i = 0;
+    foreach var v in <map<json>>j {
+        concatIntStringAny(i, v.toJsonString());
+        i += 1;
     }
     return output;
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json-typed-binding-patterns.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json-typed-binding-patterns.bal
@@ -117,7 +117,7 @@ function testJsonArrayWithType() returns string {
 function testDirectAccessInvalidElementWithoutType() returns string|error {
     output = "";
 
-    json j = checkpanic jNulldata.name;
+    json j = checkpanic jdata.random;
 
     int i = 0;
     foreach var v in <map<json>>j {
@@ -130,14 +130,12 @@ function testDirectAccessInvalidElementWithoutType() returns string|error {
 function testDirectAccessInvalidElementWithType() returns string|error {
     output = "";
 
-    json|error j = jNulldata.name;
+    json j = checkpanic jdata.random;
 
-    if (j is json) {
-        int i = 0;
-        foreach json v in <map<json>>j {
-            concatIntStringAny(i, v.toJsonString());
-            i += 1;
-        }
+    int i = 0;
+    foreach json v in <map<json>>j {
+        concatIntStringAny(i, v.toJsonString());
+        i += 1;
     }
     return output;
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json.bal
@@ -20,7 +20,7 @@ function testJSONObject () returns string|error {
 function testJSONArray () returns (string) {
     output = "";
     json j1 = {name:"bob", age:10, pass:true, subjects: [{subject:"maths", marks:75}, {subject:"English", marks:85}]};
-    json element = <json> j1.subjects;
+    json element = checkpanic j1.subjects;
     if element is json[] {
         foreach var j in element {
             concatString(j.toJsonString());
@@ -49,7 +49,7 @@ function testArrayOfJSON () returns string | error {
 function testJSONString () returns string|error {
     output = "";
     json j1 = {name:"bob", age:10, pass:true, subjects: [{subject:"maths", marks:75}, {subject:"English", marks:85}]};
-    foreach var j in <map<json>>j1.name {
+    foreach var j in <map<json>> checkpanic j1.name {
         concatString(j.toJsonString());
     }
     return output;
@@ -58,7 +58,7 @@ function testJSONString () returns string|error {
 function testJSONNumber () returns string|error {
     output = "";
     json j1 = {name:"bob", age:10, pass:true, subjects: [{subject:"maths", marks:75}, {subject:"English", marks:85}]};
-    foreach var j in <map<json>>j1.age {
+    foreach var j in <map<json>> checkpanic j1.age {
         concatString(j.toJsonString());
     }
     return output;
@@ -67,16 +67,7 @@ function testJSONNumber () returns string|error {
 function testJSONBoolean () returns string|error {
     output = "";
     json j1 = {name:"bob", age:10, pass:true, subjects: [{subject:"maths", marks:75}, {subject:"English", marks:85}]};
-    foreach var j in <map<json>>j1.pass {
-        concatString(j.toJsonString());
-    }
-    return output;
-}
-
-function testJSONNull () returns string|error {
-    output = "";
-    json j1 = {name:"bob", age:10, pass:true, subjects: [{subject:"maths", marks:75}, {subject:"English", marks:85}]};
-    foreach var j in <map<json>>j1.city {
+    foreach var j in <map<json>> checkpanic j1.pass {
         concatString(j.toJsonString());
     }
     return output;

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach-json.bal
@@ -73,6 +73,15 @@ function testJSONBoolean () returns string|error {
     return output;
 }
 
+function testJSONNull() returns string|error {
+    output = "";
+    json j1 = {name:"bob", age:10, pass:true, subjects: [{subject:"maths", marks:75}, {subject:"English", marks:85}]};
+    foreach var j in <map<json>> checkpanic j1.city {
+        concatString(j.toJsonString());
+    }
+    return output;
+}
+
 type Protocols record {
     string data;
     Protocol[] plist;

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_error_handling.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_error_handling.bal
@@ -30,14 +30,6 @@ function testArrayForeachAndTrap() returns int {
     return -1;
 }
 
-function testArrayForeachAndPanic() {
-    string[] invalidArray = ["2", "waruna", "7"];
-    int result = convertAndGetSumFromArray(invalidArray);
-    // This line should not be executed.
-    panic error(ASSERTION_ERROR_REASON,
-                message = "Program should be panic before this line");
-}
-
 function convertAndGetSumFromArray(string[] stringNumbers) returns int {
     int sum = 0;
     stringNumbers.forEach(function (string s) {
@@ -54,12 +46,6 @@ function assertTrue(any|error actual) {
         return;
     }
 
-    string actualValAsString = "";
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_error_handling.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_error_handling.bal
@@ -24,7 +24,10 @@ function testArrayForeachAndTrap() returns int {
     string[] validArray = ["2", "5", "7"];
     result = trap convertAndGetSumFromArray(validArray);
     assertTrue(result is int);
-    return <int>result;
+    if (result is int) {
+        return result;
+    }
+    return -1;
 }
 
 function testArrayForeachAndPanic() {
@@ -38,17 +41,25 @@ function testArrayForeachAndPanic() {
 function convertAndGetSumFromArray(string[] stringNumbers) returns int {
     int sum = 0;
     stringNumbers.forEach(function (string s) {
-	    int val = <int>ints:fromString(s);
+	    int val = checkpanic ints:fromString(s);
         sum = sum + val;
     });
     return sum;
 }
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertTrue(any|error actual) {
     if actual is boolean && actual {
         return;
     }
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
+
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_error_handling.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/statements/foreach/foreach_error_handling.bal
@@ -16,7 +16,7 @@
 
 import ballerina/lang.'int as ints;
 
-function testArrayForeachAndTrap() returns int {
+function testArrayForeachAndTrap() {
     string[] invalidArray = ["2", "waruna", "7"];
     int|error result = trap convertAndGetSumFromArray(invalidArray);
     assertTrue(result is error);
@@ -24,10 +24,15 @@ function testArrayForeachAndTrap() returns int {
     string[] validArray = ["2", "5", "7"];
     result = trap convertAndGetSumFromArray(validArray);
     assertTrue(result is int);
-    if (result is int) {
-        return result;
-    }
-    return -1;
+    assertTrue(checkpanic result == 14);
+}
+
+function testArrayForeachAndPanic() {
+    string[] invalidArray = ["2", "waruna", "7"];
+    int result = convertAndGetSumFromArray(invalidArray);
+    // This line should not be executed.
+    panic error(ASSERTION_ERROR_REASON,
+                message = "Program should be panic before this line");
 }
 
 function convertAndGetSumFromArray(string[] stringNumbers) returns int {

--- a/langlib/langlib-test/src/test/resources/test-src/streamlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/streamlib_test.bal
@@ -160,7 +160,7 @@ function testFilterAndMapFunc() returns boolean {
 function testReduce() returns float {
     Person[] personList = getPersonList();
     stream<Person> personStream = personList.toStream();
-    float|error? avg = personStream.reduce(function (float accum, Person person) returns float {
+    float? avg = personStream.reduce(function (float accum, Person person) returns float {
         return accum + <float>person.age / personList.length();
     }, 0.0);
     return <float>avg;

--- a/langlib/langlib-test/src/test/resources/test-src/subtypes/char_subtypes_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/subtypes/char_subtypes_test.bal
@@ -76,7 +76,7 @@ function testCharLangLib() {
         test:assertNotError(result); // Should fail.
     }
 
-    s:Char h = <s:Char> result;
+    s:Char h = <s:Char> checkpanic result;
     test:assertValueEqual("h", h);
 
     int y = h.toCodePointInt();

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
@@ -188,20 +188,8 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_bound_type_as_cet.bal
@@ -172,8 +172,15 @@ function assertTrue(any|error actual) {
         return;
     }
 
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
+                message = "expected 'true', found '" + actualValAsString + "'");
 }
 
 function assertValueEquality(anydata|error expected, anydata|error actual) {
@@ -181,6 +188,20 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -21,13 +21,7 @@ function assertTrue(any|error actual) {
         return;
     }
 
-    string actualValAsString = "";
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }
 
@@ -36,20 +30,8 @@ function assertEqual(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/type-param/type_param_narrowing_for_union_return.bal
@@ -20,8 +20,15 @@ function assertTrue(any|error actual) {
     if actual is boolean && actual {
         return;
     }
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
+
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }
 
 function assertEqual(anydata|error expected, anydata|error actual) {
@@ -29,8 +36,22 @@ function assertEqual(anydata|error expected, anydata|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 function testSimpleUnion() {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromBalString_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromBalString_test.bal
@@ -299,19 +299,8 @@ function testFromBalStringOnCycles() {
 
 function assert(anydata|error actual, anydata|error expected) {
     if (expected != actual) {
-        string expectedValAsString = "";
-        string actualValAsString = "";
-        if (expected is error) {
-            expectedValAsString = expected.toString();
-        } else {
-            expectedValAsString = expected.toString();
-        }
-
-        if (actual is error) {
-            actualValAsString = actual.toString();
-        } else {
-            actualValAsString = actual.toString();
-        }
+        string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+        string actualValAsString = actual is error ? actual.toString() : actual.toString();
 
         typedesc<anydata|error> expT = typeof expected;
         typedesc<anydata|error> actT = typeof actual;

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_fromBalString_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_fromBalString_test.bal
@@ -293,17 +293,30 @@ function testFromBalStringOnCycles() {
          "\"2\":...[4],\"3\":...[0],\"4\":...[2]}},\"2\":{\"qq\":5,\"1\":[2,3,5,...[3]],\"2\":...[2],\"3\":...[0]," +
          "\"4\":{\"mm\":5,\"1\":...[4],\"2\":...[2]}},\"3\":...[0]}";
 
-     anydata|error result = s1.fromBalString();
-
+     anydata result = checkpanic s1.fromBalString();
      assert(result.toBalString(), s1);
 }
 
 function assert(anydata|error actual, anydata|error expected) {
     if (expected != actual) {
+        string expectedValAsString = "";
+        string actualValAsString = "";
+        if (expected is error) {
+            expectedValAsString = expected.toString();
+        } else {
+            expectedValAsString = expected.toString();
+        }
+
+        if (actual is error) {
+            actualValAsString = actual.toString();
+        } else {
+            actualValAsString = actual.toString();
+        }
+
         typedesc<anydata|error> expT = typeof expected;
         typedesc<anydata|error> actT = typeof actual;
-        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
-                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+        string reason = "expected [" + expectedValAsString + "] of type [" + expT.toString()
+                            + "], but found [" + actualValAsString + "] of type [" + actT.toString() + "]";
         error e = error(reason);
         panic e;
     }

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -267,7 +267,7 @@ function testMappingJsonNoIntersectionMergeSuccess() returns boolean {
     json j1 = { one: "hello", two: "world", three: 1 };
     map<json> j2 = { x: 12.0, y: "test value" };
 
-    json|error mje = j1.mergeJson(j2);
+    json mje = checkpanic j1.mergeJson(j2);
 
     if (!(mje is map<json>) || mje.length() != 5) {
         return false;
@@ -330,7 +330,7 @@ function testMappingJsonWithIntersectionMergeSuccess() returns boolean {
         return false;
     } else {
         map<json> expMap = { a: "strings", b: "test", c: "value" };
-        map<json> mj4 = <map<json>> mj.four;
+        map<json> mj4 = <map<json>> (checkpanic mj.four);
         return mj === j1 && mj.one == "hello" && mj.two == "world" && mj.three == 1 &&
             mj4 == expMap && mj.five == 5 && j2 == j2Clone;
     }
@@ -355,7 +355,7 @@ function testMergeJsonFailureForValuesWithIntersectingCyclicRefererences() retur
     if (result is json || result.detail()["message"].toString() != "JSON Merge failed for key 'z'") {
         return false;
     } else {
-        error? cause = <error?>result.detail()["cause"];
+        error? cause = <error?>result.detail()["cause"]; // incompatible types: '(anydata|readonly)' cannot be cast to 'error?'
         if (cause is () || cause.detail()["message"].toString() != "Cannot merge JSON values with cyclic references") {
             return false;
         }
@@ -472,8 +472,22 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic AssertionError(ASSERTION_ERROR_REASON,
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 type Person2 record {
@@ -486,8 +500,9 @@ function testCloneWithTypeJsonRec1() {
     json|error ss = p.cloneWithType(json);
     assert(ss is json, true);
 
-    json j = <json> ss;
-    assert(j.toJsonString(), "{\"name\":\"N\", \"age\":3}");
+    if (ss is json) {
+        assert(ss.toJsonString(), "{\"name\":\"N\", \"age\":3}");
+    }
 }
 
 function testCloneWithTypeJsonRec2() {
@@ -495,16 +510,18 @@ function testCloneWithTypeJsonRec2() {
    Person2|error pe = pj.cloneWithType(Person2);
    assert(pe is Person2, true);
 
-   Person2 p = <Person2> pe;
-   assert(p.name, "tom");
-   assert(p.age, 2);
+   if (pe is Person2) {
+       assert(pe.name, "tom");
+       assert(pe.age, 2);
+   }
 
    Person2 s = { name : "bob", age: 4};
    json|error ss = s.cloneWithType(json);
    assert(ss is json, true);
 
-   json j = <json> ss;
-   assert(j.toJsonString(), "{\"name\":\"bob\", \"age\":4}");
+   if (ss is json) {
+       assert(ss.toJsonString(), "{\"name\":\"bob\", \"age\":4}");
+   }
 }
 
 type BRec record {
@@ -576,14 +593,20 @@ function testCloneWithTypeNumeric1() {
     int a = 1234;
     float|error b = a.cloneWithType(float);
     assert(b is float, true);
-    assert(<float> b, 1234.0);
+
+    if (b is float) {
+        assert(b, 1234.0);
+    }
 }
 
 function testCloneWithTypeNumeric2() {
     anydata a = 1234.6;
     int|error b = a.cloneWithType(int);
     assert(b is int, true);
-    assert(<int> b, 1235);
+
+    if (b is int) {
+        assert(b, 1235);
+    }
 }
 
 type X record {
@@ -603,10 +626,11 @@ function testCloneWithTypeNumeric3() {
     Y|error ye = x.cloneWithType(Y);
     assert(ye is Y, true);
 
-    Y y = <Y> ye;
-    assert(y.a, 21.0);
-    assert(y.b, "Alice");
-    assert(y["c"], <decimal> 1000.5);
+    if (ye is Y) {
+        assert(ye.a, 21.0);
+        assert(ye.b, "Alice");
+        assert(ye["c"], <decimal> 1000.5);
+    }
 }
 
 function testCloneWithTypeNumeric4() {
@@ -614,10 +638,11 @@ function testCloneWithTypeNumeric4() {
     X|error xe = j.cloneWithType(X);
     assert(xe is X, true);
 
-    X x = <X> xe;
-    assert(x.a, 21);
-    assert(x.b, "Alice");
-    assert(x.c, 1000.0);
+    if (xe is X) {
+        assert(xe.a, 21);
+        assert(xe.b, "Alice");
+        assert(xe.c, 1000.0);
+    }
 }
 
 type FloatArray float[];
@@ -625,14 +650,15 @@ type FloatOrBooleanArray (float|boolean)[];
 function testCloneWithTypeNumeric5() {
     int[] i = [1, 2];
     float[]|error j = i.cloneWithType(FloatArray);
-    (float|boolean)[]|error j2 = i.cloneWithType(FloatOrBooleanArray);
+    (float|boolean)[] j2 = checkpanic i.cloneWithType(FloatOrBooleanArray);
     assert(j is float[], true);
 
-    float[] jf = <float[]> j;
-    assert(jf.length(), i.length());
-    assert(jf[0], 1.0);
-    assert(jf[1], 2.0);
-    assert(jf, <(float|boolean)[]> j2);
+    if (j is float[]) {
+        assert(j.length(), i.length());
+        assert(j[0], 1.0);
+        assert(j[1], 2.0);
+        assert(j, <(float|boolean)[]> j2);
+    }
 }
 
 type IntMap map<int>;
@@ -640,14 +666,15 @@ type IntOrStringMap map<string|int>;
 function testCloneWithTypeNumeric6() {
     map<float> m = { a: 1.2, b: 2.7 };
     map<int>|error m2 = m.cloneWithType(IntMap);
-    map<string|int>|error m3 = m.cloneWithType(IntOrStringMap);
+    map<string|int> m3 = checkpanic m.cloneWithType(IntOrStringMap);
     assert(m2 is map<int>, true);
 
-    map<int> m2m = <map<int>> m2;
-    assert(m2m.length(), m.length());
-    assert(m2m["a"], 1);
-    assert(m2m["b"], 3);
-    assert(m2m, <map<string|int>> m3);
+    if (m2 is map<int>) {
+        assert(m2.length(), m.length());
+        assert(m2["a"], 1);
+        assert(m2["b"], 3);
+        assert(m2, <map<string|int>> m3);
+    }
 }
 
 type DecimalArray decimal[];
@@ -656,22 +683,24 @@ function testCloneWithTypeNumeric7() {
     decimal[]|error a2 = a1.cloneWithType(DecimalArray);
     assert(a2 is decimal[], true);
 
-    decimal[] a2d = <decimal[]> a2;
-    assert(a2d.length(), a1.length());
-    assert(a2d[0], <decimal> 1);
-    assert(a2d[1], <decimal> 2);
-    assert(a2d[2], <decimal> 3);
+    if (a2 is decimal[]) {
+        assert(a2.length(), a1.length());
+        assert(a2[0], <decimal> 1);
+        assert(a2[1], <decimal> 2);
+        assert(a2[2], <decimal> 3);
+    }
 }
 
 type StringArray string[];
 function testCloneWithTypeStringArray() {
    string anArray = "[\"hello\", \"world\"]";
-   json j = <json> anArray.fromJsonString();
+   json j = <json> checkpanic anArray.fromJsonString();
     string[]|error cloned = j.cloneWithType(StringArray);
     assert(cloned is string[], true);
-    string[]  clonedArr= <string[]> cloned;
-    assert(clonedArr[0], "hello");
-    assert(clonedArr[1], "world");
+    if (cloned is string[]) {
+        assert(cloned[0], "hello");
+        assert(cloned[1], "world");
+    }
 }
 
 /////////////////////////// Tests for `fromJsonWithType()` ///////////////////////////
@@ -688,11 +717,13 @@ function testFromJsonWIthTypeNegative() {
 
 function testFromJsonWithTypeRecord1() {
     string str = "{\"name\":\"Name\",\"age\":35}";
-    json j = <json> str.fromJsonString();
+    json j = <json> checkpanic str.fromJsonString();
     Student2|error p = j.fromJsonWithType(Student2);
 
     assert(p is Student2, true);
-    assert(p.toString(), "{\"name\":\"Name\",\"age\":35}");
+    if (p is Student2) {
+        assert(p.toString(), "{\"name\":\"Name\",\"age\":35}");
+    }
 }
 
 type Student3 record {
@@ -726,11 +757,13 @@ type Foo6 record {
 
 function testFromJsonWithTypeRecord2() {
     string str = "{\"name\":\"Name\",\"age\":35}";
-    json j = <json> str.fromJsonString();
+    json j = <json> checkpanic str.fromJsonString();
     Student3|error p = j.fromJsonWithType(Student3);
 
     assert(p is Student3, true);
-    assert(p.toString(), "{\"name\":\"Name\",\"age\":35}");
+    if (p is Student3) {
+        assert(p.toString(), "{\"name\":\"Name\",\"age\":35}");
+    }
 }
 
 function testFromJsonWithTypeRecord3() {
@@ -753,7 +786,7 @@ type Student2Or3 Student2|Student3;
 
 function testFromJsonWithTypeAmbiguousTargetType() {
     string str = "{\"name\":\"Name\",\"age\":35}";
-    json j = <json> str.fromJsonString();
+    json j = <json> checkpanic str.fromJsonString();
     Student3|error p = j.fromJsonWithType(Student2Or3);
     assert(p is error, true);
 }
@@ -762,9 +795,10 @@ function testFromJsonWithTypeXML() {
     string s1 = "<test>name</test>";
     xml|error x1 = s1.fromJsonWithType(xml);
     assert(x1 is xml, true);
-    xml x11 = <xml> x1;
-    json|error j = x11.toJson();
-    assert(<json> j, s1);
+    if (x1 is xml) {
+        json j = x1.toJson();
+        assert(j, s1);
+    }
 }
 
 type Student4 record {
@@ -786,7 +820,7 @@ function testFromJsonWithTypeMap() {
         title: "Some",
         year: 2010
     };
-    map<anydata>|error movieMap = movie.fromJsonWithType(MapOfAnyData);
+    map<anydata> movieMap = checkpanic movie.fromJsonWithType(MapOfAnyData);
     map<anydata> movieMap2 = <map<anydata>> movieMap;
     assert(movieMap2["title"], "Some");
     assert(movieMap2["year"], 2010);
@@ -794,7 +828,7 @@ function testFromJsonWithTypeMap() {
 
 function testFromJsonWithTypeStringArray() {
     json j = ["Hello", "World"];
-    string[]|error a = j.fromJsonWithType(StringArray);
+    string[] a = checkpanic j.fromJsonWithType(StringArray);
     string[] a2 = <string[]> a;
     assert(a2.length(), 2);
     assert(a2[0], "Hello");
@@ -810,7 +844,7 @@ type IntArray int[];
 
 function testFromJsonWithTypeIntArray() {
     json j = [1, 2];
-    int[]|error arr = j.fromJsonWithType(IntArray);
+    int[] arr = checkpanic j.fromJsonWithType(IntArray);
     int[] intArr = <int[]> arr;
     assert(intArr[0], 1);
     assert(intArr[1], 2);
@@ -879,13 +913,13 @@ function testFromJsonStringWithTypeJson() {
     assert(result["aNil"] is error, true);
     assert(result["aNull"] is (), true);
 
-    json aStringJson = <json> result["aString"];
+    json aStringJson = <json> checkpanic result["aString"];
     assert(aStringJson.toJsonString(), "aString");
 
-    json anArrayJson = <json> result["anArray"];
+    json anArrayJson = <json> checkpanic result["anArray"];
     assert(anArrayJson.toJsonString(), "[\"hello\", \"world\"]");
 
-    json anObjectJson = <json> result["anObject"];
+    json anObjectJson = <json> checkpanic result["anObject"];
     assert(anObjectJson.toJsonString(), "{\"name\":\"anObject\", \"value\":10, \"sub\":{\"subName\":\"subObject\", \"subValue\":10}}");
 
     assert(result["anInvalid"] is error, true);
@@ -895,9 +929,10 @@ function testFromJsonStringWithTypeRecord() {
     string str = "{\"name\":\"Name\",\"age\":35}";
     Student3|error studentOrError = str.fromJsonStringWithType(Student3);
 
-    assert(studentOrError is Student3, true);
-    Student3 student = <Student3> studentOrError;
-    assert(student.name, "Name");
+    if (studentOrError is Student3) {
+        Student3 student = <Student3> studentOrError;
+        assert(student.name, "Name");
+    }
 }
 
 function testFromJsonStringWithAmbiguousType() {
@@ -908,7 +943,7 @@ function testFromJsonStringWithAmbiguousType() {
 
 function testFromJsonStringWithTypeMap() {
     string s = "{\"title\":\"Some\",\"year\":2010}";
-    map<anydata>|error movieMap = s.fromJsonStringWithType(MapOfAnyData);
+    map<anydata> movieMap = checkpanic s.fromJsonStringWithType(MapOfAnyData);
     map<anydata> movieMap2 = <map<anydata>> movieMap;
     assert(movieMap2["title"], "Some");
     assert(movieMap2["year"], 2010);
@@ -916,7 +951,7 @@ function testFromJsonStringWithTypeMap() {
 
 function testFromJsonStringWithTypeStringArray() {
     string s = "[\"Hello\",\"World\"]";
-    string[]|error a = s.fromJsonStringWithType(StringArray);
+    string[] a = checkpanic s.fromJsonStringWithType(StringArray);
     string[] a2 = <string[]> a;
     assert(a2.length(), 2);
     assert(a2[0], "Hello");
@@ -930,7 +965,7 @@ function testFromJsonStringWithTypeArrayNegative() {
 
 function testFromJsonStringWithTypeIntArray() {
     string s = "[1, 2]";
-    int[]|error arr = s.fromJsonStringWithType(IntArray);
+    int[] arr = checkpanic s.fromJsonStringWithType(IntArray);
     int[] intArr = <int[]> arr;
     assert(intArr[0], 1);
     assert(intArr[1], 2);
@@ -966,7 +1001,7 @@ function testToJsonWithLiterals() {
 
 function testToJsonWithArray() {
     string[] arrString = ["hello", "world"];
-    json|error arrStringJson = arrString.toJson();
+    json arrStringJson = arrString.toJson();
     assert(arrStringJson is json[], true);
     assert(<json[]> arrStringJson, <json[]> ["hello", "world"]);
 }
@@ -977,7 +1012,7 @@ function testToJsonWithXML() {
                     <writer>Writer</writer>
                   </movie>`;
     json j = x1.toJson();
-    xml|error x2 = j.fromJsonWithType(xml);
+    xml x2 = checkpanic j.fromJsonWithType(xml);
     assert(<xml> x2, x1);
 
     map<anydata> m2 = {a: 1, b: x1};
@@ -993,7 +1028,7 @@ function testToJsonWithMap() {
     };
     json j = m.toJson();
     assert(j.toJsonString(),"{\"line1\":\"Line1\", \"line2\":\"Line2\"}");
-    map<string>|error m2 = j.fromJsonWithType(MapOfString);
+    map<string> m2 = checkpanic j.fromJsonWithType(MapOfString);
     assert(<map<string>> m2, m);
 }
 
@@ -1205,27 +1240,27 @@ function testEnsureType() {
     json w1 = 72.5;
     float|int w2 = 72.5;
     float|string name2 = "Chiran";
-    assert(<int>testEnsureTypeWithInt(), 24);
-    assert(<int>testEnsureTypeWithInt2(), 178);
-    assert(<int>testEnsureTypeWithInt3(), 0);
-    assert(<decimal>testEnsureTypeWithDecimal(), h);
-    assert(<decimal>testEnsureTypeWithDecimal2(), 24);
-    assert(<()>testEnsureTypeWithNil(), ());
-    assert( <string>testEnsureTypeWithString(), "Chiran");
-    assert(<float>testEnsureTypeWithFloat(), w1);
-    assert(<float|int>testEnsureTypeWithUnion1(), w2);
-    assert(<float|string>testEnsureTypeWithUnion2(), name2);
-    assert(<json>testEnsureTypeWithJson1(), 24);
-    assert(<json>testEnsureTypeWithJson2(),h1);
-    assert(<json>testEnsureTypeWithJson3(), {group: "O", RHD: "+"});
-    assert(<json>testEnsureTypeWithJson4(), [125.0/3, "xyz street",
+    assert(<int>(checkpanic testEnsureTypeWithInt()), 24);
+    assert(<int>(checkpanic testEnsureTypeWithInt2()), 178);
+    assert(<int>(checkpanic testEnsureTypeWithInt3()), 0);
+    assert(<decimal>(checkpanic testEnsureTypeWithDecimal()), h);
+    assert(<decimal>(checkpanic testEnsureTypeWithDecimal2()), 24);
+    assert(<()>(checkpanic testEnsureTypeWithNil()), ());
+    assert( <string>(checkpanic testEnsureTypeWithString()), "Chiran");
+    assert(<float>(checkpanic testEnsureTypeWithFloat()), w1);
+    assert(<float|int>(checkpanic testEnsureTypeWithUnion1()), w2);
+    assert(<float|string>(checkpanic testEnsureTypeWithUnion2()), name2);
+    assert(<json>(checkpanic testEnsureTypeWithJson1()), 24);
+    assert(<json>(checkpanic testEnsureTypeWithJson2()),h1);
+    assert(<json>(checkpanic testEnsureTypeWithJson3()), {group: "O", RHD: "+"});
+    assert(<json>(checkpanic testEnsureTypeWithJson4()), [125.0/3, "xyz street",
     {province: "southern", Country: "Sri Lanka"}, 81000]);
-    assert(<json>testEnsureTypeWithJson5(), 72.5);
-    assert(<json>testEnsureTypeWithJson6(), false);
-    assert(<boolean>testEnsureTypeWithCast1(), false);
-    assert(<json[]>testEnsureTypeWithCast2(), [125.0/3, "xyz street",
+    assert(<json>(checkpanic testEnsureTypeWithJson5()), 72.5);
+    assert(<json>(checkpanic testEnsureTypeWithJson6()), false);
+    assert(<boolean>(checkpanic testEnsureTypeWithCast1()), false);
+    assert(<json[]>(checkpanic testEnsureTypeWithCast2()), [125.0/3, "xyz street",
     {province: "southern", Country: "Sri Lanka"}, 81000]);
-    assert(<map<json>>testEnsureTypeWithJson3(), {group: "O", RHD: "+"});
+    assert(<map<json>>(checkpanic testEnsureTypeWithJson3()), {group: "O", RHD: "+"});
 }
 
 function testRequiredTypeWithInvalidCast1() returns error? {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -209,7 +209,7 @@ function testFromJsonDecimalString() returns map<json|error> {
     return result;
 }
 
-function testToStringMethod() returns [string, string, string, string, string, string] {
+function testToStringMethod() {
     int a = 4;
     anydata b = a;
     any c = b;
@@ -218,7 +218,14 @@ function testToStringMethod() returns [string, string, string, string, string, s
                val3 = {"x":"AA","y":(1.0/0.0)});
     FirstError err2 = FirstError(REASON_1, message = "Test passing error union to a function");
 
-    return [a.toString(), b.toString(), c.toString(), d, err1.toString(), err2.toString()];
+    assertEquality("4", a.toString());
+    assertEquality("4", b.toString());
+    assertEquality("4", c.toString());
+    assertEquality("4", d);
+    assertEquality("error(\"Failed to get account balance\",details=true,val1=NaN,val2=\"This Error\","
+                                                            + "val3={\"x\":\"AA\",\"y\":Infinity})", err1.toString());
+    assertEquality("error FirstError (\"Reason1\",message=\"Test passing error union to a function\")",
+                                                                                                    err2.toString());
 }
 
 /////////////////////////// Tests for `mergeJson()` ///////////////////////////
@@ -581,10 +588,7 @@ function testCloneWithTypeNumeric1() {
     int a = 1234;
     float|error b = a.cloneWithType(float);
     assert(b is float, true);
-
-    if (b is float) {
-        assert(b, 1234.0);
-    }
+    assert(checkpanic b, 1234.0);
 }
 
 function testCloneWithTypeNumeric2() {

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -472,20 +472,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
@@ -507,13 +495,9 @@ function testCloneWithTypeJsonRec1() {
 
 function testCloneWithTypeJsonRec2() {
    json pj = { name : "tom", age: 2};
-   Person2|error pe = pj.cloneWithType(Person2);
-   assert(pe is Person2, true);
-
-   if (pe is Person2) {
-       assert(pe.name, "tom");
-       assert(pe.age, 2);
-   }
+   Person2 pe = checkpanic pj.cloneWithType(Person2);
+   assert(pe.name, "tom");
+   assert(pe.age, 2);
 
    Person2 s = { name : "bob", age: 4};
    json|error ss = s.cloneWithType(json);

--- a/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/valuelib_test.bal
@@ -209,12 +209,16 @@ function testFromJsonDecimalString() returns map<json|error> {
     return result;
 }
 
-function testToStringMethod() returns [string, string, string, string] {
+function testToStringMethod() returns [string, string, string, string, string, string] {
     int a = 4;
     anydata b = a;
     any c = b;
     var d = c.toString();
-    return [a.toString(), b.toString(), c.toString(), d];
+    error err1 = error("Failed to get account balance", details = true, val1 = (0.0/0.0), val2 = "This Error",
+               val3 = {"x":"AA","y":(1.0/0.0)});
+    FirstError err2 = FirstError(REASON_1, message = "Test passing error union to a function");
+
+    return [a.toString(), b.toString(), c.toString(), d, err1.toString(), err2.toString()];
 }
 
 /////////////////////////// Tests for `mergeJson()` ///////////////////////////
@@ -1309,7 +1313,7 @@ function tesFromJsonWithTypeMapWithDecimal() {
         panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
     }
 
-    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
+    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget> checkpanic or;
     assertEquality(castedValue["factor"], mp["factor"]);
     assertEquality(castedValue["name"], mp["name"]);
 }

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_constrained_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_constrained_test.bal
@@ -66,7 +66,7 @@ public function xmlConstraintRuntimeCast() {
 
 public function xmlCastSingleElementAsConstrainedSequence() {
     string elemText = "<hello>xml element 1</hello>";
-    xml<'xml:Element> elementSequence = <xml<'xml:Element>> 'xml:fromString(elemText);
+    xml<'xml:Element> elementSequence = <xml<'xml:Element>> checkpanic 'xml:fromString(elemText);
     assert(elementSequence.length(), 1);
     assert((elementSequence[0]/*).toString(),"xml element 1");
 }

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -49,7 +49,7 @@ function getXML() returns xml[] {
 
 function testFromString() returns xml|error {
     string s = catalog.toString();
-    xml x = <xml> 'xml:fromString(s);
+    xml x = <xml> check 'xml:fromString(s);
     return x/<CD>/<TITLE>;
 }
 
@@ -59,7 +59,7 @@ function emptyConcatCall() returns xml {
 
 function testConcat() returns xml {
     xml x = xml `<hello>xml content</hello>`;
-    return 'xml:concat(x, <xml> testFromString(), "hello from String");
+    return 'xml:concat(x, <xml> checkpanic testFromString(), "hello from String");
 }
 
 function testIsElement() returns [boolean, boolean, boolean] {
@@ -258,21 +258,21 @@ function testAsyncFpArgsWithXmls() returns [int, xml] {
 
     int sum = 0;
     ((bookstore/*).elements()).forEach(function (xml x) {
-      int value =   <int>langint:fromString((x/<year>/*).toString()) ;
+      int value = <int> checkpanic langint:fromString((x/<year>/*).toString()) ;
       future<int> f1 = start getRandomNumber(value);
       int result = wait f1;
       sum = sum + result;
     });
 
     var filter = ((bookstore/*).elements()).filter(function (xml x) returns boolean {
-      int value =   <int>langint:fromString((x/<year>/*).toString()) ;
+      int value =   <int> checkpanic langint:fromString((x/<year>/*).toString()) ;
       future<int> f1 = start getRandomNumber(value);
       int result = wait f1;
       return result > 2000;
     });
 
     var filter2 = (filter).map(function (xml x) returns xml {
-      int value =   <int>langint:fromString((x/<year>/*).toString()) ;
+      int value =   <int> checkpanic langint:fromString((x/<year>/*).toString()) ;
       future<int> f1 = start getRandomNumber(value);
       int result = wait f1;
       return xml `<year>${result}</year>`;

--- a/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/xmllib_test.bal
@@ -49,7 +49,7 @@ function getXML() returns xml[] {
 
 function testFromString() returns xml|error {
     string s = catalog.toString();
-    xml x = <xml> check 'xml:fromString(s);
+    xml x = <xml> checkpanic 'xml:fromString(s);
     return x/<CD>/<TITLE>;
 }
 

--- a/tests/jballerina-benchmark-test/src/main/ballerina/benchmark-loops.bal
+++ b/tests/jballerina-benchmark-test/src/main/ballerina/benchmark-loops.bal
@@ -267,7 +267,8 @@ public function benchmarkLoopWithFramesForeach(int warmupCount, int benchmarkCou
         frames.push(_frame);
     }
     foreach _Frame f in frames {
-        Person p = {id: <int>f["id"], fname: <string>f["fname"], lname: <string>f["lname"]};
+        Person p = {id: <int>(checkpanic f["id"]), fname: <string>(checkpanic f["fname"]),
+                                                                            lname: <string>(checkpanic f["lname"])};
         outputList.push(p);
     }
 
@@ -283,7 +284,8 @@ public function benchmarkLoopWithFramesForeach(int warmupCount, int benchmarkCou
         frames.push(_frame);
     }
     foreach _Frame f in frames {
-        Person p = {id: <int>f["id"], fname: <string>f["fname"], lname: <string>f["lname"]};
+        Person p = {id: <int>(checkpanic f["id"]), fname: <string>(checkpanic f["fname"]),
+                                                                            lname: <string>(checkpanic f["lname"])};
         outputList.push(p);
     }
     return (nanoTime() - startTime);

--- a/tests/jballerina-benchmark-test/src/main/ballerina/executor.bal
+++ b/tests/jballerina-benchmark-test/src/main/ballerina/executor.bal
@@ -21,8 +21,8 @@ public function main(string... args) {
         println("ERROR: Please specify the number of warm-up iterations and benchmark iterations.");
         return;
     }
-    int warmupCount = <int>'int:fromString(args[0]);
-    int benchmarkCount = <int>'int:fromString(args[1]);
+    int warmupCount = <int> checkpanic 'int:fromString(args[0]);
+    int benchmarkCount = <int> checkpanic 'int:fromString(args[1]);
     string functionName = args[2];
     loadFunctions();
     (function(int warmup, int benchmark) returns int)|function()|() func = getFunction(functionName);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
@@ -274,12 +274,17 @@ public class TypeCastExpressionsTest {
 
     @Test
     public void testCastNegatives() {
-        Assert.assertEquals(resultNegative.getErrorCount(), 3);
         int errIndex = 0;
         validateError(resultNegative, errIndex++, "incompatible types: 'Def' cannot be cast to 'Abc'", 19, 15);
         validateError(resultNegative, errIndex++, "incompatible types: 'boolean' cannot be cast to '(int|foo)'",
                 30, 16);
-        validateError(resultNegative, errIndex, "incompatible types: '(int|foo)' cannot be cast to 'xml'", 35, 13);
+        validateError(resultNegative, errIndex++, "incompatible types: '(int|foo)' cannot be cast to 'xml'", 35, 13);
+        validateError(resultNegative, errIndex++, "incompatible types: '(int|error)' cannot be cast to 'int'", 67, 13);
+        validateError(resultNegative, errIndex++, "incompatible types: '(json|error)' cannot be cast to 'string'", 68
+                , 13);
+        validateError(resultNegative, errIndex++, "incompatible types: '(json|error)' cannot be cast to 'string'", 69,
+                13);
+        Assert.assertEquals(resultNegative.getErrorCount(), errIndex);
     }
 
     @DataProvider

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
@@ -572,8 +572,9 @@ public class TypesTest {
         Assert.assertEquals(returns[0].stringValue(), "[[1, 2, 3], [3, 4, 5], [7, 8, 9]]");
     }
 
-    @Test(expectedExceptions = { BLangRuntimeException.class },
-            expectedExceptionsMessageRegExp = ".*incompatible types: 'error' cannot be cast to 'string'.*")
+    @Test(expectedExceptions = {BLangRuntimeException.class},
+            expectedExceptionsMessageRegExp = ".*incompatible types: 'error' cannot be cast to 'string'.*",
+            enabled = false)
     public void testGetFromNull() {
         BRunUtil.invoke(compileResult, "testGetFromNull");
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
@@ -572,6 +572,15 @@ public class TypesTest {
         Assert.assertEquals(returns[0].stringValue(), "[[1, 2, 3], [3, 4, 5], [7, 8, 9]]");
     }
 
+    @Test(expectedExceptions = {BLangRuntimeException.class},
+            expectedExceptionsMessageRegExp = "error: \\{ballerina\\}JSONOperationError \\{\"message\":\"JSON value " +
+                    "is not " +
+                    "a mapping\"\\}\n" +
+                    "\tat types:testGetFromNull\\(types.bal:588\\)")
+    public void testGetFromNull() {
+        BRunUtil.invoke(compileResult, "testGetFromNull");
+    }
+
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = ".*incompatible types: '\\(\\)'" +
                                               " cannot be cast to 'map<json>'.*")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
@@ -572,13 +572,6 @@ public class TypesTest {
         Assert.assertEquals(returns[0].stringValue(), "[[1, 2, 3], [3, 4, 5], [7, 8, 9]]");
     }
 
-    @Test(expectedExceptions = {BLangRuntimeException.class},
-            expectedExceptionsMessageRegExp = ".*incompatible types: 'error' cannot be cast to 'string'.*",
-            enabled = false)
-    public void testGetFromNull() {
-        BRunUtil.invoke(compileResult, "testGetFromNull");
-    }
-
     @Test(expectedExceptions = BLangRuntimeException.class,
             expectedExceptionsMessageRegExp = ".*incompatible types: '\\(\\)'" +
                                               " cannot be cast to 'map<json>'.*")

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_access_negative.bal
@@ -117,20 +117,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_access_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_access_negative.bal
@@ -117,6 +117,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_readonly_types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_readonly_types.bal
@@ -117,20 +117,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_readonly_types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/annotations/annotation_readonly_types.bal
@@ -117,6 +117,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/constant/simple-literal-constant.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/constant/simple-literal-constant.bal
@@ -213,13 +213,13 @@ function testConstInMapValue() returns string {
 function testConstInJsonKey() returns json {
     string key = foo:KEY;
     json j = { key: "value" };
-    return <json>j.key;
+    return <json> checkpanic j.key;
 }
 
 function testConstInJsonValue() returns json {
     string value = foo:VALUE;
     json j = { "key": value };
-    return <json>j.key;
+    return <json> checkpanic j.key;
 }
 
 // -----------------------------------------------------------

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/functions/test_different_function_signatures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/functions/test_different_function_signatures.bal
@@ -322,8 +322,14 @@ function assertTrue(any|error actual) {
         return;
     }
 
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }
 
 function assertFalse(any|error actual) {
@@ -331,8 +337,14 @@ function assertFalse(any|error actual) {
         return;
     }
 
-    panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'false', found '" + actual.toString () + "'");
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected 'false', found '" + actualValAsString + "'");
 }
 
 function assertValueEquality(anydata|error expected, anydata|error actual) {
@@ -340,6 +352,20 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString+ "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/functions/test_different_function_signatures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/functions/test_different_function_signatures.bal
@@ -322,13 +322,7 @@ function assertTrue(any|error actual) {
         return;
     }
 
-    string actualValAsString = "";
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected 'true', found '" + actualValAsString + "'");
 }
 
@@ -337,13 +331,7 @@ function assertFalse(any|error actual) {
         return;
     }
 
-    string actualValAsString = "";
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected 'false', found '" + actualValAsString + "'");
 }
 
@@ -352,20 +340,8 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString+ "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/isolation/test_isolation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/isolation/test_isolation.bal
@@ -72,5 +72,7 @@ isolated function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/object_override_includes.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/object_override_includes.bal
@@ -84,6 +84,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/object_override_includes.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/object_override_includes.bal
@@ -84,20 +84,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_readonly_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_readonly_objects.bal
@@ -158,20 +158,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_readonly_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_readonly_objects.bal
@@ -158,6 +158,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_service_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_service_objects.bal
@@ -111,6 +111,20 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_service_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/object/test_service_objects.bal
@@ -111,20 +111,8 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/readonly/test_selectively_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/readonly/test_selectively_immutable_type.bal
@@ -473,7 +473,21 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic AssertionError(ASSERTION_ERROR_REASON,
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/readonly/test_selectively_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/readonly/test_selectively_immutable_type.bal
@@ -473,20 +473,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
@@ -79,8 +79,22 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic AssertionError("Assertion Error",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 type AssertionError error;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/error_type_test.bal
@@ -79,20 +79,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError("Assertion Error",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/never_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/never_type_test.bal
@@ -13,8 +13,16 @@ function testTypeOfNeverReturnTypedFunction() {
     if (actualFunctionType is typedesc<function () returns (never)>) {
         return;
     }
+
+    string expectedValAsString = "";
+    if (expectedFunctionType is error) {
+        expectedValAsString = expectedFunctionType.toString();
+    } else {
+        expectedValAsString = expectedFunctionType.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expectedFunctionType.toString() + "', found '" + actualFunctionType.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualFunctionType.toString() + "'");
 }
 
 function testNeverReturnTypedFunctionCall() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/never_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_balo/types/never_type_test.bal
@@ -14,13 +14,8 @@ function testTypeOfNeverReturnTypedFunction() {
         return;
     }
 
-    string expectedValAsString = "";
-    if (expectedFunctionType is error) {
-        expectedValAsString = expectedFunctionType.toString();
-    } else {
-        expectedValAsString = expectedFunctionType.toString();
-    }
-
+    string expectedValAsString =
+                expectedFunctionType is error ? expectedFunctionType.toString() : expectedFunctionType.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualFunctionType.toString() + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/modules/utils/utils.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/modules/utils/utils.bal
@@ -29,6 +29,20 @@ public function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/modules/utils/utils.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project/modules/utils/utils.bal
@@ -29,20 +29,8 @@ public function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_utils/utils.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_utils/utils.bal
@@ -29,6 +29,20 @@ public function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_utils/utils.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/balo/test_projects/test_project_utils/utils.bal
@@ -29,20 +29,8 @@ public function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test.bal
@@ -35,20 +35,8 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/distinct_error_test.bal
@@ -35,6 +35,20 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -381,6 +381,20 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/error/error_test.bal
@@ -118,13 +118,13 @@ function testOneLinePanic() returns string[] {
     if error2 is error {
         results[1] = error2.message();
         var detail = error2.detail();
-        results[2] = <string>detail.get("msg");
+        results[2] = <string> checkpanic detail.get("msg");
     }
 
     if error3 is error {
         results[3] = error3.message();
         var detail = error3.detail();
-        results[4] = <string>detail.get("message");
+        results[4] = <string> checkpanic detail.get("message");
         results[5] = detail.get("statusCode").toString();
     }
 
@@ -155,8 +155,8 @@ function testGenericErrorWithDetailRecord() returns boolean {
     error e = error(reason, message = detailMessage, statusCode = detailStatusCode);
     string errReason = e.message();
     map<anydata|readonly> errDetail = e.detail();
-    return errReason == reason && <string> errDetail.get("message") == detailMessage &&
-            <int> errDetail.get("statusCode") == detailStatusCode;
+    return errReason == reason && <string> checkpanic errDetail.get("message") == detailMessage &&
+            <int> checkpanic errDetail.get("statusCode") == detailStatusCode;
 }
 
 type ErrorReasons "reason one"|"reason two";
@@ -381,20 +381,8 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
@@ -165,6 +165,21 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/access/access.bal
@@ -166,20 +166,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr-precedence.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/binary-expr-precedence.bal
@@ -26,6 +26,12 @@ function multiBinaryANDExpr(boolean one, boolean two, boolean three) returns (in
 
 function getBoolean() returns (boolean) {
     json j = {};
-    string val = j.isPresent.toString();
+    string val;
+    json|error jVal = j.isPresent;
+    if (jVal is error) {
+        val = jVal.toString();
+    } else {
+        val = jVal.toString();
+    }
     return (val == "test");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -87,7 +87,7 @@ function testConvertMapJsonWithDecimalToOpenRecord() {
         panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
     }
 
-    OpenRecord castedValue = <OpenRecord>or;
+    OpenRecord castedValue = <OpenRecord> checkpanic or;
     assert(castedValue["factor"], mp["factor"]);
     assert(castedValue["name"], mp["name"]);
 }
@@ -99,7 +99,7 @@ function testConvertMapJsonWithDecimalUnionTarget() {
         panic error("Invalid Response", detail = "Invalid type `error` recieved from cloneWithType");
     }
 
-    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget>or;
+    OpenRecordWithUnionTarget castedValue = <OpenRecordWithUnionTarget> checkpanic or;
     assert(castedValue["factor"], mp["factor"]);
     assert(castedValue["name"], mp["name"]);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/conversion/native-conversion-stampable-values.bal
@@ -127,8 +127,11 @@ function assert(anydata|error actual, anydata|error expected) {
     if (expected != actual) {
         typedesc<anydata|error> expT = typeof expected;
         typedesc<anydata|error> actT = typeof actual;
-        string reason = "expected [" + expected.toString() + "] of type [" + expT.toString()
-                            + "], but found [" + actual.toString() + "] of type [" + actT.toString() + "]";
+
+        string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+        string actualValAsString = actual is error ? actual.toString() : actual.toString();
+        string reason = "expected [" + expectedValAsString + "] of type [" + expT.toString()
+                            + "], but found [" + actualValAsString + "] of type [" + actT.toString() + "]";
 
         panic error(reason);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/group/group-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/group/group-expr.bal
@@ -78,8 +78,8 @@ function testGroupedTypeDescRef() returns boolean {
         "age": 20,
         "name": "Person Name"
     };
-    PersonRec p1 = <PersonRec> personData.cloneWithType(PersonRec);
-    PersonRec p2 = <PersonRec> (personData).cloneWithType(PersonRec);
+    PersonRec p1 = <PersonRec> checkpanic personData.cloneWithType(PersonRec);
+    PersonRec p2 = <PersonRec> checkpanic (personData).cloneWithType(PersonRec);
     return p1 == p2;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/function-invocation-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/function-invocation-expr.bal
@@ -342,20 +342,8 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/function-invocation-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/invocations/function-invocation-expr.bal
@@ -342,6 +342,20 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -264,6 +264,20 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
     panic error(ASSERTION_ERR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/arrow-expression.bal
@@ -265,19 +265,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
@@ -302,20 +302,8 @@ function assertEquality(any|error expected, any|error  actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError("AssertionError",
                                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/function-pointers.bal
@@ -302,5 +302,20 @@ function assertEquality(any|error expected, any|error  actual) {
         return;
     }
 
-    panic AssertionError("AssertionError", message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError("AssertionError",
+                                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/global-function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/global-function-pointers.bal
@@ -91,6 +91,21 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/global-function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/global-function-pointers.bal
@@ -92,20 +92,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable-with-variable-mutability.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/iterable/basic-iterable-with-variable-mutability.bal
@@ -285,10 +285,10 @@ function testWithComplexJson() returns json[] {
     };
     json[] filteredResults = [];
     string filterFrom = "street_number";
-    json[] addressComp = <json[]>j.address_components;
+    json[] addressComp = <json[]> checkpanic j.address_components;
     int index = 0;
     addressComp.filter(function (json comp) returns boolean {
-            json[] compTypes = <json[]>comp.types;
+            json[] compTypes = <json[]> checkpanic comp.types;
             return compTypes.filter(function (json compType) returns boolean {
                         return compType.toString() == filterFrom;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/struct-function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/struct-function-pointers.bal
@@ -84,20 +84,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError("AssertionError",
                                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/struct-function-pointers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/lambda/struct-function-pointers.bal
@@ -70,7 +70,7 @@ function testClassTypeAsParamtype() {
     var f = <[FunctionType, typedesc<anydata>]> functions["func"];
     FunctionType f1 = f[0];
     json|error j = f1(new(), 1);
-    var k = <map<json>>j;
+    var k = <map<json>> checkpanic j;
     string q = <string> k["j"];
     assertEquality("1", q);
 }
@@ -84,8 +84,22 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError("Assertion Error",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError("AssertionError",
+                                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 type AssertionError error;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
@@ -91,10 +91,10 @@ function testTypeWithReadOnlyInUnionCET() {
     [int, string] tp = [1, "ballerina"];
     readonly|(int|[int, string])[] val = [1, [1, "foo"], tp, tp];
 
-    assertEquality(true, <any> val is (int|[int, string])[]);
+    assertEquality(true, <any> checkpanic val is (int|[int, string])[]);
     assertEquality(false, val is (int|[int, string])[] & readonly);
 
-    (int|[int, string])[] arr = <(int|[int, string])[]> val;
+    (int|[int, string])[] arr = <(int|[int, string])[]> checkpanic val;
 
     assertEquality(1, arr[0]);
     assertEquality(true, arr[1] is [int, string]);
@@ -126,6 +126,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor.bal
@@ -126,20 +126,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_infer_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_infer_type.bal
@@ -91,7 +91,7 @@ function testInferringForReadOnly() {
     readonly rd1 =[1, str];
 
     assertEquality(true, rd1 is [int, string] & readonly);
-    [int, string] arr1 = <[int, string] & readonly> rd1;
+    [int, string] arr1 = <[int, string] & readonly> checkpanic rd1;
 
     var fn = function() {
         arr1[0] = 12;
@@ -110,7 +110,7 @@ function testInferringForReadOnly() {
 
     assertEquality(true, rd2 is [int, [boolean, boolean], Foo, Foo & readonly] & readonly);
     assertEquality(false, rd2 is [int, [boolean, boolean], object {} & readonly, Foo & readonly] & readonly);
-    [int, [boolean, boolean], Foo, Foo] arr2 = <[int, [boolean, boolean], Foo, Foo] & readonly> rd2;
+    [int, [boolean, boolean], Foo, Foo] arr2 = <[int, [boolean, boolean], Foo, Foo] & readonly> checkpanic rd2;
 
     fn = function() {
         arr2[0] = 2;
@@ -133,7 +133,7 @@ function testInferringForReadOnlyInUnion() {
 
     assertEquality(true, rd is [int, [boolean, boolean], Foo, Foo & readonly] & readonly);
     assertEquality(false, rd is [int, [boolean, boolean], object {} & readonly, Foo & readonly] & readonly);
-    [int, [boolean, boolean], Foo, Foo] arr = <[int, [boolean, boolean], Foo, Foo] & readonly> rd;
+    [int, [boolean, boolean], Foo, Foo] arr = <[int, [boolean, boolean], Foo, Foo] & readonly> checkpanic rd;
 
     var fn = function() {
         arr[0] = 2;
@@ -156,6 +156,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_infer_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/listconstructor/list_constructor_infer_type.bal
@@ -156,20 +156,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-success.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-success.bal
@@ -318,20 +318,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-success.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/identifierliteral/identifier-literal-success.bal
@@ -317,6 +317,21 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/null_literal_usage.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/literals/null_literal_usage.bal
@@ -25,7 +25,7 @@ function testNullAssignment() returns json {
 
 function testNullInField() returns string? {
     json j = {name:"John", age:25, location:null};
-    string? l = j.location == null ? () : <string>j.location;
+    string? l = j.location == null ? () : <string> checkpanic j.location;
     return l;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor.bal
@@ -144,20 +144,8 @@ function assertEquality(any|error expected, any|error actual) {
 }
 
 function getFailureError(any|error expected, any|error actual) returns error {
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     return  error(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor.bal
@@ -112,11 +112,11 @@ function testTypeWithReadOnlyInUnionCET() {
         b: {}
     };
 
-    assertEquality(true, <any> mr is map<map<json>>);
+    assertEquality(true, <any> checkpanic mr is map<map<json>>);
     assertEquality(false, mr is map<map<json>> & readonly);
 
     // Updates should be allowed.
-    map<map<json>> mj = <map<map<json>>> mr;
+    map<map<json>> mj = <map<map<json>>> checkpanic mr;
     mj["a"]["z"] = "z";
     assertEquality(true, mj["b"] is map<json>);
     mj["b"]["a"] = 1;
@@ -144,6 +144,20 @@ function assertEquality(any|error expected, any|error actual) {
 }
 
 function getFailureError(any|error expected, any|error actual) returns error {
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     return  error(ASSERTION_ERROR_REASON,
-                    message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
@@ -292,7 +292,7 @@ function testInferringForReadOnly() {
     |} rec1 = <readonly & record {|
                    int i;
                    string str;
-               |}> rd1;
+               |}> checkpanic rd1;
 
     var fn = function() {
         rec1.i = 12;
@@ -336,7 +336,7 @@ function testInferringForReadOnly() {
                           Person & readonly pn;
                           Person & readonly pnDup;
                           (Person & readonly)|record {|boolean b;|}...;
-                      |} & readonly> rd2;
+                      |} & readonly> checkpanic rd2;
 
     fn = function() {
         rec2.pn = pn;
@@ -383,7 +383,7 @@ function testInferringForReadOnlyInUnion() {
                           Person & readonly pn;
                           Person & readonly pnDup;
                           (Person & readonly)|record {|boolean b;|}...;
-                      |} & readonly> rd;
+                      |} & readonly> checkpanic rd;
 
     var fn = function() {
         rec.pn = pn;
@@ -421,7 +421,7 @@ function testValidReadOnlyWithDifferentFieldKinds() {
     };
 
     // This should represent the inferred type.
-    assertEquality(true, <any> x is record {|
+    assertEquality(true, <any> checkpanic x is record {|
                                         boolean[] b;
                                         record {| map<int[]> & readonly d; |} c;
                                         int[] & readonly...;
@@ -431,7 +431,7 @@ function testValidReadOnlyWithDifferentFieldKinds() {
                 boolean[] b;
                 record {| map<int[]> d; |} c;
                 int[] & readonly...;
-            |}> x;
+            |}> checkpanic x;
 
     assertEquality(true, y.b.isReadOnly());
     assertEquality(<boolean[2]> [true, false], y.b);
@@ -475,7 +475,7 @@ function testValidReadOnlyInUnionWithDifferentFieldKinds() {
                 boolean[] b;
                 string c;
                 int[] & readonly...;
-            |}> x;
+            |}> checkpanic x;
 
     assertEquality(true, y.b.isReadOnly());
     assertEquality(<boolean[2]> [true, false], y.b);
@@ -497,7 +497,7 @@ function testValidReadOnlyInUnionWithDifferentFieldKinds() {
 
     assertEquality(true, x2 is record {|boolean[] b; int[]...;|});
 
-    var y2 = <record {|boolean[] b; int[]...;|}> x2;
+    var y2 = <record {|boolean[] b; int[]...;|}> checkpanic x2;
 
     assertEquality(false, y2["c"].isReadOnly());
 
@@ -516,6 +516,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/mapping_constructor_infer_record.bal
@@ -516,20 +516,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/readonly_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/readonly_field.bal
@@ -472,19 +472,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/readonly_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/readonly_field.bal
@@ -47,7 +47,7 @@ function testBasicReadOnlyField1() {
     assertTrue(res is error);
 
     error err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'name' in record of type '$anonType$"));
     assertEquality("May", details.name);
 }
@@ -73,7 +73,7 @@ function testBasicReadOnlyField2() {
     assertTrue(res is error);
 
     error err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'name' in record of type '$anonType$"));
     assertEquality("May", details.name);
 
@@ -84,7 +84,7 @@ function testBasicReadOnlyField2() {
     assertTrue(res is error);
 
     err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'id' in record of type '$anonType$"));
     assertEquality(1234, details.id);
 }
@@ -114,7 +114,7 @@ function testComplexReadOnlyField() {
     assertTrue(res is error);
 
     error err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'details' in record of type '$anonType$"));
     assertEquality("May", details.name);
 
@@ -233,7 +233,7 @@ function testReadOnlyFieldsWithSimpleMapCET() {
     assertTrue(res is error);
 
     error err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'b' in record of type '$anonType$"));
     assertEquality(2, mp["b"]);
 
@@ -260,7 +260,7 @@ function testReadOnlyFieldsWithSimpleMapCET() {
     assertTrue(res is error);
 
     err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'b' in record of type '$anonType$"));
     assertEquality(2, mp["b"]);
 }
@@ -345,7 +345,7 @@ function testReadOnlyFieldWithInferredType() {
     assertTrue(res is error);
 
     error err = <error> res;
-    assertTrue((<string> err.detail()["message"]).startsWith(
+    assertTrue((<string> checkpanic err.detail()["message"]).startsWith(
                     "cannot update 'readonly' field 'd1' in record of type '$anonType$"));
     assertEquality(d1, rec["d1"]);
 }
@@ -472,5 +472,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -149,6 +149,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/spread_op_field.bal
@@ -149,20 +149,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/var_name_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/var_name_field.bal
@@ -129,6 +129,20 @@ function testVarNameFieldInAnnotation() {
 }
 
 function getFailureError(any|error expected, any|error actual) returns error {
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     return  error(ASSERTION_ERROR_REASON,
-                    message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/var_name_field.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/mappingconstructor/var_name_field.bal
@@ -129,20 +129,8 @@ function testVarNameFieldInAnnotation() {
 }
 
 function getFailureError(any|error expected, any|error actual) returns error {
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     return  error(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/object_constructor_expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/object_constructor_expression.bal
@@ -268,7 +268,7 @@ function testObjectConstructorExprWithReadOnlyCET() {
 
     error err = <error> res;
     assertValueEquality("{ballerina/lang.object}InherentTypeViolation", err.message());
-    assertValueEquality("modification not allowed on readonly value", <string> err.detail()["message"]);
+    assertValueEquality("modification not allowed on readonly value", <string> checkpanic err.detail()["message"]);
 
     assertTrue(<any> v5 is readonly);
 }
@@ -288,7 +288,7 @@ function validateInvalidUpdateErrorForFieldA(Object ob) {
 
     error err = <error> res;
     assertValueEquality("{ballerina/lang.object}InherentTypeViolation", err.message());
-    assertValueEquality("modification not allowed on readonly value", <string> err.detail()["message"]);
+    assertValueEquality("modification not allowed on readonly value", <string> checkpanic err.detail()["message"]);
 }
 
 function validateInvalidUpdateErrorForFieldB(Object ob) {
@@ -301,7 +301,7 @@ function validateInvalidUpdateErrorForFieldB(Object ob) {
 
     error err1 = <error> res1;
     assertValueEquality("{ballerina/lang.array}InvalidUpdate", err1.message());
-    assertValueEquality("modification not allowed on readonly value", <string> err1.detail()["message"]);
+    assertValueEquality("modification not allowed on readonly value", <string> checkpanic err1.detail()["message"]);
 
     var fn2 = function () {
         ob.b = [];
@@ -312,7 +312,7 @@ function validateInvalidUpdateErrorForFieldB(Object ob) {
 
     error err2 = <error> res2;
     assertValueEquality("{ballerina/lang.object}InherentTypeViolation", err2.message());
-    assertValueEquality("modification not allowed on readonly value", <string> err2.detail()["message"]);
+    assertValueEquality("modification not allowed on readonly value", <string> checkpanic err2.detail()["message"]);
 }
 
 // assertion helpers
@@ -324,8 +324,15 @@ function assertTrue(any|error actual) {
         return;
     }
 
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'true', found '" + actual.toString () + "'");
+                message = "expected 'true', found '" + actualValAsString + "'");
 }
 
 function assertFalse(any|error actual) {
@@ -333,8 +340,15 @@ function assertFalse(any|error actual) {
         return;
     }
 
+    string actualValAsString = "";
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected 'false', found '" + actual.toString () + "'");
+                message = "expected 'false', found '" + actualValAsString + "'");
 }
 
 function assertValueEquality(anydata|error expected, anydata|error actual) {
@@ -342,6 +356,20 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/object_constructor_expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/object_constructor_expression.bal
@@ -356,20 +356,8 @@ function assertValueEquality(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/service_constructor_expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/service_constructor_expression.bal
@@ -59,6 +59,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/service_constructor_expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/object/service_constructor_expression.bal
@@ -59,20 +59,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/rawtemplate/raw_template_literal_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/rawtemplate/raw_template_literal_test.bal
@@ -21,7 +21,7 @@ function testBasicUsage() {
     ob:RawTemplate rt = `Hello ${name}!`;
 
     assert(<string[]>["Hello ", "!"], rt.strings);
-    assert("Pubudu", <string>rt.insertions[0]);
+    assert("Pubudu", <string> checkpanic rt.insertions[0]);
 }
 
 function testEmptyLiteral() {
@@ -46,9 +46,9 @@ function testLiteralWithNoStrings() {
     ob:RawTemplate rt = `${hello}${n}${world}`;
 
     assert(<string[]>["", "", "", ""], rt.strings);
-    assert("Hello", <string>rt.insertions[0]);
-    assert(10, <int>rt.insertions[1]);
-    assert("World", <string>rt.insertions[2]);
+    assert("Hello", <string> checkpanic rt.insertions[0]);
+    assert(10, <int> checkpanic rt.insertions[1]);
+    assert("World", <string> checkpanic rt.insertions[2]);
 }
 
 class Person {
@@ -71,19 +71,19 @@ function testComplexExpressions() {
 
     ob:RawTemplate rt1 = `x + y = ${x + y}`;
     assert(<string[]>["x + y = ", ""], rt1.strings);
-    assert(30, <int>rt1.insertions[0]);
+    assert(30, <int> checkpanic rt1.insertions[0]);
 
     var fn = function () returns string { return "Pubudu"; };
 
     ob:RawTemplate rt2 = `Hello ${fn()}!`;
     assert(<string[]>["Hello ", "!"], rt2.strings);
-    assert("Pubudu", <string>rt2.insertions[0]);
+    assert("Pubudu", <string> checkpanic rt2.insertions[0]);
 
     Person p = new("John Doe", 20);
 
     ob:RawTemplate rt3 = `${p} is a person`;
     assert(<string[]>["", " is a person"], rt3.strings);
-    assert("name: John Doe, age: 20", rt3.insertions[0].toString());
+    assert("name: John Doe, age: 20", (checkpanic rt3.insertions[0]).toString());
 }
 
 type Template1 object {
@@ -242,7 +242,7 @@ function testIndirectAssignmentToConcreteType() {
     error err = <error>trap rt2.insertions.push(12.34);
 
     assert("{ballerina/lang.array}InherentTypeViolation", err.message());
-    assert("incompatible types: expected 'int', found 'float'", <string>err.detail().get("message"));
+    assert("incompatible types: expected 'int', found 'float'", <string> checkpanic err.detail().get("message"));
 }
 
 class CompatibleObj {
@@ -256,16 +256,16 @@ function testModifyStringsField() {
     error err = <error>trap rt2.strings.push("Invalid");
 
     assert("{ballerina/lang.array}InvalidUpdate", err.message());
-    assert("modification not allowed on readonly value", <string>err.detail().get("message"));
+    assert("modification not allowed on readonly value", <string> checkpanic err.detail().get("message"));
 }
 
 function testAnyInUnion() {
     any|error ae = `INSERT INTO Details VALUES (${"Foo"}, ${20})`;
-    ob:RawTemplate rt = <ob:RawTemplate>ae;
+    ob:RawTemplate rt = <ob:RawTemplate> checkpanic ae;
 
     assert(<string[]>["INSERT INTO Details VALUES (", ", ", ")"], rt.strings);
-    assert("Foo", <string>rt.insertions[0]);
-    assert(20, <int>rt.insertions[1]);
+    assert("Foo", <string> checkpanic rt.insertions[0]);
+    assert(20, <int> checkpanic rt.insertions[1]);
 }
 
 function testAssignmentToUnion() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -493,7 +493,7 @@ function testJSONValueCasting() returns [string|error, int|error, float|error, b
     return [s, i, f, b];
 }
 
-function testAnyToTable(){
+function testAnyToTable() {
     table<Employee> tb = table [
                     {id:1, name:"Jane"},
                     {id:2, name:"Anne"}
@@ -501,7 +501,7 @@ function testAnyToTable(){
 
     any anyValue = tb;
     var casted = <table<Employee>> anyValue;
-    table<Employee>|error  castedValue = casted;
+    table<Employee>  castedValue = casted;
     assertEquality("[{\"id\":1,\"name\":\"Jane\"},{\"id\":2,\"name\":\"Anne\"}]", castedValue.toString());
 }
 
@@ -528,5 +528,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                        message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type-casting.bal
@@ -528,20 +528,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                         message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/typecast/type_cast_expr_negative.bal
@@ -54,3 +54,21 @@ function testFutureFunc() returns int {
 }
 
 type FooInt "foo"|int;
+
+function testCastWithErrorType() {
+    json j = {
+        name : "Name",
+        address : {
+            country : "Country",
+            city : "City"
+        }
+    };
+
+    var a = <int>foo();
+    var b = <string>j.id;
+    var c = <string>j.address.town;
+}
+
+function foo() returns int|error {
+    return 1;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures.bal
@@ -217,6 +217,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/different-function-signatures.bal
@@ -217,20 +217,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
@@ -127,11 +127,11 @@ function testReturningInMatch() returns string? {
 }
 
 function testReturnsDuringValidCheck() returns error? {
-    int x = <int> checkpanic ints:fromString("15");
+    int x = checkpanic ints:fromString("15");
 }
 
 function testValidCheckWithExplicitReturn() returns error? {
-    int x = <int> checkpanic ints:fromString("15");
+    int x = checkpanic ints:fromString("15");
     return;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
@@ -127,11 +127,11 @@ function testReturningInMatch() returns string? {
 }
 
 function testReturnsDuringValidCheck() returns error? {
-    int x = <int>ints:fromString("15");
+    int x = <int> check ints:fromString("15");
 }
 
 function testValidCheckWithExplicitReturn() returns error? {
-    int x = <int>ints:fromString("15");
+    int x = <int> check ints:fromString("15");
     return;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/function-nil-return.bal
@@ -127,11 +127,11 @@ function testReturningInMatch() returns string? {
 }
 
 function testReturnsDuringValidCheck() returns error? {
-    int x = <int> check ints:fromString("15");
+    int x = <int> checkpanic ints:fromString("15");
 }
 
 function testValidCheckWithExplicitReturn() returns error? {
-    int x = <int> check ints:fromString("15");
+    int x = <int> checkpanic ints:fromString("15");
     return;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/functions/functions_with_included_record_parameters.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/functions/functions_with_included_record_parameters.bal
@@ -326,6 +326,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/OverriddenPredeclaredImportsTestProject/overridden-predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/OverriddenPredeclaredImportsTestProject/overridden-predeclared-modules.bal
@@ -80,19 +80,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/OverriddenPredeclaredImportsTestProject/overridden-predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/OverriddenPredeclaredImportsTestProject/overridden-predeclared-modules.bal
@@ -80,5 +80,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
@@ -91,19 +91,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/imports/PredeclaredImportsTestProject/predeclared-modules.bal
@@ -91,5 +91,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
@@ -485,19 +485,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
@@ -485,5 +485,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
@@ -124,7 +124,7 @@ isolated class InvalidIsolatedClassWithNonUniqueInitializerExprs {
     ];
     final readonly & xml[] f = [xml `hello ${globStr}`, xml `<!-- int: ${globIntArr[0]} -->`, xml `ok`,
                                 xml `?pi ${globBoolMap["a"] is boolean ? "true" : globStr}?`];
-    final int g = checkpanic trap <int> 'int:fromString(globStr);
+    final int g = <int> checkpanic trap 'int:fromString(globStr);
     private float h;
 
     function init(int[][]? a) returns error? {
@@ -148,7 +148,7 @@ function testInvalidIsolatedObjectWithNonUniqueInitializerExprs() {
         ];
         final readonly & xml[] f = [xml `hello ${globStr}`, xml `<!-- int: ${globIntArr[0]} -->`, xml `ok`,
                                     xml `?pi ${globBoolMap["a"] is boolean ? "true" : globStr}?`];
-        final int g = checkpanic trap <int> 'int:fromString(globStr);
+        final int g = <int> checkpanic trap 'int:fromString(globStr);
         private float h;
 
         function init() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis.bal
@@ -453,7 +453,21 @@ isolated function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error(string `expected '${expected.toString()}', found '${actual.toString()}'`);
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(string `expected '${expectedValAsString}', found '${actualValAsString}'`);
 }
 
 type IsolatedFunction isolated function () returns int;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis.bal
@@ -453,20 +453,8 @@ isolated function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(string `expected '${expectedValAsString}', found '${actualValAsString}'`);
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/ballerina_types_as_interop_types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/ballerina_types_as_interop_types.bal
@@ -500,7 +500,7 @@ function testReadOnlyAsParamAndReturnTypes() {
     ReadOnlyIntProvider ob = new;
     readonly objectAsReadOnly = acceptAndReturnReadOnly(ob);
     assertTrue(objectAsReadOnly is readonly & object { int i; function getInt() returns int; });
-    var cObj = <object { int i; function getInt() returns int; } & readonly> objectAsReadOnly;
+    var cObj = <object { int i; function getInt() returns int; } & readonly> checkpanic objectAsReadOnly;
     assertEquality(21, cObj.getInt());
     assertEquality(ob, objectAsReadOnly);
 
@@ -529,7 +529,7 @@ function testNarrowerTypesAsReadOnlyReturnTypes() {
 
     readonly booleanAsReadOnly = getBooleanAsReadOnly();
     assertTrue(booleanAsReadOnly is boolean);
-    assertTrue(<boolean> booleanAsReadOnly);
+    assertTrue(<boolean> checkpanic booleanAsReadOnly);
 
     readonly intAsReadOnly = getIntAsReadOnly();
     assertTrue(intAsReadOnly is int);
@@ -543,7 +543,7 @@ function testNarrowerTypesAsReadOnlyReturnTypes() {
     decimal d = 120.5;
     readonly decimalAsReadOnly = getDecimalAsReadOnly(d);
     assertTrue(decimalAsReadOnly is decimal);
-    assertEquality(d, <decimal> decimalAsReadOnly);
+    assertEquality(d, <decimal> checkpanic decimalAsReadOnly);
 
     string s1 = "hello";
     string s2 = "world";
@@ -692,5 +692,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/ballerina_types_as_interop_types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/ballerina_types_as_interop_types.bal
@@ -692,19 +692,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
@@ -222,19 +222,7 @@ function assertEquals(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/instance_method_tests.bal
@@ -222,5 +222,19 @@ function assertEquals(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/object_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/object_test.bal
@@ -140,6 +140,21 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "found '" + expected.toString() + "', expected '" + actual.toString () + "'");
+                message = "found '" + expectedValAsString + "', expected '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/object_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/object_test.bal
@@ -141,20 +141,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "found '" + expectedValAsString + "', expected '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -105,7 +105,7 @@ public function testUnionReturn() returns string {
     ResourceDefinition resourceDef = {path:"path", method:"method"};
     ResourceDefinition[] resources = [resourceDef];
     ApiDefinition apiDef = {resources:resources};
-    return value:toString(getMapOrError("swagger", apiDef));
+    return value:toString(checkpanic getMapOrError("swagger", apiDef));
 }
 
 public function testBalEnvFastAsyncVoidSig() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/overloading/overloaded_constructor_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/overloading/overloaded_constructor_test.bal
@@ -87,20 +87,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/overloading/overloaded_constructor_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/overloading/overloaded_constructor_test.bal
@@ -86,6 +86,21 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/variable_return_type_test.bal
@@ -362,13 +362,13 @@ var outParameterObject = object OutParameter {
 function testDependentlyTypedMethodsWithObjectTypeInclusion() {
     OutParameterClass c1 = new;
     int|error v1 = c1.get(int);
-    assert(1234, <int> v1);
+    assert(1234, <int> checkpanic v1);
     assertSame(c1.c, c1.get(float));
-    assert("hello world", <string> c1.get(string));
+    assert("hello world", <string> checkpanic c1.get(string));
 
-    assert(321, <int> outParameterObject.get(int));
+    assert(321, <int> checkpanic outParameterObject.get(int));
     decimal|error v2 = outParameterObject.get(decimal);
-    assert(23.45d, <decimal> v2);
+    assert(23.45d, <decimal> checkpanic v2);
 }
 
 public class Bar {
@@ -446,20 +446,20 @@ public function testSubtypingWithDependentlyTypedMethods() {
     Baz baz = new;
     Qux qux = new;
 
-    assert(1, <int> bar.get(int));
-    assert(2, <int> baz.get(int));
-    assert(3, <int> qux.get(int));
+    assert(1, <int> checkpanic bar.get(int));
+    assert(2, <int> checkpanic baz.get(int));
+    assert(3, <int> checkpanic qux.get(int));
     decimal|error v2 = bar.get(decimal);
-    assert(23.45d, <decimal> v2);
+    assert(23.45d, <decimal> checkpanic v2);
     anydata|error v3 = baz.get(decimal);
-    assert(23.45d, <decimal> v3);
+    assert(23.45d, <decimal> checkpanic v3);
     v2 = qux.get(decimal);
-    assert(23.45d, <decimal> v2);
+    assert(23.45d, <decimal> checkpanic v2);
 
     Baz baz1 = bar;
     Bar bar1 = qux;
-    assert(1, <int> baz1.get(int));
-    assert(3, <int> bar1.get(int));
+    assert(1, <int> checkpanic baz1.get(int));
+    assert(3, <int> checkpanic bar1.get(int));
 
     assert(true, <any> bar is Baz);
     assert(true, <any> qux is Bar);
@@ -469,12 +469,12 @@ public function testSubtypingWithDependentlyTypedMethods() {
     assert(false, <any> qux is Quux);
 
     Corge corge = new Grault();
-    assert(200, <int> corge.get(int, string));
-    assert("Hello World!", <string> corge.get(string, int));
+    assert(200, <int> checkpanic corge.get(int, string));
+    assert("Hello World!", <string> checkpanic corge.get(string, int));
 
     Grault grault = new Corge();
-    assert(100, <int> grault.get(int, string));
-    assert("Hello World!", <string> grault.get(string, float));
+    assert(100, <int> checkpanic grault.get(int, string));
+    assert("Hello World!", <string> checkpanic grault.get(string, float));
 
     assert(true, <any> new Corge() is Grault);
     assert(true, <any> new Grault() is Corge);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/foreach-arrays.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/foreach-arrays.bal
@@ -258,20 +258,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/foreach-arrays.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/foreach-arrays.bal
@@ -258,6 +258,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/objects_subtyping.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/objects_subtyping.bal
@@ -178,6 +178,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                 message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/objects_subtyping.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/objects_subtyping.bal
@@ -178,20 +178,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                  message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/types.bal
@@ -305,7 +305,7 @@ function testGetString () returns [string, string] {
     string j1String;
     string j2String;
     j1String = <string> j1;
-    j2String = <string> j2.name;
+    j2String = <string> checkpanic j2.name;
     return [j1String, j2String];
 }
 
@@ -315,21 +315,21 @@ function testGetInt () returns [int, int] {
     int j1Int;
     int j2Int;
     j1Int = <int>j1;
-    j2Int = <int>j2.age;
+    j2Int = <int> checkpanic j2.age;
     return [j1Int, j2Int];
 }
 
 function testGetFloat () returns (float) {
     json j = {score:9.73};
     float jFloat;
-    jFloat = <float>j.score;
+    jFloat = <float> checkpanic j.score;
     return jFloat;
 }
 
 function testGetBoolean () returns (boolean) {
     json j = {pass:true};
     boolean jBoolean;
-    jBoolean = <boolean>j.pass;
+    jBoolean = <boolean> checkpanic j.pass;
     return jBoolean;
 }
 
@@ -471,10 +471,10 @@ function testGetNestedJsonElement () returns [string, string, string, string] {
     string cityString2;
     string cityString3;
     string cityString4;
-    cityString1 = <string>j.address.city;
-    cityString2 = <string>j.address.city;
-    cityString3 = <string>j.address.city;
-    cityString4 = <string>j.address.city;
+    cityString1 = <string> checkpanic j.address.city;
+    cityString2 = <string> checkpanic j.address.city;
+    cityString3 = <string> checkpanic j.address.city;
+    cityString4 = <string> checkpanic j.address.city;
     return [cityString1, cityString2, cityString3, cityString4];
 }
 
@@ -487,9 +487,9 @@ function testJsonExprAsIndex () returns (string) {
     //Moving index expression into another line since with new changes, it is a unsafe cast,
     //which returns a error value if any.
     string key;
-    key = <string>j.address.area;
+    key = <string> checkpanic j.address.area;
     string value;
-    map<json> adr = <map<json>>j.address;
+    map<json> adr = <map<json>> checkpanic j.address;
     value = <string>adr[key];
     return value;
 }
@@ -585,7 +585,7 @@ function testJsonArrayToJsonCasting () returns (json) {
 
 function testGetFromNull () returns (string) {
     json j2 = {age:43, name:null};
-    string value = <string>j2.name.fname;
+    string value = <string> checkpanic j2.name.fname;
     return value;
 }
 
@@ -599,7 +599,7 @@ function testAddToNull () returns (json) {
 
 function testJsonIntToFloat () returns (float) {
     json j = {score:4};
-    float jFloat = <float>j.score;
+    float jFloat = <float> checkpanic j.score;
     return jFloat;
 }
 
@@ -749,5 +749,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/types.bal
@@ -583,6 +583,12 @@ function testJsonArrayToJsonCasting () returns (json) {
     return j2;
 }
 
+function testGetFromNull() returns (string) {
+    json j2 = {age:43, name:null};
+    string value = <string> checkpanic j2.name.fname;
+    return value;
+}
+
 function testAddToNull () returns (json) {
     json jjj = {name:"Supun", address:null};
     map<json> jj = <map<json>>jjj;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/jvm/types.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/jvm/types.bal
@@ -583,12 +583,6 @@ function testJsonArrayToJsonCasting () returns (json) {
     return j2;
 }
 
-function testGetFromNull () returns (string) {
-    json j2 = {age:43, name:null};
-    string value = <string> checkpanic j2.name.fname;
-    return value;
-}
-
 function testAddToNull () returns (json) {
     json jjj = {name:"Supun", address:null};
     map<json> jj = <map<json>>jjj;
@@ -749,20 +743,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/distinct-class-def.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/distinct-class-def.bal
@@ -158,20 +158,8 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/distinct-class-def.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/distinct-class-def.bal
@@ -158,6 +158,20 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_class.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_class.bal
@@ -79,6 +79,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_class.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_class.bal
@@ -79,20 +79,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_service_class.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_service_class.bal
@@ -87,20 +87,8 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_service_class.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/klass/simple_service_class.bal
@@ -87,6 +87,20 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/main.function/test_main_with_multiple_typed_params.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/main.function/test_main_with_multiple_typed_params.bal
@@ -33,6 +33,6 @@ public function main(int i, float f, string s, byte b, boolean bool, json j, xml
 
     io:print("integer: " + i.toHexString() + ", float: " + f.toString() + ", string: " + s + ", byte: " +
             b.toString() + ", boolean: " + boolStr + ", JSON Name Field: " +
-            j.name.toString() + ", XML Element Name: " + element.getName() + ", Employee Name Field: " + e.name +
+            (checkpanic j.name).toString() + ", XML Element Name: " + element.getName() + ", Employee Name Field: " + e.name +
             ", string rest args: " + restArgs);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectEquivalencyProject/object-equivalency.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectEquivalencyProject/object-equivalency.bal
@@ -748,20 +748,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                  message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectEquivalencyProject/object-equivalency.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/ObjectEquivalencyProject/object-equivalency.bal
@@ -748,8 +748,22 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                 message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 public function main() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/final_object_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/final_object_fields.bal
@@ -635,6 +635,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/final_object_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/final_object_fields.bal
@@ -635,20 +635,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -272,6 +272,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object-type-reference.bal
@@ -272,20 +272,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_inclusion_with_qualifiers.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_inclusion_with_qualifiers.bal
@@ -151,5 +151,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/object_init_project/object-initializer.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/object_init_project/object-initializer.bal
@@ -313,7 +313,7 @@ function testObjInitWithCheck(int id) returns ([Student3|error, int, int]) {
         return [student, marksBeforeChange, marksAfterChange];
     }
 
-    Student3 s = <Student3> student;
+    Student3 s = <Student3> checkpanic student;
     marksBeforeChange = s.getMarks();
     s.marks = 95;
     marksAfterChange = s.getMarks();
@@ -380,7 +380,7 @@ function testInitInvocationWithCheckAndRestParams(int id, string... modules) ret
         return [student, marksBeforeChange, marksAfterChange];
     }
 
-    Student5 s = <Student5> student;
+    Student5 s = <Student5> checkpanic student;
     marksBeforeChange = s.getMarks();
     s.marks = 95;
     marksAfterChange = s.getMarks();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_objects.bal
@@ -220,6 +220,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/object/readonly_objects.bal
@@ -220,20 +220,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
@@ -167,7 +167,7 @@ public function testIteratorInStream() returns int[]|error {
     int[] intArray = [1, 2, 3, 4, 5];
     stream<int> numberStream = intArray.toStream();
     int[]|error integers = from var num in getIterableObject(numberStream.iterator())
-                     select <int> check num;
+                     select <int> checkpanic num;
 
     return integers;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-exp-iterable-objects.bal
@@ -167,7 +167,7 @@ public function testIteratorInStream() returns int[]|error {
     int[] intArray = [1, 2, 3, 4, 5];
     stream<int> numberStream = intArray.toStream();
     int[]|error integers = from var num in getIterableObject(numberStream.iterator())
-                     select <int>num;
+                     select <int> check num;
 
     return integers;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-object.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-object.bal
@@ -146,20 +146,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                       message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-object.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-object.bal
@@ -146,5 +146,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                      message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-record.bal
@@ -260,5 +260,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-record.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-expr-with-record.bal
@@ -260,20 +260,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -422,7 +422,7 @@ function testQueryExprWithTypeConversion() returns Person1[]{
 			firstName: person.firstName,
 			lastName: person.lastName,
 			deptAccess: person.deptAccess,
-			address: <Address> checkpanic m.cloneWithType(Address)
+			address: checkpanic m.cloneWithType(Address)
 		};
 
     return  outputPersonList;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-defined-type.bal
@@ -249,7 +249,7 @@ function testMapWithArity() returns boolean {
 function testJSONArrayWithArity() returns boolean {
     json[] jdata = [{name: "bob", age: 10}, {name: "tom", age: 16}];
     string[] val = from var v in jdata
-                   select <string> v.name;
+                   select <string> checkpanic v.name;
     return val == ["bob", "tom"];
 }
 
@@ -422,7 +422,7 @@ function testQueryExprWithTypeConversion() returns Person1[]{
 			firstName: person.firstName,
 			lastName: person.lastName,
 			deptAccess: person.deptAccess,
-			address: <Address> m.cloneWithType(Address)
+			address: <Address> checkpanic m.cloneWithType(Address)
 		};
 
     return  outputPersonList;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/simple-query-with-var-type.bal
@@ -206,7 +206,7 @@ function testMapWithArity() returns boolean {
 function testJSONArrayWithArity() returns boolean {
     json[] jdata = [{name: "bob", age: 10}, {name: "tom", age: 16}];
     var val = from var v in jdata
-                   select <string> v.name;
+                   select <string> checkpanic v.name;
     return val == ["bob", "tom"];
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
@@ -405,7 +405,7 @@ public function testSimpleQueryExprWithXMLElementLiteral() returns xml {
     xml res = from var x in payload/<data>/<*>
              let var year = <xml> x/<'field>[2]
              let var value = <xml> x/<'field>[3].name
-             select xml `<entry>${<string> value}</entry>`;
+             select xml `<entry>${<string> checkpanic value}</entry>`;
 
     return res;
 }
@@ -425,7 +425,7 @@ public function testSimpleQueryExprWithNestedXMLElements() returns xml {
     xml res = xml `<doc> ${from var x in payload/<data>/<*>
          let var year = <xml> x/<'field>[2]
          let var value = <xml> x/<'field>[3].name
-         select xml `<entry>${<string> value}</entry>`} </doc>`;
+         select xml `<entry>${<string> checkpanic value}</entry>`} </doc>`;
 
     return res;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
@@ -209,6 +209,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/open_record_type_reference.bal
@@ -209,20 +209,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields.bal
@@ -694,20 +694,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields.bal
@@ -694,6 +694,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_closure_default.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_closure_default.bal
@@ -33,6 +33,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_closure_default.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_closure_default.bal
@@ -33,20 +33,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_project_closed_rec_equiv/closed_record_equivalency.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_project_closed_rec_equiv/closed_record_equivalency.bal
@@ -173,7 +173,7 @@ function testRuntimeEqPublicStructsInSamePackage () returns string|error {
 
     userPA uA = uFoo;
 
-    var uB = <userPB> checkpanic uA.cloneWithType(userPB);
+    var uB = checkpanic uA.cloneWithType(userPB);
     return uB.name;
 }
 
@@ -192,8 +192,7 @@ function testRuntimeEqPublicStructs1 () returns string|error {
     // This is a safe cast
     userPA uA = uFoo;
 
-    // This is a unsafe cast
-    var uB  = <req2:closedUserPB> checkpanic uA.cloneWithType(req2:closedUserPB);
+    var uB  = checkpanic uA.cloneWithType(req2:closedUserPB);
     return uB.name;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_project_closed_rec_equiv/closed_record_equivalency.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_project_closed_rec_equiv/closed_record_equivalency.bal
@@ -173,7 +173,7 @@ function testRuntimeEqPublicStructsInSamePackage () returns string|error {
 
     userPA uA = uFoo;
 
-    var uB = <userPB> uA.cloneWithType(userPB);
+    var uB = <userPB> check uA.cloneWithType(userPB);
     return uB.name;
 }
 
@@ -193,7 +193,7 @@ function testRuntimeEqPublicStructs1 () returns string|error {
     userPA uA = uFoo;
 
     // This is a unsafe cast
-    var uB  = <req2:closedUserPB> uA.cloneWithType(req2:closedUserPB);
+    var uB  = <req2:closedUserPB> check uA.cloneWithType(req2:closedUserPB);
     return uB.name;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/record_project_closed_rec_equiv/closed_record_equivalency.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/record_project_closed_rec_equiv/closed_record_equivalency.bal
@@ -173,7 +173,7 @@ function testRuntimeEqPublicStructsInSamePackage () returns string|error {
 
     userPA uA = uFoo;
 
-    var uB = <userPB> check uA.cloneWithType(userPB);
+    var uB = <userPB> checkpanic uA.cloneWithType(userPB);
     return uB.name;
 }
 
@@ -193,7 +193,7 @@ function testRuntimeEqPublicStructs1 () returns string|error {
     userPA uA = uFoo;
 
     // This is a unsafe cast
-    var uB  = <req2:closedUserPB> check uA.cloneWithType(req2:closedUserPB);
+    var uB  = <req2:closedUserPB> checkpanic uA.cloneWithType(req2:closedUserPB);
     return uB.name;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
@@ -75,5 +75,19 @@ function assertEquals(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
@@ -75,19 +75,7 @@ function assertEquals(anydata|error expected, anydata|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
@@ -142,20 +142,8 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl.bal
@@ -142,6 +142,20 @@ function assertEquality(any|error actual, any|error expected) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl_service_name_literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl_service_name_literal.bal
@@ -81,6 +81,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error("AssertionError",
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl_service_name_literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/service_decl_service_name_literal.bal
@@ -81,20 +81,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("AssertionError",
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
@@ -336,5 +336,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-fill-test.bal
@@ -336,20 +336,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -237,8 +237,23 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 function testUpdatingJsonTupleViaArrayTypedVar() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/arrays/array-test.bal
@@ -238,20 +238,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -130,20 +130,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/assign/assign-stmt.bal
@@ -130,7 +130,22 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }
 
 function assertTrue(any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/block/block-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/block/block-stmt.bal
@@ -157,20 +157,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                  message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/block/block-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/block/block-stmt.bal
@@ -157,6 +157,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                 message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/dostatement/do-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/dostatement/do-stmt.bal
@@ -358,20 +358,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/dostatement/do-stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/dostatement/do-stmt.bal
@@ -358,6 +358,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic AssertionError(ASSERTION_ERROR_REASON,
-            message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern-with-rest-match-pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern-with-rest-match-pattern.bal
@@ -73,16 +73,16 @@ function listMatchPattern5(any v) returns int|string {
     match v {
         [1, "str", ...var a] => {
             if (a[0] is string) {
-                return <string> a[0];
+                return <string> checkpanic a[0];
             } else if (a[0] is int) {
-                return <int> a[0];
+                return <int> checkpanic a[0];
             }
         }
         [1, ...var a] => {
             if (a[0] is string) {
-                return <string> a[0];
+                return <string> checkpanic a[0];
             } else if (a[0] is int) {
-                return <int> a[0];
+                return <int> checkpanic a[0];
             }
         }
         _ => {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/matchstmt/list-match-pattern.bal
@@ -429,16 +429,16 @@ function testListMatchPattern16() {
 function listMatchPattern17(any x) returns string {
     match x {
         [var s, var i] if s is string => {
-            return "Matched with string : " + s + " added text with " + i.toString();
+            return "Matched with string : " + s + " added text with " + (checkpanic i).toString();
         }
         [var s, var i] if s is float => {
-            return "Matched with float : " + (s + 4.5).toString() + " with " + i.toString();
+            return "Matched with float : " + (s + 4.5).toString() + " with " + (checkpanic i).toString();
         }
         [var s, var i] if i is int => {
-            return "Matched with int : " + s.toString() + " with " + (i + 3456).toString();
+            return "Matched with int : " + (checkpanic s).toString() + " with " + (i + 3456).toString();
         }
         [var s, var i] if i is boolean => {
-            return "Matched with boolean : " + s.toString() + ", " + i.toString();
+            return "Matched with boolean : " + (checkpanic s).toString() + ", " + i.toString();
         }
         var y => {
             return "Matched with default type - float : " + y.toString();
@@ -464,16 +464,18 @@ function testListMatchPattern17() {
 function listMatchPattern18(any x) returns string {
     match x {
         [var s, var i, var f] if s is string => {
-            return "Matched with string : " + s + " added text with " + i.toString();
+            return "Matched with string : " + s + " added text with " + (checkpanic i).toString();
         }
         [var s, [var i, var f]] if s is float => {
-            return "Matched with float : " + (s + 4.5).toString() + " with " + i.toString() + " and " + f.toString();
+            return "Matched with float : " + (s + 4.5).toString() + " with " + (checkpanic i).toString()
+                                                                            + " and " + (checkpanic f).toString();
         }
         [[var s, var i], var f] if i is int => {
-            return "Matched with int : " + s.toString() + " with " + (i + 3456).toString() + " and " + f.toString();
+            return "Matched with int : " + (checkpanic s).toString() + " with " + (i + 3456).toString()
+                                                                            + " and " + (checkpanic f).toString();
         }
         [var s, var i] if i is boolean => {
-            return "Matched with boolean : " + s.toString() + ", " + i.toString();
+            return "Matched with boolean : " + (checkpanic s).toString() + ", " + i.toString();
         }
     }
     return "Default";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -226,5 +226,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError("AssertionError", message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError("AssertionError",
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/onfail/on-fail-clause.bal
@@ -226,20 +226,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError("AssertionError",
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/nested_retry_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/nested_retry_stmt.bal
@@ -124,20 +124,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
    }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/nested_retry_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/nested_retry_stmt.bal
@@ -124,5 +124,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
    }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt.bal
@@ -74,20 +74,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
    }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                         message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt.bal
@@ -74,5 +74,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
    }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                        message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt_with_on_fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt_with_on_fail.bal
@@ -261,19 +261,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt_with_on_fail.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/retrystmt/retry_stmt_with_on_fail.bal
@@ -259,7 +259,21 @@ function assertEquality(any|error expected, any|error actual) {
 
     if expected === actual {
         return;
-   }
+    }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/strand/strand-meta-data.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/strand/strand-meta-data.bal
@@ -183,7 +183,10 @@ public function assertEquality(any|error expected, any|error actual) {
         successCount = successCount + 1;
         return;
     }
-    errorMessages[errorCount] = "expected '" + expected.toString() + "', found '" + actual.toString() + "'";
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    errorMessages[errorCount] = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'";
     errorCount = errorCount + 1;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/lang-lib-function-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/lang-lib-function-negative.bal
@@ -28,8 +28,8 @@ function sensitiveF(@untainted Person p) {
 
 function driver() {
     Person p = getTaintedParson();
-    json jp = <json> checkpanic p.cloneWithType(json);
-    Person sameP = <Person> checkpanic jp.cloneWithType(Person);
+    json jp = checkpanic p.cloneWithType(json);
+    Person sameP = checkpanic jp.cloneWithType(Person);
     sensitiveF(sameP);
     sensitiveF(sameP.cloneReadOnly());
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/lang-lib-function-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/taintchecking/propagation/lang-lib-function-negative.bal
@@ -28,8 +28,8 @@ function sensitiveF(@untainted Person p) {
 
 function driver() {
     Person p = getTaintedParson();
-    json jp = <json> p.cloneWithType(json);
-    Person sameP = <Person> jp.cloneWithType(Person);
+    json jp = <json> checkpanic p.cloneWithType(json);
+    Person sameP = <Person> checkpanic jp.cloneWithType(Person);
     sensitiveF(sameP);
     sensitiveF(sameP.cloneReadOnly());
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
@@ -221,20 +221,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions.bal
@@ -221,5 +221,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/any/any-type-success.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/any/any-type-success.bal
@@ -131,5 +131,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                        message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/any/any-type-success.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/any/any-type-success.bal
@@ -131,20 +131,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                         message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -963,5 +963,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/anydata/anydata_test.bal
@@ -963,20 +963,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte_as_int_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte_as_int_test.bal
@@ -227,6 +227,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte_as_int_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/byte/byte_as_int_test.bal
@@ -227,20 +227,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/test_final_local_no_init_var.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/test_final_local_no_init_var.bal
@@ -68,19 +68,7 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/test_final_local_no_init_var.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finaltypes/test_final_local_no_init_var.bal
@@ -68,5 +68,19 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -495,12 +495,7 @@ function assertEquality(any|error expected, any|error actual) {
     }
     typedesc<any|error> tActual = typeof actual;
 
-    string expectedValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + tActual.toString() + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -494,8 +494,15 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
     typedesc<any|error> tActual = typeof actual;
+
+    string expectedValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + tActual.toString() + "'");
+                message = "expected '" + expectedValAsString + "', found '" + tActual.toString() + "'");
 }
 
 //public const '\- = "-";

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/future/future_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/future/future_positive.bal
@@ -197,20 +197,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                  message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/future/future_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/future/future_positive.bal
@@ -197,6 +197,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                 message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -174,20 +174,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON, message = "expected '" + expectedValAsString + "', found '" +
                                                         actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/test_intersection_type.bal
@@ -174,6 +174,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic error(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" +
-                                                        actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic error(ASSERTION_ERROR_REASON, message = "expected '" + expectedValAsString + "', found '" +
+                                                        actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/json-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/json-value.bal
@@ -59,7 +59,7 @@ function testGetString () returns [string, string] {
     string j1String;
     string j2String;
     j1String = <string> j1;
-    j2String = <string> j2.name;
+    j2String = <string> checkpanic j2.name;
     return [j1String, j2String];
 }
 
@@ -69,28 +69,28 @@ function testGetInt () returns [int, int] {
     int j1Int;
     int j2Int;
     j1Int = <int>j1;
-    j2Int = <int>j2.age;
+    j2Int = <int> checkpanic j2.age;
     return [j1Int, j2Int];
 }
 
 function testGetFloat () returns (float) {
     json j = {score:9.73};
     float jFloat;
-    jFloat = <float>j.score;
+    jFloat = <float> checkpanic j.score;
     return jFloat;
 }
 
 function testGetDecimal() returns (decimal) {
     json j = {score:9.5};
     decimal jDecimal;
-    jDecimal = <decimal>j.score;
+    jDecimal = <decimal> checkpanic j.score;
     return jDecimal;
 }
 
 function testGetBoolean () returns (boolean) {
     json j = {pass:true};
     boolean jBoolean;
-    jBoolean = <boolean>j.pass;
+    jBoolean = <boolean> checkpanic j.pass;
     return jBoolean;
 }
 
@@ -242,7 +242,7 @@ function testUpdateJsonArrayInArray () returns (json) {
 function testGetNestedJsonElement () returns (string) {
     json j = {name:"aaa", age:25, parent:{name:"bbb", age:50}, address:{city:"Colombo", "country":"SriLanka"}, array:[1, 5, 7]};
     string cityString;
-    cityString = <string>j.address.city;
+    cityString = <string> checkpanic j.address.city;
     return cityString;
 }
 
@@ -353,7 +353,7 @@ function testAddToNull () returns (json) {
 
 function testJsonIntToFloat () returns (float) {
     json j = {score:4};
-    float jFloat = <float>j.score;
+    float jFloat = <float> checkpanic j.score;
     return jFloat;
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/record_to_json.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/jsontype/record_to_json.bal
@@ -137,14 +137,14 @@ function testRecursiveCheckAgainstJson() {
 
     json j1 = b1;
     assert(true, j1.i is int);
-    assert(1, <int> j1.i);
+    assert(1, checkpanic j1.i);
     assert(true, j1.b is ());
 
     json j2 = b2;
     assert(true, j2.i is int);
-    assert(2, <int> j2.i);
+    assert(2, checkpanic j2.i);
     assert(true, j2.b is Bar);
-    assert(b1, <Bar> j2.b);
+    assert(b1, <Bar> checkpanic j2.b);
 }
 
 // Util functions

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/map/map-access-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/map/map-access-expr.bal
@@ -92,7 +92,7 @@ function testGetMapValues () returns [string, string] {
     }, values);
     var nam = <string> values[0];
     var jsn = <json> values[8];
-    var city = <string> jsn.city;
+    var city = <string> checkpanic jsn.city;
     return [nam, city];
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_inherently_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_inherently_immutable_type.bal
@@ -199,20 +199,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_inherently_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_inherently_immutable_type.bal
@@ -88,7 +88,7 @@ function testSimpleAssignmentForInherentlyImmutableBasicTypes() {
 
     readonly j = assertTrue;
     assertTrue(j is function (any|error actual));
-    function (any|error actual) trueFunc = <function (any|error actual)> j;
+    function (any|error actual) trueFunc = <function (any|error actual)> checkpanic j;
     trueFunc(true);
 
     Employee employee = {name: "Jo"};
@@ -199,5 +199,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
@@ -1023,20 +1023,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/readonly/test_selectively_immutable_type.bal
@@ -119,7 +119,7 @@ function testSimpleInitializationForSelectivelyImmutableListTypes() {
     assertTrue(r2 is [Employee, Employee] & readonly);
     assertTrue(r2 is Employee[2] & readonly);
 
-    [Employee, Employee] & readonly empTup = <[Employee, Employee] & readonly> r2;
+    [Employee, Employee] & readonly empTup = <[Employee, Employee] & readonly> checkpanic r2;
 
     assertEquality(emp, empTup[0]);
     record {} rec = empTup[0];
@@ -145,7 +145,7 @@ function testSimpleInitializationForSelectivelyImmutableListTypes() {
     assertTrue(r3 is [Details[], Employee...] & readonly);
     assertTrue(r3 is [[Details, Details], Employee] & readonly);
 
-    [[Details, Details], Employee] & readonly vals = <[[Details, Details], Employee] & readonly> r3;
+    [[Details, Details], Employee] & readonly vals = <[[Details, Details], Employee] & readonly> checkpanic r3;
     assertTrue(vals[0].isReadOnly());
 
     Details d1 = vals[0][0];
@@ -246,7 +246,7 @@ function testSimpleInitializationForSelectivelyImmutableTableTypes() {
     readonly r1 = a;
     assertTrue(r1 is table<map<string>> & readonly);
 
-    table<map<string>> tbString = <table<map<string>>> <any> r1;
+    table<map<string>> tbString = <table<map<string>>> <any> checkpanic r1;
     assertEquality(2, tbString.length());
 
     map<string>[] mapArr = tbString.toArray();
@@ -264,7 +264,7 @@ function testSimpleInitializationForSelectivelyImmutableTableTypes() {
     assertTrue(r2 is table<Identifier> key(name) & readonly);
     assertTrue(r2 is table<Identifier> & readonly);
 
-    table<Identifier> tbDetails = <table<Identifier>> <any> r2;
+    table<Identifier> tbDetails = <table<Identifier>> <any> checkpanic r2;
     assertEquality(3, tbDetails.length());
 
     Identifier[] detailsArr = tbDetails.toArray();
@@ -1023,5 +1023,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/stream/stream-value.bal
@@ -101,7 +101,7 @@ function testStreamConstructWithFilter() returns boolean {
         return intVal % 2 == 1;
     });
 
-    ResultValue? oddNumber = <ResultValue?> oddNumberStream.next();
+    ResultValue? oddNumber = <ResultValue?> checkpanic oddNumberStream.next();
     testPassed = testPassed && (<int>oddNumber["value"] % 2 == 1);
 
     oddNumber = getRecordValue(oddNumberStream.next());

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/map-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/map-constraint-table-value.bal
@@ -45,20 +45,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                             message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/map-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/map-constraint-table-value.bal
@@ -45,5 +45,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                            message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -418,5 +418,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                        message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-constraint-table-value.bal
@@ -418,20 +418,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                         message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
@@ -184,20 +184,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError("AssertionError",
                         message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/record-type-table-key.bal
@@ -184,5 +184,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError("AssertionError", message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError("AssertionError",
+                        message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/xml-type-table-key.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/xml-type-table-key.bal
@@ -153,20 +153,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError("AssertionError",
                         message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/table/xml-type-table-key.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/table/xml-type-table-key.bal
@@ -153,5 +153,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError("AssertionError", message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError("AssertionError",
+                        message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -260,6 +260,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_basic_test.bal
@@ -260,20 +260,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_fill_member_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_fill_member_test.bal
@@ -173,20 +173,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic error(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_fill_member_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/tuples/tuple_fill_member_test.bal
@@ -173,6 +173,21 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERROR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -208,20 +208,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
-
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
     panic AssertionError(ASSERTION_ERROR_REASON,
                     message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -208,5 +208,20 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    panic AssertionError(ASSERTION_ERROR_REASON, message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
+    panic AssertionError(ASSERTION_ERROR_REASON,
+                    message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
@@ -218,6 +218,21 @@ function assertEquality(any|error expected, any|error actual) {
     if expected === actual {
         return;
     }
+
+    string expectedValAsString = "";
+    string actualValAsString = "";
+    if (expected is error) {
+        expectedValAsString = expected.toString();
+    } else {
+        expectedValAsString = expected.toString();
+    }
+
+    if (actual is error) {
+        actualValAsString = actual.toString();
+    } else {
+        actualValAsString = actual.toString();
+    }
+
     panic error(ASSERTION_ERR_REASON,
-                message = "expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+                message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/uniontypes/union_types_basic.bal
@@ -219,19 +219,8 @@ function assertEquality(any|error expected, any|error actual) {
         return;
     }
 
-    string expectedValAsString = "";
-    string actualValAsString = "";
-    if (expected is error) {
-        expectedValAsString = expected.toString();
-    } else {
-        expectedValAsString = expected.toString();
-    }
-
-    if (actual is error) {
-        actualValAsString = actual.toString();
-    } else {
-        actualValAsString = actual.toString();
-    }
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
 
     panic error(ASSERTION_ERR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + actualValAsString + "'");


### PR DESCRIPTION
## Purpose
$subject
In the previous implementation, we can cast a value and get the string of the value, without considering value is an error.
ex: 
```
int|error v = -1;
int a1 = <int> v;
string a2 = v.toString();
```

With this PR, we disallow that kind of type cast and toString method call in compile time.

Fixes #27028 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
