### PR TITLE
Fix hardcoded java command in RunExecutableTask

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunExecutableTask.java
@@ -86,7 +86,7 @@ public class RunExecutableTask implements Task {
                 MODULE_INIT_CLASS_NAME);
         try {
             List<String> commands = new ArrayList<>();
-            commands.add("java");
+            commands.add(System.getProperty("java.command"));
             // Sets classpath with executable thin jar and all dependency jar paths.
             commands.add("-cp");
             commands.add(getAllClassPaths(jarResolver));


### PR DESCRIPTION
## Purpose
> Fix hardcoded java command in RunExecutableTask

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
