### PR TITLE
Add support for enums

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/LangLibrary.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
@@ -98,7 +99,24 @@ public class LangLibrary {
      */
     public List<FunctionSymbol> getMethods(TypeDescKind typeDescKind) {
         String langLibName = getAssociatedLangLibName(typeDescKind);
+        return getMethods(langLibName);
+    }
 
+    /**
+     * Given an internal type kind, return the list of lang library functions that can be called using a method call
+     * expr, on an expression of that type.
+     *
+     * @param typeKind A type kind
+     * @return The associated list of lang library functions
+     */
+    public List<FunctionSymbol> getMethods(TypeKind typeKind) {
+        String langLibName = getAssociatedLangLibName(typeKind);
+        return getMethods(langLibName);
+    }
+
+    // Private Methods
+
+    private List<FunctionSymbol> getMethods(String langLibName) {
         if (wrappedLangLibMethods.containsKey(langLibName)) {
             return wrappedLangLibMethods.get(langLibName);
         }
@@ -116,8 +134,6 @@ public class LangLibrary {
 
         return wrappedMethods;
     }
-
-    // Private Methods
 
     private void populateMethodList(List<FunctionSymbol> list, Map<String, BInvokableSymbol> langLib) {
         for (Map.Entry<String, BInvokableSymbol> entry : langLib.entrySet()) {
@@ -149,6 +165,34 @@ public class LangLibrary {
             case XML:
             case TABLE:
                 return typeDescKind.getName();
+            default:
+                return LANG_VALUE;
+        }
+    }
+
+    private String getAssociatedLangLibName(TypeKind typeKind) {
+        switch (typeKind) {
+            case INT:
+            case BYTE:
+                return TypeKind.INT.typeName();
+            case ARRAY:
+            case TUPLE:
+                return TypeKind.ARRAY.typeName();
+            case RECORD:
+            case MAP:
+                return TypeKind.MAP.typeName();
+            case FLOAT:
+            case DECIMAL:
+            case STRING:
+            case BOOLEAN:
+            case STREAM:
+            case OBJECT:
+            case ERROR:
+            case FUTURE:
+            case TYPEDESC:
+            case XML:
+            case TABLE:
+                return typeKind.typeName();
             default:
                 return LANG_VALUE;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -326,7 +326,8 @@ public class SymbolFactory {
         BallerinaConstantSymbol.ConstantSymbolBuilder symbolBuilder =
                 new BallerinaConstantSymbol.ConstantSymbolBuilder(name, constantSymbol.pkgID, constantSymbol);
         symbolBuilder.withConstValue(constantSymbol.getConstValue())
-                .withTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.literalType));
+                .withTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.type));
+
         if ((constantSymbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -21,6 +21,7 @@ package io.ballerina.compiler.api.impl;
 import io.ballerina.compiler.api.impl.symbols.BallerinaAnnotationSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaClassSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaConstantSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaEnumSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaFunctionSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaMethodSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaModule;
@@ -133,6 +134,10 @@ public class SymbolFactory {
             if (symbol instanceof BClassSymbol) {
                 return createClassSymbol((BClassSymbol) symbol, name);
             }
+            if (Symbols.isFlagOn(symbol.flags, Flags.ENUM)) {
+                return createEnumSymbol((BTypeSymbol) symbol, name);
+            }
+
             // create the typeDefs
             return createTypeDefinition((BTypeSymbol) symbol, name);
         }
@@ -275,6 +280,17 @@ public class SymbolFactory {
     public BallerinaTypeDefinitionSymbol createTypeDefinition(BTypeSymbol typeSymbol, String name) {
         BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder symbolBuilder =
                 new BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder(name, typeSymbol.pkgID, typeSymbol);
+
+        if (isFlagOn(typeSymbol.flags, Flags.PUBLIC)) {
+            symbolBuilder.withQualifier(Qualifier.PUBLIC);
+        }
+
+        return symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(typeSymbol.type, true)).build();
+    }
+
+    public BallerinaEnumSymbol createEnumSymbol(BTypeSymbol typeSymbol, String name) {
+        BallerinaEnumSymbol.EnumSymbolBuilder symbolBuilder =
+                new BallerinaEnumSymbol.EnumSymbolBuilder(name, typeSymbol.pkgID, typeSymbol);
 
         if (isFlagOn(typeSymbol.flags, Flags.PUBLIC)) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -326,7 +326,8 @@ public class SymbolFactory {
         BallerinaConstantSymbol.ConstantSymbolBuilder symbolBuilder =
                 new BallerinaConstantSymbol.ConstantSymbolBuilder(name, constantSymbol.pkgID, constantSymbol);
         symbolBuilder.withConstValue(constantSymbol.getConstValue())
-                .withTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.type));
+                .withTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.type))
+                .withBroaderTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.literalType));
 
         if ((constantSymbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -968,16 +968,16 @@ class SymbolFinder extends BLangNodeVisitor {
     @Override
     public void visit(BLangUserDefinedType userDefinedType) {
         // Becomes null for undefined types
-        if (userDefinedType.type.tsymbol == null) {
+        if (userDefinedType.symbol == null) {
             return;
         }
 
-        if (userDefinedType.type.tsymbol.origin == VIRTUAL
-                || setEnclosingNode(userDefinedType.type.tsymbol, userDefinedType.typeName.pos)) {
+        if (userDefinedType.symbol.origin == VIRTUAL
+                || setEnclosingNode(userDefinedType.symbol, userDefinedType.typeName.pos)) {
             return;
         }
 
-        setEnclosingNode(userDefinedType.type.tsymbol.owner, userDefinedType.pkgAlias.pos);
+        setEnclosingNode(userDefinedType.symbol.owner, userDefinedType.pkgAlias.pos);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -41,11 +41,11 @@ import java.util.Optional;
 public abstract class AbstractTypeSymbol implements TypeSymbol {
 
     protected final CompilerContext context;
+    protected List<FunctionSymbol> langLibFunctions;
 
     private final TypeDescKind typeDescKind;
     private final ModuleID moduleID;
     private final BType bType;
-    private List<FunctionSymbol> langLibFunctions;
     private final Documentation docAttachment;
 
     public AbstractTypeSymbol(CompilerContext context, TypeDescKind typeDescKind, ModuleID moduleID, BType bType) {
@@ -115,8 +115,7 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         return bType;
     }
 
-    // Private util methods
-    private List<FunctionSymbol> filterLangLibMethods(List<FunctionSymbol> functions, BType internalType) {
+    protected List<FunctionSymbol> filterLangLibMethods(List<FunctionSymbol> functions, BType internalType) {
         Types types = Types.getInstance(this.context);
         List<FunctionSymbol> filteredFunctions = new ArrayList<>();
 
@@ -131,6 +130,8 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
 
         return filteredFunctions;
     }
+
+    // Private util methods
 
     private BType getTargetBType(TypeSymbol typeSymbol) {
         if (typeSymbol.kind() == SymbolKind.TYPE) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -36,15 +36,18 @@ import java.util.List;
 public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements ConstantSymbol {
 
     private final Object constValue;
+    private TypeSymbol broaderType;
 
     private BallerinaConstantSymbol(String name,
                                     PackageID moduleID,
                                     List<Qualifier> qualifiers,
                                     TypeSymbol typeDescriptor,
+                                    TypeSymbol broaderType,
                                     Object constValue,
                                     BSymbol bSymbol) {
         super(name, moduleID, SymbolKind.CONSTANT, qualifiers, typeDescriptor, bSymbol);
         this.constValue = constValue;
+        this.broaderType = broaderType;
     }
 
     /**
@@ -55,6 +58,11 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     @Override
     public Object constValue() {
         return constValue;
+    }
+
+    @Override
+    public TypeSymbol broaderTypeDescriptor() {
+        return this.broaderType;
     }
 
     @Override
@@ -83,6 +91,7 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     public static class ConstantSymbolBuilder extends VariableSymbolBuilder {
 
         private Object constantValue;
+        private TypeSymbol broaderType;
 
         public ConstantSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
             super(name, moduleID, symbol);
@@ -93,6 +102,7 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
                     this.moduleID,
                     this.qualifiers,
                     this.typeDescriptor,
+                    this.broaderType,
                     this.constantValue,
                     this.bSymbol);
         }
@@ -105,6 +115,11 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
         @Override
         public ConstantSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
             super.withTypeDescriptor(typeDescriptor);
+            return this;
+        }
+
+        public ConstantSymbolBuilder withBroaderTypeDescriptor(TypeSymbol typeDescriptor) {
+            this.broaderType = typeDescriptor;
             return this;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -18,8 +18,10 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -53,6 +55,26 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     @Override
     public Object constValue() {
         return constValue;
+    }
+
+    @Override
+    public TypeDescKind typeKind() {
+        return TypeDescKind.SINGLETON;
+    }
+
+    @Override
+    public String signature() {
+        return this.typeDescriptor().signature();
+    }
+
+    @Override
+    public List<FunctionSymbol> langLibMethods() {
+        return this.typeDescriptor().langLibMethods();
+    }
+
+    @Override
+    public boolean assignableTo(TypeSymbol targetType) {
+        return this.typeDescriptor().assignableTo(targetType);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.impl.symbols;
+
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
+import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implements EnumSymbol {
+
+    protected BallerinaEnumSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
+                                  TypeSymbol typeDescriptor, BSymbol bSymbol) {
+        super(name, moduleID, qualifiers, typeDescriptor, bSymbol);
+    }
+
+    @Override
+    public List<ConstantSymbol> members() {
+        return null;
+    }
+
+    @Override
+    public SymbolKind kind() {
+        return SymbolKind.ENUM;
+    }
+
+    /**
+     * An enum symbol builder.
+     *
+     * @since 2.0.0
+     */
+    public static class EnumSymbolBuilder extends SymbolBuilder<BallerinaEnumSymbol.EnumSymbolBuilder> {
+
+        protected List<Qualifier> qualifiers = new ArrayList<>();
+        protected TypeSymbol typeDescriptor;
+
+        public EnumSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
+            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol);
+        }
+
+        public EnumSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
+            this.typeDescriptor = typeDescriptor;
+            return this;
+        }
+
+        public EnumSymbolBuilder withQualifier(Qualifier qualifier) {
+            this.qualifiers.add(qualifier);
+            return this;
+        }
+
+        @Override
+        public BallerinaEnumSymbol build() {
+            return new BallerinaEnumSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
+                                           this.bSymbol);
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -27,18 +27,27 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
+/**
+ * Represents an enum.
+ *
+ * @since 2.0.0
+ */
 public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implements EnumSymbol {
 
-    protected BallerinaEnumSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
-                                  TypeSymbol typeDescriptor, BSymbol bSymbol) {
+    private List<ConstantSymbol> members;
+
+    protected BallerinaEnumSymbol(String name, PackageID moduleID, List<ConstantSymbol> members,
+                                  List<Qualifier> qualifiers, TypeSymbol typeDescriptor, BSymbol bSymbol) {
         super(name, moduleID, qualifiers, typeDescriptor, bSymbol);
+        this.members = Collections.unmodifiableList(members);
     }
 
     @Override
     public List<ConstantSymbol> members() {
-        return null;
+        return this.members;
     }
 
     @Override
@@ -53,11 +62,17 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
      */
     public static class EnumSymbolBuilder extends SymbolBuilder<BallerinaEnumSymbol.EnumSymbolBuilder> {
 
+        protected List<ConstantSymbol> members;
         protected List<Qualifier> qualifiers = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
         public EnumSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
             super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol);
+        }
+
+        public EnumSymbolBuilder withMembers(List<ConstantSymbol> members) {
+            this.members = members;
+            return this;
         }
 
         public EnumSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
@@ -72,8 +87,8 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
 
         @Override
         public BallerinaEnumSymbol build() {
-            return new BallerinaEnumSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
-                                           this.bSymbol);
+            return new BallerinaEnumSymbol(this.name, this.moduleID, this.members, this.qualifiers,
+                                           this.typeDescriptor, this.bSymbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -17,11 +17,16 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.LangLibrary;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.SingletonTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BFiniteType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+
+import java.util.List;
 
 /**
  * Represents a singleton type descriptor.
@@ -36,6 +41,19 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
                                         BType bType) {
         super(context, TypeDescKind.SINGLETON, moduleID, bType);
         this.typeName = shape.toString();
+    }
+
+    @Override
+    public List<FunctionSymbol> langLibMethods() {
+        if (this.langLibFunctions == null) {
+            LangLibrary langLibrary = LangLibrary.getInstance(this.context);
+            BFiniteType internalType = (BFiniteType) this.getBType();
+            BType valueType = internalType.getValueSpace().iterator().next().type;
+            List<FunctionSymbol> functions = langLibrary.getMethods(valueType.getKind());
+            this.langLibFunctions = filterLangLibMethods(functions, valueType);
+        }
+
+        return this.langLibFunctions;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -25,7 +25,6 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
-import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -22,8 +22,10 @@ import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
@@ -197,7 +199,8 @@ public class TypesFactory {
 
         final TypeKind kind = bType.getKind();
         return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel
-                || bType instanceof BIntSubType || bType instanceof BStringSubType || bType instanceof BXMLSubType;
+                || bType instanceof BIntSubType || bType instanceof BStringSubType || bType instanceof BXMLSubType
+                || bType.tsymbol.kind == SymbolKind.ENUM;
     }
 
     public static TypeDescKind getTypeDescKind(TypeKind bTypeKind) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface ConstantSymbol extends VariableSymbol {
+public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol {
 
     /**
      * Get the constant value.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
@@ -30,4 +30,11 @@ public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol {
      * @return {@link Object} value of the constant
      */
     Object constValue();
+
+    /**
+     * Gets the broader type of constant expression associated with this symbol.
+     *
+     * @return {@link TypeSymbol} of the broader type
+     */
+    TypeSymbol broaderTypeDescriptor();
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/EnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/EnumSymbol.java
@@ -17,24 +17,19 @@
  */
 package io.ballerina.compiler.api.symbols;
 
+import java.util.List;
+
 /**
- * Represents the types of Symbols.
+ * Represents an enum.
  *
  * @since 2.0.0
  */
-public enum SymbolKind {
-    MODULE,
-    XMLNS,
-    FUNCTION,
-    METHOD,
-    CONSTANT,
-    TYPE_DEFINITION,
-    TYPE,
-    VARIABLE,
-    SERVICE,
-    CLASS,
-    WORKER,
-    ANNOTATION,
-    FIELD,
-    ENUM
+public interface EnumSymbol extends TypeDefinitionSymbol, Qualifiable, Deprecatable {
+
+    /**
+     * Retrieves a list of the members of this enum.
+     *
+     * @return A {@link List} of enum members
+     */
+    List<ConstantSymbol> members();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
@@ -142,7 +142,7 @@ public enum Flag {
      */
     CONFIGURABLE,
     /**
-     * Indicates flagged node is an enum
+     * Indicates flagged node is an enum.
      */
     ENUM
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
@@ -140,5 +140,9 @@ public enum Flag {
     /**
      * Indicates flagged node is configurable.
      */
-    CONFIGURABLE
+    CONFIGURABLE,
+    /**
+     * Indicates flagged node is an enum
+     */
+    ENUM
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/SymbolKind.java
@@ -37,6 +37,7 @@ public enum SymbolKind {
     PACKAGE_VARIABLE,
     TRANSFORMER,
     TYPE_DEF,
+    ENUM,
     ERROR,
 
     PARAMETER,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3408,6 +3408,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         if (publicQualifier) {
             bLangTypeDefinition.flagSet.add(Flag.PUBLIC);
         }
+        bLangTypeDefinition.flagSet.add(Flag.ENUM);
 
         bLangTypeDefinition.setName((BLangIdentifier) transform(enumDeclarationNode.identifier()));
         bLangTypeDefinition.pos = getPosition(enumDeclarationNode);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -51,6 +51,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
@@ -1166,6 +1167,10 @@ public class SymbolEnter extends BLangNodeVisitor {
                                                            env.scope.owner, typeDefinition.pos, SOURCE);
         }
 
+        if (typeDefinition.flagSet.contains(Flag.ENUM)) {
+            definedType.tsymbol = createEnumSymbol(typeDefinition, definedType);
+        }
+
         typeDefinition.setPrecedence(this.typePrecedence++);
         BTypeSymbol typeDefSymbol;
         if (definedType.tsymbol.name != Names.EMPTY) {
@@ -1240,6 +1245,18 @@ public class SymbolEnter extends BLangNodeVisitor {
             // constructors are only defined for named types.
             defineErrorConstructorSymbol(typeDefinition.name.pos, typeDefSymbol);
         }
+    }
+
+    private BEnumSymbol createEnumSymbol(BLangTypeDefinition typeDefinition, BType definedType) {
+        List<BConstantSymbol> enumMembers = new ArrayList<>();
+
+        List<BLangType> members = ((BLangUnionTypeNode) typeDefinition.typeNode).memberTypeNodes;
+        for (BLangType member : members) {
+            enumMembers.add((BConstantSymbol) ((BLangUserDefinedType) member).symbol);
+        }
+
+        return new BEnumSymbol(enumMembers, Flags.asMask(typeDefinition.flagSet), Names.EMPTY, env.enclPkg.symbol.pkgID,
+                               definedType, env.scope.owner, typeDefinition.pos, SOURCE);
     }
 
     private BObjectType getDistinctObjectType(BLangTypeDefinition typeDefinition, BObjectType definedType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -1318,6 +1318,7 @@ public class SymbolResolver extends BLangNodeVisitor {
                     tSymbol.type.flags |= Flags.PARAMETERIZED;
 
                     this.resultType = tSymbol.type;
+                    userDefinedTypeNode.symbol = tSymbol;
                     return;
                 }
             }
@@ -1338,6 +1339,7 @@ public class SymbolResolver extends BLangNodeVisitor {
             return;
         }
 
+        userDefinedTypeNode.symbol = symbol;
         resultType = symbol.type;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -27,6 +27,11 @@ import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.List;
 
+/**
+ * Represents an enum.
+ *
+ * @since 2.0.0
+ */
 public class BEnumSymbol extends BTypeSymbol {
 
     public List<BConstantSymbol> members;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.semantics.model.symbols;
+
+import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.symbols.SymbolOrigin;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.util.Name;
+
+import java.util.List;
+
+public class BEnumSymbol extends BTypeSymbol {
+
+    public List<BConstantSymbol> members;
+
+    public BEnumSymbol(List<BConstantSymbol> members, long flags, Name name, PackageID pkgID, BType type,
+                       BSymbol owner, Location pos, SymbolOrigin origin) {
+        super(SymTag.ENUM, flags, name, pkgID, type, owner, pos, origin);
+        this.members = members;
+        this.kind = SymbolKind.ENUM;
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
@@ -50,4 +50,5 @@ public class SymTag {
     public static final int FUNCTION_TYPE = 1 << 26 | TYPE | VARIABLE_NAME;
     public static final int CONSTRUCTOR = 1 << 27 | INVOKABLE;
     public static final int LET = 1 << 28;
+    public static final int ENUM = 1 << 29 | TYPE_DEF;
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangUserDefinedType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/types/BLangUserDefinedType.java
@@ -20,6 +20,7 @@ package org.wso2.ballerinalang.compiler.tree.types;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.types.UserDefinedTypeNode;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 
@@ -32,6 +33,7 @@ import java.util.Set;
 public class BLangUserDefinedType extends BLangType implements UserDefinedTypeNode {
     public BLangIdentifier pkgAlias;
     public BLangIdentifier typeName;
+    public BSymbol symbol;
 
     public BLangUserDefinedType() {
         this.flagSet = new HashSet<>();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -69,6 +69,8 @@ public class Flags {
     public static final long ISOLATED_PARAM = ISOLATED << 1;                    //  30
     public static final long CONFIGURABLE = ISOLATED_PARAM << 1;                 //  31
 
+    public static final long ENUM = CONFIGURABLE << 1;                          // 32
+
     public static int asMask(Set<Flag> flagSet) {
         int mask = 0;
         for (Flag flag : flagSet) {
@@ -160,6 +162,9 @@ public class Flags {
                 case CONFIGURABLE:
                     mask |= CONFIGURABLE;
                     break;
+                case ENUM:
+                    mask |= ENUM;
+                    break;
             }
         }
         return mask;
@@ -250,6 +255,9 @@ public class Flags {
                     break;
                 case CONFIGURABLE:
                     flagVal = CONFIGURABLE;
+                    break;
+                case ENUM:
+                    flagVal = ENUM;
                     break;
                 default:
                     continue;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -71,8 +71,8 @@ public class Flags {
 
     public static final long ENUM = CONFIGURABLE << 1;                          // 32
 
-    public static int asMask(Set<Flag> flagSet) {
-        int mask = 0;
+    public static long asMask(Set<Flag> flagSet) {
+        long mask = 0;
         for (Flag flag : flagSet) {
             switch (flag) {
                 case PUBLIC:

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
@@ -15,16 +15,15 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
-import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ArrayTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
 import org.ballerinalang.annotation.JavaSPIService;
-import org.ballerinalang.langserver.common.utils.SymbolUtil;
 import org.ballerinalang.langserver.common.utils.completion.QNameReferenceUtil;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
@@ -70,14 +69,12 @@ public class ArrayTypeDescriptorNodeContext extends AbstractCompletionProvider<A
 
     private Predicate<Symbol> constantFilter() {
         return symbol -> {
-            Optional<? extends TypeSymbol> typeDescriptor = SymbolUtil.getTypeDescriptor(symbol);
-            typeDescriptor =
-                    typeDescriptor.isPresent() && typeDescriptor.get().typeKind() == TypeDescKind.TYPE_REFERENCE ?
-                            Optional.ofNullable(((TypeReferenceTypeSymbol) typeDescriptor.get()).typeDescriptor())
-                            : typeDescriptor;
-            return symbol.kind() == SymbolKind.CONSTANT
-                    && typeDescriptor.isPresent()
-                    && typeDescriptor.get().typeKind() == TypeDescKind.INT;
+            if (symbol.kind() != SymbolKind.CONSTANT) {
+                return false;
+            }
+
+            TypeSymbol constExprType = ((ConstantSymbol) symbol).broaderTypeDescriptor();
+            return constExprType != null && constExprType.typeKind() == TypeDescKind.INT;
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/class_def/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/class_def/config/config7.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/anon_func_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/anon_func_expr_ctx_config9.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/check_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/check_expression_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/check_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/check_expression_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/check_expression_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/check_expression_ctx_config5.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/fail_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/fail_expr_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/list_constructor_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config8.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/mapping_expr_ctx_config9.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/member_access_expr_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/object_constructor_expr_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/object_constructor_expr_ctx_config10.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_config15.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_config16.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_join_clause_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_join_clause_config13.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_join_clause_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_join_clause_config9.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_let_clause_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_let_clause_config6.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_let_clause_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_let_clause_config7.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_let_clause_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_let_clause_config8.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_limit_clause_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_limit_clause_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_onconflict_clause_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_onconflict_clause_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_orderby_clause_config2a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_orderby_clause_config2a.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_select_clause_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_select_clause_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_where_clause_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/query_expr_ctx_where_clause_config2.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/trap_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/trap_expression_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/trap_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/trap_expression_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/typeof_expression_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config5.json
@@ -8,7 +8,7 @@
     {
       "label": "MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "9223372036854775807",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -34,7 +34,7 @@
     {
       "label": "SIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "2147483647",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -47,7 +47,7 @@
     {
       "label": "SIGNED32_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-2147483648",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -60,7 +60,7 @@
     {
       "label": "SIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "32767",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -73,7 +73,7 @@
     {
       "label": "SIGNED16_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-32768",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -86,7 +86,7 @@
     {
       "label": "SIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "127",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -99,7 +99,7 @@
     {
       "label": "SIGNED8_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-128",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -112,7 +112,7 @@
     {
       "label": "UNSIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "4294967295",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -125,7 +125,7 @@
     {
       "label": "UNSIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "65535",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -138,7 +138,7 @@
     {
       "label": "UNSIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "255",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_def_ctx_config6.json
@@ -8,7 +8,7 @@
     {
       "label": "MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "9223372036854775807",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -34,7 +34,7 @@
     {
       "label": "SIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "2147483647",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -47,7 +47,7 @@
     {
       "label": "SIGNED32_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-2147483648",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -60,7 +60,7 @@
     {
       "label": "SIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "32767",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -73,7 +73,7 @@
     {
       "label": "SIGNED16_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-32768",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -86,7 +86,7 @@
     {
       "label": "SIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "127",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -99,7 +99,7 @@
     {
       "label": "SIGNED8_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-128",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -112,7 +112,7 @@
     {
       "label": "UNSIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "4294967295",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -125,7 +125,7 @@
     {
       "label": "UNSIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "65535",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -138,7 +138,7 @@
     {
       "label": "UNSIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "255",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config1.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config2.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/var_ref_ctx_config5.json
@@ -8,7 +8,7 @@
     {
       "label": "MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "9223372036854775807",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -34,7 +34,7 @@
     {
       "label": "SIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "2147483647",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -47,7 +47,7 @@
     {
       "label": "SIGNED32_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-2147483648",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -60,7 +60,7 @@
     {
       "label": "SIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "32767",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -73,7 +73,7 @@
     {
       "label": "SIGNED16_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-32768",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -86,7 +86,7 @@
     {
       "label": "SIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "127",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -99,7 +99,7 @@
     {
       "label": "SIGNED8_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-128",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -112,7 +112,7 @@
     {
       "label": "UNSIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "4294967295",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -125,7 +125,7 @@
     {
       "label": "UNSIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "65535",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -138,7 +138,7 @@
     {
       "label": "UNSIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "255",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_def/config/config16.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_def/config/config16.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,6 +29,33 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
     {
@@ -60,40 +87,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -118,6 +111,13 @@
       "kind": "Interface",
       "detail": "Object",
       "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/function_def/config/config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/function_def/config/config17.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,6 +29,33 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
     {
@@ -60,40 +87,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -118,6 +111,13 @@
       "kind": "Interface",
       "detail": "Object",
       "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config5.json
@@ -55,10 +55,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -72,7 +72,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -99,10 +99,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "'test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -116,7 +116,29 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -143,28 +165,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -187,10 +187,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -204,7 +204,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -407,7 +407,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value two",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -440,7 +440,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config6.json
@@ -55,10 +55,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -72,7 +72,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -99,10 +99,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "'test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -116,7 +116,29 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -143,28 +165,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -187,10 +187,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -204,7 +204,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -407,7 +407,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value two",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -440,7 +440,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config7.json
@@ -55,10 +55,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -72,7 +72,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -99,10 +99,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "'test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -116,7 +116,29 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -143,28 +165,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -187,10 +187,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -204,7 +204,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -407,7 +407,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value two",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -433,7 +433,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/record_type_desc/config/config8.json
@@ -55,10 +55,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -72,7 +72,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -99,10 +99,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "'test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -116,7 +116,29 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -143,28 +165,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -187,10 +187,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -204,7 +204,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -407,7 +407,7 @@
     {
       "label": "STRING_VAL_TWO",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value two",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -433,7 +433,7 @@
     {
       "label": "STRING_VAL",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "string value",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/assignment_stmt_ctx_config5.json
@@ -8,7 +8,7 @@
     {
       "label": "MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "9223372036854775807",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -34,7 +34,7 @@
     {
       "label": "SIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "2147483647",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -47,7 +47,7 @@
     {
       "label": "SIGNED32_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-2147483648",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -60,7 +60,7 @@
     {
       "label": "SIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "32767",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -73,7 +73,7 @@
     {
       "label": "SIGNED16_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-32768",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -86,7 +86,7 @@
     {
       "label": "SIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "127",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -99,7 +99,7 @@
     {
       "label": "SIGNED8_MIN_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "-128",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -112,7 +112,7 @@
     {
       "label": "UNSIGNED32_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "4294967295",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -125,7 +125,7 @@
     {
       "label": "UNSIGNED16_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "65535",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -138,7 +138,7 @@
     {
       "label": "UNSIGNED8_MAX_VALUE",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "255",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/do_stmt_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/statement_context/config/do_stmt_ctx_config2.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,33 +29,6 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
       "insertTextFormat": "Snippet"
     },
     {
@@ -87,6 +60,47 @@
       "insertTextFormat": "Snippet"
     },
     {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "Listener",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
+      "insertTextFormat": "Snippet"
+    },
+    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -104,20 +118,6 @@
         "left": "Represents a response.\n"
       },
       "insertText": "Response",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "Listener",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "Listener",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc1.json
@@ -6,10 +6,10 @@
   "source": "typedesc_context/source/array_typedesc1.bal",
   "items": [
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -23,7 +23,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -50,10 +50,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/module1",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "module1",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -67,7 +67,51 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -94,50 +138,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -160,10 +160,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -177,7 +177,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -275,7 +275,7 @@
     {
       "label": "TEST_CONST",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "12",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc2.json
@@ -6,10 +6,10 @@
   "source": "typedesc_context/source/array_typedesc2.bal",
   "items": [
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -23,7 +23,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -50,10 +50,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/module1",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "module1",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -67,7 +67,51 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/module1;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -94,50 +138,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
-      "label": "ballerina/module1",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "module1",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/module1;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -160,10 +160,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -177,7 +177,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -275,7 +275,7 @@
     {
       "label": "TEST_CONST",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "12",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc3.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/array_typedesc4.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15a.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15a.json
@@ -55,10 +55,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -72,7 +72,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -99,10 +99,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "'test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -116,7 +116,29 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -143,28 +165,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -187,10 +187,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -204,7 +204,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -433,7 +433,7 @@
     {
       "label": "TEST_CONST",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "12",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15b.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15b.json
@@ -55,10 +55,10 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ballerina/lang.test",
+      "label": "ballerina/lang.transaction",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'test",
+      "insertText": "'transaction",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -72,7 +72,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'test;\n"
+          "newText": "import ballerina/lang.'transaction;\n"
         }
       ]
     },
@@ -99,10 +99,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.transaction",
+      "label": "ballerina/lang.test",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'transaction",
+      "insertText": "'test",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -116,7 +116,29 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'transaction;\n"
+          "newText": "import ballerina/lang.'test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "insertText": "'runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.'runtime;\n"
         }
       ]
     },
@@ -143,28 +165,6 @@
       ]
     },
     {
-      "label": "ballerina/lang.value",
-      "kind": "Module",
-      "detail": "Module",
-      "insertText": "'value",
-      "insertTextFormat": "Snippet",
-      "additionalTextEdits": [
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import ballerina/lang.'value;\n"
-        }
-      ]
-    },
-    {
       "label": "ballerina/lang.query",
       "kind": "Module",
       "detail": "Module",
@@ -187,10 +187,10 @@
       ]
     },
     {
-      "label": "ballerina/lang.runtime",
+      "label": "ballerina/lang.value",
       "kind": "Module",
       "detail": "Module",
-      "insertText": "'runtime",
+      "insertText": "'value",
       "insertTextFormat": "Snippet",
       "additionalTextEdits": [
         {
@@ -204,7 +204,7 @@
               "character": 0
             }
           },
-          "newText": "import ballerina/lang.'runtime;\n"
+          "newText": "import ballerina/lang.'value;\n"
         }
       ]
     },
@@ -433,7 +433,7 @@
     {
       "label": "TEST_CONST",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "12",
       "documentation": {
         "right": {
           "kind": "markdown",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15c.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15c.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,6 +29,33 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
     {
@@ -60,40 +87,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -118,6 +111,13 @@
       "kind": "Interface",
       "detail": "Object",
       "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15d.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/typedesc_context/config/function_typedesc15d.json
@@ -8,7 +8,7 @@
     {
       "label": "TEST_INT_CONST1",
       "kind": "Variable",
-      "detail": "int",
+      "detail": "1",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -21,7 +21,7 @@
     {
       "label": "TEST_STRING_CONST1",
       "kind": "Variable",
-      "detail": "string",
+      "detail": "HELLO WORLD",
       "documentation": {
         "right": {
           "kind": "markdown",
@@ -29,6 +29,33 @@
         }
       },
       "insertText": "TEST_STRING_CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ResponseMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
+      },
+      "insertText": "ResponseMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RequestMessage",
+      "kind": "Enum",
+      "detail": "Union",
+      "documentation": {
+        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
+      },
+      "insertText": "RequestMessage",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "AnnotationType",
+      "kind": "Struct",
+      "detail": "Record",
+      "insertText": "AnnotationType",
       "insertTextFormat": "Snippet"
     },
     {
@@ -60,40 +87,6 @@
       "insertTextFormat": "Snippet"
     },
     {
-      "label": "ResponseMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `listener` when sending out the outbound response."
-      },
-      "insertText": "ResponseMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "RequestMessage",
-      "kind": "Enum",
-      "detail": "Union",
-      "documentation": {
-        "left": "The types of messages that are accepted by HTTP `client` when sending out the outbound request."
-      },
-      "insertText": "RequestMessage",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "AnnotationType",
-      "kind": "Struct",
-      "detail": "Record",
-      "insertText": "AnnotationType",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "TestObject1",
-      "kind": "Interface",
-      "detail": "Object",
-      "insertText": "TestObject1",
-      "insertTextFormat": "Snippet"
-    },
-    {
       "label": "Client",
       "kind": "Interface",
       "detail": "Object",
@@ -118,6 +111,13 @@
       "kind": "Interface",
       "detail": "Object",
       "insertText": "Listener",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "TestObject1",
+      "kind": "Interface",
+      "detail": "Object",
+      "insertText": "TestObject1",
       "insertTextFormat": "Snippet"
     },
     {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -40,7 +40,6 @@ import java.util.stream.Stream;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -47,6 +47,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.SINGLETON;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STREAM;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
@@ -93,7 +94,7 @@ public class LangLibFunctionTest {
     public void testFloatLangLib() {
         Symbol symbol = getSymbol(16, 7);
         TypeSymbol type = ((ConstantSymbol) symbol).typeDescriptor();
-        assertEquals(type.typeKind(), FLOAT);
+        assertEquals(type.typeKind(), SINGLETON);
 
         List<String> expFunctions = List.of("isFinite", "isInfinite", "isNaN", "abs", "round", "floor", "ceiling",
                                             "sqrt", "cbrt", "pow", "log", "log10", "exp", "sin", "cos", "tan", "asin",

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -87,6 +87,9 @@ public class SymbolAtCursorTest {
                 {63, 41, "lname"},
                 {72, 4, "test"},
                 {72, 7, "test"},
+                {76, 25, "RSA"},
+                {82, 8, "rsa"},
+                {83, 15, "RSA"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -109,6 +109,7 @@ public class SymbolAtCursorTest {
     @DataProvider(name = "EnumPosProvider")
     public Object[][] getEnumPos() {
         return new Object[][]{
+                {16, 5, "Colour"},
                 {17, 6, "RED"},
                 {21, 18, "RED"},
                 {22, 8, "Colour"},

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -110,11 +110,11 @@ public class SymbolAtCursorTest {
     public Object[][] getEnumPos() {
         return new Object[][]{
                 {17, 6, "RED"},
-//                {21, 18, "RED"}, // TODO: issue #25841
+                {21, 18, "RED"},
                 {22, 8, "Colour"},
                 {26, 45, "Colour"},
-//                {30, 17, "GREEN"}, // TODO: issue #25841
-//                {31, 28, "BLUE"}, // TODO: issue #25841
+                {30, 17, "GREEN"},
+                {31, 28, "BLUE"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -140,21 +140,22 @@ public class SymbolLookupTest {
 
     @DataProvider(name = "PositionProvider3")
     public Object[][] getPositionsForTypedefs() {
-        List<String> moduleLevelSymbols = asList("aString", "anInt", "HELLO", "testAnonTypes", "Person", "PersonObj");
+        List<String> moduleLevelSymbols = asList("aString", "anInt", "HELLO", "testAnonTypes", "Person", "PersonObj",
+                                                 "Colour", "RED", "GREEN", "BLUE");
         return new Object[][]{
-                {18, 0, 6, moduleLevelSymbols},
+                {18, 0, 10, moduleLevelSymbols},
 //                {22, 20, 6, moduleLevelSymbols}, // TODO: Filter out field symbols
 //                {28, 22, 6, moduleLevelSymbols}, // TODO: Filter out field symbols
-                {30, 65, 14, getSymbolNames(moduleLevelSymbols, "parent", "pParent", "name", "pName", "age", "pAge",
+                {30, 65, 18, getSymbolNames(moduleLevelSymbols, "parent", "pParent", "name", "pName", "age", "pAge",
                                             "self", "init")},
-                {39, 8, 13, getSymbolNames(moduleLevelSymbols, "parent", "name", "age", "self", "getAge", "getName",
+                {39, 8, 17, getSymbolNames(moduleLevelSymbols, "parent", "name", "age", "self", "getAge", "getName",
                                            "init")},
-                {46, 9, 7, getSymbolNames(moduleLevelSymbols, "x")},
-                {48, 19, 7, getSymbolNames(moduleLevelSymbols, "x")},
+                {46, 9, 11, getSymbolNames(moduleLevelSymbols, "x")},
+                {48, 19, 11, getSymbolNames(moduleLevelSymbols, "x")},
                 // TODO: Fix filtering out 'person'
-                {50, 15, 8, getSymbolNames(moduleLevelSymbols, "x", "person")},
+                {50, 15, 12, getSymbolNames(moduleLevelSymbols, "x", "person")},
 //                {50, 16, 9, getSymbolNames(moduleLevelSymbols, "x", "person", "name", "age")},
-                {51, 0, 8, getSymbolNames(moduleLevelSymbols, "x", "person")},
+                {51, 0, 12, getSymbolNames(moduleLevelSymbols, "x", "person")},
 //                {52, 17, 11, getSymbolNames(moduleLevelSymbols, "x", "person", "p2", "name", "age")},
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -110,8 +110,10 @@ public class TypedescriptorTest {
     @Test
     public void testConstantType() {
         Symbol symbol = getSymbol(16, 7);
+        assertEquals(((ConstantSymbol) symbol).typeKind(), SINGLETON);
+
         TypeSymbol type = ((ConstantSymbol) symbol).typeDescriptor();
-        assertEquals(type.typeKind(), FLOAT);
+        assertEquals(type.typeKind(), SINGLETON);
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -45,12 +45,14 @@ import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
 import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.tools.text.LineRange;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 import static io.ballerina.compiler.api.symbols.ParameterKind.DEFAULTABLE;
@@ -435,6 +437,21 @@ public class TypedescriptorTest {
         for (TypeSymbol inclusion : typeInclusions) {
             assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), OBJECT);
             assertTrue(expTypes.contains(inclusion.name()));
+        }
+    }
+
+    @Test
+    public void testEnumsAsTypes() {
+        Optional<TypeSymbol> type = model.type("typedesc_test.bal",
+                                               LineRange.from("typedesc_test.bal", from(160, 37), from(160, 38)));
+        assertEquals(type.get().typeKind(), TYPE_REFERENCE);
+        assertEquals(type.get().name(), "Colour");
+
+        TypeSymbol enumType = ((TypeReferenceTypeSymbol) type.get()).typeDescriptor();
+        assertEquals(enumType.typeKind(), UNION);
+
+        for (TypeSymbol memberType : ((UnionTypeSymbol) enumType).memberTypeDescriptors()) {
+            assertEquals(memberType.typeKind(), SINGLETON);
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
@@ -72,3 +72,14 @@ enum Colour {
 function testFunctionCall() {
     test();
 }
+
+# The key algorithms supported by the Crypto module.
+public type KeyAlgorithm RSA;
+
+# The RSA algorithm.
+public const RSA = "RSA";
+
+function testExprs()  {
+    RSA rsa = "RSA";
+    string s = RSA;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_with_typedefs_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_lookup_with_typedefs_test.bal
@@ -54,3 +54,7 @@ function testAnonTypes() {
 }
 
 const HELLO = "Hello";
+
+enum Colour {
+    RED, BLUE, GREEN
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -151,3 +151,12 @@ class EmployeeObj {
     *PersonObj;
     string designation;
 }
+
+enum Colour {
+    RED, BLUE, GREEN
+}
+
+function testEnumAsAType() {
+    Colour c = "RED";
+    string s = "Selected colour: " + c;
+}


### PR DESCRIPTION
## Purpose
This PR improves the support for enums in the semantic API by introducing a separate symbol for enums.

Fix #25872

## Remarks
**To be merged after #27165**

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
