### PR TITLE
Support accessing transaction previous attempt info from the next retry

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -2654,6 +2654,12 @@ public class Desugar extends BLangNodeVisitor {
             retryBlockStmt.parent = env.enclInvokable;
             retryBlockStmt.scope = new Scope(env.scope.owner);
 
+            if (retryNode.commonStmtForRetries != null) {
+                BLangSimpleVariableDef prevAttemptDef = (BLangSimpleVariableDef) retryNode.commonStmtForRetries;
+                retryBlockStmt.scope.define(prevAttemptDef.var.symbol.name, prevAttemptDef.var.symbol);
+                retryBlockStmt.stmts.add(retryNode.commonStmtForRetries);
+            }
+
             // <RetryManagerType> $retryManager$ = new();
             BLangSimpleVariableDef retryManagerVarDef = createRetryManagerDef(retryNode.retrySpec, retryNode.pos);
             retryBlockStmt.stmts.add(retryManagerVarDef);
@@ -2960,7 +2966,15 @@ public class Desugar extends BLangNodeVisitor {
     public void visit(BLangRetryTransaction retryTransaction) {
         BLangBlockStmt retryBody = ASTBuilderUtil.createBlockStmt(retryTransaction.pos);
         retryBody.stmts.add(retryTransaction.transaction);
+
+        //transactions:Info? prevAttempt = ();
+        BLangSimpleVariableDef prevAttemptVarDef = transactionDesugar.createPrevAttemptInfoVarDef(env,
+                retryTransaction.pos);
+        retryTransaction.transaction.prevAttemptInfo = ASTBuilderUtil.createVariableRef(retryTransaction.pos,
+                prevAttemptVarDef.var.symbol);
+
         BLangRetry retry = (BLangRetry) TreeBuilder.createRetryNode();
+        retry.commonStmtForRetries = prevAttemptVarDef;
         retry.retryBody = retryBody;
         retry.retrySpec = retryTransaction.retrySpec;
         result = rewrite(retry, env);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/Desugar.java
@@ -3702,7 +3702,7 @@ public class Desugar extends BLangNodeVisitor {
                 Lists.of(errorVar), onFailReturnType, onFailClause.body.stmts,
                 env, onFailClause.body.scope);
 
-        onFailFunc.capturedClosureEnv = env.createClone();
+        onFailFunc.capturedClosureEnv = env;
         onFailFunc.parent = env.enclInvokable;
         BLangSimpleVarRef thrownErrorRef = ASTBuilderUtil.createVariableRef(onFailClause.pos, errorVar.symbol);
         onFailErrorVariableDef.var.expr = addConversionExprIfRequired(thrownErrorRef, onFailErrorVariableDef.var.type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -263,7 +263,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private final SymbolResolver symResolver;
     private int loopCount;
     private int transactionCount;
-    private int retryCount;
     private boolean statementReturns;
     private boolean failureHandled;
     private boolean matchClauseReturns;
@@ -282,20 +281,16 @@ public class CodeAnalyzer extends BLangNodeVisitor {
     private Stack<Boolean> doneWithinTransactionCheckStack = new Stack<>();
     private Stack<Boolean> transactionalFuncCheckStack = new Stack<>();
     private Stack<Boolean> returnWithinLambdaWrappingCheckStack = new Stack<>();
-    private BLangTransaction innerTransactionBlock = null;
-    private BLangRetry innerRetryBlock = null;
     private BLangNode parent;
     private Names names;
     private SymbolEnv env;
     private final Stack<LinkedHashSet<BType>> returnTypes = new Stack<>();
     private final Stack<LinkedHashSet<BType>> errorTypes = new Stack<>();
-    private final Stack<BType> onFailErrorType = new Stack<>();
     private boolean isJSONContext;
     private boolean enableExperimentalFeatures;
     private int commitCount;
     private int rollbackCount;
     private boolean withinTransactionScope;
-    private boolean withinTransactionBlock;
     private boolean commitRollbackAllowed;
     private int commitCountWithinBlock;
     private int rollbackCountWithinBlock;
@@ -578,7 +573,6 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         boolean failureHandled = this.failureHandled;
 
         boolean previousWithinTxScope = this.withinTransactionScope;
-        boolean previousWithinTrxBlock = this.withinTransactionBlock;
         int previousCommitCount = this.commitCount;
         int previousRollbackCount = this.rollbackCount;
         boolean prevCommitRollbackAllowed = this.commitRollbackAllowed;
@@ -586,20 +580,11 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         this.commitCount = 0;
         this.rollbackCount = 0;
 
-        if (this.withinTransactionBlock) {
-            this.innerTransactionBlock = transactionNode;
-        }
-
         this.withinTransactionScope = true;
-
-        if (!this.withinTransactionBlock) {
-            this.withinTransactionBlock = true;
-        }
 
         this.loopWithinTransactionCheckStack.push(false);
         this.returnWithinTransactionCheckStack.push(false);
         this.doneWithinTransactionCheckStack.push(false);
-        this.returnWithinLambdaWrappingCheckStack.push(false);
         this.transactionCount++;
         if (!this.failureHandled) {
             this.failureHandled = transactionNode.onFailClause != null;
@@ -610,21 +595,11 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             this.dlog.error(transactionNode.pos, DiagnosticErrorCode.INVALID_COMMIT_COUNT);
         }
 
-        transactionNode.statementBlockReturns = this.returnWithinLambdaWrappingCheckStack.peek();
-        this.returnWithinLambdaWrappingCheckStack.pop();
         this.transactionCount--;
         this.withinTransactionScope = previousWithinTxScope;
-        this.withinTransactionBlock = previousWithinTrxBlock;
         this.commitCount = previousCommitCount;
         this.rollbackCount = previousRollbackCount;
         this.commitRollbackAllowed = prevCommitRollbackAllowed;
-        if (this.innerTransactionBlock != null) {
-            transactionNode.statementBlockReturns = this.innerTransactionBlock.statementBlockReturns;
-        }
-
-        if (!this.withinTransactionBlock) {
-            this.innerTransactionBlock = null;
-        }
         this.returnWithinTransactionCheckStack.pop();
         this.loopWithinTransactionCheckStack.pop();
         this.doneWithinTransactionCheckStack.pop();
@@ -688,35 +663,20 @@ public class CodeAnalyzer extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangRetry retryNode) {
-        this.returnWithinLambdaWrappingCheckStack.push(false);
         this.errorTypes.push(new LinkedHashSet<>());
         boolean failureHandled = this.failureHandled;
         this.checkStatementExecutionValidity(retryNode);
-        this.retryCount++;
         if (!this.failureHandled) {
             this.failureHandled = retryNode.onFailClause != null;
-        }
-        if (retryCount > 1) {
-            this.innerRetryBlock = retryNode;
         }
         retryNode.retrySpec.accept(this);
         retryNode.retryBody.accept(this);
         this.failureHandled = failureHandled;
-        if (!this.returnWithinLambdaWrappingCheckStack.peek() && this.innerRetryBlock != null) {
-            retryNode.retryBodyReturns = this.innerRetryBlock.retryBodyReturns;
-        } else {
-            retryNode.retryBodyReturns = this.returnWithinLambdaWrappingCheckStack.peek();
-        }
-        this.returnWithinLambdaWrappingCheckStack.pop();
         this.resetLastStatement();
         this.resetErrorThrown();
         retryNode.retryBody.isBreakable = retryNode.onFailClause != null;
         analyzeOnFailClause(retryNode.onFailClause);
         this.errorTypes.pop();
-        this.retryCount--;
-        if (this.retryCount == 0) {
-            this.innerRetryBlock = null;
-        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangRetry.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangRetry.java
@@ -33,8 +33,8 @@ public class BLangRetry extends BLangStatement implements RetryNode {
 
     public BLangRetrySpec retrySpec;
     public BLangBlockStmt retryBody;
-    public boolean retryBodyReturns;
     public BLangOnFailClause onFailClause;
+    public BLangStatement commonStmtForRetries;
 
     public BLangRetrySpec getRetrySpec() {
         return retrySpec;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTransaction.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangTransaction.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.tree.statements.BlockStatementNode;
 import org.ballerinalang.model.tree.statements.TransactionNode;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 
 /**
  * @since 1.3.0
@@ -30,8 +31,8 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
 public class BLangTransaction extends BLangStatement implements TransactionNode {
 
     public BLangBlockStmt transactionBody;
-    public boolean statementBlockReturns;
     public BLangOnFailClause onFailClause;
+    public BLangExpression prevAttemptInfo;
 
     public BLangTransaction() {
     }


### PR DESCRIPTION
## Purpose
> Set previous attempt information accessible for the next retry within the transaction in retry transaction statement.

Fixes #27381

## Approach
> Declare previous attempt information variable outside the retry while loop

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [x] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
