### PR TITLE
Add request/response limit config to listener/client configs

### DIFF
--- a/gradle/javaLibsProject.gradle
+++ b/gradle/javaLibsProject.gradle
@@ -38,7 +38,7 @@ dependencies {
     dist 'org.wso2.carbon:org.wso2.carbon.core:5.1.0'
     dist 'org.wso2.securevault:org.wso2.securevault:1.0.0-wso2v2'
     dist 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
-    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.17'
+    dist 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.18'
     dist 'org.bouncycastle:bcprov-jdk15on:1.61'
     dist 'org.bouncycastle:bcpkix-jdk15on:1.61'
 

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -96,7 +96,7 @@ dependencies {
         implementation 'org.wso2.carbon.messaging:org.wso2.carbon.messaging:2.3.7'
         implementation 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'
         implementation 'org.wso2.orbit.org.yaml:snakeyaml:1.26.0.wso2v1'
-        implementation 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.17'
+        implementation 'org.wso2.transport.http:org.wso2.transport.http.netty:6.3.18'
         implementation 'org.wso2.transport.file:org.wso2.transport.local-file-system:6.0.55'
         implementation 'org.wso2.staxon:staxon-core:1.2.0.wso2v2'
         implementation 'org.quartz-scheduler:quartz:2.3.1'

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/delimiterBasedCompletionForCompleteSource1.json
@@ -1,10 +1,10 @@
 {
     "position": {
-        "line": 2,
-        "character": 47
+        "line":2,
+        "character":47
     },
     "source": "function/source/delimiterBasedCompletionForCompleteSource1.bal",
-    "items": [
+    "items":[
         {
             "label": "AUTH_HEADER",
             "kind": "Variable",
@@ -2495,6 +2495,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "ResponseLimitConfigs",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "ClientHttp2Settings",
             "kind": "Struct",
             "detail": "Record",
@@ -3583,6 +3594,17 @@
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/ifWhileConditionContextCompletion4.json
@@ -1,10 +1,10 @@
 {
     "position": {
-        "line": 4,
-        "character": 21
+        "line":4,
+        "character":21
     },
     "source": "function/source/ifWhileConditionContextCompletion4.bal",
-    "items": [
+    "items":[
         {
             "label": "HttpServiceConfig",
             "kind": "Struct",
@@ -263,6 +263,17 @@
             },
             "sortText": "180",
             "insertText": "ClientHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "ResponseLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {
@@ -1050,6 +1061,17 @@
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/matchStatementSuggestions4.json
@@ -1,10 +1,10 @@
 {
     "position": {
-        "line": 11,
-        "character": 15
+        "line":11,
+        "character":15
     },
     "source": "function/source/matchStatementSuggestions4.bal",
-    "items": [
+    "items":[
         {
             "label": "AUTH_HEADER",
             "kind": "Variable",
@@ -2495,6 +2495,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "ResponseLimitConfigs",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "ClientHttp2Settings",
             "kind": "Struct",
             "detail": "Record",
@@ -3583,6 +3594,17 @@
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/function/workerDeclarationContext4.json
@@ -266,6 +266,17 @@
             "insertTextFormat":"Snippet"
         },
         {
+            "label":"ResponseLimitConfigs",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText":"180",
+            "insertText":"ResponseLimitConfigs",
+            "insertTextFormat":"Snippet"
+        },
+        {
             "label":"ClientHttp2Settings",
             "kind":"Struct",
             "detail":"Record",
@@ -1050,6 +1061,17 @@
             },
             "sortText":"180",
             "insertText":"ListenerHttp1Settings",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"RequestLimitConfigs",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText":"180",
+            "insertText":"RequestLimitConfigs",
             "insertTextFormat":"Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/object/objectTest13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/object/objectTest13.json
@@ -1,10 +1,10 @@
 {
     "position": {
-        "line": 3,
-        "character": 9
+        "line":3,
+        "character":9
     },
     "source": "object/source/objectTest13.bal",
-    "items": [
+    "items":[
         {
             "label": "HttpServiceConfig",
             "kind": "Struct",
@@ -263,6 +263,17 @@
             },
             "sortText": "180",
             "insertText": "ClientHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "ResponseLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {
@@ -1050,6 +1061,17 @@
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/packageimport/packageImport1.json
@@ -1,10 +1,10 @@
 {
     "position": {
-        "line": 3,
-        "character": 9
+        "line":3,
+        "character":9
     },
     "source": "packageimport/source/module2/packageImport.bal",
-    "items": [
+    "items":[
         {
             "label": "AUTH_HEADER",
             "kind": "Variable",
@@ -2495,6 +2495,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "ResponseLimitConfigs",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "ClientHttp2Settings",
             "kind": "Struct",
             "detail": "Record",
@@ -3583,6 +3594,17 @@
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/globalVarDefPackageContent.json
@@ -1,10 +1,10 @@
 {
     "position": {
-        "line": 3,
-        "character": 13
+        "line":3,
+        "character":13
     },
     "source": "toplevel/source/globalVarDefPackageContent.bal",
-    "items": [
+    "items":[
         {
             "label": "AUTH_HEADER",
             "kind": "Variable",
@@ -2495,6 +2495,17 @@
             "insertTextFormat": "Snippet"
         },
         {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "120",
+            "insertText": "ResponseLimitConfigs",
+            "insertTextFormat": "Snippet"
+        },
+        {
             "label": "ClientHttp2Settings",
             "kind": "Struct",
             "detail": "Record",
@@ -3583,6 +3594,17 @@
             },
             "sortText": "120",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "120",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon2.json
@@ -4,7 +4,7 @@
         "character":27
     },
     "source": "toplevel/source/statementWithMissingSemiColon2.bal",
-    "items": [
+    "items":[
         {
             "label": "HttpServiceConfig",
             "kind": "Struct",
@@ -263,6 +263,17 @@
             },
             "sortText": "180",
             "insertText": "ClientHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "ResponseLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "ResponseLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {
@@ -1050,6 +1061,17 @@
             },
             "sortText": "180",
             "insertText": "ListenerHttp1Settings",
+            "insertTextFormat": "Snippet"
+        },
+        {
+            "label": "RequestLimitConfigs",
+            "kind": "Struct",
+            "detail": "Record",
+            "documentation": {
+                "left": "Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText": "180",
+            "insertText": "RequestLimitConfigs",
             "insertTextFormat": "Snippet"
         },
         {

--- a/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/toplevel/statementWithMissingSemiColon3.json
@@ -2495,6 +2495,17 @@
             "insertTextFormat":"Snippet"
         },
         {
+            "label":"ResponseLimitConfigs",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides inbound response status line, total header and entity body size threshold configurations.\n"
+            },
+            "sortText":"120",
+            "insertText":"ResponseLimitConfigs",
+            "insertTextFormat":"Snippet"
+        },
+        {
             "label":"ClientHttp2Settings",
             "kind":"Struct",
             "detail":"Record",
@@ -3583,6 +3594,17 @@
             },
             "sortText":"120",
             "insertText":"ListenerHttp1Settings",
+            "insertTextFormat":"Snippet"
+        },
+        {
+            "label":"RequestLimitConfigs",
+            "kind":"Struct",
+            "detail":"Record",
+            "documentation":{
+                "left":"Provides inbound request URI, total header and entity body size threshold configurations.\n"
+            },
+            "sortText":"120",
+            "insertText":"RequestLimitConfigs",
             "insertTextFormat":"Snippet"
         },
         {

--- a/stdlib/grpc/src/main/ballerina/Ballerina.toml
+++ b/stdlib/grpc/src/main/ballerina/Ballerina.toml
@@ -21,8 +21,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.17"
-    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
+    version = "6.3.18"
+    path = "./lib/org.wso2.transport.http.netty-6.3.18.jar"
     groupId = "org.wso2.transport.http"
     modules = ["grpc"]
 

--- a/stdlib/http/src/main/ballerina/Ballerina.toml
+++ b/stdlib/http/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.17"
-    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
+    version = "6.3.18"
+    path = "./lib/org.wso2.transport.http.netty-6.3.18.jar"
     groupId = "org.wso2.transport.http"
     modules = ["http"]
 

--- a/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/client_endpoint.bal
@@ -260,15 +260,20 @@ public type ClientConfiguration record {|
 # + keepAlive - Specifies whether to reuse a connection for multiple requests
 # + chunking - The chunking behaviour of the request
 # + proxy - Proxy server related options
-# + maxStatusLineLength - Maximum allowed length for response status line(`HTTP/1.0 200 OK`). Exceeding this limit will
-#                         result in an error
-# + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in an error
-# + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there is no
-#                       restriction `maxEntityBodySize`, On the Exceeding this limit will result in an error
 public type ClientHttp1Settings record {|
     KeepAlive keepAlive = KEEPALIVE_AUTO;
     Chunking chunking = CHUNKING_AUTO;
     ProxyConfig? proxy = ();
+|};
+
+# Provides inbound response status line, total header and entity body size threshold configurations.
+#
+# + maxStatusLineLength - Maximum allowed length for response status line(`HTTP/1.1 200 OK`). Exceeding this limit will
+#                         result in a `ClientError`
+# + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in a `ClientError`
+# + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there is no
+#                       restriction `maxEntityBodySize`, On the Exceeding this limit will result in a `ClientError`
+public type ResponseLimitConfigs record {|
     int maxStatusLineLength = 4096;
     int maxHeaderSize = 8192;
     int maxEntityBodySize = -1;

--- a/stdlib/http/src/main/ballerina/src/http/http_commons.bal
+++ b/stdlib/http/src/main/ballerina/src/http/http_commons.bal
@@ -206,6 +206,7 @@ type HTTPError record {
 # + circuitBreaker - Configurations associated with the behaviour of the Circuit Breaker
 # + retryConfig - Configurations associated with retrying
 # + cookieConfig - Configurations associated with cookies
+# + responseLimits - Configurations associated with inbound response size limits
 public type CommonClientConfiguration record {|
     string httpVersion = HTTP_1_1;
     ClientHttp1Settings http1Settings = {};
@@ -220,6 +221,7 @@ public type CommonClientConfiguration record {|
     CircuitBreakerConfig? circuitBreaker = ();
     RetryConfig? retryConfig = ();
     CookieConfig? cookieConfig = ();
+    ResponseLimitConfigs responseLimits = {};
 |};
 
 //////////////////////////////

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -201,6 +201,7 @@ public type Local record {|
 # + auth - Listener authenticaton configurations
 # + server - The server name which should appear as a response header
 # + webSocketCompressionEnabled - Enable support for compression in WebSocket
+# + requestLimits - Configurations associated with inbound request size limits
 public type ListenerConfiguration record {|
     string host = "0.0.0.0";
     ListenerHttp1Settings http1Settings = {};
@@ -212,6 +213,7 @@ public type ListenerConfiguration record {|
     ListenerAuth auth?;
     string? server = ();
     boolean webSocketCompressionEnabled = true;
+    RequestLimitConfigs requestLimits = {};
 |};
 
 # Provides settings related to HTTP/1.x protocol.
@@ -231,6 +233,21 @@ public type ListenerConfiguration record {|
 public type ListenerHttp1Settings record {|
     KeepAlive keepAlive = KEEPALIVE_AUTO;
     int maxPipelinedRequests = MAX_PIPELINED_REQUESTS;
+    int maxUriLength = 4096;
+    int maxHeaderSize = 8192;
+    int maxEntityBodySize = -1;
+|};
+
+# Provides inbound request URI, total header and entity body size threshold configurations.
+#
+# + maxUriLength - Maximum allowed length for a URI. Exceeding this limit will result in a
+#                  `414 - URI Too Long` response.
+# + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in a
+#                   `431 - Request Header Fields Too Large` response.
+# + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there
+#                       is no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a
+#                       `413 - Payload Too Large` response.
+public type RequestLimitConfigs record {|
     int maxUriLength = 4096;
     int maxHeaderSize = 8192;
     int maxEntityBodySize = -1;

--- a/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
+++ b/stdlib/http/src/main/ballerina/src/http/service_endpoint.bal
@@ -221,32 +221,22 @@ public type ListenerConfiguration record {|
 # + keepAlive - Can be set to either `KEEPALIVE_AUTO`, which respects the `connection` header, or `KEEPALIVE_ALWAYS`,
 #               which always keeps the connection alive, or `KEEPALIVE_NEVER`, which always closes the connection
 # + maxPipelinedRequests - Defines the maximum number of requests that can be processed at a given time on a single
-#                          connection. By default 10 requests can be pipelined on a single cinnection and user can
+#                          connection. By default 10 requests can be pipelined on a single connection and user can
 #                          change this limit appropriately.
-# + maxUriLength - Maximum allowed length for a URI. Exceeding this limit will result in a
-#                  `414 - URI Too Long` response.
-# + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in a
-#                   `431 - Request Header Fields Too Large` response.
-# + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there
-#                       is no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a
-#                       `413 - Payload Too Large` response.
 public type ListenerHttp1Settings record {|
     KeepAlive keepAlive = KEEPALIVE_AUTO;
     int maxPipelinedRequests = MAX_PIPELINED_REQUESTS;
-    int maxUriLength = 4096;
-    int maxHeaderSize = 8192;
-    int maxEntityBodySize = -1;
 |};
 
 # Provides inbound request URI, total header and entity body size threshold configurations.
 #
-# + maxUriLength - Maximum allowed length for a URI. Exceeding this limit will result in a
-#                  `414 - URI Too Long` response.
+# + maxUriLength - Maximum allowed length for a URI. Exceeding this limit will result in a `414 - URI Too Long`
+#                  response
 # + maxHeaderSize - Maximum allowed size for headers. Exceeding this limit will result in a
-#                   `431 - Request Header Fields Too Large` response.
+#                   `431 - Request Header Fields Too Large` response
 # + maxEntityBodySize - Maximum allowed size for the entity body. By default it is set to -1 which means there
 #                       is no restriction `maxEntityBodySize`, On the Exceeding this limit will result in a
-#                       `413 - Payload Too Large` response.
+#                       `413 - Payload Too Large` response
 public type RequestLimitConfigs record {|
     int maxUriLength = 4096;
     int maxHeaderSize = 8192;

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpConstants.java
@@ -370,6 +370,8 @@ public class HttpConstants {
     public static final String HTTP2_PRIOR_KNOWLEDGE = "http2PriorKnowledge";
     public static final String HTTP1_SETTINGS = "http1Settings";
     public static final String HTTP2_SETTINGS = "http2Settings";
+    public static final String REQUEST_LIMITS = "requestLimits";
+    public static final String RESPONSE_LIMITS = "responseLimits";
 
     //Connection Throttling field names
     public static final String CONNECTION_THROTTLING_STRUCT_REFERENCE = "connectionThrottling";

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/HttpUtil.java
@@ -1470,22 +1470,24 @@ public class HttpUtil {
         String host = endpointConfig.getStringValue(HttpConstants.ENDPOINT_CONFIG_HOST);
         MapValue sslConfig = endpointConfig.getMapValue(HttpConstants.ENDPOINT_CONFIG_SECURE_SOCKET);
         String httpVersion = endpointConfig.getStringValue(HttpConstants.ENDPOINT_CONFIG_VERSION);
-        MapValue<String, Object> http1Settings = null;
         long idleTimeout = endpointConfig.getIntValue(HttpConstants.ENDPOINT_CONFIG_TIMEOUT);
 
         ListenerConfiguration listenerConfiguration = new ListenerConfiguration();
         if (HTTP_1_1_VERSION.equals(httpVersion)) {
-            http1Settings = (MapValue<String, Object>) endpointConfig.get(HttpConstants.HTTP1_SETTINGS);
+            MapValue<String, Object> http1Settings =
+                    (MapValue<String, Object>) endpointConfig.get(HttpConstants.HTTP1_SETTINGS);
             listenerConfiguration.setPipeliningLimit(http1Settings.getIntValue(HttpConstants.PIPELINING_REQUEST_LIMIT));
             String keepAlive = http1Settings.getStringValue(HttpConstants.ENDPOINT_CONFIG_KEEP_ALIVE);
             listenerConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAlive));
-            // Set Request validation limits.
-            setInboundMgsSizeValidationConfig(
-                    http1Settings.getIntValue(HttpConstants.MAX_URI_LENGTH),
-                    http1Settings.getIntValue(HttpConstants.MAX_HEADER_SIZE),
-                    http1Settings.getIntValue(HttpConstants.MAX_ENTITY_BODY_SIZE),
-                    listenerConfiguration.getMsgSizeValidationConfig());
         }
+
+        // Set Request validation limits.
+        MapValue<String, Object> requestLimits =
+                (MapValue<String, Object>) endpointConfig.getMapValue(HttpConstants.REQUEST_LIMITS);
+        setInboundMgsSizeValidationConfig(requestLimits.getIntValue(HttpConstants.MAX_URI_LENGTH),
+                                          requestLimits.getIntValue(HttpConstants.MAX_HEADER_SIZE),
+                                          requestLimits.getIntValue(HttpConstants.MAX_ENTITY_BODY_SIZE),
+                                          listenerConfiguration.getMsgSizeValidationConfig());
 
         if (host == null || host.trim().isEmpty()) {
             listenerConfiguration.setHost(ConfigRegistry.getInstance().getConfigOrDefault("b7a.http.host",

--- a/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
+++ b/stdlib/http/src/main/java/org/ballerinalang/net/http/clientendpoint/CreateSimpleHttpClient.java
@@ -86,13 +86,15 @@ public class CreateSimpleHttpClient {
             senderConfiguration.setChunkingConfig(HttpUtil.getChunkConfig(chunking));
             String keepAliveConfig = http1Settings.getStringValue(HttpConstants.CLIENT_EP_IS_KEEP_ALIVE);
             senderConfiguration.setKeepAliveConfig(HttpUtil.getKeepAliveConfig(keepAliveConfig));
-            // Set Response validation limits.
-            HttpUtil.setInboundMgsSizeValidationConfig(
-                    http1Settings.getIntValue(HttpConstants.MAX_STATUS_LINE_LENGTH),
-                    http1Settings.getIntValue(HttpConstants.MAX_HEADER_SIZE),
-                    http1Settings.getIntValue(HttpConstants.MAX_ENTITY_BODY_SIZE),
-                    senderConfiguration.getMsgSizeValidationConfig());
         }
+
+        // Set Response validation limits.
+        MapValue<String, Object> responseLimits = (MapValue<String, Object>) clientEndpointConfig.get(
+                HttpConstants.RESPONSE_LIMITS);
+        HttpUtil.setInboundMgsSizeValidationConfig(responseLimits.getIntValue(HttpConstants.MAX_STATUS_LINE_LENGTH),
+                                                   responseLimits.getIntValue(HttpConstants.MAX_HEADER_SIZE),
+                                                   responseLimits.getIntValue(HttpConstants.MAX_ENTITY_BODY_SIZE),
+                                                   senderConfiguration.getMsgSizeValidationConfig());
         try {
             populateSenderConfigurations(senderConfiguration, clientEndpointConfig, scheme);
         } catch (RuntimeException e) {

--- a/stdlib/mime/src/main/ballerina/Ballerina.toml
+++ b/stdlib/mime/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.17"
-    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
+    version = "6.3.18"
+    path = "./lib/org.wso2.transport.http.netty-6.3.18.jar"
     groupId = "org.wso2.transport.http"
     modules = ["mime"]
 

--- a/stdlib/websub/src/main/ballerina/Ballerina.toml
+++ b/stdlib/websub/src/main/ballerina/Ballerina.toml
@@ -14,8 +14,8 @@ target = "java8"
 
     [[platform.libraries]]
     artifactId = "org.wso2.transport.http.netty"
-    version = "6.3.17"
-    path = "./lib/org.wso2.transport.http.netty-6.3.17.jar"
+    version = "6.3.18"
+    path = "./lib/org.wso2.transport.http.netty-6.3.18.jar"
     groupId = "org.wso2.transport.http"
     modules = ["web-sub"]
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -40,7 +40,7 @@ public class HttpBaseTest extends BaseTest {
                 9102, 9103, 9104, 9105, 9106, 9107, 9108, 9109, 9110, 9111, 9112, 9113, 9114, 9115, 9116, 9117, 9118,
                 9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225, 9226, 9227, 9228, 9229, 9230, 9231, 9232, 9233,
                 9234, 9235, 9236, 9237, 9238, 9239, 9240, 9241, 9242, 9243, 9244, 9245, 9246, 9247, 9248, 9249, 9250,
-                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260, 9261, 9262, 9263, 9264, 9265 };
+                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260, 9261, 9262, 9263, 9264, 9265, 9266 };
         String balFile = Paths.get("src", "test", "resources", "http").toAbsolutePath().toString();
         String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
                                                                    "private.key").toAbsolutePath().toString());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/HttpBaseTest.java
@@ -40,7 +40,7 @@ public class HttpBaseTest extends BaseTest {
                 9102, 9103, 9104, 9105, 9106, 9107, 9108, 9109, 9110, 9111, 9112, 9113, 9114, 9115, 9116, 9117, 9118,
                 9119, 9217, 9218, 9219, 9220, 9221, 9222, 9223, 9225, 9226, 9227, 9228, 9229, 9230, 9231, 9232, 9233,
                 9234, 9235, 9236, 9237, 9238, 9239, 9240, 9241, 9242, 9243, 9244, 9245, 9246, 9247, 9248, 9249, 9250,
-                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260, 9261, 9262, 9263, 9264 };
+                9251, 9252, 9253, 9254, 9255, 9256, 9257, 9258, 9259, 9260, 9261, 9262, 9263, 9264, 9265 };
         String balFile = Paths.get("src", "test", "resources", "http").toAbsolutePath().toString();
         String privateKey = StringEscapeUtils.escapeJava(Paths.get("src", "test", "resources", "certsAndKeys",
                                                                    "private.key").toAbsolutePath().toString());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/RequestLimitsConfigurationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/RequestLimitsConfigurationTest.java
@@ -91,6 +91,18 @@ public class RequestLimitsConfigurationTest extends HttpBaseTest {
         Assert.assertEquals(httpResponse.status().toString(), expectedMessage, "Response status does not match.");
     }
 
+    @Test(description = "Tests the fallback behaviour when header size is greater than the configured http2 service")
+    public void testHttp2ServiceInvalidHeaderLength() {
+        String expectedMessage = "431 Request Header Fields Too Large";
+        HttpClient httpClient = new HttpClient(TEST_HOST, 9265);
+        FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET,
+                                            "/http2service/invalidHeaderSize");
+        httpRequest.headers().set("X-Test", getLargeHeader());
+        FullHttpResponse httpResponse = httpClient.sendRequest(httpRequest);
+        Assert.assertNotNull(httpResponse, "Response is empty.");
+        Assert.assertEquals(httpResponse.status().toString(), expectedMessage, "Response status does not match.");
+    }
+
     private String getLargeHeader() {
         StringBuilder header = new StringBuilder("x");
         for (int i = 0; i < 9000; i++) {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/ResponseLimitsConfigurationTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/service/http/configuration/ResponseLimitsConfigurationTest.java
@@ -106,4 +106,29 @@ public class ResponseLimitsConfigurationTest extends HttpBaseTest {
                                     "entity body size exceeds: Entity body is larger than 1024 bytes. ",
                             "Message content mismatched");
     }
+
+    @Test(description = "Test when header size is less than the configured maxHeaderSize threshold in http2 client " +
+            "but the backend sends http 1.1 response")
+    public void testValidHeaderLengthWithHttp2Client() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, SUCCESS);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/http2"), headers);
+        Assert.assertEquals(response.getResponseCode(), 200, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "Hello World!!!", "Message content mismatched");
+        Assert.assertEquals(response.getHeaders().get("x-header"), "Validated", "Header content mismatched");
+    }
+
+    @Test(description = "Test when header size is greater than the configured maxHeaderSize threshold in http2 client" +
+            " but the backend sends http 1.1 response")
+    public void testInvalidHeaderLengthWithHttp2Client() throws IOException {
+        Map<String, String> headers = new HashMap<>();
+        headers.put(X_TEST_TYPE, ERROR);
+        HttpResponse response = HttpClientRequest.doGet(
+                serverInstance.getServiceURLHttp(9261, "responseLimit/http2"), headers);
+        Assert.assertEquals(response.getResponseCode(), 500, "Response code mismatched");
+        Assert.assertEquals(response.getData(), "error {ballerina/http}GenericClientError message=Response max " +
+                "header size exceeds: HTTP header is larger than 1024 bytes.", "Header content mismatched");
+        Assert.assertNull(response.getHeaders().get("x-header"), "Message content mismatched");
+    }
 }

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/32_service-request-limits.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/32_service-request-limits.bal
@@ -17,26 +17,33 @@
 import ballerina/http;
 
 http:ListenerConfiguration urlLimitConfig = {
-    http1Settings: {
+    requestLimits: {
         maxUriLength: 1024
     }
 };
 
 http:ListenerConfiguration lowUrlLimitConfig = {
-    http1Settings: {
+    requestLimits: {
         maxUriLength: 2
     }
 };
 
 http:ListenerConfiguration lowHeaderConfig = {
-    http1Settings: {
+    requestLimits: {
         maxHeaderSize: 30
     }
 };
 
 http:ListenerConfiguration midSizeHeaderConfig = {
-    http1Settings: {
+    requestLimits: {
         maxHeaderSize: 100
+    }
+};
+
+http:ListenerConfiguration http2lowHeaderConfig = {
+    httpVersion: "2.0",
+    requestLimits: {
+        maxHeaderSize: 30
     }
 };
 
@@ -44,6 +51,7 @@ listener http:Listener normalRequestLimitEP = new(9234, urlLimitConfig);
 listener http:Listener lowRequestLimitEP = new(9235, lowUrlLimitConfig);
 listener http:Listener lowHeaderLimitEP = new(9236, lowHeaderConfig);
 listener http:Listener midHeaderLimitEP = new(9237, midSizeHeaderConfig);
+listener http:Listener http2HeaderLimitEP = new(9265, http2lowHeaderConfig);
 
 @http:ServiceConfig {basePath:"/requestUriLimit"}
 service urlLimitService on normalRequestLimitEP {
@@ -89,6 +97,18 @@ service headerLimitService on midHeaderLimitEP {
         path:"/validHeaderSize"
     }
     resource function validHeader(http:Caller caller, http:Request req) {
+        checkpanic caller->respond("Hello World!!!");
+    }
+}
+
+@http:ServiceConfig {basePath:"/http2service"}
+service http2HeaderLimitService on http2HeaderLimitEP {
+
+    @http:ResourceConfig {
+        methods:["GET"],
+        path:"/invalidHeaderSize"
+    }
+    resource function invalidHeader(http:Caller caller, http:Request req) {
         checkpanic caller->respond("Hello World!!!");
     }
 }

--- a/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/48_inbound_response_limits.bal
+++ b/tests/jballerina-integration-test/src/test/resources/http/src/httpservices/48_inbound_response_limits.bal
@@ -45,7 +45,7 @@ http:ClientConfiguration http2headerLimitConfig = {
 http:Client statusLimitClient = new("http://localhost:9262/backend/statustest", statusLineLimitConfig);
 http:Client headerLimitClient = new("http://localhost:9263/backend/headertest", headerLimitConfig);
 http:Client entityBodyLimitClient = new("http://localhost:9264/backend/entitybodytest", entityBodyLimitConfig);
-http:Client http2headerLimitClient = new("http://localhost:9263/backend/headertest", http2headerLimitConfig);
+http:Client http2headerLimitClient = new("http://localhost:9266/backend/headertest", http2headerLimitConfig);
 
 @http:ServiceConfig {basePath:"/responseLimit"}
 service passthruLimitService on new http:Listener(9261) {
@@ -128,7 +128,7 @@ service entitybodyBackendService on new http:Listener(9264) {
 
 
 @http:ServiceConfig {basePath:"/backend"}
-service headertBackendService on new http:Listener(9263) {
+service http2headertBackendService on new http:Listener(9266) {
     resource function headertest(http:Caller caller, http:Request req) {
         http:Response res = new;
         string testType = req.getHeader("x-test-type");


### PR DESCRIPTION
## Purpose
> $subject and pass limit configs regardless of the http version to configure the codec. So that if either client or listener fallback, messages will be treated as per the given configs

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/27251

## Samples
```ballerina
http:Client clientEP = new ("http://localhost:9092/hello", config = {
    responseLimits : {
        maxStatusLineLength : 50,
        maxHeaderSize : 1000,
        maxEntityBodySize: 50
        }
    }
);

listener http:Listener eP = new (9092, config = {
    requestLimits : {
        maxUriLength : 50,
        maxHeaderSize : 600,
        maxEntityBodySize: 70
        }
    }
);
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
