### PR TITLE
Recursively set readonly flag for runtime types

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/creators/ValueCreator.java
@@ -608,8 +608,7 @@ public class ValueCreator {
      * @param keyValues initial map values to be populated.
      * @return map value
      */
-    public static BMap<BString, Object> createMapValue(MapType mapType,
-                                                       BMapInitialValueEntry[] keyValues) {
+    public static BMap<BString, Object> createMapValue(MapType mapType, BMapInitialValueEntry[] keyValues) {
         return new MapValueImpl<>(mapType, keyValues);
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableJsonDataSource.java
@@ -201,22 +201,21 @@ public class TableJsonDataSource implements JsonDataSource {
             MapValue<BString, Object> jsonData = new MapValueImpl<>(new BMapType(PredefinedTypes.TYPE_JSON));
             boolean structError = true;
             if (data != null) {
-                Type internalType = structFields[index].type;
+                Type internalType = structFields[index].getFieldType();
                 if (internalType.getTag() == TypeTags.OBJECT_TYPE_TAG
                         || internalType.getTag() == TypeTags.RECORD_TYPE_TAG) {
                     BField[] internalStructFields =
                             ((BStructureType) internalType).getFields().values().toArray(new BField[0]);
                     for (int i = 0; i < internalStructFields.length; i++) {
-                        BString internalKeyName = StringUtils.fromString(internalStructFields[i].name);
+                        BString internalKeyName = StringUtils.fromString(internalStructFields[i].getFieldName());
                         Object value = data.get(internalKeyName);
                         if (value instanceof BigDecimal) {
-                            jsonData.put(StringUtils.fromString(internalStructFields[i].name),
-                                         ((BigDecimal) value).doubleValue());
+                            jsonData.put(internalKeyName, ((BigDecimal) value).doubleValue());
                         } else if (value instanceof MapValueImpl) {
-                            jsonData.put(StringUtils.fromString(internalStructFields[i].name),
+                            jsonData.put(internalKeyName,
                                          getStructData((MapValueImpl) value, internalStructFields, i, internalKeyName));
                         } else {
-                            jsonData.put(StringUtils.fromString(internalStructFields[i].name), value);
+                            jsonData.put(internalKeyName, value);
                         }
                         structError = false;
                     }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableOmDataSource.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TableOmDataSource.java
@@ -163,7 +163,7 @@ public class TableOmDataSource extends AbstractPushOMDataSource {
                     .values().toArray(new BField[0]);
             if (internalStructFields != null) {
                 for (int i = 0; i < internalStructFields.length; i++) {
-                    BString internalKeyName = StringUtils.fromString(internalStructFields[i].name);
+                    BString internalKeyName = StringUtils.fromString(internalStructFields[i].getFieldName());
                     Object val = structData.get(internalKeyName);
                     xmlStreamWriter.writeStartElement("", internalStructFields[i].getFieldName(), "");
                     if (val instanceof MapValueImpl) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -960,7 +960,7 @@ public class TypeChecker {
             List<Type> fieldTypes = new ArrayList<>();
             Arrays.stream(srcTableType.getFieldNames()).forEach(field -> fieldTypes
                     .add(Objects.requireNonNull(getTableConstraintField(srcTableType.getConstrainedType(), field))
-                    .type));
+                    .getFieldType()));
 
             if (fieldTypes.size() == 1) {
                 return checkConstraints(fieldTypes.get(0), targetType.getKeyType(), unresolvedTypes);
@@ -990,7 +990,7 @@ public class TypeChecker {
                     return null;
                 }
 
-                if (fields.stream().allMatch(field -> isSameType(field.type, fields.get(0).type))) {
+                if (fields.stream().allMatch(field -> isSameType(field.getFieldType(), fields.get(0).getFieldType()))) {
                     return fields.get(0);
                 }
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BField.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BField.java
@@ -27,9 +27,9 @@ import io.ballerina.runtime.api.types.Type;
  */
 public class BField implements Field {
 
-    public Type type;
-    public String name;
-    public long flags;
+    private final Type type;
+    private final String name;
+    private final long flags;
 
     public BField(Type fieldType, String fieldName, long flags) {
         this.type = fieldType;

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BMapType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BMapType.java
@@ -26,6 +26,7 @@ import io.ballerina.runtime.api.types.MapType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.values.MapValueImpl;
+import io.ballerina.runtime.internal.values.ReadOnlyUtils;
 
 /**
  * {@code BMapType} represents a type of a map in Ballerina.
@@ -40,36 +41,32 @@ import io.ballerina.runtime.internal.values.MapValueImpl;
 @SuppressWarnings("unchecked")
 public class BMapType extends BType implements MapType {
 
-    private Type constraint;
+    private final Type constraint;
     private final boolean readonly;
     private IntersectionType immutableType;
-
-    /**
-     * Create a type from the given name.
-     *
-     * @param typeName string name of the type.
-     * @param constraint constraint type which particular map is bound to.
-     * @param pkg package for the type.
-     */
-    public BMapType(String typeName, Type constraint, Module pkg) {
-        super(typeName, pkg, MapValueImpl.class);
-        this.constraint = constraint;
-        this.readonly = false;
-    }
-
-    public BMapType(String typeName, Type constraint, Module pkg, boolean readonly) {
-        super(typeName, pkg, MapValueImpl.class);
-        this.constraint = constraint;
-        this.readonly = readonly;
-    }
 
     public BMapType(Type constraint) {
         this(constraint, false);
     }
 
     public BMapType(Type constraint, boolean readonly) {
-        super(TypeConstants.MAP_TNAME, null, MapValueImpl.class);
-        this.constraint = constraint;
+        this(TypeConstants.MAP_TNAME, constraint, null, readonly);
+    }
+
+    /**
+     * Create a type from the given name.
+     *
+     * @param typeName   string name of the type.
+     * @param constraint constraint type which particular map is bound to.
+     * @param pkg        package for the type.
+     */
+    public BMapType(String typeName, Type constraint, Module pkg) {
+        this(typeName, constraint, pkg, false);
+    }
+
+    public BMapType(String typeName, Type constraint, Module pkg, boolean readonly) {
+        super(typeName, pkg, MapValueImpl.class);
+        this.constraint = readonly ? ReadOnlyUtils.getReadOnlyType(constraint) : constraint;
         this.readonly = readonly;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTableType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BTableType.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.constants.TypeConstants;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.internal.values.ReadOnlyUtils;
 import io.ballerina.runtime.internal.values.TableValue;
 import io.ballerina.runtime.internal.values.TableValueImpl;
 
@@ -32,7 +33,7 @@ import io.ballerina.runtime.internal.values.TableValueImpl;
  */
 public class BTableType extends BType implements TableType {
 
-    private Type constraint;
+    private final Type constraint;
     private Type keyType;
     private String[] fieldNames;
 
@@ -40,23 +41,18 @@ public class BTableType extends BType implements TableType {
     private IntersectionType immutableType;
 
     public BTableType(Type constraint, String[] fieldNames, boolean readonly) {
-        super(TypeConstants.TABLE_TNAME, null, TableValue.class);
-        this.constraint = constraint;
+        this(constraint, readonly);
         this.fieldNames = fieldNames;
-        this.keyType = null;
-        this.readonly = readonly;
     }
 
     public BTableType(Type constraint, Type keyType, boolean readonly) {
-        super(TypeConstants.TABLE_TNAME, null, TableValue.class);
-        this.constraint = constraint;
+        this(constraint, readonly);
         this.keyType = keyType;
-        this.readonly = readonly;
     }
 
     public BTableType(Type constraint, boolean readonly) {
         super(TypeConstants.TABLE_TNAME, null, TableValue.class);
-        this.constraint = constraint;
+        this.constraint = readonly ? ReadOnlyUtils.getReadOnlyType(constraint) : constraint;
         this.readonly = readonly;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BXmlType.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/types/BXmlType.java
@@ -23,6 +23,7 @@ import io.ballerina.runtime.api.constants.TypeConstants;
 import io.ballerina.runtime.api.types.IntersectionType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.XmlType;
+import io.ballerina.runtime.internal.values.ReadOnlyUtils;
 import io.ballerina.runtime.internal.values.XmlSequence;
 import io.ballerina.runtime.internal.values.XmlValue;
 
@@ -56,12 +57,13 @@ public class BXmlType extends BType implements XmlType {
         super(typeName, pkg, XmlValue.class);
         this.tag = tag;
         this.readonly = readonly;
+        this.constraint = null;
     }
 
     public BXmlType(Type constraint, boolean readonly) {
         super(TypeConstants.XML_TNAME, null, XmlValue.class);
         this.tag = TypeTags.XML_TAG;
-        this.constraint = constraint;
+        this.constraint = readonly ? ReadOnlyUtils.getReadOnlyType(constraint) : constraint;
         this.readonly = readonly;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/ArrayValueImpl.java
@@ -73,7 +73,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
     private BString[] bStringValues;
     // ------------------------ Constructors -------------------------------------------------------------------
 
-    @Deprecated
     public ArrayValueImpl(Object[] values, ArrayType type) {
         this.refValues = values;
         this.arrayType = type;
@@ -83,35 +82,30 @@ public class ArrayValueImpl extends AbstractArrayValue {
         }
     }
 
-    @Deprecated
     public ArrayValueImpl(long[] values) {
         this.intValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_INT);
     }
 
-    @Deprecated
     public ArrayValueImpl(boolean[] values) {
         this.booleanValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BOOLEAN);
     }
 
-    @Deprecated
     public ArrayValueImpl(byte[] values) {
         this.byteValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_BYTE);
     }
 
-    @Deprecated
     public ArrayValueImpl(double[] values) {
         this.floatValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_FLOAT);
     }
 
-    @Deprecated
     public ArrayValueImpl(String[] values) {
         this.size = values.length;
         bStringValues = new BString[size];
@@ -121,14 +115,12 @@ public class ArrayValueImpl extends AbstractArrayValue {
         setArrayType(PredefinedTypes.TYPE_STRING);
     }
 
-    @Deprecated
     public ArrayValueImpl(BString[] values) {
         this.bStringValues = values;
         this.size = values.length;
         setArrayType(PredefinedTypes.TYPE_STRING);
     }
 
-    @Deprecated
     public ArrayValueImpl(ArrayType type) {
         this.arrayType = type;
         ArrayType arrayType = type;
@@ -228,7 +220,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
         }
     }
 
-    @Deprecated
     public ArrayValueImpl(ArrayType type, long size) {
         this.arrayType = type;
         this.elementType = type.getElementType();
@@ -238,7 +229,6 @@ public class ArrayValueImpl extends AbstractArrayValue {
         }
     }
 
-    @Deprecated
     public ArrayValueImpl(ArrayType type, long size, ListInitialValueEntry[] initialValues) {
         this.arrayType = type;
         this.elementType = type.getElementType();

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MapValueImpl.java
@@ -184,7 +184,7 @@ public class MapValueImpl<K, V> extends LinkedHashMap<K, V> implements RefValue,
             BRecordType recordType = (BRecordType) this.type;
             Map fields = recordType.getFields();
             if (fields.containsKey(key.toString())) {
-                expectedType = ((BField) fields.get(key.toString())).type;
+                expectedType = ((BField) fields.get(key.toString())).getFieldType();
             } else {
                 if (recordType.sealed) {
                     // Panic if this record type does not contain a key by the specified name.

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MappingInitialValueEntry.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/values/MappingInitialValueEntry.java
@@ -39,8 +39,8 @@ public abstract class MappingInitialValueEntry implements BMapInitialValueEntry 
      */
     public static class KeyValueEntry extends MappingInitialValueEntry {
 
-        public Object key;
-        public Object value;
+        public final Object key;
+        public final Object value;
 
         public KeyValueEntry(Object key, Object value) {
             this.key = key;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/MockListener.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/MockListener.java
@@ -56,7 +56,7 @@ public class MockListener {
                                               err = error;
                                               latch.countDown();
                                           }
-                             }, new HashMap<>(), null);
+                             }, new HashMap<>());
             latch.await();
         }
         return err;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinfunctions/FreezeAndIsFrozenTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/builtinfunctions/FreezeAndIsFrozenTest.java
@@ -14,6 +14,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.ballerinalang.test.expressions.builtinfunctions;
 
 import org.ballerinalang.core.model.values.BBoolean;
@@ -46,8 +47,6 @@ import static org.ballerinalang.test.BAssertUtil.validateError;
  */
 public class FreezeAndIsFrozenTest {
 
-    private static final String FREEZE_ERROR_OCCURRED_ERR_MSG =
-            "error occurred on freeze: 'freeze()' not allowed on 'PersonObj'";
     private static final String FREEZE_SUCCESSFUL = "freeze successful";
 
     private CompileResult result;
@@ -169,7 +168,7 @@ public class FreezeAndIsFrozenTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array\\}InvalidUpdate \\{\"message\"" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InvalidUpdate \\{\"message\"" +
                     ":\"modification not allowed on readonly value\".*",
             dataProvider = "frozenBasicTypeArrayModificationFunctions")
     public void testFrozenBasicTypeArrayModification(String frozenBasicTypeArrayModificationFunction) {
@@ -177,63 +176,63 @@ public class FreezeAndIsFrozenTest {
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InvalidUpdate \\{\"message\":" +
                     "\"modification not allowed on readonly value.*")
     public void testFrozenDecimalArrayModification() {
         BRunUtil.invoke(result, "testFrozenDecimalArrayModification", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array\\}InvalidUpdate \\{\"message\":\"" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InvalidUpdate \\{\"message\":\"" +
                     "modification not allowed on readonly value\"}.*")
     public void testFrozenJsonArrayModification() {
         BRunUtil.invoke(result, "testFrozenJsonArrayModification", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Invalid map insertion: modification not allowed on readonly value\".*")
     public void testFrozenJsonModification() {
         BRunUtil.invoke(result, "testFrozenJsonModification", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Invalid map insertion: modification not allowed on readonly value\".*")
     public void testAdditionToFrozenJson() {
         BRunUtil.invoke(result, "testAdditionToFrozenJson", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":\"Failed " +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":\"Failed " +
                     "to remove element from map: modification not allowed on readonly value.*")
     public void testRemovalFromFrozenJson() {
         BRunUtil.invoke(result, "testRemovalFromFrozenJson", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Invalid map insertion: modification not allowed on readonly value\".*")
     public void testFrozenInnerJsonModification() {
         BRunUtil.invoke(result, "testFrozenInnerJsonModification", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Invalid map insertion: modification not allowed on readonly value\".*")
     public void testAdditionToFrozenInnerJson() {
         BRunUtil.invoke(result, "testAdditionToFrozenInnerJson", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Failed to remove element from map: modification not allowed on readonly value\".*")
     public void testRemovalFromFrozenInnerJson() {
         BRunUtil.invoke(result, "testRemovalFromFrozenInnerJson", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.xml\\}XMLOperationError \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.xml}XMLOperationError \\{\"message\":" +
                     "\"Failed to set children to xml element: modification not allowed on readonly value\".*")
     public void testFrozenXmlSetChildren() {
         BRunUtil.invoke(result, "testFrozenXmlSetChildren", new BValue[0]);
@@ -241,105 +240,105 @@ public class FreezeAndIsFrozenTest {
 
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.xml\\}XMLOperationError \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.xml}XMLOperationError \\{\"message\":" +
                     "\"Failed to set children to xml element: modification not allowed on readonly value\".*")
     public void testFrozenXmlSetChildrenDeep() {
         BRunUtil.invoke(result, "testFrozenXmlSetChildrenDeep", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":\"" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":\"" +
                     "Invalid map insertion: modification not allowed on readonly value\".*")
     public void testFrozenMapUpdate() {
         BRunUtil.invoke(result, "testFrozenMapUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":\"" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":\"" +
                     "Failed to remove element from map: modification not allowed on readonly value\".*")
     public void testFrozenMapRemoval() {
         BRunUtil.invoke(result, "testFrozenMapRemoval", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Failed to clear map: modification not allowed on readonly value\".*")
     public void testFrozenMapClear() {
         BRunUtil.invoke(result, "testFrozenMapClear", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\"" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\"" +
                     ":\"Invalid map insertion: modification not allowed on readonly value\".*")
     public void testFrozenInnerMapUpdate() {
         BRunUtil.invoke(result, "testFrozenInnerMapUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Failed to remove element from map: modification not allowed on readonly value\".*")
     public void testFrozenInnerMapRemoval() {
         BRunUtil.invoke(result, "testFrozenInnerMapRemoval", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Failed to clear map: modification not allowed on readonly value\".*")
     public void testFrozenInnerMapClear() {
         BRunUtil.invoke(result, "testFrozenInnerMapClear", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InvalidUpdate \\{\"message\":" +
                     "\"modification not allowed on readonly value\".*")
     public void testFrozenAnyArrayAddition() {
         BRunUtil.invoke(result, "testFrozenAnyArrayAddition", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InvalidUpdate \\{\"message\":" +
                     "\"modification not allowed on readonly value\".*")
     public void testFrozenAnyArrayUpdate() {
         BRunUtil.invoke(result, "testFrozenAnyArrayUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Invalid update of record field: modification not allowed on readonly value\".*")
     public void testFrozenAnyArrayElementUpdate() {
         BRunUtil.invoke(result, "testFrozenAnyArrayElementUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.array}InvalidUpdate \\{\"message\":" +
                     "\"modification not allowed on readonly value\".*")
     public void testFrozenTupleUpdate() {
         BRunUtil.invoke(result, "testFrozenTupleUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":\"" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":\"" +
                     "Invalid update of record field: modification not allowed on readonly value\".*")
     public void testFrozenRecordUpdate() {
         BRunUtil.invoke(result, "testFrozenRecordUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map\\}InvalidUpdate \\{\"message\":" +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.map}InvalidUpdate \\{\"message\":" +
                     "\"Invalid update of record field: modification not allowed on readonly value\".*")
     public void testFrozenInnerRecordUpdate() {
         BRunUtil.invoke(result, "testFrozenInnerRecordUpdate", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.table\\}InvalidUpdate message=Failed to add " +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.table}InvalidUpdate message=Failed to add " +
                     "data to the table: modification not allowed on readonly value.*", enabled = false)
     public void testFrozenTableAddition() {
         BRunUtil.invoke(result, "testFrozenTableAddition", new BValue[0]);
     }
 
     @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.table\\}InvalidUpdate message=Failed to " +
+            expectedExceptionsMessageRegExp = "error: \\{ballerina/lang.table}InvalidUpdate message=Failed to " +
                     "remove data from the table: modification not allowed on readonly value.*", enabled = false)
     public void testFrozenTableRemoval() {
         BRunUtil.invoke(result, "testFrozenTableRemoval", new BValue[0]);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/DeepReadOnlyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/DeepReadOnlyTest.java
@@ -1,0 +1,110 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+
+package org.ballerinalang.test.types;
+
+import io.ballerina.runtime.api.PredefinedTypes;
+import io.ballerina.runtime.api.creators.TypeCreator;
+import io.ballerina.runtime.api.types.ArrayType;
+import io.ballerina.runtime.api.types.MapType;
+import io.ballerina.runtime.api.types.TableType;
+import io.ballerina.runtime.api.types.TupleType;
+import io.ballerina.runtime.api.types.Type;
+import io.ballerina.runtime.api.types.UnionType;
+import io.ballerina.runtime.internal.types.BXmlType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Test recursive setting of readonly flag when creating runtime types.
+ */
+public class DeepReadOnlyTest {
+
+    @Test
+    public void testArray() {
+        MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(mapType.isReadOnly());
+        MapType mapOfMapType = TypeCreator.createMapType(mapType);
+        Assert.assertFalse(mapOfMapType.isReadOnly());
+        ArrayType arrayType = TypeCreator.createArrayType(mapOfMapType, true);
+        Assert.assertTrue(arrayType.getElementType().isReadOnly());
+        Assert.assertTrue(((MapType) arrayType.getElementType()).getConstrainedType().isReadOnly());
+    }
+
+    @Test
+    public void testMap() {
+        ArrayType arrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(arrayType.isReadOnly());
+        MapType mapType = TypeCreator.createMapType(arrayType, true);
+        Assert.assertTrue(mapType.getConstrainedType().isReadOnly());
+    }
+
+    @Test
+    public void testTable() {
+        MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(mapType.isReadOnly());
+        TableType tableType = TypeCreator.createTableType(mapType, true);
+        Assert.assertTrue(tableType.getConstrainedType().isReadOnly());
+    }
+
+    @Test
+    public void testTuple() {
+        MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(mapType.isReadOnly());
+        ArrayType arrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(arrayType.isReadOnly());
+        List<Type> ls = new ArrayList<>();
+        ls.add(mapType);
+        TupleType tupleType = TypeCreator.createTupleType(ls, arrayType, 0, true);
+        Assert.assertTrue(tupleType.getTupleTypes().get(0).isReadOnly());
+        Assert.assertTrue(tupleType.getRestType().isReadOnly());
+    }
+
+    @Test
+    public void testUnion() {
+        MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(mapType.isReadOnly());
+        ArrayType arrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(arrayType.isReadOnly());
+        List<Type> ls = new ArrayList<>();
+        ls.add(mapType);
+        ls.add(arrayType);
+        UnionType unionType = TypeCreator.createUnionType(ls, true);
+        Assert.assertTrue(unionType.getMemberTypes().get(0).isReadOnly());
+        Assert.assertTrue(unionType.getMemberTypes().get(1).isReadOnly());
+    }
+
+    @Test
+    public void testXml() {
+        ArrayType arrayType = TypeCreator.createArrayType(PredefinedTypes.TYPE_INT);
+        Assert.assertFalse(arrayType.isReadOnly());
+        BXmlType xmlType = (BXmlType) TypeCreator.createXMLType(arrayType, true);
+        Assert.assertTrue(xmlType.constraint.isReadOnly());
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class,
+          expectedExceptionsMessageRegExp = "map cannot be a readonly type.")
+    public void testInvalid() {
+        MapType mapType = TypeCreator.createMapType(PredefinedTypes.TYPE_FUTURE);
+        MapType mapMapType = TypeCreator.createMapType(mapType);
+        TypeCreator.createArrayType(mapMapType, true);
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/testng-jballerina.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng-jballerina.xml
@@ -152,6 +152,7 @@
             <!--<class name="org.ballerinalang.test.types.table.TableLiteralIterableTest"/>-->
             <!--<class name="org.ballerinalang.test.types.TypeUnificationTest"/>-->
             <!--<class name="org.ballerinalang.test.error.ErrorTest" />-->
+            <class name="org.ballerinalang.test.types.DeepReadOnlyTest"/>
             <class name="org.ballerinalang.test.expressions.async.BasicAsyncOperationsTest">
                 <methods>
                     <exclude name="testAsyncNonNativeBasic6" />

--- a/tests/jballerina-unit-test/src/test/resources/testng-new-parser.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng-new-parser.xml
@@ -198,6 +198,7 @@
             </class>
             <!-- <class name="org.ballerinalang.test.types.TypeUnificationTest"/> -->
             <!--<class name="org.ballerinalang.test.error.ErrorTest" />-->
+            <class name="org.ballerinalang.test.types.DeepReadOnlyTest"/>
             <class name="org.ballerinalang.test.expressions.async.BasicAsyncOperationsTest">
                 <methods>
                     <exclude name="testAsyncNonNativeBasic6" />

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -217,6 +217,7 @@
             </class>
             <!-- <class name="org.ballerinalang.test.types.TypeUnificationTest"/> -->
             <!--<class name="org.ballerinalang.test.error.ErrorTest" />-->
+            <class name="org.ballerinalang.test.types.DeepReadOnlyTest"/>
             <class name="org.ballerinalang.test.expressions.async.BasicAsyncOperationsTest">
                 <methods>
                     <exclude name="testAsyncNonNativeBasic6" />


### PR DESCRIPTION
## Purpose
This is done when creating the runtime types using the constructor.

Resolve https://github.com/ballerina-platform/ballerina-lang/issues/26991

## Approach
> Use the util function to set the `readonly` flag recursively`

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
