### PR TITLE
Use PackageID in all places

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/PackageID.java
@@ -105,18 +105,20 @@ public class PackageID {
     public static final PackageID RUNTIME = new PackageID(Names.BALLERINA_ORG, Lists.of(Names.LANG, Names.RUNTIME),
                                                           RUNTIME_VERSION);
     public static final PackageID TRANSACTION = new PackageID(Names.BALLERINA_ORG,
-            Lists.of(Names.LANG, Names.TRANSACTION), TRANSACTION_VERSION);
+                                                              Lists.of(Names.LANG, Names.TRANSACTION),
+                                                              TRANSACTION_VERSION);
     public static final PackageID TRANSACTION_INTERNAL = new PackageID(Names.BALLERINA_INTERNAL_ORG,
-            Lists.of(Names.TRANSACTION), TRANSACTION_INTERNAL_VERSION);
+                                                                       Lists.of(Names.TRANSACTION),
+                                                                       TRANSACTION_INTERNAL_VERSION);
 
-    public final Name orgName;
+    public Name orgName;
     public Name name;
-    public Name version = DEFAULT_VERSION;
+    public Name version;
 
-    public boolean isUnnamed = false;
-    public Name sourceFileName = null;
+    public final boolean isUnnamed;
+    public final Name sourceFileName;
 
-    public List<Name> nameComps;
+    public final List<Name> nameComps;
 
     public PackageID(Name orgName, List<Name> nameComps, Name version) {
         this.orgName = orgName;
@@ -126,18 +128,33 @@ public class PackageID {
                         .map(Name::getValue)
                         .collect(Collectors.joining(".")));
         this.version = version;
+        isUnnamed = false;
+        sourceFileName = null;
     }
 
     public PackageID(Name orgName, Name name, Name version) {
         this.orgName = orgName;
         this.name = name;
         this.version = version;
+        this.nameComps = createNameComps(name);
+        isUnnamed = false;
+        sourceFileName = null;
+    }
+
+    public PackageID(Name orgName, Name name, Name version, Name sourceFileName) {
+        this.orgName = orgName;
+        this.name = name;
+        this.version = version;
+        this.nameComps = createNameComps(name);
+        isUnnamed = false;
+        this.sourceFileName = sourceFileName;
+    }
+
+    private List<Name> createNameComps(Name name) {
         if (name == Names.DEFAULT_PACKAGE) {
-            this.nameComps = Lists.of(Names.DEFAULT_PACKAGE);
-        } else {
-            this.nameComps = Arrays.stream(name.value.split("\\."))
-                    .map(Name::new).collect(Collectors.toList());
+            return Lists.of(Names.DEFAULT_PACKAGE);
         }
+        return Arrays.stream(name.value.split("\\.")).map(Name::new).collect(Collectors.toList());
     }
 
     /**
@@ -163,13 +180,12 @@ public class PackageID {
      */
     public PackageID(String sourceFileName) {
         this.orgName = Names.ANON_ORG;
-//        this.name = new Name(Names.DOT + sourceFileName);
         this.name = Names.DEFAULT_PACKAGE;
-        this.nameComps = new ArrayList<>(1) {{
-            add(name);
-        }};
+        this.nameComps = new ArrayList<>(1);
+        nameComps.add(name);
         this.isUnnamed = true;
         this.sourceFileName = new Name(sourceFileName);
+        this.version = DEFAULT_VERSION;
     }
 
     public Name getName() {
@@ -222,16 +238,16 @@ public class PackageID {
             return this.name.value;
         }
 
-        String orgName = "";
+        String org = "";
         if (this.orgName != null && !this.orgName.equals(Names.ANON_ORG)) {
-            orgName = this.orgName + Names.ORG_NAME_SEPARATOR.value;
+            org = this.orgName + Names.ORG_NAME_SEPARATOR.value;
         }
 
         if (version.equals(Names.EMPTY)) {
-            return orgName + this.name.value;
+            return org + this.name.value;
         }
 
-        return orgName + this.name + Names.VERSION_SEPARATOR.value + this.version;
+        return org + this.name + Names.VERSION_SEPARATOR.value + this.version;
     }
 
     public Name getOrgName() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -1684,11 +1684,11 @@ public class BIRGen extends BLangNodeVisitor {
 
         BTypeSymbol objectTypeSymbol = getObjectTypeSymbol(connectorInitExpr.type);
         BIRNonTerminator.NewInstance instruction;
-        if (isInSamePackage(objectTypeSymbol, this.env.enclPkg)) {
+        if (isInSamePackage(objectTypeSymbol, env.enclPkg.packageID)) {
             BIRTypeDefinition def = typeDefs.get(objectTypeSymbol);
             instruction = new BIRNonTerminator.NewInstance(connectorInitExpr.pos, def, toVarRef);
         } else {
-            BType objectType = connectorInitExpr.type.tag != TypeTags.UNION ? connectorInitExpr.type  :
+            BType objectType = connectorInitExpr.type.tag != TypeTags.UNION ? connectorInitExpr.type :
                     ((BUnionType) connectorInitExpr.type).getMemberTypes().stream()
                             .filter(bType -> bType.tag != TypeTags.ERROR)
                             .findFirst()
@@ -1702,10 +1702,8 @@ public class BIRGen extends BLangNodeVisitor {
         this.env.targetOperand = toVarRef;
     }
 
-    private boolean isInSamePackage(BSymbol objectTypeSymbol, BIRPackage enclPkg) {
-        return objectTypeSymbol.pkgID.orgName.equals(enclPkg.org) &&
-                objectTypeSymbol.pkgID.name.equals(enclPkg.name) &&
-                objectTypeSymbol.pkgID.version.equals(enclPkg.version);
+    private boolean isInSamePackage(BSymbol objectTypeSymbol, PackageID packageID) {
+        return objectTypeSymbol.pkgID.equals(packageID);
     }
 
     @Override
@@ -1922,7 +1920,7 @@ public class BIRGen extends BLangNodeVisitor {
     private BIRGlobalVariableDcl getVarRef(BLangPackageVarRef astPackageVarRefExpr) {
         BSymbol symbol = astPackageVarRefExpr.symbol;
         if ((symbol.tag & SymTag.CONSTANT) == SymTag.CONSTANT ||
-                !isInSamePackage(astPackageVarRefExpr.varSymbol, env.enclPkg)) {
+                !isInSamePackage(astPackageVarRefExpr.varSymbol, env.enclPkg.packageID)) {
             return new BIRGlobalVariableDcl(astPackageVarRefExpr.pos, symbol.flags, symbol.type, symbol.pkgID,
                                             symbol.name, VarScope.GLOBAL, VarKind.CONSTANT, symbol.name.value,
                                             symbol.origin.toBIROrigin());

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -23,8 +23,6 @@ import io.ballerina.projects.PlatformLibrary;
 import io.ballerina.projects.PlatformLibraryScope;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.compiler.CompilerOptionName;
-import org.ballerinalang.compiler.JarResolver;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.CompiledJarFile;
 import org.wso2.ballerinalang.compiler.PackageCache;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropValidator;
@@ -39,27 +37,19 @@ import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.io.BufferedReader;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
-import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-
-import static org.ballerinalang.compiler.JarResolver.JAR_RESOLVER_KEY;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.encodeModuleIdentifiers;
-import static org.wso2.ballerinalang.compiler.util.ProjectDirConstants.BALLERINA_HOME;
 
 /**
  * JVM byte code generator from BIR model.
@@ -73,13 +63,9 @@ public class CodeGenerator {
     private PackageCache packageCache;
     private BLangDiagnosticLog dlog;
     private BIREmitter birEmitter;
-    private boolean baloGen;
     private CompilerContext compilerContext;
-    private boolean skipTests;
     private boolean dumbBIR;
     private final String dumpBIRFile;
-    private boolean skipModuleDependencies;
-    private Path ballerinaHome = Paths.get(System.getProperty(BALLERINA_HOME));
 
     private CodeGenerator(CompilerContext compilerContext) {
 
@@ -90,12 +76,8 @@ public class CodeGenerator {
         this.birEmitter = BIREmitter.getInstance(compilerContext);
         this.compilerContext = compilerContext;
         CompilerOptions compilerOptions = CompilerOptions.getInstance(compilerContext);
-        this.skipTests = getBooleanValueIfSet(compilerOptions, CompilerOptionName.SKIP_TESTS);
-        this.baloGen = getBooleanValueIfSet(compilerOptions, CompilerOptionName.BALO_GENERATION);
         this.dumbBIR = getBooleanValueIfSet(compilerOptions, CompilerOptionName.DUMP_BIR);
         this.dumpBIRFile = compilerOptions.get(CompilerOptionName.DUMP_BIR_FILE);
-        this.skipModuleDependencies = getBooleanValueIfSet(compilerOptions,
-                CompilerOptionName.SKIP_MODULE_DEPENDENCIES);
     }
 
     public static CodeGenerator getInstance(CompilerContext context) {
@@ -185,60 +167,11 @@ public class CodeGenerator {
         InteropValidator interopValidator = new InteropValidator(interopValidationClassLoader, symbolTable);
 
         //Rewrite identiifier names with encoding special characters
-        encodeModuleIdentifiers(packageSymbol.bir, Names.getInstance(this.compilerContext));
+        JvmDesugarPhase.encodeModuleIdentifiers(packageSymbol.bir, Names.getInstance(this.compilerContext));
 
         // TODO Get-rid of the following assignment
         packageSymbol.compiledJarFile = jvmPackageGen.generate(packageSymbol.bir, interopValidator, true);
         return packageSymbol.compiledJarFile;
-    }
-
-    private Set<Path> findDependencies(PackageID packageID) {
-
-        Set<Path> moduleDependencies = new HashSet<>();
-
-        if (skipModuleDependencies) {
-            return moduleDependencies;
-        }
-
-        if (baloGen) {
-            moduleDependencies.addAll(readInteropDependencies());
-        }
-
-        JarResolver jarResolver = compilerContext.get(JAR_RESOLVER_KEY);
-
-        if (jarResolver != null) {
-            moduleDependencies.addAll(jarResolver.nativeDependencies(packageID));
-        }
-
-        return moduleDependencies;
-    }
-
-    private Set<Path> findTestDependencies(PackageID testPackageId, Set<Path> moduleDependencies) {
-
-        Set<Path> testDependencies = new HashSet<>(moduleDependencies);
-
-        JarResolver jarResolver = compilerContext.get(JAR_RESOLVER_KEY);
-
-        if (jarResolver != null) {
-            testDependencies.addAll(jarResolver.nativeDependenciesForTests(testPackageId));
-        }
-
-        return testDependencies;
-    }
-
-    private HashSet<Path> readInteropDependencies() {
-
-        HashSet<Path> interopDependencies = new HashSet<>();
-        try (BufferedReader br = new BufferedReader(new InputStreamReader(
-                new FileInputStream("build/interopJars.txt"), Charset.forName("UTF-8")))) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                interopDependencies.add(Paths.get(line));
-            }
-        } catch (IOException e) {
-            throw new BLangCompilerException("error reading interop jar file names", e);
-        }
-        return interopDependencies;
     }
 
     private ClassLoader makeClassLoader(Set<Path> moduleDependencies) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmCodeGenUtil.java
@@ -216,19 +216,18 @@ public class JvmCodeGenUtil {
     }
 
     static void generateStrandMetadata(MethodVisitor mv, String moduleClass,
-                                       BIRNode.BIRPackage module, AsyncDataCollector asyncDataCollector) {
+                                       PackageID packageID, AsyncDataCollector asyncDataCollector) {
         asyncDataCollector.getStrandMetadata().forEach(
-                (varName, metaData) -> genStrandMetadataField(mv, moduleClass, module, varName, metaData));
+                (varName, metaData) -> genStrandMetadataField(mv, moduleClass, packageID, varName, metaData));
     }
 
-    private static void genStrandMetadataField(MethodVisitor mv, String moduleClass, BIRNode.BIRPackage module,
+    private static void genStrandMetadataField(MethodVisitor mv, String moduleClass, PackageID packageID,
                                                String varName, ScheduleFunctionInfo metaData) {
-
         mv.visitTypeInsn(Opcodes.NEW, STRAND_METADATA);
         mv.visitInsn(Opcodes.DUP);
-        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(module.org.value));
-        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(module.name.value));
-        mv.visitLdcInsn(module.version.value);
+        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(packageID.orgName.value));
+        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(packageID.name.value));
+        mv.visitLdcInsn(packageID.version.value);
         if (metaData.typeName == null) {
             mv.visitInsn(Opcodes.ACONST_NULL);
         } else {
@@ -260,26 +259,14 @@ public class JvmCodeGenUtil {
     }
 
     public static String getPackageName(PackageID packageID) {
-        return getPackageName(packageID.orgName, packageID.name, packageID.version);
+        return getPackageNameWithSeparator(packageID, "/");
     }
 
-    public static String getPackageName(BIRNode.BIRPackage module) {
-        return getPackageName(module.org, module.name, module.version);
-    }
-
-    public static String getPackageName(Name orgName, Name moduleName, Name version) {
-        return getPackageName(orgName.getValue(), moduleName.getValue(), version.getValue());
-    }
-
-    public static String getPackageName(String orgName, String moduleName, String version) {
-        return getPackageNameWithSeparator(orgName, moduleName, version, "/");
-    }
-
-    private static String getPackageNameWithSeparator(String orgName, String moduleName, String version,
-                                                      String separator) {
+    private static String getPackageNameWithSeparator(PackageID packageID, String separator) {
         String packageName = "";
-        orgName = IdentifierUtils.encodeNonFunctionIdentifier(orgName);
-        moduleName = IdentifierUtils.encodeNonFunctionIdentifier(moduleName);
+        String orgName = IdentifierUtils.encodeNonFunctionIdentifier(packageID.orgName.value);
+        String moduleName = IdentifierUtils.encodeNonFunctionIdentifier(packageID.name.value);
+        String version = packageID.version.value;
         if (!moduleName.equals(ENCODED_DOT_CHARACTER)) {
             if (!version.equals("")) {
                 packageName = getVersionDirectoryName(version) + separator;
@@ -297,23 +284,17 @@ public class JvmCodeGenUtil {
         return name.replace(".", "_");
     }
 
-    public static String getModuleLevelClassName(BIRNode.BIRPackage module, String sourceFileName) {
-        return getModuleLevelClassName(module.org.value, module.name.value, module.version.value, sourceFileName);
+    public static String getModuleLevelClassName(PackageID packageID, String sourceFileName) {
+        return getModuleLevelClassName(packageID, sourceFileName, "/");
     }
 
-    public static String getModuleLevelClassName(String orgName, String moduleName, String version,
-                                                 String sourceFileName) {
-        return getModuleLevelClassName(orgName, moduleName, version, sourceFileName, "/");
-    }
-
-    static String getModuleLevelClassName(String orgName, String moduleName, String version, String sourceFileName,
-                                          String separator) {
+    static String getModuleLevelClassName(PackageID packageID, String sourceFileName, String separator) {
         String className = cleanupSourceFileName(sourceFileName);
         // handle source file path start with '/'.
         if (className.startsWith(JAVA_PACKAGE_SEPERATOR)) {
             className = className.substring(1);
         }
-        return getPackageNameWithSeparator(orgName, moduleName, version, separator) + className;
+        return getPackageNameWithSeparator(packageID, separator) + className;
     }
 
     private static String cleanupSourceFileName(String name) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmDesugarPhase.java
@@ -21,6 +21,7 @@ package org.wso2.ballerinalang.compiler.bir.codegen;
 import io.ballerina.runtime.internal.IdentifierUtils;
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.bir.codegen.methodgen.InitMethodGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
@@ -247,15 +248,15 @@ public class JvmDesugarPhase {
     }
 
     static void encodeModuleIdentifiers(BIRNode.BIRPackage module, Names names) {
-        encodePackageIdentifiers(module, names);
+        encodePackageIdentifiers(module.packageID, names);
         encodeGlobalVariableIdentifiers(module.globalVars, names);
         encodeFunctionIdentifiers(module.functions, names);
         encodeTypeDefIdentifiers(module.typeDefs, names);
     }
 
-    private static void encodePackageIdentifiers(BIRNode.BIRPackage module, Names names) {
-        module.org = names.fromString(IdentifierUtils.encodeNonFunctionIdentifier(module.org.value));
-        module.name = names.fromString(IdentifierUtils.encodeNonFunctionIdentifier(module.name.value));
+    private static void encodePackageIdentifiers(PackageID packageID, Names names) {
+        packageID.orgName = names.fromString(IdentifierUtils.encodeNonFunctionIdentifier(packageID.orgName.value));
+        packageID.name = names.fromString(IdentifierUtils.encodeNonFunctionIdentifier(packageID.name.value));
     }
 
     private static void encodeTypeDefIdentifiers(List<BIRTypeDefinition> typeDefs, Names names) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmInstructionGen.java
@@ -189,11 +189,11 @@ public class JvmInstructionGen {
     private final MethodVisitor mv;
     private final BIRVarToJVMIndexMap indexMap;
     private final String currentPackageName;
-    private final BIRNode.BIRPackage currentPackage;
+    private final PackageID currentPackage;
     private final JvmPackageGen jvmPackageGen;
     private final SymbolTable symbolTable;
 
-    public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, BIRNode.BIRPackage currentPackage,
+    public JvmInstructionGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, PackageID currentPackage,
                              JvmPackageGen jvmPackageGen) {
         this.mv = mv;
         this.indexMap = indexMap;
@@ -1381,8 +1381,8 @@ public class JvmInstructionGen {
         if (objectStoreIns.onInitialization) {
             BObjectType objectType = (BObjectType) objectStoreIns.lhsOp.variableDcl.type;
             this.mv.visitMethodInsn(INVOKESPECIAL,
-                                    getTypeValueClassName(objectType.tsymbol.pkgID, toNameString(objectType)),
-                                    "setOnInitialization",
+                                    getTypeValueClassName(JvmCodeGenUtil.getPackageName(objectType.tsymbol.pkgID),
+                                                          toNameString(objectType)), "setOnInitialization",
                                     String.format("(L%s;L%s;)V", JvmConstants.B_STRING_VALUE, OBJECT), false);
             return;
         }
@@ -1608,23 +1608,25 @@ public class JvmInstructionGen {
         BType type = jvmPackageGen.lookupTypeDef(objectNewIns);
         String className;
         if (objectNewIns.isExternalDef) {
-            className = getTypeValueClassName(objectNewIns.externalPackageId, objectNewIns.objectName);
+            className = getTypeValueClassName(JvmCodeGenUtil.getPackageName(objectNewIns.externalPackageId),
+                                              objectNewIns.objectName);
         } else {
-            className = getTypeValueClassName(this.currentPackage, objectNewIns.def.name.value);
+            className = getTypeValueClassName(JvmCodeGenUtil.getPackageName(currentPackage),
+                                              objectNewIns.def.name.value);
         }
 
         this.mv.visitTypeInsn(NEW, className);
         this.mv.visitInsn(DUP);
 
         loadType(mv, type);
-        reloadObjectCtorAnnots(type, objectNewIns.externalPackageId, strandIndex);
+        reloadObjectCtorAnnots(type, strandIndex);
         this.mv.visitTypeInsn(CHECKCAST, OBJECT_TYPE_IMPL);
         this.mv.visitMethodInsn(INVOKESPECIAL, className, JVM_INIT_METHOD, String.format("(L%s;)V", OBJECT_TYPE_IMPL),
                 false);
         this.storeToVar(objectNewIns.lhsOp.variableDcl);
     }
 
-    private void reloadObjectCtorAnnots(BType type, PackageID packageID, int strandIndex) {
+    private void reloadObjectCtorAnnots(BType type, int strandIndex) {
         if ((type.flags & Flags.OBJECT_CTOR) == Flags.OBJECT_CTOR) {
             this.mv.visitInsn(DUP);
             this.mv.visitTypeInsn(CHECKCAST, OBJECT_TYPE_IMPL);
@@ -1897,7 +1899,7 @@ public class JvmInstructionGen {
         BType type = newTypeDesc.type;
         String className = TYPEDESC_VALUE_IMPL;
         if (type.tag == TypeTags.RECORD) {
-            className = getTypeDescClassName(type.tsymbol.pkgID, toNameString(type));
+            className = getTypeDescClassName(JvmCodeGenUtil.getPackageName(type.tsymbol.pkgID), toNameString(type));
         }
         this.mv.visitTypeInsn(NEW, className);
         this.mv.visitInsn(DUP);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -183,9 +183,10 @@ class JvmObservabilityGen {
      * @param pkg The package containing the function
      */
     private void rewriteAsyncInvocations(BIRFunction func, BIRTypeDefinition attachedTypeDef, BIRPackage pkg) {
-        Name org = new Name(IdentifierUtils.decodeIdentifier(pkg.org.value));
-        Name module = new Name(IdentifierUtils.decodeIdentifier(pkg.name.value));
-        PackageID currentPkgId = new PackageID(org, module, pkg.version);
+        PackageID packageID = pkg.packageID;
+        Name org = new Name(IdentifierUtils.decodeIdentifier(packageID.orgName.getValue()));
+        Name module = new Name(IdentifierUtils.decodeIdentifier(packageID.name.getValue()));
+        PackageID currentPkgId = new PackageID(org, module, packageID.version);
         BSymbol functionOwner;
         List<BIRFunction> scopeFunctionsList;
         if (attachedTypeDef == null) {
@@ -598,7 +599,7 @@ class JvmObservabilityGen {
                                                     String resourcePathOrFunction, String resourceAccessor,
                                                     boolean isResource, boolean isRemote, BIRPackage pkg,
                                                     Location originalInsPosition) {
-        String pkgId = generatePackageId(pkg);
+        String pkgId = generatePackageId(pkg.packageID);
         String position = generatePositionId(originalInsPosition);
 
         BIROperand pkgOperand = generateGlobalConstantOperand(pkg, symbolTable.stringType, pkgId);
@@ -639,7 +640,7 @@ class JvmObservabilityGen {
                                                     boolean isRemote, boolean isMainEntryPoint, boolean isWorker,
                                                     BIROperand objectOperand, String action, BIRPackage pkg,
                                                     Location originalInsPosition) {
-        String pkgId = generatePackageId(pkg);
+        String pkgId = generatePackageId(pkg.packageID);
         String position = generatePositionId(originalInsPosition);
 
         BIROperand pkgOperand = generateGlobalConstantOperand(pkg, symbolTable.stringType, pkgId);
@@ -740,7 +741,7 @@ class JvmObservabilityGen {
      */
     private BIROperand generateGlobalConstantOperand(BIRPackage pkg, BType constantType, Object constantValue) {
         return compileTimeConstants.computeIfAbsent(constantValue, k -> {
-            PackageID pkgId = new PackageID(pkg.org, pkg.name, pkg.version);
+            PackageID pkgId = pkg.packageID;
             BIRGlobalVariableDcl constLoadVariableDcl =
                     new BIRGlobalVariableDcl(COMPILE_TIME_CONST_POS, 0,
                             constantType, pkgId, new Name("$observabilityConst" + constantIndex++),
@@ -818,7 +819,8 @@ class JvmObservabilityGen {
         boolean isObservableAnnotationPresent = false;
         for (BIRAnnotationAttachment annot : callIns.calleeAnnotAttachments) {
             if (OBSERVABLE_ANNOTATION.equals(
-                    JvmCodeGenUtil.getPackageName(annot.packageID.orgName, annot.packageID.name, Names.EMPTY) +
+                    JvmCodeGenUtil.getPackageName(
+                            new PackageID(annot.packageID.orgName, annot.packageID.name, Names.EMPTY)) +
                             annot.annotTagRef.value)) {
                 isObservableAnnotationPresent = true;
                 break;
@@ -914,7 +916,7 @@ class JvmObservabilityGen {
      * @param pkg The module for which the ID should be generated
      * @return The generated ID
      */
-    private String generatePackageId(BIRPackage pkg) {
-        return String.format("%s/%s:%s", pkg.org.value, pkg.name.value, pkg.version.value);
+    private String generatePackageId(PackageID pkg) {
+        return String.format("%s/%s:%s", pkg.orgName.value, pkg.name.value, pkg.version.value);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -152,20 +152,20 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodG
  */
 public class JvmTerminatorGen {
 
-    private MethodVisitor mv;
-    private BIRVarToJVMIndexMap indexMap;
-    private LabelGenerator labelGen;
-    private JvmErrorGen errorGen;
-    private String currentPackageName;
-    private String moduleInitClass;
-    private JvmPackageGen jvmPackageGen;
-    private JvmInstructionGen jvmInstructionGen;
-    private PackageCache packageCache;
-    private SymbolTable symbolTable;
-    private ResolvedTypeBuilder typeBuilder;
+    private final MethodVisitor mv;
+    private final BIRVarToJVMIndexMap indexMap;
+    private final LabelGenerator labelGen;
+    private final JvmErrorGen errorGen;
+    private final String currentPackageName;
+    private final String moduleInitClass;
+    private final JvmPackageGen jvmPackageGen;
+    private final JvmInstructionGen jvmInstructionGen;
+    private final PackageCache packageCache;
+    private final SymbolTable symbolTable;
+    private final ResolvedTypeBuilder typeBuilder;
 
     public JvmTerminatorGen(MethodVisitor mv, BIRVarToJVMIndexMap indexMap, LabelGenerator labelGen,
-                            JvmErrorGen errorGen, BIRNode.BIRPackage module, JvmInstructionGen jvmInstructionGen,
+                            JvmErrorGen errorGen, PackageID packageID, JvmInstructionGen jvmInstructionGen,
                             JvmPackageGen jvmPackageGen) {
 
         this.mv = mv;
@@ -176,9 +176,8 @@ public class JvmTerminatorGen {
         this.packageCache = jvmPackageGen.packageCache;
         this.jvmInstructionGen = jvmInstructionGen;
         this.symbolTable = jvmPackageGen.symbolTable;
-        this.currentPackageName = JvmCodeGenUtil.getPackageName(module);
-        this.moduleInitClass = JvmCodeGenUtil.getModuleLevelClassName(module.org.value, module.name.value,
-                                                                      module.version.value, MODULE_INIT_CLASS_NAME);
+        this.currentPackageName = JvmCodeGenUtil.getPackageName(packageID);
+        this.moduleInitClass = JvmCodeGenUtil.getModuleLevelClassName(packageID, MODULE_INIT_CLASS_NAME);
         this.typeBuilder = new ResolvedTypeBuilder();
     }
 
@@ -424,15 +423,8 @@ public class JvmTerminatorGen {
     }
 
     private void genCallTerm(BIRTerminator.Call callIns, int localVarOffset) {
-
-        PackageID calleePkgId = callIns.calleePkg;
-
-        String orgName = calleePkgId.orgName.value;
-        String moduleName = calleePkgId.name.value;
-        String version = calleePkgId.version.value;
-
         // invoke the function
-        this.genCall(callIns, orgName, moduleName, version, localVarOffset);
+        this.genCall(callIns, callIns.calleePkg, localVarOffset);
 
         // store return
         this.storeReturnFromCallIns(callIns.lhsOp != null ? callIns.lhsOp.variableDcl : null);
@@ -670,53 +662,52 @@ public class JvmTerminatorGen {
     }
 
 
-    private void genCall(BIRTerminator.Call callIns, String orgName, String moduleName,
-                             String version, int localVarOffset) {
+    private void genCall(BIRTerminator.Call callIns, PackageID packageID, int localVarOffset) {
 
         if (!callIns.isVirtual) {
-            this.genFuncCall(callIns, orgName, moduleName, version, localVarOffset);
+            this.genFuncCall(callIns, packageID, localVarOffset);
             return;
         }
 
         BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
         if (selfArg.type.tag == TypeTags.OBJECT) {
-            this.genVirtualCall(callIns, orgName, moduleName, localVarOffset);
+            this.genVirtualCall(callIns, JvmCodeGenUtil.isBallerinaBuiltinModule(
+                    packageID.orgName.getValue(), packageID.name.getValue()), localVarOffset);
         } else {
             // then this is a function attached to a built-in type
-            this.genBuiltinTypeAttachedFuncCall(callIns, orgName, moduleName, version, localVarOffset);
+            this.genBuiltinTypeAttachedFuncCall(callIns, packageID, localVarOffset);
         }
     }
 
-    private void genFuncCall(BIRTerminator.Call callIns, String orgName, String moduleName, String version,
-                             int localVarOffset) {
+    private void genFuncCall(BIRTerminator.Call callIns, PackageID packageID, int localVarOffset) {
         String methodName = callIns.name.value;
-        this.genStaticCall(callIns, orgName, moduleName, version, localVarOffset, methodName, methodName);
+        this.genStaticCall(callIns, packageID, localVarOffset, methodName, methodName);
     }
 
-    private void genBuiltinTypeAttachedFuncCall(BIRTerminator.Call callIns, String orgName,
-                                                String moduleName,  String version, int localVarOffset) {
+    private void genBuiltinTypeAttachedFuncCall(BIRTerminator.Call callIns, PackageID packageID, int localVarOffset) {
 
         String methodLookupName = callIns.name.value;
         int optionalIndex = methodLookupName.indexOf(".");
         int index = optionalIndex != -1 ? optionalIndex + 1 : 0;
         String methodName = methodLookupName.substring(index);
-        this.genStaticCall(callIns, orgName, moduleName, version, localVarOffset, methodName, methodLookupName);
+        this.genStaticCall(callIns, packageID, localVarOffset, methodName, methodLookupName);
     }
 
-    private void genStaticCall(BIRTerminator.Call callIns, String orgName, String moduleName,
-                               String version, int localVarOffset,
+    private void genStaticCall(BIRTerminator.Call callIns, PackageID packageID, int localVarOffset,
                                String methodName, String methodLookupName) {
         // load strand
         this.mv.visitVarInsn(ALOAD, localVarOffset);
         String encodedMethodName = IdentifierUtils.encodeFunctionIdentifier(methodLookupName);
-        String lookupKey = JvmCodeGenUtil.getPackageName(orgName, moduleName, version) + encodedMethodName;
+        String lookupKey = JvmCodeGenUtil.getPackageName(packageID) + encodedMethodName;
 
         int argsCount = callIns.args.size();
         int i = 0;
         while (i < argsCount) {
             BIROperand arg = callIns.args.get(i);
             boolean userProvidedArg = this.visitArg(arg);
-            this.loadBooleanArgToIndicateUserProvidedArg(orgName, moduleName, userProvidedArg);
+            this.loadBooleanArgToIndicateUserProvidedArg(
+                    JvmCodeGenUtil.isBallerinaBuiltinModule(packageID.orgName.getValue(), packageID.name.getValue()),
+                    userProvidedArg);
             i += 1;
         }
         BIRFunctionWrapper functionWrapper = jvmPackageGen.lookupBIRFunctionWrapper(lookupKey);
@@ -726,7 +717,8 @@ public class JvmTerminatorGen {
             jvmClass = functionWrapper.fullQualifiedClassName;
             methodDesc = functionWrapper.jvmMethodDescription;
         } else {
-            BPackageSymbol symbol = packageCache.getSymbol(orgName + "/" + moduleName);
+            BPackageSymbol symbol = packageCache.getSymbol(
+                    packageID.orgName.getValue() + "/" + packageID.name.getValue());
             Name decodedMethodName = new Name(IdentifierUtils.decodeIdentifier(methodName));
             BInvokableSymbol funcSymbol = (BInvokableSymbol) symbol.scope.lookup(decodedMethodName).symbol;
             BInvokableType type = (BInvokableType) funcSymbol.type;
@@ -744,7 +736,7 @@ public class JvmTerminatorGen {
                 balFileName = MODULE_INIT_CLASS_NAME;
             }
 
-            jvmClass = JvmCodeGenUtil.getModuleLevelClassName(orgName, moduleName, version,
+            jvmClass = JvmCodeGenUtil.getModuleLevelClassName(packageID,
                                                               JvmCodeGenUtil.cleanupPathSeparators(balFileName));
             //TODO: add receiver:  BType attachedType = type.r != null ? receiver.type : null;
             BType retType = typeBuilder.build(type.retType);
@@ -753,7 +745,7 @@ public class JvmTerminatorGen {
         this.mv.visitMethodInsn(INVOKESTATIC, jvmClass, encodedMethodName, methodDesc, false);
     }
 
-    private void genVirtualCall(BIRTerminator.Call callIns, String orgName, String moduleName, int localVarOffset) {
+    private void genVirtualCall(BIRTerminator.Call callIns, boolean isBuiltInModule, int localVarOffset) {
         // load self
         BIRNode.BIRVariableDcl selfArg = callIns.args.get(0).variableDcl;
         this.loadVar(selfArg);
@@ -792,7 +784,7 @@ public class JvmTerminatorGen {
             this.mv.visitInsn(L2I);
             j += 1;
 
-            this.loadBooleanArgToIndicateUserProvidedArg(orgName, moduleName, userProvidedArg);
+            this.loadBooleanArgToIndicateUserProvidedArg(isBuiltInModule, userProvidedArg);
             JvmCastGen.addBoxInsn(this.mv, symbolTable.booleanType);
             this.mv.visitInsn(AASTORE);
 
@@ -807,9 +799,8 @@ public class JvmTerminatorGen {
         JvmCastGen.addUnboxInsn(this.mv, returnType);
     }
 
-    private void loadBooleanArgToIndicateUserProvidedArg(String orgName, String moduleName, boolean userProvided) {
-
-        if (JvmCodeGenUtil.isBallerinaBuiltinModule(orgName, moduleName)) {
+    private void loadBooleanArgToIndicateUserProvidedArg(boolean isBuiltInModule, boolean userProvided) {
+        if (isBuiltInModule) {
             return;
         }
         // Extra boolean is not gen for extern functions for now until the wrapper function is implemented.
@@ -876,7 +867,8 @@ public class JvmTerminatorGen {
             this.mv.visitLdcInsn((long) paramIndex);
             this.mv.visitInsn(L2I);
 
-            this.loadBooleanArgToIndicateUserProvidedArg(orgName, moduleName, userProvidedArg);
+            this.loadBooleanArgToIndicateUserProvidedArg(JvmCodeGenUtil.isBallerinaBuiltinModule(orgName, moduleName),
+                                                         userProvidedArg);
             JvmCastGen.addBoxInsn(this.mv, symbolTable.booleanType);
             this.mv.visitInsn(AASTORE);
             paramIndex += 1;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -27,7 +27,6 @@ import org.objectweb.asm.MethodVisitor;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.AsyncDataCollector;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.BIRVarToJVMIndexMap;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.ScheduleFunctionInfo;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRTypeDefinition;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
@@ -61,7 +60,6 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.TypeFlags;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
 import org.wso2.ballerinalang.compiler.util.Name;
-import org.wso2.ballerinalang.compiler.util.ResolvedTypeBuilder;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -198,8 +196,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmValueGen.getTypeVal
  * @since 1.2.0
  */
 public class JvmTypeGen {
-
-    private static ResolvedTypeBuilder typeBuilder = new ResolvedTypeBuilder();
 
     /**
      * Create static fields to hold the user defined types.
@@ -449,7 +445,7 @@ public class JvmTypeGen {
     // -------------------------------------------------------
 
     static void generateValueCreatorMethods(ClassWriter cw, List<BIRTypeDefinition> typeDefs,
-                                            BIRNode.BIRPackage moduleId, String typeOwnerClass,
+                                            PackageID moduleId, String typeOwnerClass,
                                             SymbolTable symbolTable, AsyncDataCollector asyncDataCollector) {
 
         List<BIRTypeDefinition> recordTypeDefs = new ArrayList<>();
@@ -480,7 +476,7 @@ public class JvmTypeGen {
     }
 
     private static void generateRecordValueCreateMethod(ClassWriter cw, List<BIRTypeDefinition> recordTypeDefs,
-                                                        BIRNode.BIRPackage moduleId, String typeOwnerClass,
+                                                        PackageID moduleId, String typeOwnerClass,
                                                         AsyncDataCollector asyncDataCollector) {
         MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, CREATE_RECORD_VALUE,
                 String.format("(L%s;)L%s;", STRING_VALUE, MAP_VALUE),
@@ -539,7 +535,7 @@ public class JvmTypeGen {
     }
 
     private static void generateObjectValueCreateMethod(ClassWriter cw, List<BIRTypeDefinition> objectTypeDefs,
-                                                        BIRNode.BIRPackage moduleId, String typeOwnerClass,
+                                                        PackageID moduleId, String typeOwnerClass,
                                                         SymbolTable symbolTable,
                                                         AsyncDataCollector asyncDataCollector) {
 
@@ -1118,7 +1114,7 @@ public class JvmTypeGen {
      * @param bType type to load
      */
     public static void loadType(MethodVisitor mv, BType bType) {
-        String typeFieldName = "";
+        String typeFieldName;
         if (bType == null || bType.tag == TypeTags.NIL) {
             typeFieldName = "TYPE_NULL";
         } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmValueGen.java
@@ -28,6 +28,7 @@ import org.wso2.ballerinalang.compiler.bir.codegen.internal.AsyncDataCollector;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.FieldNameHashComparator;
 import org.wso2.ballerinalang.compiler.bir.codegen.internal.NameHashComparator;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.BIRFunctionWrapper;
+import org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JFieldFunctionWrapper;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.JMethodFunctionWrapper;
 import org.wso2.ballerinalang.compiler.bir.codegen.interop.OldStyleExternalFunctionWrapper;
@@ -131,7 +132,6 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmDesugarPhase.enrich
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.computeLockNameFromString;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmTypeGen.getTypeDesc;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.desugarOldExternFuncs;
-import static org.wso2.ballerinalang.compiler.bir.codegen.interop.ExternalMethodGen.lookupBIRFunctionWrapper;
 import static org.wso2.ballerinalang.compiler.bir.codegen.interop.InteropMethodGen.desugarInteropFuncs;
 
 /**
@@ -176,12 +176,13 @@ class JvmValueGen {
             BType bType = optionalTypeDef.type;
             if ((bType.tag == TypeTags.OBJECT && Symbols.isFlagOn(
                     bType.tsymbol.flags, Flags.CLASS)) || bType.tag == TypeTags.RECORD) {
-                desugarObjectMethods(module, bType, optionalTypeDef.attachedFuncs, initMethodGen, jvmPackageGen);
+                desugarObjectMethods(module.packageID, bType, optionalTypeDef.attachedFuncs, initMethodGen,
+                                     jvmPackageGen);
             }
         }
     }
 
-    private static void desugarObjectMethods(BIRNode.BIRPackage module, BType bType,
+    private static void desugarObjectMethods(PackageID module, BType bType,
                                              List<BIRNode.BIRFunction> attachedFuncs, InitMethodGen initMethodGen,
                                              JvmPackageGen jvmPackageGen) {
         if (attachedFuncs == null) {
@@ -192,7 +193,8 @@ class JvmValueGen {
                 continue;
             }
             if (JvmCodeGenUtil.isExternFunc(birFunc)) {
-                BIRFunctionWrapper extFuncWrapper = lookupBIRFunctionWrapper(module, birFunc, bType, jvmPackageGen);
+                BIRFunctionWrapper extFuncWrapper = ExternalMethodGen.lookupBIRFunctionWrapper(module, birFunc, bType,
+                                                                                               jvmPackageGen);
                 if (extFuncWrapper instanceof OldStyleExternalFunctionWrapper) {
                     desugarOldExternFuncs((OldStyleExternalFunctionWrapper) extFuncWrapper, birFunc, initMethodGen);
                 } else if (extFuncWrapper instanceof JMethodFunctionWrapper) {
@@ -221,7 +223,7 @@ class JvmValueGen {
         for (NamedNode node : nodes) {
             if (node != null) {
                 labels.add(i, new Label());
-                String name = decodeIdentifier(node.getName().value);;
+                String name = decodeIdentifier(node.getName().value);
                 hashCodes[i] = name.hashCode();
                 i += 1;
             }
@@ -252,32 +254,8 @@ class JvmValueGen {
         mv.visitInsn(ATHROW);
     }
 
-    static String getTypeDescClassName(Object module, String typeName) {
-
-        String packageName = calculateJavaPkgName(module);
+    static String getTypeDescClassName(String packageName, String typeName) {
         return packageName + TYPEDESC_CLASS_PREFIX + typeName;
-    }
-
-    static String getTypeValueClassName(Object module, String typeName) {
-
-        String packageName = calculateJavaPkgName(module);
-        return packageName + VALUE_CLASS_PREFIX + typeName;
-    }
-
-    private static String calculateJavaPkgName(Object module) {
-
-        String packageName;
-        if (module instanceof BIRNode.BIRPackage) {
-            BIRNode.BIRPackage birPackage = (BIRNode.BIRPackage) module;
-            packageName = JvmCodeGenUtil.getPackageName(birPackage);
-        } else if (module instanceof PackageID) {
-            PackageID packageID = (PackageID) module;
-            packageName = JvmCodeGenUtil.getPackageName(packageID);
-        } else {
-            throw new ClassCastException("module should be PackageID or BIRPackage but is : "
-                    + (module == null ? "null" : module.getClass()));
-        }
-        return packageName;
     }
 
     static List<Label> createDecodedLabelsForEqualCheck(MethodVisitor mv, int nameRegIndex,
@@ -640,6 +618,14 @@ class JvmValueGen {
         mv.visitEnd();
     }
 
+    static String getTypeValueClassName(PackageID packageID, String typeName) {
+        return getTypeValueClassName(JvmCodeGenUtil.getPackageName(packageID), typeName);
+    }
+
+    static String getTypeValueClassName(String packageName, String typeName) {
+        return packageName + VALUE_CLASS_PREFIX + typeName;
+    }
+
     private StringBuilder calcClosureMapSignature(int size) {
         StringBuilder closureParamSignature = new StringBuilder();
         for (int i = 0; i < size; i++) {
@@ -687,7 +673,7 @@ class JvmValueGen {
         this.createRecordInitWrapper(cw, className, typeDef);
         this.createLambdas(cw, asyncDataCollector);
         JvmCodeGenUtil.visitStrandMetadataField(cw, asyncDataCollector);
-        this.generateStaticInitializer(cw, className, module, asyncDataCollector);
+        this.generateStaticInitializer(cw, className, module.packageID, asyncDataCollector);
         cw.visitEnd();
 
         return jvmPackageGen.getBytes(cw, typeDef);
@@ -742,8 +728,8 @@ class JvmValueGen {
         mv.visitEnd();
     }
 
-    private void generateStaticInitializer(ClassWriter cw, String moduleClass, BIRNode.BIRPackage module,
-                                                  AsyncDataCollector asyncDataCollector) {
+    private void generateStaticInitializer(ClassWriter cw, String moduleClass, PackageID module,
+                                           AsyncDataCollector asyncDataCollector) {
 
         if (asyncDataCollector.getStrandMetadata().isEmpty()) {
             return;
@@ -1334,21 +1320,21 @@ class JvmValueGen {
     }
 
     void generateValueClasses(Map<String, byte[]> jarEntries) {
-
+        String packageName = JvmCodeGenUtil.getPackageName(module.packageID);
         module.typeDefs.parallelStream().forEach(optionalTypeDef -> {
             BType bType = optionalTypeDef.type;
             if (bType.tag == TypeTags.OBJECT && Symbols.isFlagOn(bType.tsymbol.flags, Flags.CLASS)) {
                 BObjectType objectType = (BObjectType) bType;
-                String className = getTypeValueClassName(this.module, optionalTypeDef.name.value);
+                String className = getTypeValueClassName(packageName, optionalTypeDef.name.value);
                 byte[] bytes = this.createObjectValueClass(objectType, className, optionalTypeDef);
                 jarEntries.put(className + ".class", bytes);
             } else if (bType.tag == TypeTags.RECORD) {
                 BRecordType recordType = (BRecordType) bType;
-                String className = getTypeValueClassName(this.module, optionalTypeDef.name.value);
+                String className = getTypeValueClassName(packageName, optionalTypeDef.name.value);
                 byte[] bytes = this.createRecordValueClass(recordType, className, optionalTypeDef);
                 jarEntries.put(className + ".class", bytes);
 
-                String typedescClass = getTypeDescClassName(this.module, optionalTypeDef.name.value);
+                String typedescClass = getTypeDescClassName(packageName, optionalTypeDef.name.value);
                 bytes = this.createRecordTypeDescClass(recordType, typedescClass, optionalTypeDef);
                 jarEntries.put(typedescClass + ".class", bytes);
             }
@@ -1378,7 +1364,7 @@ class JvmValueGen {
         this.createObjectSetOnInitializationMethod(cw, fields, className);
         this.createLambdas(cw, asyncDataCollector);
         JvmCodeGenUtil.visitStrandMetadataField(cw, asyncDataCollector);
-        this.generateStaticInitializer(cw, className, module, asyncDataCollector);
+        this.generateStaticInitializer(cw, className, module.packageID, asyncDataCollector);
 
         cw.visitEnd();
         return jvmPackageGen.getBytes(cw, typeDef);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/BIRFunctionWrapper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/BIRFunctionWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 
 /**
@@ -26,19 +27,14 @@ import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
  */
 public class BIRFunctionWrapper {
 
-    public String orgName;
-    public String moduleName;
-    public String version;
-    public BIRNode.BIRFunction func;
-    public String fullQualifiedClassName;
-    public String jvmMethodDescription;
+    public final PackageID packageID;
+    public final BIRNode.BIRFunction func;
+    public final String fullQualifiedClassName;
+    public final String jvmMethodDescription;
 
-    public BIRFunctionWrapper(String orgName, String moduleName, String version, BIRNode.BIRFunction func,
+    public BIRFunctionWrapper(PackageID packageID, BIRNode.BIRFunction func,
                               String fullQualifiedClassName, String jvmMethodDescription) {
-
-        this.orgName = orgName;
-        this.moduleName = moduleName;
-        this.version = version;
+        this.packageID = packageID;
         this.func = func;
         this.fullQualifiedClassName = fullQualifiedClassName;
         this.jvmMethodDescription = jvmMethodDescription;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropMethodGen.java
@@ -19,6 +19,7 @@
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
 import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -36,7 +37,6 @@ import org.wso2.ballerinalang.compiler.bir.codegen.methodgen.InitMethodGen;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRBasicBlock;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRFunction;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRPackage;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRVariableDcl;
 import org.wso2.ballerinalang.compiler.bir.model.BIROperand;
 import org.wso2.ballerinalang.compiler.bir.model.BIRTerminator;
@@ -124,11 +124,8 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmPackageGen.getFunct
  */
 public class InteropMethodGen {
 
-    static void genJFieldForInteropField(JFieldFunctionWrapper jFieldFuncWrapper,
-                                         ClassWriter classWriter,
-                                         BIRPackage birModule,
-                                         JvmPackageGen jvmPackageGen,
-                                         String moduleClassName,
+    static void genJFieldForInteropField(JFieldFunctionWrapper jFieldFuncWrapper, ClassWriter classWriter,
+                                         PackageID birModule, JvmPackageGen jvmPackageGen, String moduleClassName,
                                          AsyncDataCollector asyncDataCollector) {
 
         BIRVarToJVMIndexMap indexMap = new BIRVarToJVMIndexMap();
@@ -537,7 +534,6 @@ public class InteropMethodGen {
     }
 
     public static String getSignatureForJType(JType jType) {
-
         if (jType.jTag == JTypeTags.JREF) {
             return ((JType.JRefType) jType).typeValue;
         } else if (jType.jTag == JTypeTags.JARRAY) { //must be JArrayType
@@ -734,18 +730,14 @@ public class InteropMethodGen {
     static BIRFunctionWrapper createJInteropFunctionWrapper(InteropValidator interopValidator,
                                                             InteropValidationRequest jInteropValidationReq,
                                                             BIRFunction birFunc,
-                                                            String orgName,
-                                                            String moduleName,
-                                                            String version,
+                                                            PackageID packageID,
                                                             String birModuleClassName,
                                                             SymbolTable symbolTable) {
-
         if (interopValidator.isEntryModuleValidation()) {
             addDefaultableBooleanVarsToSignature(birFunc, symbolTable.booleanType);
         }
         // Update the function wrapper only for Java interop functions
-        BIRFunctionWrapper birFuncWrapper = getFunctionWrapper(birFunc, orgName, moduleName,
-                version, birModuleClassName);
+        BIRFunctionWrapper birFuncWrapper = getFunctionWrapper(birFunc, packageID, birModuleClassName);
         if (jInteropValidationReq instanceof InteropValidationRequest.MethodValidationRequest) {
             InteropValidationRequest.MethodValidationRequest methodValidationRequest =
                     ((InteropValidationRequest.MethodValidationRequest) jInteropValidationReq);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JFieldFunctionWrapper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JFieldFunctionWrapper.java
@@ -27,9 +27,8 @@ public class JFieldFunctionWrapper extends BIRFunctionWrapper implements Externa
     JavaField jField;
 
     JFieldFunctionWrapper(BIRFunctionWrapper functionWrapper, JavaField jField) {
-
-        super(functionWrapper.orgName, functionWrapper.moduleName, functionWrapper.version, functionWrapper.func,
-                functionWrapper.fullQualifiedClassName, functionWrapper.jvmMethodDescription);
+        super(functionWrapper.packageID, functionWrapper.func, functionWrapper.fullQualifiedClassName,
+              functionWrapper.jvmMethodDescription);
         this.jField = jField;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodFunctionWrapper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JMethodFunctionWrapper.java
@@ -28,8 +28,8 @@ public class JMethodFunctionWrapper extends BIRFunctionWrapper implements Extern
 
     JMethodFunctionWrapper(BIRFunctionWrapper functionWrapper, JMethod jMethod) {
 
-        super(functionWrapper.orgName, functionWrapper.moduleName, functionWrapper.version, functionWrapper.func,
-                functionWrapper.fullQualifiedClassName, functionWrapper.jvmMethodDescription);
+        super(functionWrapper.packageID, functionWrapper.func, functionWrapper.fullQualifiedClassName,
+              functionWrapper.jvmMethodDescription);
         this.jMethod = jMethod;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JavaMethodCall.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JavaMethodCall.java
@@ -42,7 +42,6 @@ public class JavaMethodCall extends BIRTerminator {
                           BIROperand lhsOp, String jClassName, String jMethodVMSig, String name, BIRBasicBlock thenBB) {
 
         super(pos, kind);
-        this.pos = pos;
         this.args = args;
         this.kind = kind;
         this.lhsOp = lhsOp;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/OldStyleExternalFunctionWrapper.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/OldStyleExternalFunctionWrapper.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.bir.codegen.interop;
 
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 
@@ -33,11 +34,11 @@ public class OldStyleExternalFunctionWrapper extends BIRFunctionWrapper implemen
     List<BType> jMethodPramTypes;
     String jMethodVMSig;
 
-    public OldStyleExternalFunctionWrapper(String orgName, String moduleName, String version, BIRNode.BIRFunction func,
+    public OldStyleExternalFunctionWrapper(PackageID packageID, BIRNode.BIRFunction func,
                                            String fullQualifiedClassName, String jvmMethodDescription,
                                            String jClassName, List<BType> jMethodPramTypes, String jMethodVMSig) {
 
-        super(orgName, moduleName, version, func, fullQualifiedClassName, jvmMethodDescription);
+        super(packageID, func, fullQualifiedClassName, jvmMethodDescription);
 
         this.jClassName = jClassName;
         this.jMethodPramTypes = jMethodPramTypes;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
@@ -78,10 +78,9 @@ public class ConfigMethodGen {
 
     public void generateConfigInit(List<PackageID> imprtMods, BIRNode.BIRPackage pkg, String moduleInitClass,
                                    Map<String, byte[]> jarEntries) {
-        String innerClassName = JvmCodeGenUtil
-                .getModuleLevelClassName(pkg.org.value, pkg.name.value, pkg.version.value, CONFIGURATION_CLASS_NAME);
+        String innerClassName = JvmCodeGenUtil.getModuleLevelClassName(pkg.packageID, CONFIGURATION_CLASS_NAME);
         ClassWriter cw = new BallerinaClassWriter(COMPUTE_FRAMES);
-        cw.visit(V1_8,  ACC_PUBLIC | ACC_SUPER, innerClassName, null, OBJECT, null);
+        cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, innerClassName, null, OBJECT, null);
 
         MethodVisitor mv = cw.visitMethod(ACC_PRIVATE, JVM_INIT_METHOD, "()V", null, null);
         mv.visitCode();
@@ -103,7 +102,7 @@ public class ConfigMethodGen {
             generateInvokeConfiguration(mv, id);
         }
 
-        generateInvokeConfiguration(mv, MethodGenUtils.packageToModuleId(pkg));
+        generateInvokeConfiguration(mv, pkg.packageID);
         initializeConfigVariables(mv);
 
         mv.visitInsn(RETURN);
@@ -118,10 +117,8 @@ public class ConfigMethodGen {
 
 
     private void generateInvokeConfiguration(MethodVisitor mv, PackageID id) {
-        String moduleClass = JvmCodeGenUtil.getModuleLevelClassName(id.orgName.value, id.name.value, id.version.value,
-                CONFIGURATION_CLASS_NAME);
-        String initClass = JvmCodeGenUtil.getModuleLevelClassName(id.orgName.value, id.name.value, id.version.value,
-                MODULE_INIT_CLASS_NAME);
+        String moduleClass = JvmCodeGenUtil.getModuleLevelClassName(id, CONFIGURATION_CLASS_NAME);
+        String initClass = JvmCodeGenUtil.getModuleLevelClassName(id, MODULE_INIT_CLASS_NAME);
 
         mv.visitMethodInsn(INVOKESTATIC, moduleClass, POPULATE_CONFIG_DATA_METHOD,
                 String.format("()[L%s;", VARIABLE_KEY), false);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/FrameClassGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/FrameClassGen.java
@@ -18,6 +18,7 @@
 
 package org.wso2.ballerinalang.compiler.bir.codegen.methodgen;
 
+import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Opcodes;
@@ -43,7 +44,8 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
 public class FrameClassGen {
 
     public void generateFrameClasses(BIRNode.BIRPackage pkg, Map<String, byte[]> pkgEntries) {
-        pkg.functions.parallelStream().forEach(func -> generateFrameClassForFunction(pkg, func, pkgEntries, null));
+        pkg.functions.parallelStream().forEach(
+                func -> generateFrameClassForFunction(pkg.packageID, func, pkgEntries, null));
 
         for (BIRNode.BIRTypeDefinition typeDef : pkg.typeDefs) {
             List<BIRNode.BIRFunction> attachedFuncs = typeDef.attachedFuncs;
@@ -59,17 +61,16 @@ public class FrameClassGen {
             } else {
                 attachedType = typeDef.type;
             }
-            attachedFuncs.parallelStream().forEach(func ->
-                                                           generateFrameClassForFunction(pkg, func, pkgEntries,
-                                                                                         attachedType));
+            attachedFuncs.parallelStream().forEach(func -> generateFrameClassForFunction(
+                    pkg.packageID, func, pkgEntries, attachedType));
         }
     }
 
-    private void generateFrameClassForFunction(BIRNode.BIRPackage pkg, BIRNode.BIRFunction func,
+    private void generateFrameClassForFunction(PackageID packageID, BIRNode.BIRFunction func,
                                                Map<String, byte[]> pkgEntries,
                                                BType attachedType) {
-        String frameClassName = MethodGenUtils.getFrameClassName(JvmCodeGenUtil.getPackageName(pkg), func.name.value,
-                                                                 attachedType);
+        String frameClassName = MethodGenUtils.getFrameClassName(JvmCodeGenUtil.getPackageName(packageID),
+                                                                 func.name.value, attachedType);
         ClassWriter cw = new BallerinaClassWriter(COMPUTE_FRAMES);
         if (func.pos != null && func.pos.lineRange().filePath() != null) {
             cw.visitSource(func.pos.lineRange().filePath(), null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/InitMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/InitMethodGen.java
@@ -105,7 +105,7 @@ public class InitMethodGen {
         generateLambdaForModuleFunction(cw, MODULE_START, initClass);
 
         MethodVisitor mv = visitFunction(cw, MethodGenUtils
-                .calculateLambdaStopFuncName(MethodGenUtils.packageToModuleId(pkg)));
+                .calculateLambdaStopFuncName(pkg.packageID));
 
         invokeStopFunction(initClass, mv);
 
@@ -167,9 +167,9 @@ public class InitMethodGen {
         mv.visitInsn(DUP);
         mv.visitMethodInsn(INVOKESPECIAL, typeOwnerClass, JVM_INIT_METHOD, "()V", false);
         mv.visitVarInsn(ASTORE, 1);
-        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(module.org.value));
-        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(module.name.value));
-        mv.visitLdcInsn(module.version.value);
+        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(module.packageID.orgName.getValue()));
+        mv.visitLdcInsn(IdentifierUtils.decodeIdentifier(module.packageID.name.getValue()));
+        mv.visitLdcInsn(module.packageID.version.getValue());
         mv.visitVarInsn(ALOAD, 1);
         mv.visitMethodInsn(INVOKESTATIC, String.format("%s", VALUE_CREATOR), "addValueCreator",
                            String.format("(L%s;L%s;L%s;L%s;)V", STRING_VALUE, STRING_VALUE, STRING_VALUE,
@@ -181,18 +181,16 @@ public class InitMethodGen {
         MethodGenUtils.visitReturn(mv);
     }
 
-    public void addInitAndTypeInitInstructions(BIRNode.BIRPackage pkg, BIRNode.BIRFunction func) {
+    public void addInitAndTypeInitInstructions(PackageID packageID, BIRNode.BIRFunction func) {
         List<BIRNode.BIRBasicBlock> basicBlocks = new ArrayList<>();
         nextId = -1;
         BIRNode.BIRBasicBlock nextBB = new BIRNode.BIRBasicBlock(getNextBBId());
         basicBlocks.add(nextBB);
 
-        PackageID modID = MethodGenUtils.packageToModuleId(pkg);
-
         BIRNode.BIRBasicBlock typeOwnerCreateBB = new BIRNode.BIRBasicBlock(getNextBBId());
         basicBlocks.add(typeOwnerCreateBB);
 
-        nextBB.terminator = new BIRTerminator.Call(null, InstructionKind.CALL, false, modID,
+        nextBB.terminator = new BIRTerminator.Call(null, InstructionKind.CALL, false, packageID,
                                                    new Name(CURRENT_MODULE_INIT),
                                                    new ArrayList<>(), null, typeOwnerCreateBB, Collections.emptyList(),
                                                    Collections.emptySet());
@@ -247,9 +245,8 @@ public class InitMethodGen {
             addCheckedInvocation(modInitFunc, id, initFuncName, retVarRef, boolRef);
         }
 
-        PackageID currentModId = MethodGenUtils.packageToModuleId(pkg);
         String currentInitFuncName = MethodGenUtils.encodeModuleSpecialFuncName(initName);
-        BIRNode.BIRBasicBlock lastBB = addCheckedInvocation(modInitFunc, currentModId, currentInitFuncName, retVarRef,
+        BIRNode.BIRBasicBlock lastBB = addCheckedInvocation(modInitFunc, pkg.packageID, currentInitFuncName, retVarRef,
                                                             boolRef);
 
         lastBB.terminator = new BIRTerminator.Return(null);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/LambdaGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/LambdaGen.java
@@ -112,9 +112,8 @@ public class LambdaGen {
             if (balFileName == null || !balFileName.endsWith(JvmConstants.BAL_EXTENSION)) {
                 balFileName = JvmConstants.MODULE_INIT_CLASS_NAME;
             }
-            jvmClass = JvmCodeGenUtil.getModuleLevelClassName(lambdaDetails.orgName, lambdaDetails.moduleName,
-                                                              lambdaDetails.version, JvmCodeGenUtil
-                                                                      .cleanupPathSeparators(balFileName));
+            jvmClass = JvmCodeGenUtil.getModuleLevelClassName(lambdaDetails.packageID, JvmCodeGenUtil
+                    .cleanupPathSeparators(balFileName));
         }
         mv.visitMethodInsn(INVOKESTATIC, jvmClass, lambdaDetails.encodedFuncName, methodDesc, false);
         JvmCastGen.addBoxInsn(mv, lambdaDetails.returnType);
@@ -130,8 +129,8 @@ public class LambdaGen {
     }
 
     private void handleLambdaVirtual(BIRTerminator.AsyncCall ins, LambdaDetails lambdaDetails, MethodVisitor mv) {
-        boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(lambdaDetails.orgName,
-                                                                          lambdaDetails.moduleName);
+        boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(lambdaDetails.packageID.orgName.getValue(),
+                                                                          lambdaDetails.packageID.name.getValue());
         List<BIROperand> paramTypes = ins.args;
         genLoadDataForObjectAttachedLambdas(ins, mv, lambdaDetails.closureMapsCount, paramTypes,
                                             isBuiltinModule);
@@ -184,8 +183,8 @@ public class LambdaGen {
     }
 
     private void handleAsyncNonVirtual(LambdaDetails lambdaDetails, MethodVisitor mv, List<BType> paramBTypes) {
-        boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(lambdaDetails.orgName,
-                                                                          lambdaDetails.moduleName);
+        boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(lambdaDetails.packageID.orgName.getValue(),
+                                                                          lambdaDetails.packageID.name.getValue());
         List<BType> paramTypes = getFpParamTypes(lambdaDetails);
         // load and cast param values= asyncIns.args;
         int argIndex = 1;
@@ -247,8 +246,9 @@ public class LambdaGen {
             paramIndex += 1;
             argIndex += 1;
 
-            boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(lambdaDetails.orgName,
-                                                                              lambdaDetails.moduleName);
+            boolean isBuiltinModule = JvmCodeGenUtil.isBallerinaBuiltinModule(
+                    lambdaDetails.packageID.orgName.getValue(),
+                    lambdaDetails.packageID.name.getValue());
             if (!isBuiltinModule) {
                 addBooleanTypeToLambdaParamTypes(mv, lambdaDetails.closureMapsCount, argIndex);
                 paramBTypes.add(paramIndex - 1, symbolTable.booleanType);
@@ -351,9 +351,7 @@ public class LambdaGen {
     private LambdaDetails populateAsyncLambdaDetails(BIRTerminator.AsyncCall asyncIns) {
         LambdaDetails lambdaDetails = new LambdaDetails();
         lambdaDetails.lhsType = asyncIns.lhsOp != null ? asyncIns.lhsOp.variableDcl.type : null;
-        lambdaDetails.orgName = asyncIns.calleePkg.orgName.value;
-        lambdaDetails.moduleName = asyncIns.calleePkg.name.value;
-        lambdaDetails.version = asyncIns.calleePkg.version.value;
+        lambdaDetails.packageID = asyncIns.calleePkg;
         lambdaDetails.funcName = asyncIns.name.getValue();
         if (!asyncIns.isVirtual) {
             populateLambdaFunctionDetails(lambdaDetails);
@@ -364,9 +362,7 @@ public class LambdaGen {
     private LambdaDetails populateFpLambdaDetails(BIRNonTerminator.FPLoad fpIns) {
         LambdaDetails lambdaDetails = new LambdaDetails();
         lambdaDetails.lhsType = fpIns.lhsOp.variableDcl.type;
-        lambdaDetails.orgName = fpIns.pkgId.orgName.value;
-        lambdaDetails.moduleName = fpIns.pkgId.name.value;
-        lambdaDetails.version = fpIns.pkgId.version.value;
+        lambdaDetails.packageID = fpIns.pkgId;
         lambdaDetails.funcName = fpIns.funcName.getValue();
         lambdaDetails.closureMapsCount = fpIns.closureMaps.size();
         populateLambdaFunctionDetails(lambdaDetails);
@@ -375,12 +371,12 @@ public class LambdaGen {
 
     private void populateLambdaFunctionDetails(LambdaDetails lambdaDetails) {
         lambdaDetails.encodedFuncName = IdentifierUtils.encodeFunctionIdentifier(lambdaDetails.funcName);
-        lambdaDetails.lookupKey = JvmCodeGenUtil.getPackageName(
-                lambdaDetails.orgName, lambdaDetails.moduleName, lambdaDetails.version) + lambdaDetails.encodedFuncName;
+        lambdaDetails.lookupKey = JvmCodeGenUtil.getPackageName(lambdaDetails.packageID) +
+                lambdaDetails.encodedFuncName;
         lambdaDetails.functionWrapper = jvmPackageGen.lookupBIRFunctionWrapper(lambdaDetails.lookupKey);
         if (lambdaDetails.functionWrapper == null) {
             BPackageSymbol symbol = jvmPackageGen.packageCache.getSymbol(
-                    lambdaDetails.orgName + "/" + lambdaDetails.moduleName);
+                    lambdaDetails.packageID.orgName + "/" + lambdaDetails.packageID.name);
             lambdaDetails.funcSymbol = (BInvokableSymbol) symbol.scope.lookup(
                     new Name(lambdaDetails.funcName)).symbol;
         }
@@ -438,9 +434,7 @@ public class LambdaGen {
 
     private static class LambdaDetails {
         BType lhsType;
-        String orgName;
-        String moduleName;
-        String version;
+        PackageID packageID;
         String funcName;
         boolean isExternFunction;
         String encodedFuncName = null;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -18,6 +18,7 @@
 
 package org.wso2.ballerinalang.compiler.bir.codegen.methodgen;
 
+import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -99,7 +100,7 @@ public class MainMethodGen {
 
         // set system properties
         initConfigurations(mv);
-        invokeConfigInit(mv, pkg);
+        invokeConfigInit(mv, pkg.packageID);
         // start all listeners
         startListeners(mv, serviceEPAvailable);
 
@@ -107,7 +108,8 @@ public class MainMethodGen {
         // register a shutdown hook to call package stop() method.
         genShutdownHook(mv, initClass);
 
-        if (MethodGenUtils.hasInitFunction(pkg)) {
+        boolean hasInitFunction = MethodGenUtils.hasInitFunction(pkg);
+        if (hasInitFunction) {
             generateMethodCall(initClass, asyncDataCollector, mv, JvmConstants.MODULE_INIT,
                                MethodGenUtils.INIT_FUNCTION_SUFFIX, INIT_FUTURE_VAR);
         }
@@ -116,7 +118,7 @@ public class MainMethodGen {
             generateUserMainFunctionCall(userMainFunc, initClass, asyncDataCollector, mv);
         }
 
-        if (MethodGenUtils.hasInitFunction(pkg)) {
+        if (hasInitFunction) {
             generateMethodCall(initClass, asyncDataCollector, mv, JvmConstants.MODULE_START, "start", START_FUTURE_VAR);
             setListenerFound(mv, serviceEPAvailable);
         }
@@ -150,8 +152,8 @@ public class MainMethodGen {
         mv.visitMethodInsn(INVOKEVIRTUAL, JvmConstants.SCHEDULER, JvmConstants.SCHEDULER_START_METHOD, "()V", false);
     }
 
-    private void invokeConfigInit(MethodVisitor mv, BIRNode.BIRPackage module) {
-        String configClass = JvmCodeGenUtil.getModuleLevelClassName(module, CONFIGURATION_CLASS_NAME);
+    private void invokeConfigInit(MethodVisitor mv, PackageID packageID) {
+        String configClass = JvmCodeGenUtil.getModuleLevelClassName(packageID, CONFIGURATION_CLASS_NAME);
         mv.visitVarInsn(ALOAD, 0);
         mv.visitMethodInsn(INVOKESTATIC, configClass, CONFIGURE_INIT, "()V", false);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -19,6 +19,7 @@
 package org.wso2.ballerinalang.compiler.bir.codegen.methodgen;
 
 import org.ballerinalang.compiler.BLangCompilerException;
+import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
@@ -175,7 +176,7 @@ public class MethodGen {
         MethodVisitor mv = cw.visitMethod(access, funcName, desc, null, null);
         mv.visitCode();
 
-        visitModuleStartFunction(module, funcName, mv);
+        visitModuleStartFunction(module.packageID, funcName, mv);
 
         Label methodStartLabel = new Label();
         mv.visitLabel(methodStartLabel);
@@ -207,9 +208,9 @@ public class MethodGen {
 
         addCasesForBasicBlocks(func, funcName, labelGen, labels, states);
 
-        JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, module, jvmPackageGen);
+        JvmInstructionGen instGen = new JvmInstructionGen(mv, indexMap, module.packageID, jvmPackageGen);
         JvmErrorGen errorGen = new JvmErrorGen(mv, indexMap, instGen);
-        JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, module, instGen,
+        JvmTerminatorGen termGen = new JvmTerminatorGen(mv, indexMap, labelGen, errorGen, module.packageID, instGen,
                                                         jvmPackageGen);
 
         mv.visitVarInsn(ILOAD, stateVarIndex);
@@ -219,7 +220,7 @@ public class MethodGen {
         generateBasicBlocks(mv, labelGen, errorGen, instGen, termGen, func, returnVarRefIndex,
                             stateVarIndex, localVarOffset, module, attachedType, moduleClassName, asyncDataCollector);
         mv.visitLabel(resumeLabel);
-        String frameName = MethodGenUtils.getFrameClassName(JvmCodeGenUtil.getPackageName(module), funcName,
+        String frameName = MethodGenUtils.getFrameClassName(JvmCodeGenUtil.getPackageName(module.packageID), funcName,
                                                             attachedType);
         genGetFrameOnResumeIndex(localVarOffset, mv, frameName);
 
@@ -260,12 +261,12 @@ public class MethodGen {
         return retType;
     }
 
-    private void visitModuleStartFunction(BIRPackage module, String funcName, MethodVisitor mv) {
+    private void visitModuleStartFunction(PackageID packageID, String funcName, MethodVisitor mv) {
         if (!isModuleStartFunction(funcName)) {
             return;
         }
         mv.visitInsn(ICONST_1);
-        mv.visitFieldInsn(PUTSTATIC, JvmCodeGenUtil.getModuleLevelClassName(module, MODULE_INIT_CLASS_NAME),
+        mv.visitFieldInsn(PUTSTATIC, JvmCodeGenUtil.getModuleLevelClassName(packageID, MODULE_INIT_CLASS_NAME),
                           MODULE_START_ATTEMPTED, "Z");
     }
 
@@ -489,13 +490,13 @@ public class MethodGen {
         JvmCodeGenUtil.generateDiagnosticPos(terminator.pos, mv);
         if ((MethodGenUtils.isModuleInitFunction(func) || isModuleTestInitFunction(func)) &&
                 terminator instanceof Return) {
-            generateAnnotLoad(mv, module.typeDefs, JvmCodeGenUtil.getPackageName(module), localVarOffset);
+            generateAnnotLoad(mv, module.typeDefs, JvmCodeGenUtil.getPackageName(module.packageID), localVarOffset);
         }
         //set module start success to true for $_init class
         if (isModuleStartFunction(funcName) && terminator.kind == InstructionKind.RETURN) {
             mv.visitInsn(ICONST_1);
             mv.visitFieldInsn(PUTSTATIC,
-                              JvmCodeGenUtil.getModuleLevelClassName(module, MODULE_INIT_CLASS_NAME),
+                              JvmCodeGenUtil.getModuleLevelClassName(module.packageID, MODULE_INIT_CLASS_NAME),
                               MODULE_STARTED, "Z");
         }
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGenUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGenUtils.java
@@ -66,10 +66,6 @@ public class MethodGenUtils {
         return func.name.value.equals(encodeModuleSpecialFuncName(INIT_FUNCTION_SUFFIX));
     }
 
-    static PackageID packageToModuleId(BIRNode.BIRPackage mod) {
-        return new PackageID(mod.org, mod.name, mod.version);
-    }
-
     static void submitToScheduler(MethodVisitor mv, String moduleClassName,
                                    String workerName, AsyncDataCollector asyncDataCollector) {
         String metaDataVarName = JvmCodeGenUtil.getStrandMetadataVarName("main");

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ModuleStopMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ModuleStopMethodGen.java
@@ -105,9 +105,8 @@ public class ModuleStopMethodGen {
         mv.visitMethodInsn(INVOKESPECIAL, SCHEDULER, JVM_INIT_METHOD, "(IZ)V", false);
         mv.visitVarInsn(ASTORE, schedulerIndex);
 
-        PackageID currentModId = MethodGenUtils.packageToModuleId(module);
-        String moduleInitClass = getModuleInitClassName(currentModId);
-        String fullFuncName = MethodGenUtils.calculateLambdaStopFuncName(currentModId);
+        String moduleInitClass = getModuleInitClassName(module.packageID);
+        String fullFuncName = MethodGenUtils.calculateLambdaStopFuncName(module.packageID);
         String lambdaName = generateStopDynamicListenerLambdaBody(cw);
         generateCallStopDynamicListenersLambda(mv, lambdaName, moduleInitClass, asyncDataCollector);
         scheduleStopLambda(mv, initClass, fullFuncName, moduleInitClass, asyncDataCollector);
@@ -242,8 +241,7 @@ public class ModuleStopMethodGen {
     }
 
     private String getModuleInitClassName(PackageID id) {
-        return JvmCodeGenUtil.getModuleLevelClassName(id.orgName.value, id.name.value, id.version.value,
-                                                      MODULE_INIT_CLASS_NAME);
+        return JvmCodeGenUtil.getModuleLevelClassName(id, MODULE_INIT_CLASS_NAME);
     }
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
@@ -73,11 +73,11 @@ public class BIREmitter {
         modStr += emitLBreaks(1);
         modStr += "module";
         modStr += emitSpaces(1);
-        modStr += emitName(mod.org) + "/" + emitName(mod.name);
+        modStr += emitName(mod.packageID.orgName) + "/" + emitName(mod.packageID.name);
         modStr += emitSpaces(1);
         modStr += "v";
         modStr += emitSpaces(1);
-        modStr += emitName(mod.version) + ";";
+        modStr += emitName(mod.packageID.version) + ";";
         modStr += emitLBreaks(2);
         modStr += emitImports(mod.importModules);
         modStr += emitLBreaks(2);
@@ -105,13 +105,13 @@ public class BIREmitter {
     private String emitImport(BIRNode.BIRImportModule impMod) {
 
         String impStr = "import ";
-        impStr += emitName(impMod.org) + "/";
-        impStr += emitName(impMod.name);
-        if (!isEmpty(impMod.version)) {
+        impStr += emitName(impMod.packageID.orgName) + "/";
+        impStr += emitName(impMod.packageID.name);
+        if (!isEmpty(impMod.packageID.version)) {
             impStr += emitSpaces(1);
             impStr += "v";
             impStr += emitSpaces(1);
-            impStr += emitName(impMod.version);
+            impStr += emitName(impMod.packageID.version);
         }
         impStr += ";";
         return impStr;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -15,6 +15,7 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
+
 package org.wso2.ballerinalang.compiler.bir.model;
 
 import io.ballerina.tools.diagnostics.Location;
@@ -40,9 +41,9 @@ import java.util.TreeSet;
  * @since 0.980.0
  */
 public abstract class BIRNode {
-    public Location pos;
+    public final Location pos;
 
-    public BIRNode(Location pos) {
+    protected BIRNode(Location pos) {
         this.pos = pos;
     }
 
@@ -54,24 +55,18 @@ public abstract class BIRNode {
      * @since 0.980.0
      */
     public static class BIRPackage extends BIRNode {
-        public Name org;
-        public Name name;
-        public Name version;
-        public Name sourceFileName;
-        public List<BIRImportModule> importModules;
-        public List<BIRTypeDefinition> typeDefs;
-        public List<BIRGlobalVariableDcl> globalVars;
-        public List<BIRFunction> functions;
-        public List<BIRAnnotation> annotations;
-        public List<BIRConstant> constants;
+        public final PackageID packageID;
+        public final List<BIRImportModule> importModules;
+        public final List<BIRTypeDefinition> typeDefs;
+        public final List<BIRGlobalVariableDcl> globalVars;
+        public final List<BIRFunction> functions;
+        public final List<BIRAnnotation> annotations;
+        public final List<BIRConstant> constants;
 
         public BIRPackage(Location pos, Name org, Name name, Name version,
                           Name sourceFileName) {
             super(pos);
-            this.org = org;
-            this.name = name;
-            this.version = version;
-            this.sourceFileName = sourceFileName;
+            packageID = new PackageID(org, name, version, sourceFileName);
             this.importModules = new ArrayList<>();
             this.typeDefs = new ArrayList<>();
             this.globalVars = new ArrayList<>();
@@ -84,10 +79,6 @@ public abstract class BIRNode {
         public void accept(BIRVisitor visitor) {
             visitor.visit(this);
         }
-
-        public Name getSourceFileName() {
-            return sourceFileName;
-        }
     }
 
     /**
@@ -96,15 +87,11 @@ public abstract class BIRNode {
      * @since 0.990.0
      */
     public static class BIRImportModule extends BIRNode {
-        public Name org;
-        public Name name;
-        public Name version;
+        public final PackageID packageID;
 
         public BIRImportModule(Location pos, Name org, Name name, Name version) {
             super(pos);
-            this.org = org;
-            this.name = name;
-            this.version = version;
+            packageID = new PackageID(org, name, version);
         }
 
         @Override
@@ -461,7 +448,7 @@ public abstract class BIRNode {
 
         @Override
         public String toString() {
-            return String.valueOf(type) + " " + String.valueOf(name);
+            return type + " " + name;
         }
 
         @Override
@@ -652,7 +639,7 @@ public abstract class BIRNode {
     public abstract static class BIRAnnotationValue {
         public BType type;
 
-        public BIRAnnotationValue(BType type) {
+        protected BIRAnnotationValue(BType type) {
             this.type = type;
         }
     }
@@ -737,7 +724,7 @@ public abstract class BIRNode {
     public abstract static class BIRDocumentableNode extends BIRNode {
         public MarkdownDocAttachment markdownDocAttachment;
 
-        public BIRDocumentableNode(Location pos) {
+        protected BIRDocumentableNode(Location pos) {
             super(pos);
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -22,6 +22,7 @@ import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.model.elements.AttachPoint;
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationArrayValue;
 import org.wso2.ballerinalang.compiler.bir.model.BIRNode.BIRAnnotationAttachment;
@@ -68,7 +69,7 @@ public class BIRBinaryWriter {
 
 
         // Write the package details in the form of constant pool entry
-        birbuf.writeInt(BIRWriterUtils.addPkgCPEntry(this.birPackage, this.cp));
+        birbuf.writeInt(BIRWriterUtils.addPkgCPEntry(birPackage.packageID, this.cp));
 
         //Write import module declarations
         writeImportModuleDecls(birbuf, birPackage.importModules);
@@ -101,9 +102,10 @@ public class BIRBinaryWriter {
     private void writeImportModuleDecls(ByteBuf buf, List<BIRNode.BIRImportModule> birImpModList) {
         buf.writeInt(birImpModList.size());
         birImpModList.forEach(impMod -> {
-            buf.writeInt(addStringCPEntry(impMod.org.value));
-            buf.writeInt(addStringCPEntry(impMod.name.value));
-            buf.writeInt(addStringCPEntry(impMod.version.value));
+            PackageID packageID =  impMod.packageID;
+            buf.writeInt(addStringCPEntry(packageID.orgName.getValue()));
+            buf.writeInt(addStringCPEntry(packageID.name.getValue()));
+            buf.writeInt(addStringCPEntry(packageID.version.getValue()));
         });
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
@@ -514,8 +514,7 @@ public class BIRInstructionWriter extends BIRVisitor {
     }
 
     int addPkgCPEntry(PackageID packageID) {
-        return BIRWriterUtils
-                .addPkgCPEntry(packageID.orgName.value, packageID.name.value, packageID.version.value, this.cp);
+        return BIRWriterUtils.addPkgCPEntry(packageID, this.cp);
     }
 
     // private methods

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRWriterUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRWriterUtils.java
@@ -22,7 +22,6 @@ package org.wso2.ballerinalang.compiler.bir.writer;
 import io.ballerina.tools.diagnostics.Location;
 import io.netty.buffer.ByteBuf;
 import org.ballerinalang.model.elements.PackageID;
-import org.wso2.ballerinalang.compiler.bir.model.BIRNode;
 
 /**
  * Common functions used in BIR writers.
@@ -57,18 +56,10 @@ public class BIRWriterUtils {
         return cp.addCPEntry(new CPEntry.StringCPEntry(value));
     }
 
-    public static int addPkgCPEntry(String orgName, String name, String version, ConstantPool cp) {
-        int orgCPIndex = addStringCPEntry(orgName, cp);
-        int nameCPIndex = addStringCPEntry(name, cp);
-        int versionCPIndex = addStringCPEntry(version, cp);
-        return cp.addCPEntry(new CPEntry.PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
-    }
-
-    public static int addPkgCPEntry(BIRNode.BIRPackage birPackage, ConstantPool cp) {
-        return addPkgCPEntry(birPackage.org.value, birPackage.name.value, birPackage.version.value, cp);
-    }
-
     public static int addPkgCPEntry(PackageID packageID, ConstantPool cp) {
-        return addPkgCPEntry(packageID.orgName.value, packageID.name.value, packageID.version.value, cp);
+        int orgCPIndex = addStringCPEntry(packageID.orgName.getValue(), cp);
+        int nameCPIndex = addStringCPEntry(packageID.name.getValue(), cp);
+        int versionCPIndex = addStringCPEntry(packageID.version.getValue(), cp);
+        return cp.addCPEntry(new CPEntry.PackageCPEntry(orgCPIndex, nameCPIndex, versionCPIndex));
     }
 }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BCompileUtil.java
@@ -171,9 +171,7 @@ public class BCompileUtil {
 
         BIRNode.BIRPackage birPackage = bLangPackage.symbol.bir;
 
-        String initClassName = BFileUtil.getQualifiedClassName(birPackage.org.value,
-                                                               birPackage.name.value,
-                                                               birPackage.version.value,
+        String initClassName = BFileUtil.getQualifiedClassName(birPackage.packageID,
                                                                TestConstant.MODULE_INIT_CLASS_NAME);
         Class<?> initClazz = classLoader.loadClass(initClassName);
         final Scheduler scheduler = new Scheduler(false);
@@ -621,10 +619,7 @@ public class BCompileUtil {
     public static ExitDetails run(CompileResult compileResult, String[] args) {
 
         BIRNode.BIRPackage compiledPkg = ((BLangPackage) compileResult.getAST()).symbol.bir;
-        String initClassName = BFileUtil.getQualifiedClassName(compiledPkg.org.value,
-                                                               compiledPkg.name.value,
-                                                               compiledPkg.version.value,
-                                                               MODULE_INIT_CLASS_NAME);
+        String initClassName = BFileUtil.getQualifiedClassName(compiledPkg.packageID, MODULE_INIT_CLASS_NAME);
         URLClassLoader classLoader = compileResult.classLoader;
 
         try {

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.util;
 
 import io.ballerina.runtime.internal.IdentifierUtils;
 import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.io.BufferedReader;
@@ -124,19 +125,18 @@ public class BFileUtil {
     /**
      * Provides Qualified Class Name.
      *
-     * @param orgName     Org name
-     * @param packageName Package name
-     * @param version Package version
-     * @param className   Class name
+     * @param packageID Package id
+     * @param className Class name
      * @return Qualified class name
      */
-    public static String getQualifiedClassName(String orgName, String packageName, String version, String className) {
-        if (!IdentifierUtils.encodeNonFunctionIdentifier(Names.DEFAULT_PACKAGE.value).equals(packageName)) {
-            className = packageName + "." + version.replace('.', '_') + "." + className;
+    public static String getQualifiedClassName(PackageID packageID, String className) {
+        if (!IdentifierUtils.encodeNonFunctionIdentifier(Names.DEFAULT_PACKAGE.value).equals(
+                packageID.name.getValue())) {
+            className = packageID.name + "." + packageID.version.getValue().replace('.', '_') + "." + className;
         }
 
-        if (!Names.ANON_ORG.value.equals(orgName)) {
-            className = orgName + "." +  className;
+        if (!Names.ANON_ORG.value.equals(packageID.orgName.getValue())) {
+            className = packageID.orgName.getValue() + "." + className;
         }
 
         return className;

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BRunUtil.java
@@ -252,8 +252,8 @@ public class BRunUtil {
 
         Object jvmResult;
         BIRNode.BIRPackage birPackage = ((BLangPackage) compileResult.getAST()).symbol.bir;
-        String funcClassName = BFileUtil.getQualifiedClassName(birPackage.org.value, birPackage.name.value,
-                birPackage.version.value, getClassName(function.pos.lineRange().filePath()));
+        String funcClassName = BFileUtil.getQualifiedClassName(birPackage.packageID,
+                                                               getClassName(function.pos.lineRange().filePath()));
         try {
             Class<?> funcClass = compileResult.getClassLoader().loadClass(funcClassName);
             Method method = getMethod(functionName, funcClass);
@@ -387,8 +387,7 @@ public class BRunUtil {
 
         Object jvmResult;
         BIRNode.BIRPackage birPackage = ((BLangPackage) compileResult.getAST()).symbol.bir;
-        String funcClassName = BFileUtil.getQualifiedClassName(birPackage.org.value, birPackage.name.value,
-                                                               birPackage.version.value,
+        String funcClassName = BFileUtil.getQualifiedClassName(birPackage.packageID,
                                                                getClassName(function.pos.lineRange().filePath()));
         try {
             Class<?> funcClass = compileResult.getClassLoader().loadClass(funcClassName);


### PR DESCRIPTION
## Purpose
> This is an attempt to use the PackageID class in all places instead of using separate entities such as orgname, module name and version.

## Approach
>  Use PackageID in all places

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
