### PR TITLE
Add an API to get the symbols of the attached annotations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -324,6 +324,10 @@ public class SymbolFactory {
             members.add(this.createConstantSymbol(member, member.name.value));
         }
 
+        for (BAnnotationSymbol annot : enumSymbol.annots) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        }
+
         return symbolBuilder
                 .withMembers(members)
                 .withTypeDescriptor(typesFactory.getTypeDescriptor(enumSymbol.type, true))

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -378,6 +378,10 @@ public class SymbolFactory {
             symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(symbol.attachedType.getType()));
         }
 
+        for (BAnnotationSymbol annot : symbol.annots) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        }
+
         return symbolBuilder.build();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -187,6 +187,9 @@ public class SymbolFactory {
         }
 
         for (BLangAnnotationAttachment annAttachment : invokableSymbol.annAttachments) {
+            if (annAttachment.annotationSymbol == null) {
+                continue;
+            }
             builder.withAnnotation(createAnnotationSymbol(annAttachment.annotationSymbol));
         }
 
@@ -247,8 +250,8 @@ public class SymbolFactory {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
 
-        for (BAnnotationSymbol annot : symbol.annots) {
-            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : symbol.getAnnotations()) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return symbolBuilder
@@ -260,8 +263,8 @@ public class SymbolFactory {
         BallerinaWorkerSymbol.WorkerSymbolBuilder builder =
                 new BallerinaWorkerSymbol.WorkerSymbolBuilder(name, symbol.pkgID, symbol);
 
-        for (BAnnotationSymbol annot : symbol.annots) {
-            builder.withAnnotation(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : symbol.getAnnotations()) {
+            builder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return builder.withReturnType(typesFactory.getTypeDescriptor(((BFutureType) symbol.type).constraint)).build();
@@ -286,8 +289,8 @@ public class SymbolFactory {
         }
 
         List<AnnotationSymbol> annotSymbols = new ArrayList<>();
-        for (BAnnotationSymbol annot : symbol.annots) {
-            annotSymbols.add(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : symbol.getAnnotations()) {
+            annotSymbols.add(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return new BallerinaParameterSymbol(name, typeDescriptor, qualifiers, annotSymbols, kind);
@@ -324,8 +327,8 @@ public class SymbolFactory {
             members.add(this.createConstantSymbol(member, member.name.value));
         }
 
-        for (BAnnotationSymbol annot : enumSymbol.annots) {
-            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : enumSymbol.getAnnotations()) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return symbolBuilder
@@ -363,8 +366,8 @@ public class SymbolFactory {
             type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
         }
 
-        for (BAnnotationSymbol annot : classSymbol.annots) {
-            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : classSymbol.getAnnotations()) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return symbolBuilder.withTypeDescriptor((ObjectTypeSymbol) type).build();
@@ -388,8 +391,8 @@ public class SymbolFactory {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
 
-        for (BAnnotationSymbol annot : constantSymbol.annots) {
-            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : constantSymbol.getAnnotations()) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return symbolBuilder.build();
@@ -411,8 +414,8 @@ public class SymbolFactory {
             symbolBuilder.withTypeDescriptor(typesFactory.getTypeDescriptor(symbol.attachedType.getType()));
         }
 
-        for (BAnnotationSymbol annot : symbol.annots) {
-            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : symbol.getAnnotations()) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         return symbolBuilder.build();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -338,6 +338,10 @@ public class SymbolFactory {
             type = ((TypeReferenceTypeSymbol) type).typeDescriptor();
         }
 
+        for (BAnnotationSymbol annot : classSymbol.annots) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        }
+
         return symbolBuilder.withTypeDescriptor((ObjectTypeSymbol) type).build();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -241,6 +241,10 @@ public class SymbolFactory {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
 
+        for (BAnnotationSymbol annot : symbol.annots) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
+        }
+
         return symbolBuilder
                 .withTypeDescriptor(typesFactory.getTypeDescriptor(symbol.type))
                 .build();
@@ -361,6 +365,10 @@ public class SymbolFactory {
 
         if ((constantSymbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
+        }
+
+        for (BAnnotationSymbol annot : constantSymbol.annots) {
+            symbolBuilder.withAnnotation(createAnnotationSymbol(annot));
         }
 
         return symbolBuilder.build();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -44,15 +44,17 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
     private final List<Qualifier> qualifiers;
     private final TypeSymbol typeDescriptor;
     private final List<AnnotationAttachPoint> attachPoints;
+    private final List<AnnotationSymbol> annots;
     private final boolean deprecated;
 
     private BallerinaAnnotationSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
                                       TypeSymbol typeDescriptor, List<AnnotationAttachPoint> attachPoints,
-                                      BSymbol bSymbol) {
+                                      List<AnnotationSymbol> annots, BSymbol bSymbol) {
         super(name, moduleID, SymbolKind.ANNOTATION, bSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.typeDescriptor = typeDescriptor;
         this.attachPoints = Collections.unmodifiableList(attachPoints);
+        this.annots = Collections.unmodifiableList(annots);
         this.deprecated = Symbols.isFlagOn(bSymbol.flags, Flags.DEPRECATED);
     }
 
@@ -88,7 +90,7 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     @Override
@@ -106,15 +108,16 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
         private final List<Qualifier> qualifiers = new ArrayList<>();
         private TypeSymbol typeDescriptor;
         private List<AnnotationAttachPoint> attachPoints;
+        private List<AnnotationSymbol> annots = new ArrayList<>();
 
         public AnnotationSymbolBuilder(String name, PackageID moduleID, BAnnotationSymbol annotationSymbol) {
             super(name, moduleID, SymbolKind.ANNOTATION, annotationSymbol);
-            withAnnotationSymbol(annotationSymbol);
+            withAttachPoints(annotationSymbol);
         }
 
         public BallerinaAnnotationSymbol build() {
             return new BallerinaAnnotationSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
-                    this.attachPoints, this.bSymbol);
+                                                 this.attachPoints, this.annots, this.bSymbol);
         }
 
         /**
@@ -122,7 +125,7 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
          *
          * @param annotationSymbol annotation symbol to evaluate
          */
-        private void withAnnotationSymbol(BAnnotationSymbol annotationSymbol) {
+        private void withAttachPoints(BAnnotationSymbol annotationSymbol) {
             this.attachPoints = getAttachPoints(annotationSymbol.maskedPoints);
         }
 
@@ -133,6 +136,11 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
 
         public AnnotationSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
             this.typeDescriptor = typeDescriptor;
+            return this;
+        }
+
+        public AnnotationSymbolBuilder withAnnotation(AnnotationSymbol annot) {
+            this.annots.add(annot);
             return this;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -87,6 +87,11 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
     }
 
     @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
+    }
+
+    @Override
     public boolean deprecated() {
         return this.deprecated;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -51,15 +51,18 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
 
     private final ObjectTypeSymbol typeDescriptor;
     private final List<Qualifier> qualifiers;
+    private final List<AnnotationSymbol> annots;
     private final boolean deprecated;
     private final BClassSymbol internalSymbol;
     private final CompilerContext context;
     private MethodSymbol initMethod;
 
     protected BallerinaClassSymbol(CompilerContext context, String name, PackageID moduleID, List<Qualifier> qualifiers,
-                                   ObjectTypeSymbol typeDescriptor, BClassSymbol classSymbol) {
+                                   List<AnnotationSymbol> annots, ObjectTypeSymbol typeDescriptor,
+                                   BClassSymbol classSymbol) {
         super(name, moduleID, SymbolKind.CLASS, classSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
+        this.annots = Collections.unmodifiableList(annots);
         this.typeDescriptor = typeDescriptor;
         this.deprecated = Symbols.isFlagOn(classSymbol.flags, Flags.DEPRECATED);
         this.internalSymbol = classSymbol;
@@ -100,7 +103,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     @Override
@@ -157,6 +160,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     public static class ClassSymbolBuilder extends SymbolBuilder<BallerinaClassSymbol.ClassSymbolBuilder> {
 
         protected List<Qualifier> qualifiers = new ArrayList<>();
+        protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected ObjectTypeSymbol typeDescriptor;
         protected CompilerContext context;
 
@@ -175,9 +179,14 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
             return this;
         }
 
+        public ClassSymbolBuilder withAnnotation(AnnotationSymbol annot) {
+            this.annots.add(annot);
+            return this;
+        }
+
         @Override
         public BallerinaClassSymbol build() {
-            return new BallerinaClassSymbol(this.context, this.name, this.moduleID, this.qualifiers,
+            return new BallerinaClassSymbol(this.context, this.name, this.moduleID, this.qualifiers, this.annots,
                                             this.typeDescriptor, (BClassSymbol) this.bSymbol);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -95,6 +96,11 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public List<TypeQualifier> typeQualifiers() {
         return this.typeDescriptor.typeQualifiers();
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -26,6 +27,8 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -63,6 +66,11 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     @Override
     public TypeSymbol broaderTypeDescriptor() {
         return this.broaderType;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -27,8 +27,6 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -44,11 +42,12 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     private BallerinaConstantSymbol(String name,
                                     PackageID moduleID,
                                     List<Qualifier> qualifiers,
+                                    List<AnnotationSymbol> annots,
                                     TypeSymbol typeDescriptor,
                                     TypeSymbol broaderType,
                                     Object constValue,
                                     BSymbol bSymbol) {
-        super(name, moduleID, SymbolKind.CONSTANT, qualifiers, typeDescriptor, bSymbol);
+        super(name, moduleID, SymbolKind.CONSTANT, qualifiers, annots, typeDescriptor, bSymbol);
         this.constValue = constValue;
         this.broaderType = broaderType;
     }
@@ -66,11 +65,6 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     @Override
     public TypeSymbol broaderTypeDescriptor() {
         return this.broaderType;
-    }
-
-    @Override
-    public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     @Override
@@ -106,13 +100,8 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
         }
 
         public BallerinaConstantSymbol build() {
-            return new BallerinaConstantSymbol(this.name,
-                    this.moduleID,
-                    this.qualifiers,
-                    this.typeDescriptor,
-                    this.broaderType,
-                    this.constantValue,
-                    this.bSymbol);
+            return new BallerinaConstantSymbol(this.name, this.moduleID, this.qualifiers, this.annots,
+                                               this.typeDescriptor, this.broaderType, this.constantValue, this.bSymbol);
         }
 
         public ConstantSymbolBuilder withConstValue(Object constValue) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.EnumSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -48,6 +49,11 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
     @Override
     public List<ConstantSymbol> members() {
         return this.members;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -39,11 +39,14 @@ import java.util.List;
 public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implements EnumSymbol {
 
     private List<ConstantSymbol> members;
+    private List<AnnotationSymbol> annots;
 
     protected BallerinaEnumSymbol(String name, PackageID moduleID, List<ConstantSymbol> members,
-                                  List<Qualifier> qualifiers, TypeSymbol typeDescriptor, BSymbol bSymbol) {
+                                  List<Qualifier> qualifiers, List<AnnotationSymbol> annots, TypeSymbol typeDescriptor,
+                                  BSymbol bSymbol) {
         super(name, moduleID, qualifiers, typeDescriptor, bSymbol);
         this.members = Collections.unmodifiableList(members);
+        this.annots = annots;
     }
 
     @Override
@@ -53,7 +56,7 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     @Override
@@ -70,6 +73,7 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
 
         protected List<ConstantSymbol> members;
         protected List<Qualifier> qualifiers = new ArrayList<>();
+        protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
         public EnumSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
@@ -91,9 +95,14 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
             return this;
         }
 
+        public EnumSymbolBuilder withAnnotation(AnnotationSymbol annot) {
+            this.annots.add(annot);
+            return this;
+        }
+
         @Override
         public BallerinaEnumSymbol build() {
-            return new BallerinaEnumSymbol(this.name, this.moduleID, this.members, this.qualifiers,
+            return new BallerinaEnumSymbol(this.name, this.moduleID, this.members, this.qualifiers, this.annots,
                                            this.typeDescriptor, this.bSymbol);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -17,15 +17,20 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -39,12 +44,14 @@ public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol
     private final BField bField;
     private final CompilerContext context;
     private TypeSymbol typeDescriptor;
+    private boolean deprecated;
 
     public BallerinaFieldSymbol(CompilerContext context, BField bField) {
         super(bField.name.value, bField.symbol.pkgID, SymbolKind.FIELD, bField.symbol);
         this.context = context;
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
+        this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);
     }
 
     /**
@@ -79,6 +86,16 @@ public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol
         }
 
         return this.typeDescriptor;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
+    }
+
+    @Override
+    public boolean deprecated() {
+        return this.deprecated;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -17,12 +17,14 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -44,6 +46,7 @@ public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol
     private final BField bField;
     private final CompilerContext context;
     private TypeSymbol typeDescriptor;
+    private List<AnnotationSymbol> annots;
     private boolean deprecated;
 
     public BallerinaFieldSymbol(CompilerContext context, BField bField) {
@@ -90,7 +93,18 @@ public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        if (this.annots != null) {
+            return this.annots;
+        }
+
+        List<AnnotationSymbol> annots = new ArrayList<>();
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+        for (BAnnotationSymbol annot : bField.symbol.annots) {
+            annots.add(symbolFactory.createAnnotationSymbol(annot));
+        }
+
+        this.annots = Collections.unmodifiableList(annots);
+        return this.annots;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -99,8 +99,8 @@ public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol
 
         List<AnnotationSymbol> annots = new ArrayList<>();
         SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
-        for (BAnnotationSymbol annot : bField.symbol.annots) {
-            annots.add(symbolFactory.createAnnotationSymbol(annot));
+        for (org.ballerinalang.model.symbols.AnnotationSymbol annot : bField.symbol.getAnnotations()) {
+            annots.add(symbolFactory.createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
         this.annots = Collections.unmodifiableList(annots);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -77,6 +78,11 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     @Override
     public boolean deprecated() {
         return this.deprecated;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -40,16 +40,19 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
 
     private final FunctionTypeSymbol typeDescriptor;
     private final List<Qualifier> qualifiers;
+    private final List<AnnotationSymbol> annots;
     private final boolean isExternal;
     private final boolean deprecated;
 
     protected BallerinaFunctionSymbol(String name,
                                       PackageID moduleID,
                                       List<Qualifier> qualifiers,
+                                      List<AnnotationSymbol> annots,
                                       FunctionTypeSymbol typeDescriptor,
                                       BInvokableSymbol invokableSymbol) {
         super(name, moduleID, SymbolKind.FUNCTION, invokableSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
+        this.annots = Collections.unmodifiableList(annots);
         this.typeDescriptor = typeDescriptor;
         this.isExternal = Symbols.isFlagOn(invokableSymbol.flags, Flags.NATIVE);
         this.deprecated = Symbols.isFlagOn(invokableSymbol.flags, Flags.DEPRECATED);
@@ -82,7 +85,7 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     /**
@@ -91,14 +94,14 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     public static class FunctionSymbolBuilder extends SymbolBuilder<FunctionSymbolBuilder> {
 
         protected List<Qualifier> qualifiers = new ArrayList<>();
+        protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected FunctionTypeSymbol typeDescriptor;
 
         public FunctionSymbolBuilder(String name, PackageID moduleID, BInvokableSymbol bSymbol) {
             this(name, moduleID, SymbolKind.FUNCTION, bSymbol);
         }
 
-        public FunctionSymbolBuilder(String name, PackageID moduleID, SymbolKind kind,
-                BInvokableSymbol bSymbol) {
+        public FunctionSymbolBuilder(String name, PackageID moduleID, SymbolKind kind, BInvokableSymbol bSymbol) {
             super(name, moduleID, kind, bSymbol);
         }
 
@@ -117,10 +120,15 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
             return this;
         }
 
+        public FunctionSymbolBuilder withAnnotation(AnnotationSymbol annot) {
+            this.annots.add(annot);
+            return this;
+        }
+
         @Override
         public BallerinaFunctionSymbol build() {
-            return new BallerinaFunctionSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
-                                               (BInvokableSymbol) this.bSymbol);
+            return new BallerinaFunctionSymbol(this.name, this.moduleID, this.qualifiers, this.annots,
+                                               this.typeDescriptor, (BInvokableSymbol) this.bSymbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
@@ -27,6 +28,8 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.tools.diagnostics.Location;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;
@@ -82,6 +85,11 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     @Override
     public boolean deprecated() {
         return this.functionSymbol.deprecated();
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return this.functionSymbol.annotations();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -28,8 +28,6 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.tools.diagnostics.Location;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.StringJoiner;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -16,11 +16,13 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -76,6 +78,11 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
     @Override
     public List<Qualifier> qualifiers() {
         return qualifiers;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -37,16 +37,18 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
 
     // add the metadata field
     private List<Qualifier> qualifiers;
+    private List<AnnotationSymbol> annots;
     private String parameterName;
     private TypeSymbol typeDescriptor;
     private ParameterKind kind;
 
     public BallerinaParameterSymbol(String parameterName, TypeSymbol typeDescriptor, List<Qualifier> qualifiers,
-                                    ParameterKind kind) {
+                                    List<AnnotationSymbol> annots, ParameterKind kind) {
         // TODO: Add the metadata
         this.parameterName = parameterName;
         this.typeDescriptor = typeDescriptor;
         this.qualifiers = Collections.unmodifiableList(qualifiers);
+        this.annots = Collections.unmodifiableList(annots);
         this.kind = kind;
     }
 
@@ -82,7 +84,7 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -82,7 +82,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return Collections.emptyList();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
@@ -77,6 +78,11 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
     @Override
     public boolean readonly() {
         return this.readonly;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -76,6 +77,11 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     @Override
     public boolean deprecated() {
         return this.deprecated;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -39,6 +39,7 @@ import java.util.List;
 public class BallerinaVariableSymbol extends BallerinaSymbol implements VariableSymbol {
 
     private final List<Qualifier> qualifiers;
+    private final List<AnnotationSymbol> annots;
     private final TypeSymbol typeDescriptorImpl;
     private final boolean deprecated;
 
@@ -46,10 +47,12 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
                                       PackageID moduleID,
                                       SymbolKind ballerinaSymbolKind,
                                       List<Qualifier> qualifiers,
+                                      List<AnnotationSymbol> annots,
                                       TypeSymbol typeDescriptorImpl,
                                       BSymbol bSymbol) {
         super(name, moduleID, ballerinaSymbolKind, bSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
+        this.annots = Collections.unmodifiableList(annots);
         this.typeDescriptorImpl = typeDescriptorImpl;
         this.deprecated = Symbols.isFlagOn(bSymbol.flags, Flags.DEPRECATED);
     }
@@ -81,7 +84,7 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     /**
@@ -90,6 +93,7 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     public static class VariableSymbolBuilder extends SymbolBuilder<VariableSymbolBuilder> {
 
         protected List<Qualifier> qualifiers = new ArrayList<>();
+        protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
         public VariableSymbolBuilder(String name, PackageID moduleID, BSymbol bSymbol) {
@@ -98,12 +102,8 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
 
         @Override
         public BallerinaVariableSymbol build() {
-            return new BallerinaVariableSymbol(this.name,
-                    this.moduleID,
-                    this.ballerinaSymbolKind,
-                    this.qualifiers,
-                    this.typeDescriptor,
-                    this.bSymbol);
+            return new BallerinaVariableSymbol(this.name, this.moduleID, this.ballerinaSymbolKind, this.qualifiers,
+                                               this.annots, this.typeDescriptor, this.bSymbol);
         }
 
         public VariableSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
@@ -113,6 +113,11 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
 
         public VariableSymbolBuilder withQualifier(Qualifier qualifier) {
             this.qualifiers.add(qualifier);
+            return this;
+        }
+
+        public VariableSymbolBuilder withAnnotation(AnnotationSymbol annot) {
+            this.annots.add(annot);
             return this;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -17,11 +17,16 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.WorkerSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Represents a ballerina worker.
@@ -49,6 +54,11 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
     @Override
     public TypeSymbol returnType() {
         return returnType;
+    }
+
+    @Override
+    public List<AnnotationSymbol> annotations() {
+        return Collections.unmodifiableList(new ArrayList<>());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -25,7 +25,6 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -36,14 +35,13 @@ import java.util.List;
 public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymbol {
 
     private TypeSymbol returnType;
+    private List<AnnotationSymbol> annots;
 
-    private BallerinaWorkerSymbol(String name,
-                                      PackageID moduleID,
-                                      SymbolKind ballerinaSymbolKind,
-                                      TypeSymbol returnType,
-                                      BSymbol symbol) {
+    private BallerinaWorkerSymbol(String name, PackageID moduleID, SymbolKind ballerinaSymbolKind,
+                                  TypeSymbol returnType, List<AnnotationSymbol> annots, BSymbol symbol) {
         super(name, moduleID, ballerinaSymbolKind, symbol);
         this.returnType = returnType;
+        this.annots = annots;
     }
 
     /**
@@ -58,7 +56,7 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
 
     @Override
     public List<AnnotationSymbol> annotations() {
-        return Collections.unmodifiableList(new ArrayList<>());
+        return this.annots;
     }
 
     /**
@@ -67,6 +65,7 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
     public static class WorkerSymbolBuilder extends SymbolBuilder<WorkerSymbolBuilder> {
 
         protected TypeSymbol returnType;
+        protected List<AnnotationSymbol> annots = new ArrayList<>();
 
         public WorkerSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
             super(name, moduleID, SymbolKind.WORKER, symbol);
@@ -74,15 +73,17 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
 
         @Override
         public BallerinaWorkerSymbol build() {
-            return new BallerinaWorkerSymbol(this.name,
-                    this.moduleID,
-                    this.ballerinaSymbolKind,
-                    this.returnType,
-                    this.bSymbol);
+            return new BallerinaWorkerSymbol(this.name, this.moduleID, this.ballerinaSymbolKind, this.returnType,
+                                             this.annots, this.bSymbol);
         }
 
         public WorkerSymbolBuilder withReturnType(TypeSymbol typeDescriptor) {
             this.returnType = typeDescriptor;
+            return this;
+        }
+
+        public WorkerSymbolBuilder withAnnotation(AnnotationSymbol annot) {
+            this.annots.add(annot);
             return this;
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Annotatable.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Annotatable.java
@@ -15,21 +15,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package io.ballerina.compiler.api.symbols;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
- * Represents a class symbol.
+ * Represents a symbol which may have annotations attached to it.
  *
  * @since 2.0.0
  */
-public interface ClassSymbol extends ObjectTypeSymbol, Qualifiable, Deprecatable, Annotatable {
+public interface Annotatable {
 
     /**
-     * Get the init method.
+     * Retrieves a list of the symbols of the annotations attached to the symbol.
      *
-     * @return {@link Optional} init method
+     * @return The list of annotation symbols
      */
-    Optional<MethodSymbol> initMethod();
+    List<AnnotationSymbol> annotations();
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnnotationSymbol.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface AnnotationSymbol extends Symbol, Qualifiable, Deprecatable {
+public interface AnnotationSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
 
     /**
      * Get the type descriptor.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol {
+public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol, Annotatable, Deprecatable {
 
     /**
      * Get the constant value.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/EnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/EnumSymbol.java
@@ -24,7 +24,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public interface EnumSymbol extends TypeDefinitionSymbol, Qualifiable, Deprecatable {
+public interface EnumSymbol extends TypeDefinitionSymbol, Qualifiable, Deprecatable, Annotatable {
 
     /**
      * Retrieves a list of the members of this enum.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FieldSymbol.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface FieldSymbol extends Symbol {
+public interface FieldSymbol extends Symbol, Annotatable, Deprecatable {
 
     /**
      * Whether optional field or not.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface FunctionSymbol extends Symbol, Qualifiable, Deprecatable {
+public interface FunctionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
 
     /**
      * Get the type descriptor of the function.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterSymbol.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface ParameterSymbol {
+public interface ParameterSymbol extends Annotatable {
 
     /**
      * Get the parameter name.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDefinitionSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface TypeDefinitionSymbol extends Symbol, Qualifiable, Deprecatable {
+public interface TypeDefinitionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
 
     /**
      * Get the module qualified name.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable {
+public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
 
     /**
      * Get the Type of the variable.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/WorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/WorkerSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface WorkerSymbol extends Symbol {
+public interface WorkerSymbol extends Symbol, Annotatable {
 
     /**
      * Get the return type.

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/Annotatable.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/Annotatable.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.model.symbols;
+
+import java.util.List;
+
+/**
+ * Provides APIs for adding and getting annotations from an annotatable symbol.
+ *
+ * @since 2.0.0
+ */
+public interface Annotatable {
+
+    /**
+     * Adds the specified annotation symbol to the annotatable symbol. If the specified symbol is null, it's ignored.
+     *
+     * @param symbol The symbol of the annotation attached
+     */
+    void addAnnotation(AnnotationSymbol symbol);
+
+    /**
+     * Returns a list of the annotations attached to this symbol.
+     *
+     * @return A list of annotation symbols
+     */
+    List<? extends AnnotationSymbol> getAnnotations();
+}

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/AnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/AnnotationSymbol.java
@@ -20,6 +20,6 @@ package org.ballerinalang.model.symbols;
 /**
  * @since 0.94
  */
-public interface AnnotationSymbol extends Symbol {
+public interface AnnotationSymbol extends Annotatable {
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/ConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/ConstantSymbol.java
@@ -21,6 +21,6 @@ package org.ballerinalang.model.symbols;
 /**
  * @since 0.985.0
  */
-public interface ConstantSymbol extends Symbol {
+public interface ConstantSymbol extends Annotatable {
 
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/InvokableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/symbols/InvokableSymbol.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * @since 0.94
  */
-public interface InvokableSymbol extends Symbol {
+public interface InvokableSymbol extends Annotatable {
 
     List<? extends VariableSymbol> getParameters();
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3421,6 +3421,10 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         }
         Collections.reverse(bLangUnionTypeNode.memberTypeNodes);
         bLangTypeDefinition.setTypeNode(bLangUnionTypeNode);
+
+        bLangTypeDefinition.annAttachments = applyAll(getAnnotations(enumDeclarationNode.metadata()));
+        bLangTypeDefinition.markdownDocumentationAttachment =
+                createMarkdownDocumentationAttachment(getDocumentationString(enumDeclarationNode.metadata()));
         return bLangTypeDefinition;
     }
 
@@ -3431,6 +3435,10 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         if (publicQualifier) {
             bLangConstant.flagSet.add(Flag.PUBLIC);
         }
+
+        bLangConstant.annAttachments = applyAll(getAnnotations(member.metadata()));
+        bLangConstant.markdownDocumentationAttachment =
+                createMarkdownDocumentationAttachment(getDocumentationString(member.metadata()));
 
         bLangConstant.setName((BLangIdentifier) transform(member.identifier()));
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -39,6 +39,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
@@ -443,6 +445,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             analyzeDef(typeDefinition.typeNode, env);
         }
 
+        final List<BAnnotationSymbol> annotSymbols = new ArrayList<>();
+
         typeDefinition.annAttachments.forEach(annotationAttachment -> {
             if (typeDefinition.typeNode.getKind() == NodeKind.OBJECT_TYPE) {
                 annotationAttachment.attachPoints.add(AttachPoint.Point.OBJECT);
@@ -450,7 +454,13 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
             annotationAttachment.attachPoints.add(AttachPoint.Point.TYPE);
 
             annotationAttachment.accept(this);
+            annotSymbols.add(annotationAttachment.annotationSymbol);
         });
+
+        if (typeDefinition.flagSet.contains(Flag.ENUM)) {
+            ((BEnumSymbol) typeDefinition.symbol).annots = annotSymbols;
+        }
+
         validateAnnotationAttachmentCount(typeDefinition.annAttachments);
         validateBuiltinTypeAnnotationAttachment(typeDefinition.annAttachments);
     }
@@ -460,10 +470,12 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         AttachPoint.Point attachedPoint = classDefinition.flagSet.contains(Flag.SERVICE)
                 ? AttachPoint.Point.SERVICE
                 : AttachPoint.Point.CLASS;
+        BClassSymbol symbol = (BClassSymbol) classDefinition.symbol;
 
         classDefinition.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachPoints.add(attachedPoint);
             annotationAttachment.accept(this);
+            symbol.annots.add(annotationAttachment.annotationSymbol);
         });
         validateAnnotationAttachmentCount(classDefinition.annAttachments);
 
@@ -610,9 +622,11 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
     }
 
     public void visit(BLangAnnotation annotationNode) {
+        BAnnotationSymbol symbol = (BAnnotationSymbol) annotationNode.symbol;
         annotationNode.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachPoints.add(AttachPoint.Point.ANNOTATION);
             annotationAttachment.accept(this);
+            symbol.annots.add(annotationAttachment.annotationSymbol);
         });
         validateAnnotationAttachmentCount(annotationNode.annAttachments);
     }
@@ -689,6 +703,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                     annotationAttachment.attachPoints.add(AttachPoint.Point.VAR);
                 }
                 annotationAttachment.accept(this);
+                varNode.symbol.annots.add(annotationAttachment.annotationSymbol);
             });
         }
         validateAnnotationAttachmentCount(varNode.annAttachments);
@@ -768,6 +783,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         for (BLangAnnotationAttachment annotationAttachment : varNode.annAttachments) {
             annotationAttachment.attachPoints.addAll(attachPointsList);
             annotationAttachment.accept(this);
+            varNode.symbol.annots.add(annotationAttachment.annotationSymbol);
         }
     }
 
@@ -3090,6 +3106,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         constant.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachPoints.add(AttachPoint.Point.CONST);
             annotationAttachment.accept(this);
+            constant.symbol.annots.add(annotationAttachment.annotationSymbol);
         });
 
         BLangExpression expression = constant.expr;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -458,7 +458,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         });
 
         if (typeDefinition.flagSet.contains(Flag.ENUM)) {
-            ((BEnumSymbol) typeDefinition.symbol).annots = annotSymbols;
+            ((BEnumSymbol) typeDefinition.symbol).addAnnotations(annotSymbols);
         }
 
         validateAnnotationAttachmentCount(typeDefinition.annAttachments);
@@ -475,7 +475,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         classDefinition.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachPoints.add(attachedPoint);
             annotationAttachment.accept(this);
-            symbol.annots.add(annotationAttachment.annotationSymbol);
+            symbol.addAnnotation(annotationAttachment.annotationSymbol);
         });
         validateAnnotationAttachmentCount(classDefinition.annAttachments);
 
@@ -626,7 +626,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         annotationNode.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachPoints.add(AttachPoint.Point.ANNOTATION);
             annotationAttachment.accept(this);
-            symbol.annots.add(annotationAttachment.annotationSymbol);
+            symbol.addAnnotation(annotationAttachment.annotationSymbol);
         });
         validateAnnotationAttachmentCount(annotationNode.annAttachments);
     }
@@ -703,7 +703,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                     annotationAttachment.attachPoints.add(AttachPoint.Point.VAR);
                 }
                 annotationAttachment.accept(this);
-                varNode.symbol.annots.add(annotationAttachment.annotationSymbol);
+                varNode.symbol.addAnnotation(annotationAttachment.annotationSymbol);
             });
         }
         validateAnnotationAttachmentCount(varNode.annAttachments);
@@ -783,7 +783,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         for (BLangAnnotationAttachment annotationAttachment : varNode.annAttachments) {
             annotationAttachment.attachPoints.addAll(attachPointsList);
             annotationAttachment.accept(this);
-            varNode.symbol.annots.add(annotationAttachment.annotationSymbol);
+            varNode.symbol.addAnnotation(annotationAttachment.annotationSymbol);
         }
     }
 
@@ -3106,7 +3106,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         constant.annAttachments.forEach(annotationAttachment -> {
             annotationAttachment.attachPoints.add(AttachPoint.Point.CONST);
             annotationAttachment.accept(this);
-            constant.symbol.annots.add(annotationAttachment.annotationSymbol);
+            constant.symbol.addAnnotation(annotationAttachment.annotationSymbol);
         });
 
         BLangExpression expression = constant.expr;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -615,7 +615,6 @@ public class SymbolEnter extends BLangNodeVisitor {
                                                          env.scope.owner, classDefinition.name.pos,
                                                          getOrigin(className, flags), classDefinition.isServiceDecl);
         tSymbol.scope = new Scope(tSymbol);
-        tSymbol.annots = getAnnotationSymbols(classDefinition.annAttachments);
         tSymbol.markdownDocumentation = getMarkdownDocAttachment(classDefinition.markdownDocumentationAttachment);
 
 
@@ -679,7 +678,6 @@ public class SymbolEnter extends BLangNodeVisitor {
                                                                             annotName, env.enclPkg.symbol.pkgID, null,
                                                                             env.scope.owner, annotationNode.pos,
                                                                             getOrigin(annotName));
-        annotationSymbol.annots = getAnnotationSymbols(annotationNode.annAttachments);
         annotationSymbol.markdownDocumentation =
                 getMarkdownDocAttachment(annotationNode.markdownDocumentationAttachment);
         if (isDeprecated(annotationNode.annAttachments)) {
@@ -1177,7 +1175,6 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         if (typeDefinition.flagSet.contains(Flag.ENUM)) {
             definedType.tsymbol = createEnumSymbol(typeDefinition, definedType);
-            ((BEnumSymbol) definedType.tsymbol).annots = getAnnotationSymbols(typeDefinition.annAttachments);
         }
 
         typeDefinition.setPrecedence(this.typePrecedence++);
@@ -1502,7 +1499,6 @@ public class SymbolEnter extends BLangNodeVisitor {
             staticType = symTable.semanticError;
         }
         BConstantSymbol constantSymbol = getConstantSymbol(constant);
-        constantSymbol.annots = getAnnotationSymbols(constant.annAttachments);
         constant.symbol = constantSymbol;
 
         NodeKind nodeKind = constant.expr.getKind();
@@ -2758,14 +2754,6 @@ public class SymbolEnter extends BLangNodeVisitor {
     private Name getFieldSymbolName(BLangSimpleVariable receiver, BLangSimpleVariable variable) {
         return names.fromString(Symbols.getAttachedFuncSymbolName(
                 receiver.type.tsymbol.name.value, variable.name.value));
-    }
-
-    private List<BAnnotationSymbol> getAnnotationSymbols(List<BLangAnnotationAttachment> annots) {
-        List<BAnnotationSymbol> annotSymbols = new ArrayList<>();
-        for (BLangAnnotationAttachment annot : annots) {
-            annotSymbols.add(annot.annotationSymbol);
-        }
-        return annotSymbols;
     }
 
     private MarkdownDocAttachment getMarkdownDocAttachment(BLangMarkdownDocumentation docNode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -49,6 +49,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolEnv;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstructorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
@@ -610,10 +611,11 @@ public class SymbolEnter extends BLangNodeVisitor {
         boolean isPublicType = flags.contains(Flag.PUBLIC);
         Name className = names.fromIdNode(classDefinition.name);
 
-        BTypeSymbol tSymbol = Symbols.createClassSymbol(Flags.asMask(flags), className, env.enclPkg.symbol.pkgID, null,
-                                                        env.scope.owner, classDefinition.name.pos,
-                                                        getOrigin(className, flags), classDefinition.isServiceDecl);
+        BClassSymbol tSymbol = Symbols.createClassSymbol(Flags.asMask(flags), className, env.enclPkg.symbol.pkgID, null,
+                                                         env.scope.owner, classDefinition.name.pos,
+                                                         getOrigin(className, flags), classDefinition.isServiceDecl);
         tSymbol.scope = new Scope(tSymbol);
+        tSymbol.annots = getAnnotationSymbols(classDefinition.annAttachments);
         tSymbol.markdownDocumentation = getMarkdownDocAttachment(classDefinition.markdownDocumentationAttachment);
 
 
@@ -677,6 +679,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                                                                             annotName, env.enclPkg.symbol.pkgID, null,
                                                                             env.scope.owner, annotationNode.pos,
                                                                             getOrigin(annotName));
+        annotationSymbol.annots = getAnnotationSymbols(annotationNode.annAttachments);
         annotationSymbol.markdownDocumentation =
                 getMarkdownDocAttachment(annotationNode.markdownDocumentationAttachment);
         if (isDeprecated(annotationNode.annAttachments)) {
@@ -1174,6 +1177,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         if (typeDefinition.flagSet.contains(Flag.ENUM)) {
             definedType.tsymbol = createEnumSymbol(typeDefinition, definedType);
+            ((BEnumSymbol) definedType.tsymbol).annots = getAnnotationSymbols(typeDefinition.annAttachments);
         }
 
         typeDefinition.setPrecedence(this.typePrecedence++);
@@ -1498,6 +1502,7 @@ public class SymbolEnter extends BLangNodeVisitor {
             staticType = symTable.semanticError;
         }
         BConstantSymbol constantSymbol = getConstantSymbol(constant);
+        constantSymbol.annots = getAnnotationSymbols(constant.annAttachments);
         constant.symbol = constantSymbol;
 
         NodeKind nodeKind = constant.expr.getKind();
@@ -2753,6 +2758,14 @@ public class SymbolEnter extends BLangNodeVisitor {
     private Name getFieldSymbolName(BLangSimpleVariable receiver, BLangSimpleVariable variable) {
         return names.fromString(Symbols.getAttachedFuncSymbolName(
                 receiver.type.tsymbol.name.value, variable.name.value));
+    }
+
+    private List<BAnnotationSymbol> getAnnotationSymbols(List<BLangAnnotationAttachment> annots) {
+        List<BAnnotationSymbol> annotSymbols = new ArrayList<>();
+        for (BLangAnnotationAttachment annot : annots) {
+            annotSymbols.add(annot.annotationSymbol);
+        }
+        return annotSymbols;
     }
 
     private MarkdownDocAttachment getMarkdownDocAttachment(BLangMarkdownDocumentation docNode) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
@@ -43,7 +43,7 @@ public class BAnnotationSymbol extends BTypeSymbol implements AnnotationSymbol {
     public BTypeSymbol attachedType;
     public Set<AttachPoint> points;
     public int maskedPoints;
-    public List<BAnnotationSymbol> annots;
+    private List<BAnnotationSymbol> annots;
 
     public BAnnotationSymbol(Name name, long flags, Set<AttachPoint> points, PackageID pkgID,
                              BType type, BSymbol owner, Location pos, SymbolOrigin origin) {
@@ -51,6 +51,18 @@ public class BAnnotationSymbol extends BTypeSymbol implements AnnotationSymbol {
         this.points = points;
         this.maskedPoints = getMaskedPoints(points);
         this.annots = new ArrayList<>();
+    }
+
+    @Override
+    public void addAnnotation(AnnotationSymbol symbol) {
+        if (symbol != null) {
+            this.annots.add((BAnnotationSymbol) symbol);
+        }
+    }
+
+    @Override
+    public List<? extends AnnotationSymbol> getAnnotations() {
+        return this.annots;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
@@ -27,8 +27,10 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.util.AttachPoints;
 
+import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.ANNOTATION;
@@ -41,12 +43,14 @@ public class BAnnotationSymbol extends BTypeSymbol implements AnnotationSymbol {
     public BTypeSymbol attachedType;
     public Set<AttachPoint> points;
     public int maskedPoints;
+    public List<BAnnotationSymbol> annots;
 
     public BAnnotationSymbol(Name name, long flags, Set<AttachPoint> points, PackageID pkgID,
                              BType type, BSymbol owner, Location pos, SymbolOrigin origin) {
         super(ANNOTATION, flags, name, pkgID, type, owner, pos, origin);
         this.points = points;
         this.maskedPoints = getMaskedPoints(points);
+        this.annots = new ArrayList<>();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BAnnotationSymbol.java
@@ -55,9 +55,10 @@ public class BAnnotationSymbol extends BTypeSymbol implements AnnotationSymbol {
 
     @Override
     public void addAnnotation(AnnotationSymbol symbol) {
-        if (symbol != null) {
-            this.annots.add((BAnnotationSymbol) symbol);
+        if (symbol == null) {
+            return;
         }
+        this.annots.add((BAnnotationSymbol) symbol);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
@@ -48,9 +48,10 @@ public class BClassSymbol extends BObjectTypeSymbol implements Annotatable {
 
     @Override
     public void addAnnotation(AnnotationSymbol symbol) {
-        if (symbol != null) {
-            this.annots.add((BAnnotationSymbol) symbol);
+        if (symbol == null) {
+            return;
         }
+        this.annots.add((BAnnotationSymbol) symbol);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
@@ -19,6 +19,8 @@ package org.wso2.ballerinalang.compiler.semantics.model.symbols;
 
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.Annotatable;
+import org.ballerinalang.model.symbols.AnnotationSymbol;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
@@ -32,10 +34,10 @@ import java.util.List;
  *
  * @since 2.0
  */
-public class BClassSymbol extends BObjectTypeSymbol {
+public class BClassSymbol extends BObjectTypeSymbol implements Annotatable {
 
     public boolean isServiceDecl;
-    public List<BAnnotationSymbol> annots;
+    private List<BAnnotationSymbol> annots;
 
     public BClassSymbol(int symTag, long flags, Name name, PackageID pkgID, BType type,
                         BSymbol owner, Location pos, SymbolOrigin origin) {
@@ -45,9 +47,21 @@ public class BClassSymbol extends BObjectTypeSymbol {
     }
 
     @Override
+    public void addAnnotation(AnnotationSymbol symbol) {
+        if (symbol != null) {
+            this.annots.add((BAnnotationSymbol) symbol);
+        }
+    }
+
+    @Override
+    public List<? extends AnnotationSymbol> getAnnotations() {
+        return this.annots;
+    }
+
+    @Override
     public BClassSymbol createLabelSymbol() {
         BClassSymbol copy = Symbols.createClassSymbol(flags, Names.EMPTY, pkgID, type, owner, pos, origin,
-                isServiceDecl);
+                                                      isServiceDecl);
         copy.attachedFuncs = attachedFuncs;
         copy.initializerFunc = initializerFunc;
         copy.isLabel = true;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BClassSymbol.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.ArrayList;
+import java.util.List;
 
 /**
  * {@code BClassSymbol} represents a class symbol in a scope.
@@ -34,11 +35,13 @@ import java.util.ArrayList;
 public class BClassSymbol extends BObjectTypeSymbol {
 
     public boolean isServiceDecl;
+    public List<BAnnotationSymbol> annots;
 
     public BClassSymbol(int symTag, long flags, Name name, PackageID pkgID, BType type,
                         BSymbol owner, Location pos, SymbolOrigin origin) {
         super(symTag, flags, name, pkgID, type, owner, pos, origin);
         this.referencedFunctions = new ArrayList<>();
+        this.annots = new ArrayList<>();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -20,6 +20,8 @@ package org.wso2.ballerinalang.compiler.semantics.model.symbols;
 
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.Annotatable;
+import org.ballerinalang.model.symbols.AnnotationSymbol;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -33,10 +35,10 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public class BEnumSymbol extends BTypeSymbol {
+public class BEnumSymbol extends BTypeSymbol implements Annotatable {
 
     public List<BConstantSymbol> members;
-    public List<BAnnotationSymbol> annots;
+    private List<BAnnotationSymbol> annots;
 
     public BEnumSymbol(List<BConstantSymbol> members, long flags, Name name, PackageID pkgID, BType type,
                        BSymbol owner, Location pos, SymbolOrigin origin) {
@@ -44,5 +46,23 @@ public class BEnumSymbol extends BTypeSymbol {
         this.members = members;
         this.kind = SymbolKind.ENUM;
         this.annots = new ArrayList<>();
+    }
+
+    @Override
+    public void addAnnotation(AnnotationSymbol symbol) {
+        if (symbol != null) {
+            this.annots.add((BAnnotationSymbol) symbol);
+        }
+    }
+
+    public void addAnnotations(List<BAnnotationSymbol> annotSymbols) {
+        for (BAnnotationSymbol symbol : annotSymbols) {
+            addAnnotation(symbol);
+        }
+    }
+
+    @Override
+    public List<? extends AnnotationSymbol> getAnnotations() {
+        return this.annots;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -35,11 +36,13 @@ import java.util.List;
 public class BEnumSymbol extends BTypeSymbol {
 
     public List<BConstantSymbol> members;
+    public List<BAnnotationSymbol> annots;
 
     public BEnumSymbol(List<BConstantSymbol> members, long flags, Name name, PackageID pkgID, BType type,
                        BSymbol owner, Location pos, SymbolOrigin origin) {
         super(SymTag.ENUM, flags, name, pkgID, type, owner, pos, origin);
         this.members = members;
         this.kind = SymbolKind.ENUM;
+        this.annots = new ArrayList<>();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BEnumSymbol.java
@@ -50,9 +50,10 @@ public class BEnumSymbol extends BTypeSymbol implements Annotatable {
 
     @Override
     public void addAnnotation(AnnotationSymbol symbol) {
-        if (symbol != null) {
-            this.annots.add((BAnnotationSymbol) symbol);
+        if (symbol == null) {
+            return;
         }
+        this.annots.add((BAnnotationSymbol) symbol);
     }
 
     public void addAnnotations(List<BAnnotationSymbol> annotSymbols) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -55,9 +55,10 @@ public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
 
     @Override
     public void addAnnotation(AnnotationSymbol symbol) {
-        if (symbol != null) {
-            this.annots.add((BAnnotationSymbol) symbol);
+        if (symbol == null) {
+            return;
         }
+        this.annots.add((BAnnotationSymbol) symbol);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -19,6 +19,8 @@ package org.wso2.ballerinalang.compiler.semantics.model.symbols;
 
 import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.symbols.Annotatable;
+import org.ballerinalang.model.symbols.AnnotationSymbol;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.symbols.VariableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -32,9 +34,9 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.VAR
 /**
  * @since 0.94
  */
-public class BVarSymbol extends BSymbol implements VariableSymbol {
+public class BVarSymbol extends BSymbol implements VariableSymbol, Annotatable {
 
-    public List<BAnnotationSymbol> annots;
+    private List<BAnnotationSymbol> annots;
     public boolean defaultableParam = false;
 
     // Only used for type-narrowing. Cache of the original symbol.
@@ -49,6 +51,18 @@ public class BVarSymbol extends BSymbol implements VariableSymbol {
                       SymbolOrigin origin) {
         super(VARIABLE, flags, name, pkgID, type, owner, pos, origin);
         this.annots = new ArrayList<>();
+    }
+
+    @Override
+    public void addAnnotation(AnnotationSymbol symbol) {
+        if (symbol != null) {
+            this.annots.add((BAnnotationSymbol) symbol);
+        }
+    }
+
+    @Override
+    public List<? extends AnnotationSymbol> getAnnotations() {
+        return this.annots;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BVarSymbol.java
@@ -24,6 +24,9 @@ import org.ballerinalang.model.symbols.VariableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.VARIABLE;
 
 /**
@@ -31,6 +34,7 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.SymTag.VAR
  */
 public class BVarSymbol extends BSymbol implements VariableSymbol {
 
+    public List<BAnnotationSymbol> annots;
     public boolean defaultableParam = false;
 
     // Only used for type-narrowing. Cache of the original symbol.
@@ -44,6 +48,7 @@ public class BVarSymbol extends BSymbol implements VariableSymbol {
     public BVarSymbol(long flags, Name name, PackageID pkgID, BType type, BSymbol owner, Location pos,
                       SymbolOrigin origin) {
         super(VARIABLE, flags, name, pkgID, type, owner, pos, origin);
+        this.annots = new ArrayList<>();
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -34,6 +34,7 @@ import java.util.Optional;
 import static io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
+import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
@@ -84,6 +85,8 @@ public class AnnotationsTest {
                 {98, 18, VARIABLE, of("v5")},
                 {103, 22, METHOD, of("v3")},
 //                {112, 11, WORKER, of("v1")} // TODO: Uncomment after fixing #27461
+                {121, 5, ENUM, of("v1", "v5")},
+                {125, 4, CONSTANT, of("v1")}
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -36,9 +36,7 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
-import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
-import static io.ballerina.compiler.api.symbols.SymbolKind.WORKER;
 import static io.ballerina.tools.text.LinePosition.from;
 import static java.util.List.of;
 import static org.testng.Assert.assertEquals;
@@ -75,7 +73,7 @@ public class AnnotationsTest {
     public Object[][] getPos() {
         return new Object[][]{
                 {46, 6, CONSTANT, of("v1")},
-                {52, 12, TYPE_DEFINITION, of("v1")},
+//                {52, 12, TYPE_DEFINITION, of("v1")}, // TODO: Uncomment after fixing #27461
                 {53, 15, VARIABLE, of("v5")},
                 {65, 6, CLASS, of("v1", "v2", "v2")},
                 {66, 15, VARIABLE, of("v5")},
@@ -85,7 +83,7 @@ public class AnnotationsTest {
                 {86, 11, ANNOTATION, of("v1")},
                 {98, 18, VARIABLE, of("v5")},
                 {103, 22, METHOD, of("v3")},
-                {112, 11, WORKER, of("v1")}
+//                {112, 11, WORKER, of("v1")} // TODO: Uncomment after fixing #27461
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Annotatable;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
+import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
+import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.compiler.api.symbols.SymbolKind.WORKER;
+import static io.ballerina.tools.text.LinePosition.from;
+import static java.util.List.of;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for retrieving annotations from a symbol.
+ *
+ * @since 2.0.0
+ */
+public class AnnotationsTest {
+
+    private SemanticModel model;
+    private final String fileName = "annotations_test.bal";
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/annotations_test.bal");
+    }
+
+    @Test(dataProvider = "PosProvider")
+    public void test(int line, int col, SymbolKind kind, List<String> annots) {
+        Optional<Symbol> symbol = model.symbol(fileName, from(line, col));
+        assertEquals(symbol.get().kind(), kind);
+
+        List<AnnotationSymbol> annotSymbols = ((Annotatable) symbol.get()).annotations();
+
+        assertEquals(annotSymbols.size(), annots.size());
+        for (int i = 0; i < annotSymbols.size(); i++) {
+            assertEquals(annotSymbols.get(i).name(), annots.get(i));
+        }
+    }
+
+    @DataProvider(name = "PosProvider")
+    public Object[][] getPos() {
+        return new Object[][]{
+                {46, 6, CONSTANT, of("v1")},
+                {52, 12, TYPE_DEFINITION, of("v1")},
+                {53, 15, VARIABLE, of("v5")},
+                {65, 6, CLASS, of("v1", "v2", "v2")},
+                {66, 15, VARIABLE, of("v5")},
+                {71, 20, METHOD, of("v3")},
+                {71, 69, VARIABLE, of("v4")},
+                {81, 16, FUNCTION, of("v3")},
+                {86, 11, ANNOTATION, of("v1")},
+                {98, 18, VARIABLE, of("v5")},
+                {103, 22, METHOD, of("v3")},
+                {112, 11, WORKER, of("v1")}
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
@@ -1,0 +1,136 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Annot record {
+    string foo;
+    int bar?;
+};
+
+public annotation Annot v1 on type, class, service, annotation, var, const, worker;
+annotation Annot[] v2 on class;
+public annotation Annot v3 on function;
+annotation Annot v4 on parameter;
+public annotation v5 on return, field;
+
+@v1 {
+    foo: "annot on constant"
+}
+const strValue = "v1 value";
+
+@v1 {
+    foo: strValue,
+    bar: 1
+}
+public type T1 record {
+    @v5 string name;
+};
+
+@v1 {
+    foo: strValue
+}
+@v2 {
+    foo: "v2 value 1"
+}
+@v2 {
+    foo: "v2 value 2"
+}
+class Foo {
+    @v5 string name = "ballerina";
+
+    @v3 {
+        foo: "v31 value"
+    }
+    public function setName(@v4 { foo: "v41 value required" } string name,
+                            @v4 { foo: "v41 value defaultable" } int id = 0,
+                            @v4 { foo: "v41 value rest" } string... others) returns @v5 () {
+        self.name = name;
+    }
+}
+
+@v3 {
+    foo: "annot on function"
+}
+public function sum(int x, int y) returns int => x + y;
+
+@v1 {
+    foo: "annot on annotation"
+}
+annotation v6 on var;
+
+type Greet service object {
+    resource function get greeting() returns json;
+};
+
+@v1 {
+    foo: "annot on service"
+}
+service Greet / on new Listener() {
+
+    @v5
+    public string msg = "Hello"
+
+    @v3 {
+        foo: "annot on resource function"
+    }
+    resource function get greeting() returns json => { output: msg };
+}
+
+function test() {
+    int a = 10;
+
+    @v1 {
+        foo: "annot on worker"
+    }
+    worker w1 {
+       a += 10;
+    }
+}
+
+// util
+
+public class Listener {
+
+    public function start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+
+    public function detach(service object {} s) returns error? {
+    }
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
@@ -35,7 +35,7 @@ type Annot record {
     int bar?;
 };
 
-public annotation Annot v1 on type, class, service, annotation, var, const, worker;
+public const annotation Annot v1 on source type, class, service, annotation, var, const, worker;
 annotation Annot[] v2 on class;
 public annotation Annot v3 on function;
 annotation Annot v4 on parameter;
@@ -96,12 +96,12 @@ type Greet service object {
 service Greet / on new Listener() {
 
     @v5
-    public string msg = "Hello"
+    public string msg = "Hello";
 
     @v3 {
         foo: "annot on resource function"
     }
-    resource function get greeting() returns json => { output: msg };
+    resource function get greeting() returns json => { output: self.msg };
 }
 
 function test() {
@@ -115,11 +115,24 @@ function test() {
     }
 }
 
+@v1 {
+    foo: "annot on enum"
+}
+@v5
+enum Colour {
+    @v1 {
+        foo: "annot on enum member"
+    }
+    RED,
+    GREEN,
+    BLUE
+}
+
 // util
 
 public class Listener {
 
-    public function start() returns error? {
+    public function 'start() returns error? {
     }
 
     public function gracefulStop() returns error? {

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -21,6 +21,7 @@
 <suite name="ballerina-semantic-api-test-suite">
     <test name="semantic-api-test" parallel="false">
         <classes>
+            <class name="io.ballerina.semantic.api.test.AnnotationsTest" />
             <class name="io.ballerina.semantic.api.test.ClassSymbolTest" />
             <class name="io.ballerina.semantic.api.test.DiagnosticsTest" />
             <class name="io.ballerina.semantic.api.test.ExpressionTypeTest" />


### PR DESCRIPTION
## Purpose
This PR adds an API to retrieve the symbols of the annotations attached to constructs.

Fix #27012

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
