### PR TITLE
Fix string-literal in resource-path in absence of preceding type

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -6898,6 +6898,7 @@ public class BallerinaParser extends AbstractParser {
         switch (nextToken.kind) {
             case SLASH_TOKEN:
             case ON_KEYWORD:
+            case STRING_LITERAL_TOKEN: // should belong to the resource path
                 reportInvalidQualifierList(qualifiers);
                 return STNodeFactory.createEmptyNode();
             default:

--- a/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_19.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/service-decl/service_decl_assert_19.json
@@ -25,7 +25,7 @@
               ]
             },
             {
-              "kind": "SINGLETON_TYPE_DESC",
+              "kind": "LIST",
               "children": [
                 {
                   "kind": "STRING_LITERAL",
@@ -43,10 +43,6 @@
                   ]
                 }
               ]
-            },
-            {
-              "kind": "LIST",
-              "children": []
             },
             {
               "kind": "ON_KEYWORD",


### PR DESCRIPTION
## Purpose
$subject.

## Approach
N/A

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples  