### PR TITLE
Fix empty metadata node creation when top-level recovery is a KEEP

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -238,7 +238,7 @@ public class BallerinaParser extends AbstractParser {
                     // If the solution is {@link Action#KEEP}, that means next immediate token is
                     // at the correct place, but some token after that is not. There only one such
                     // cases here, which is the `case IDENTIFIER_TOKEN`. So accept it, and continue.
-                    metadata = STNodeFactory.createEmptyNodeList();
+                    metadata = STNodeFactory.createEmptyNode();
                     break;
                 }
 
@@ -7527,7 +7527,7 @@ public class BallerinaParser extends AbstractParser {
     /**
      * Parse annotations.
      * <p>
-     * <i>Note: In the ballerina spec ({@link https://ballerina.io/spec/lang/2020R1/#annots})
+     * <i>Note: In the <a href="https://ballerina.io/spec/lang/2020R1/#annots">ballerina spec</a>
      * annotations-list is specified as one-or-more annotations. And the usage is marked as
      * optional annotations-list. However, for the consistency of the tree, here we make the
      * annotation-list as zero-or-more annotations, and the usage is not-optional.</i>

--- a/compiler/ballerina-parser/src/test/resources/declarations/module-var-decl/module_var_decl_assert_10.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/module-var-decl/module_var_decl_assert_10.json
@@ -19,10 +19,6 @@
               "children": []
             },
             {
-              "kind": "LIST",
-              "children": []
-            },
-            {
               "kind": "TYPED_BINDING_PATTERN",
               "hasDiagnostics": true,
               "children": [

--- a/compiler/ballerina-parser/src/test/resources/misc/resiliency/resiliency_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/resiliency/resiliency_assert_03.json
@@ -76,10 +76,6 @@
               "children": []
             },
             {
-              "kind": "LIST",
-              "children": []
-            },
-            {
               "kind": "TYPED_BINDING_PATTERN",
               "hasDiagnostics": true,
               "children": [
@@ -209,10 +205,6 @@
           "kind": "MODULE_VAR_DECL",
           "hasDiagnostics": true,
           "children": [
-            {
-              "kind": "LIST",
-              "children": []
-            },
             {
               "kind": "LIST",
               "children": []

--- a/compiler/ballerina-parser/src/test/resources/misc/typed-binding-patterns/typed_binding_patterns_assert_22.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/typed-binding-patterns/typed_binding_patterns_assert_22.json
@@ -136,10 +136,6 @@
               "children": []
             },
             {
-              "kind": "LIST",
-              "children": []
-            },
-            {
               "kind": "TYPED_BINDING_PATTERN",
               "hasDiagnostics": true,
               "children": [

--- a/compiler/ballerina-parser/src/test/resources/types/singleton-type/singleton_type_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/types/singleton-type/singleton_type_assert_07.json
@@ -7,10 +7,6 @@
       "children": []
     },
     {
-      "kind": "LIST",
-      "children": []
-    },
-    {
       "kind": "TYPED_BINDING_PATTERN",
       "hasDiagnostics": true,
       "children": [


### PR DESCRIPTION
## Purpose
$subject.

Fixes #26603
Fixes #27420

## Approach
N/A

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples