### PR TITLE
Handle union of streams with type params

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -189,7 +189,8 @@ public class TypeParamAnalyzer {
             case TypeTags.MAP:
                 return containsTypeParam(((BMapType) type).constraint, resolvedTypes);
             case TypeTags.STREAM:
-                return containsTypeParam(((BStreamType) type).constraint, resolvedTypes);
+                 return containsTypeParam(((BStreamType) type).constraint, resolvedTypes) ||
+                        containsTypeParam(((BStreamType) type).error, resolvedTypes);
             case TypeTags.TABLE:
                 return (containsTypeParam(((BTableType) type).constraint, resolvedTypes) ||
                         ((BTableType) type).keyTypeConstraint != null
@@ -327,7 +328,10 @@ public class TypeParamAnalyzer {
                     findTypeParamInStream(loc, ((BStreamType) expType), ((BStreamType) actualType), env, resolvedTypes,
                                           result);
                 }
-                // TODO : Handle unions after - github.com/ballerina-platform/ballerina-lang/issues/22570
+                if (actualType.tag == TypeTags.UNION) {
+                    findTypeParamInStreamForUnion(loc, ((BStreamType) expType), ((BUnionType) actualType), env,
+                            resolvedTypes, result);
+                }
                 return;
             case TypeTags.TABLE:
                 if (actualType.tag == TypeTags.TABLE) {
@@ -424,6 +428,29 @@ public class TypeParamAnalyzer {
         findTypeParam(loc, expType.constraint, actualType.constraint, env, resolvedTypes, result);
         findTypeParam(loc, expType.error, (actualType.error != null) ? actualType.error : symTable.nilType, env,
                       resolvedTypes, result);
+    }
+
+    private void findTypeParamInStreamForUnion(Location loc, BStreamType expType, BUnionType actualType,
+                                       SymbolEnv env, HashSet<BType> resolvedTypes, FindTypeParamResult result) {
+        LinkedHashSet<BType> constraints = new LinkedHashSet<>();
+        LinkedHashSet<BType> errors = new LinkedHashSet<>();
+        for (BType type : actualType.getMemberTypes()) {
+            if (type.tag == TypeTags.STREAM) {
+                constraints.add(((BStreamType) type).constraint);
+                if (((BStreamType) type).error != null) {
+                    errors.add(((BStreamType) type).error);
+                }
+            }
+        }
+
+        BUnionType cUnionType = BUnionType.create(null, constraints);
+        findTypeParam(loc, expType.constraint, cUnionType, env, resolvedTypes, result);
+        if (!errors.isEmpty()) {
+            BUnionType eUnionType = BUnionType.create(null, errors);
+            findTypeParam(loc, expType.error, eUnionType, env, resolvedTypes, result);
+        } else {
+            findTypeParam(loc, expType.error, symTable.nilType, env, resolvedTypes, result);
+        }
     }
 
     private void findTypeParamInTable(Location loc, BTableType expType, BTableType actualType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeParamAnalyzer.java
@@ -189,8 +189,7 @@ public class TypeParamAnalyzer {
             case TypeTags.MAP:
                 return containsTypeParam(((BMapType) type).constraint, resolvedTypes);
             case TypeTags.STREAM:
-                 return containsTypeParam(((BStreamType) type).constraint, resolvedTypes) ||
-                        containsTypeParam(((BStreamType) type).error, resolvedTypes);
+                 return containsTypeParam(((BStreamType) type).constraint, resolvedTypes);
             case TypeTags.TABLE:
                 return (containsTypeParam(((BTableType) type).constraint, resolvedTypes) ||
                         ((BTableType) type).keyTypeConstraint != null


### PR DESCRIPTION
## Purpose
$title. This will partially fix #22570 with a workaround of using type guards (ref. Samples). However, without type guards, this will result in https://github.com/ballerina-platform/ballerina-lang/issues/27344

## Approach
n/a

## Samples
```ballerina
    Foo[] fooList = [];
    stream<Foo>|stream<Bar> fooBarStream = fooList.toStream();
    if (fooBarStream is stream<Foo>) {
        record {|Foo|Bar value;|}|error? res1 = fooBarStream.next();
        record {|Foo value;|}|error? res2 = fooBarStream.next();
        var res3 = fooBarStream.next();
    }
```

## Remarks
- #22570 
- #27344

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
