### PR TITLE
Add SemVer pre-release and build-metadata version parsing support 

### DIFF
--- a/compiler/ballerina-lang/build.gradle
+++ b/compiler/ballerina-lang/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.ow2.asm:asm-util'
     implementation 'org.ow2.asm:asm-tree'
     implementation 'commons-io:commons-io'
+    implementation 'com.github.zafarkhaja:java-semver'
     testCompile 'org.testng:testng'
 }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SemanticVersion.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/SemanticVersion.java
@@ -17,9 +17,11 @@
  */
 package io.ballerina.projects;
 
+import com.github.zafarkhaja.semver.ParseException;
+import com.github.zafarkhaja.semver.UnexpectedCharacterException;
+import com.github.zafarkhaja.semver.Version;
+
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Represents a semantic version according to the semvar specification.
@@ -27,105 +29,93 @@ import java.util.regex.Pattern;
  * @since 2.0.0
  */
 public class SemanticVersion {
-    private static final Pattern pattern = Pattern.compile("(\\d+)\\.(\\d+)(?:\\.)?(\\d*)");
-    private final int major;
-    private final int minor;
-    private final int patch;
+    private final Version version;
 
-    public SemanticVersion(int major, int minor, int patch) {
-        this.major = major;
-        this.minor = minor;
-        this.patch = patch;
-    }
-
-    public static SemanticVersion from(int major, int minor, int patch) {
-        return new SemanticVersion(major, minor, patch);
+    private SemanticVersion(Version version) {
+        this.version = version;
     }
 
     public static SemanticVersion from(String versionString) {
-        Matcher matcher = pattern.matcher(versionString);
-        if (!matcher.matches()) {
-            // TODO Proper error handling
-            throw new ProjectException("Specified version: '" + versionString + "' is not semvar compatible");
+        try {
+            Version v = Version.valueOf(versionString);
+            return new SemanticVersion(v);
+        } catch (IllegalArgumentException e) {
+            throw new ProjectException("Version cannot be empty");
+        } catch (UnexpectedCharacterException e) {
+            throw new ProjectException("Invalid version: '" + versionString + "'. " + e.toString());
+        } catch (ParseException e) {
+            throw new ProjectException("Invalid version: '" + versionString + "'. " + e.toString());
         }
-
-        int major = Integer.parseInt(matcher.group(1));
-        int minor = Integer.parseInt(matcher.group(2));
-        String patchStr = matcher.group(3);
-        int patch = (patchStr != null && !patchStr.isEmpty()) ? Integer.parseInt(patchStr) : 0;
-        return SemanticVersion.from(major, minor, patch);
     }
 
     public int major() {
-        return major;
+        return version.getMajorVersion();
     }
 
     public int minor() {
-        return minor;
+        return version.getMinorVersion();
     }
 
     public int patch() {
-        return patch;
+        return version.getPatchVersion();
+    }
+
+    public String preReleaseVersion() {
+        return version.getPreReleaseVersion();
+    }
+
+    public String buildMetadata() {
+        return version.getBuildMetadata();
     }
 
     @Override
-    public boolean equals(Object o) {
-        if (this == o) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
 
-        if (o == null || getClass() != o.getClass()) {
+        if (other == null || getClass() != other.getClass()) {
             return false;
         }
 
-        SemanticVersion that = (SemanticVersion) o;
-        return major == that.major &&
-                minor == that.minor &&
-                patch == that.patch;
+        SemanticVersion otherSemVer = (SemanticVersion) other;
+        return version.equals(otherSemVer.version);
     }
 
     @Override
     public String toString() {
-        return major + "." + minor + "." + patch;
+        return version.toString();
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(major, minor, patch);
+        return version.hashCode();
     }
 
     public VersionCompatibilityResult compareTo(SemanticVersion other) {
         Objects.requireNonNull(other);
 
-        if (this.major == other.major && this.minor == other.minor && this.patch == other.patch) {
+        if (this.equals(other)) {
             return VersionCompatibilityResult.EQUAL;
         }
 
         // Versions cannot be equal from this point onwards
-        if (this.major == 0 && other.major == 0) {
+        if (this.major() == 0 && other.major() == 0) {
             return VersionCompatibilityResult.INCOMPATIBLE;
         }
 
-        if (this.major == 0 || other.major == 0) {
+        if (this.major() != other.major()) {
             return VersionCompatibilityResult.INCOMPATIBLE;
         }
 
-        // We've eliminated initial versions now.
-        if (this.major == other.major && this.minor == other.minor) {
-            return this.patch < other.patch ?
-                    VersionCompatibilityResult.LESS_THAN :
-                    VersionCompatibilityResult.GREATER_THAN;
+        // We've eliminated initial versions and versions with different major component.
+        // Now we just need to check minor, patch and pre-release components.
+        int result = this.version.compareTo(other.version);
+        if (result < 0) {
+            return VersionCompatibilityResult.LESS_THAN;
+        } else {
+            return VersionCompatibilityResult.GREATER_THAN;
         }
-
-        if (this.major == other.major) {
-            return this.minor < other.minor ?
-                    VersionCompatibilityResult.LESS_THAN :
-                    VersionCompatibilityResult.GREATER_THAN;
-        }
-
-        return this.major < other.major ?
-                VersionCompatibilityResult.LESS_THAN :
-                VersionCompatibilityResult.GREATER_THAN;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/module-info.java
+++ b/compiler/ballerina-lang/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module io.ballerina.lang {
     requires org.apache.commons.io;
     requires io.ballerina.toml;
     requires io.ballerina.central.client;
+    requires java.semver;
     exports io.ballerina.compiler.api;
     exports io.ballerina.compiler.api.symbols;
     exports io.ballerina.compiler.api.impl;

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/SemanticVersionComparisonTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/SemanticVersionComparisonTests.java
@@ -75,7 +75,7 @@ public class SemanticVersionComparisonTests {
 
         v1 = SemanticVersion.from("1.1.1");
         v2 = SemanticVersion.from("2.1.1");
-        Assert.assertEquals(v1.compareTo(v2), VersionCompatibilityResult.LESS_THAN);
+        Assert.assertEquals(v1.compareTo(v2), VersionCompatibilityResult.INCOMPATIBLE);
 
         v1 = SemanticVersion.from("1.1.2");
         v2 = SemanticVersion.from("1.1.1");
@@ -87,6 +87,6 @@ public class SemanticVersionComparisonTests {
 
         v1 = SemanticVersion.from("2.1.1");
         v2 = SemanticVersion.from("1.1.1");
-        Assert.assertEquals(v1.compareTo(v2), VersionCompatibilityResult.GREATER_THAN);
+        Assert.assertEquals(v1.compareTo(v2), VersionCompatibilityResult.INCOMPATIBLE);
     }
 }

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/SemanticVersionTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/SemanticVersionTests.java
@@ -1,0 +1,63 @@
+/*
+ *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.projects;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Contain cases to validate the functionality of {@code SemanticVersion}.
+ *
+ * @since 2.0.0
+ */
+public class SemanticVersionTests {
+
+    @Test
+    public void testPreReleaseVersion() {
+        SemanticVersion version = SemanticVersion.from("1.0.1-alpha");
+        Assert.assertEquals(version.major(), 1);
+        Assert.assertEquals(version.minor(), 0);
+        Assert.assertEquals(version.patch(), 1);
+        Assert.assertEquals(version.preReleaseVersion(), "alpha");
+
+        version = SemanticVersion.from("1.0.1-alpha.1.2.3.4.23423");
+        Assert.assertEquals(version.preReleaseVersion(), "alpha.1.2.3.4.23423");
+    }
+
+    @Test
+    public void testBuildMetadata() {
+        SemanticVersion version = SemanticVersion.from("1.0.1+20130313144700");
+        Assert.assertEquals(version.major(), 1);
+        Assert.assertEquals(version.minor(), 0);
+        Assert.assertEquals(version.patch(), 1);
+        Assert.assertEquals(version.buildMetadata(), "20130313144700");
+
+        version = SemanticVersion.from("1.0.1+20130313144700.A1234.34343a");
+        Assert.assertEquals(version.buildMetadata(), "20130313144700.A1234.34343a");
+    }
+
+    @Test
+    public void testPreReleaseAndBuildMetadata() {
+        SemanticVersion version = SemanticVersion.from("1.0.1-alpha1.0.0+20130313144700.1.2.a");
+        Assert.assertEquals(version.major(), 1);
+        Assert.assertEquals(version.minor(), 0);
+        Assert.assertEquals(version.patch(), 1);
+        Assert.assertEquals(version.preReleaseVersion(), "alpha1.0.0");
+        Assert.assertEquals(version.buildMetadata(), "20130313144700.1.2.a");
+    }
+}

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/VersionConflictResolutionTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/VersionConflictResolutionTests.java
@@ -61,6 +61,12 @@ public class VersionConflictResolutionTests {
                 getDependencyGraph(testSourcesDirectory.resolve("conflicts_2_expected.json")));
     }
 
+    @Test(expectedExceptions = ProjectException.class, expectedExceptionsMessageRegExp =
+            "Two incompatible versions exist in the dependency graph: samjs/package_b versions: 1.1.0, 2.1.0")
+    public void testVersionConflictsMajor() throws IOException {
+        getDependencyGraph(testSourcesDirectory.resolve("conflicts_negative_1.json"));
+    }
+
     private void compareGraphs(DependencyGraph<PackageDescriptor> actualDependencyGraph,
                                DependencyGraph<PackageDescriptor> expectedDependencyGraph) {
         Collection<PackageDescriptor> actualNodes = actualDependencyGraph.getNodes();

--- a/compiler/ballerina-lang/src/test/resources/project_api/version_conflicts/conflicts_negative_1.json
+++ b/compiler/ballerina-lang/src/test/resources/project_api/version_conflicts/conflicts_negative_1.json
@@ -8,7 +8,7 @@
                 {
                     "org": "samjs",
                     "name": "package_b",
-                    "version": "2.1.0"
+                    "version": "1.1.0"
                 },
                 {
                     "org": "samjs",

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -129,6 +129,7 @@ dependencies {
         implementation 'me.tongfei:progressbar:0.7.4'
         implementation 'org.jline:jline:3.11.0'
         implementation 'jakarta.activation:jakarta.activation-api:1.2.2'
+        implementation 'com.github.zafarkhaja:java-semver:0.9.0'
 
         implementation 'javax.transaction:javax.transaction-api:1.3'
         implementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'


### PR DESCRIPTION
## Purpose
This PR introduces SemVer pre-release and build metadata version parsing and comparison capability to the Ballerina project API implementation. 

Relates to #27373 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
