### PR TITLE
Cache bir and thin jar in the distribution cache location for tests

### DIFF
--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -64,7 +64,7 @@ public class SymbolBIRTest {
         }
     }
 
-    @Test(enabled = false)
+    @Test
     public void testSymbolLookupInBIR() {
         Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_imports_test.bal");
         Package currentPackage = project.currentPackage();

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -34,7 +34,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
-import java.util.UUID;
 
 import static io.ballerina.projects.util.ProjectConstants.DIST_CACHE_DIRECTORY;
 
@@ -47,7 +46,6 @@ public class BCompileUtil {
 
     private static final Path testSourcesDirectory = Paths.get("src/test/resources").toAbsolutePath().normalize();
     private static final Path testBuildDirectory = Paths.get("build").toAbsolutePath().normalize();
-    public static final String TEST_COMPILATION_CACHE_DIR_NAME = "test_compilation_cache";
 
     public static Project loadProject(String sourceFilePath) {
         Path sourcePath = Paths.get(sourceFilePath);
@@ -71,15 +69,6 @@ public class BCompileUtil {
         CompileResult compileResult = new CompileResult(currentPackage, jBallerinaBackend);
         invokeModuleInit(compileResult);
         return compileResult;
-    }
-
-    public static Project getProject(String sourceFilePath) {
-        Path sourcePath = Paths.get(sourceFilePath);
-        String sourceFileName = sourcePath.getFileName().toString();
-        Path sourceRoot = testSourcesDirectory.resolve(sourcePath.getParent());
-
-        Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
-        return ProjectLoader.loadProject(projectPath);
     }
 
     public static CompileResult compileAndCacheBalo(String sourceFilePath) {
@@ -177,8 +166,7 @@ public class BCompileUtil {
         }
 
         private static TestCompilationCache from(Project project) {
-            Path testCompilationCachePath = testBuildDirectory.resolve(TEST_COMPILATION_CACHE_DIR_NAME).
-                    resolve(UUID.randomUUID().toString());
+            Path testCompilationCachePath = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
             return new TestCompilationCache(project, testCompilationCachePath);
         }
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DeprecatedAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/DeprecatedAnnotationTest.java
@@ -53,7 +53,7 @@ public class DeprecatedAnnotationTest {
     public void setup() throws IOException {
         String sourceRoot =
                 "test-src" + File.separator + "documentation" + File.separator + "deprecated_annotation_project";
-        io.ballerina.projects.Project project = BCompileUtil.getProject(sourceRoot);
+        io.ballerina.projects.Project project = BCompileUtil.loadProject(sourceRoot);
         Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator.generateModuleDocMap(project);
         Project docerinaProject = BallerinaDocGenerator.getDocsGenModel(moduleDocMap, project.currentPackage()
                         .packageOrg().toString(), project.currentPackage().packageVersion().toString());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ErrorsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ErrorsTest.java
@@ -43,7 +43,7 @@ public class ErrorsTest {
     public void setup() throws IOException {
         String sourceRoot =
                 "test-src" + File.separator + "documentation" + File.separator + "errors_project";
-        io.ballerina.projects.Project project = BCompileUtil.getProject(sourceRoot);
+        io.ballerina.projects.Project project = BCompileUtil.loadProject(sourceRoot);
         Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator.generateModuleDocMap(project);
         Project docerinaProject = BallerinaDocGenerator.getDocsGenModel(moduleDocMap, project.currentPackage()
                 .packageOrg().toString(), project.currentPackage().packageVersion().toString());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/FieldLevelDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/FieldLevelDocsTest.java
@@ -62,7 +62,7 @@ public class FieldLevelDocsTest {
     public void setup() throws IOException {
         String sourceRoot =
                 "test-src" + File.separator + "documentation" + File.separator + "record_object_fields_project";
-        io.ballerina.projects.Project project = BCompileUtil.getProject(sourceRoot);
+        io.ballerina.projects.Project project = BCompileUtil.loadProject(sourceRoot);
         Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator.generateModuleDocMap(project);
         Project docerinaProject = BallerinaDocGenerator.getDocsGenModel(moduleDocMap, project.currentPackage()
                 .packageOrg().toString(), project.currentPackage().packageVersion().toString());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/MultilineDocsTest.java
@@ -58,7 +58,7 @@ public class MultilineDocsTest {
     public void setup() throws IOException {
         String sourceRoot =
                 "test-src" + File.separator + "documentation" + File.separator + "multi_line_docs_project";
-        io.ballerina.projects.Project project = BCompileUtil.getProject(sourceRoot);
+        io.ballerina.projects.Project project = BCompileUtil.loadProject(sourceRoot);
         Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator.generateModuleDocMap(project);
         Project docerinaProject = BallerinaDocGenerator.getDocsGenModel(moduleDocMap, project.currentPackage()
                 .packageOrg().toString(), project.currentPackage().packageVersion().toString());

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ObjectFieldDefaultValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/documentation/ObjectFieldDefaultValueTest.java
@@ -45,7 +45,7 @@ public class ObjectFieldDefaultValueTest {
     public void setup() throws IOException {
         String sourceRoot =
                 "test-src" + File.separator + "documentation" + File.separator + "default_value_initialization";
-        io.ballerina.projects.Project project = BCompileUtil.getProject(sourceRoot);
+        io.ballerina.projects.Project project = BCompileUtil.loadProject(sourceRoot);
         Map<String, ModuleDoc> moduleDocMap = BallerinaDocGenerator.generateModuleDocMap(project);
         Project docerinaProject = BallerinaDocGenerator.getDocsGenModel(moduleDocMap, project.currentPackage()
                 .packageOrg().toString(), project.currentPackage().packageVersion().toString());


### PR DESCRIPTION
## Purpose
This PR will update the cache location of TestCompilationCache to be build distribution cache so bir's are also cached in the same location for balo based tests.

This PR also removes an unused method getProject as it is replaced by the loadProject method.

Fixes #27049

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
