### PR TITLE
Use log output files & enable windows ballerina CLI tests

### DIFF
--- a/.github/workflows/CI_windows.yml
+++ b/.github/workflows/CI_windows.yml
@@ -33,5 +33,5 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build with Gradle
-        run: ./gradlew.bat build --continue -x :ballerina-lang:test -x :jballerina-unit-test:test -x :jballerina-integration-test:test  -x :jballerina-debugger-integration-test:test  -x :ballerina-cli:test  -x createJavadoc --stacktrace -scan --console=plain --no-daemon --no-parallel
+        run: ./gradlew.bat build --continue -x :ballerina-lang:test -x :jballerina-unit-test:test -x :jballerina-integration-test:test  -x :jballerina-debugger-integration-test:test  -x createJavadoc --stacktrace -scan --console=plain --no-daemon --no-parallel
 

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/FileUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/FileUtils.java
@@ -18,12 +18,8 @@
 
 package io.ballerina.cli.utils;
 
-import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
+import java.io.File;
 import java.nio.file.Path;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Optional;
 
 /**
@@ -93,26 +89,25 @@ public class FileUtils {
             return Math.max(lastUnixPos, lastWindowsPos);
         }
     }
-    
+
     /**
-     * Iterate and delete all files and subdirectories of a given path.
+     * Delete the given directory along with all files and sub directories.
      *
-     * @param directory Directory path.
-     * @throws IOException Exception when walking the file tree.
+     * @param directoryPath Directory to delete.
      */
-    public static void deleteDirectory(Path directory) throws IOException {
-        Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-                Files.delete(file);
-                return FileVisitResult.CONTINUE;
+    public static boolean deleteDirectory(Path directoryPath) {
+        File directory = new File(String.valueOf(directoryPath));
+        if (directory.isDirectory()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                for (File f : files) {
+                    boolean success = deleteDirectory(f.toPath());
+                    if (!success) {
+                        return false;
+                    }
+                }
             }
-            
-            @Override
-            public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
-                Files.delete(dir);
-                return FileVisitResult.CONTINUE;
-            }
-        });
+        }
+        return directory.delete();
     }
 }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/BuildCommandTest.java
@@ -36,6 +36,7 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
 
+import static io.ballerina.cli.cmd.CommandOutputUtils.getOutput;
 import static io.ballerina.cli.utils.FileUtils.deleteDirectory;
 
 /**
@@ -72,11 +73,7 @@ public class BuildCommandTest extends BaseCommandTest {
         buildCommand.execute();
 
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\thello_world.bal\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\thello_world.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-hello-world-bal.txt"));
 
         Assert.assertTrue(Files.exists(this.testResources
                 .resolve("valid-bal-file")
@@ -100,11 +97,7 @@ public class BuildCommandTest extends BaseCommandTest {
         buildCommand.execute();
 
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\thello_world.bal\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\tfoo.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-foo-bal.txt"));
 
         Assert.assertTrue(Files.exists(this.testResources.resolve("valid-bal-file").resolve("foo.jar")));
         long executableSize = Files.size(this.testResources.resolve("valid-bal-file").resolve("foo.jar"));
@@ -116,11 +109,7 @@ public class BuildCommandTest extends BaseCommandTest {
         buildCommand.execute();
 
         buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\thello_world.bal\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\tbar.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-bar-bal.txt"));
 
         Assert.assertTrue(Files.exists(this.testResources.resolve("valid-bal-file").resolve("bar.jar")));
         Assert.assertEquals(Files.size(this.testResources.resolve("valid-bal-file").resolve("bar.jar")),
@@ -136,13 +125,10 @@ public class BuildCommandTest extends BaseCommandTest {
         buildCommand.execute();
 
         buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\thello_world.bal\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\t" +
-                helloExecutableTmpDir.toAbsolutePath().resolve("hello_world.jar") +
-                "\n");
+        String helloWorldJarLog = getOutput("build-bal-with-absolute-jar-path.txt")
+                .replace("<ABSOLUTE_JAR_PATH>",
+                         helloExecutableTmpDir.toAbsolutePath().resolve("hello_world.jar").toString());
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), helloWorldJarLog);
 
         Assert.assertTrue(Files.exists(helloExecutableTmpDir.toAbsolutePath().resolve("hello_world.jar")));
 
@@ -155,13 +141,10 @@ public class BuildCommandTest extends BaseCommandTest {
         buildCommand.execute();
 
         buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\thello_world.bal\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\t" +
-                helloExecutableTmpDir.toAbsolutePath().resolve("hippo.jar") +
-                "\n");
+        String hippoJarLog = getOutput("build-bal-with-absolute-jar-path.txt")
+                .replace("<ABSOLUTE_JAR_PATH>",
+                         helloExecutableTmpDir.toAbsolutePath().resolve("hippo.jar").toString());
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), hippoJarLog);
 
         Assert.assertTrue(Files.exists(helloExecutableTmpDir.toAbsolutePath().resolve("hippo.jar")));
         deleteDirectory(helloExecutableTmpDir);
@@ -217,10 +200,7 @@ public class BuildCommandTest extends BaseCommandTest {
             buildCommand.execute();
         } catch (BLauncherException e) {
             String buildLog = readOutput(true);
-            Assert.assertEquals(buildLog.replaceAll("\r", ""),
-                    "\nCompiling source\n" +
-                            "\thello_world.bal\n" +
-                            "ERROR [hello_world.bal:(3:1,3:1)] invalid token ';'\n");
+            Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-syntax-err-bal.txt"));
             Assert.assertTrue(e.getDetailedMessages().get(0).contains("compilation contains errors"));
         }
     }
@@ -234,18 +214,8 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n\n" +
-                "\twinery\n" +
-                "\tNo tests found\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""),
+                            getOutput("build-bal-project.txt"));
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());
@@ -266,18 +236,7 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse(projectPath.toString());
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n\n" +
-                "\twinery\n" +
-                "\tNo tests found\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-bal-project.txt"));
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());
@@ -299,17 +258,7 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-bal-project-with-tests.txt"));
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());
@@ -348,30 +297,8 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        String actualOutput1 = "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery\n" +
-                "\twinery.storage\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n";
-        String actualOutput2 = "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery.storage\n" +
-                "\twinery\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n";
+        String actualOutput1 = getOutput("build-multi-module-project-winery.txt");
+        String actualOutput2 = getOutput("build-multi-module-project-winery-storage.txt");
         Assert.assertTrue(buildLog.replaceAll("\r", "").equals(actualOutput1)
                 || buildLog.replaceAll("\r", "").equals(actualOutput2));
 
@@ -402,14 +329,7 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-project-default-build-options.txt"));
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());
@@ -434,23 +354,10 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery\n" +
-                "\n" +
-                "Generating Test Report\n" +
-                "\t" + projectPath.resolve("target").resolve("report").resolve("test_results.json").toString() + "\n" +
-                "\n" +
-                "warning: Could not find the required HTML report tools for code coverage at " +
-                "<ballerina.home>/lib/tools/coverage/report.zip\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        String expectedLog = getOutput("build-bal-project-override-build-options.txt")
+                .replace("<TEST_RESULTS_JSON_PATH>",
+                         projectPath.resolve("target").resolve("report").resolve("test_results.json").toString());
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), expectedLog);
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());
@@ -478,23 +385,10 @@ public class BuildCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery\n" +
-                "\n" +
-                "Generating Test Report\n" +
-                "\t" + projectPath.resolve("target").resolve("report").resolve("test_results.json").toString() + "\n" +
-                "\n" +
-                "warning: Could not find the required HTML report tools for code coverage at " +
-                "<ballerina.home>/lib/tools/coverage/report.zip\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        String expectedLog = getOutput("build-bal-project-override-build-options.txt")
+                .replace("<TEST_RESULTS_JSON_PATH>",
+                         projectPath.resolve("target").resolve("report").resolve("test_results.json").toString());
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), expectedLog);
 
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/CommandOutputUtils.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/CommandOutputUtils.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.cli.cmd;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.ballerina.cli.utils.OsUtils.isWindows;
+
+/**
+ * Doc output utilities.
+ *
+ * @since 2.0.0
+ */
+public class CommandOutputUtils {
+
+    private static final Path commandOutputsDir = Paths
+            .get("src", "test", "resources", "test-resources", "command-outputs");
+
+    private CommandOutputUtils() {
+    }
+
+    static String getOutput(String outputFileName) throws IOException {
+        if (isWindows()) {
+            return Files.readString(commandOutputsDir.resolve("windows").resolve(outputFileName));
+        } else {
+            return Files.readString(commandOutputsDir.resolve("unix").resolve(outputFileName));
+        }
+    }
+}

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/CommandOutputUtils.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/CommandOutputUtils.java
@@ -39,7 +39,8 @@ public class CommandOutputUtils {
 
     static String getOutput(String outputFileName) throws IOException {
         if (isWindows()) {
-            return Files.readString(commandOutputsDir.resolve("windows").resolve(outputFileName));
+            return Files.readString(commandOutputsDir.resolve("windows").resolve(outputFileName))
+                    .replaceAll("\r", "");
         } else {
             return Files.readString(commandOutputsDir.resolve("unix").resolve(outputFileName));
         }

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PushCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/PushCommandTest.java
@@ -31,6 +31,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
+import static io.ballerina.cli.cmd.CommandOutputUtils.getOutput;
+
 /**
  * Push command tests.
  *
@@ -93,18 +95,7 @@ public class PushCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse();
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n\n" +
-                "\twinery\n" +
-                "\tNo tests found\n" +
-                "\n" +
-                "Creating balo\n" +
-                "\ttarget/balo/foo-winery-any-0.1.0.balo\n" +
-                "\n" +
-                "Generating executable\n" +
-                "\ttarget/bin/winery.jar\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("build-bal-project.txt"));
         Assert.assertTrue(
                 projectPath.resolve("target").resolve("balo").resolve("foo-winery-any-0.1.0.balo").toFile().exists());
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/RunCommandTest.java
@@ -14,6 +14,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Objects;
 
+import static io.ballerina.cli.cmd.CommandOutputUtils.getOutput;
+
 /**
  * Run command tests.
  *
@@ -51,10 +53,7 @@ public class RunCommandTest extends BaseCommandTest {
         runCommand.execute();
 
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfile_create.bal\n" +
-                "\n" +
-                "Running executable\n\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("run-bal.txt"));
 
         Assert.assertTrue(tempFile.toFile().exists());
 

--- a/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
+++ b/cli/ballerina-cli/src/test/java/io/ballerina/cli/cmd/TestCommandTest.java
@@ -36,6 +36,8 @@ import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Objects;
 
+import static io.ballerina.cli.cmd.CommandOutputUtils.getOutput;
+
 /**
  * Build command tests.
  *
@@ -119,11 +121,7 @@ public class TestCommandTest extends BaseCommandTest {
         new CommandLine(testCommand).parse();
         testCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("test-project.txt"));
     }
 
     @Test(description = "Build a valid ballerina project")
@@ -144,11 +142,7 @@ public class TestCommandTest extends BaseCommandTest {
         new CommandLine(buildCommand).parse(projectPath.toString());
         buildCommand.execute();
         String buildLog = readOutput(true);
-        Assert.assertEquals(buildLog.replaceAll("\r", ""), "\nCompiling source\n" +
-                "\tfoo/winery:0.1.0\n" +
-                "\n" +
-                "Running Tests\n" +
-                "\twinery\n");
+        Assert.assertEquals(buildLog.replaceAll("\r", ""), getOutput("test-project.txt"));
     }
 
     static class Copy extends SimpleFileVisitor<Path> {

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-override-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-override-build-options.txt
@@ -1,0 +1,17 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery
+
+Generating Test Report
+	<TEST_RESULTS_JSON_PATH>
+
+warning: Could not find the required HTML report tools for code coverage at <ballerina.home>/lib/tools/coverage/report.zip
+
+Creating balo
+	target/balo/foo-winery-any-0.1.0.balo
+
+Generating executable
+	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-with-tests.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project-with-tests.txt
@@ -1,0 +1,12 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery
+
+Creating balo
+	target/balo/foo-winery-any-0.1.0.balo
+
+Generating executable
+	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-project.txt
@@ -1,0 +1,14 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+
+	winery
+	No tests found
+
+Creating balo
+	target/balo/foo-winery-any-0.1.0.balo
+
+Generating executable
+	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-with-absolute-jar-path.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bal-with-absolute-jar-path.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	<ABSOLUTE_JAR_PATH>

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bar-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-bar-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	bar.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-foo-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-foo-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	foo.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-hello-world-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-hello-world-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	hello_world.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-multi-module-project-winery-storage.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-multi-module-project-winery-storage.txt
@@ -1,0 +1,13 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery.storage
+	winery
+
+Creating balo
+	target/balo/foo-winery-any-0.1.0.balo
+
+Generating executable
+	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-multi-module-project-winery.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-multi-module-project-winery.txt
@@ -1,0 +1,13 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery
+	winery.storage
+
+Creating balo
+	target/balo/foo-winery-any-0.1.0.balo
+
+Generating executable
+	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-project-default-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-project-default-build-options.txt
@@ -1,0 +1,9 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Creating balo
+	target/balo/foo-winery-any-0.1.0.balo
+
+Generating executable
+	target/bin/winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-syntax-err-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/build-syntax-err-bal.txt
@@ -1,0 +1,4 @@
+
+Compiling source
+	hello_world.bal
+ERROR [hello_world.bal:(3:1,3:1)] invalid token ';'

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/run-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/run-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	file_create.bal
+
+Running executable
+

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/test-project.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/unix/test-project.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-override-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-override-build-options.txt
@@ -1,0 +1,17 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery
+
+Generating Test Report
+	<TEST_RESULTS_JSON_PATH>
+
+warning: Could not find the required HTML report tools for code coverage at <ballerina.home>/lib/tools/coverage/report.zip
+
+Creating balo
+	target\balo\foo-winery-any-0.1.0.balo
+
+Generating executable
+	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-override-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-override-build-options.txt
@@ -8,7 +8,7 @@ Running Tests
 Generating Test Report
 	<TEST_RESULTS_JSON_PATH>
 
-warning: Could not find the required HTML report tools for code coverage at <ballerina.home>/lib/tools/coverage/report.zip
+warning: Could not find the required HTML report tools for code coverage at <ballerina.home>\lib\tools\coverage\report.zip
 
 Creating balo
 	target\balo\foo-winery-any-0.1.0.balo

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-with-tests.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project-with-tests.txt
@@ -1,0 +1,12 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery
+
+Creating balo
+	target\balo\foo-winery-any-0.1.0.balo
+
+Generating executable
+	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-project.txt
@@ -1,0 +1,14 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+
+	winery
+	No tests found
+
+Creating balo
+	target\balo\foo-winery-any-0.1.0.balo
+
+Generating executable
+	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-with-absolute-jar-path.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bal-with-absolute-jar-path.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	<ABSOLUTE_JAR_PATH>

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bar-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-bar-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	bar.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-foo-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-foo-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	foo.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-hello-world-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-hello-world-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	hello_world.bal
+
+Generating executable
+	hello_world.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-multi-module-project-winery-storage.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-multi-module-project-winery-storage.txt
@@ -1,0 +1,13 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery.storage
+	winery
+
+Creating balo
+	target\balo\foo-winery-any-0.1.0.balo
+
+Generating executable
+	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-multi-module-project-winery.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-multi-module-project-winery.txt
@@ -1,0 +1,13 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery
+	winery.storage
+
+Creating balo
+	target\balo\foo-winery-any-0.1.0.balo
+
+Generating executable
+	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-project-default-build-options.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-project-default-build-options.txt
@@ -1,0 +1,9 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Creating balo
+	target\balo\foo-winery-any-0.1.0.balo
+
+Generating executable
+	target\bin\winery.jar

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-syntax-err-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/build-syntax-err-bal.txt
@@ -1,0 +1,4 @@
+
+Compiling source
+	hello_world.bal
+ERROR [hello_world.bal:(3:1,3:1)] invalid token ';'

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/run-bal.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/run-bal.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	file_create.bal
+
+Running executable
+

--- a/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/test-project.txt
+++ b/cli/ballerina-cli/src/test/resources/test-resources/command-outputs/windows/test-project.txt
@@ -1,0 +1,6 @@
+
+Compiling source
+	foo/winery:0.1.0
+
+Running Tests
+	winery


### PR DESCRIPTION
## Purpose
> Use log output files for CLI tests and enable windows CLI tests.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
