### PR TITLE
Add a test for service constructor re-ordering for annotations

### DIFF
--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BasicCasesTest.java
@@ -93,7 +93,7 @@ public class BasicCasesTest extends BaseTestCase {
 
     @Test
     public void testAnnotationAccess() throws BallerinaTestException {
-        String msg = "3 passing";
+        String msg = "4 passing";
         LogLeecher clientLeecher = new LogLeecher(msg);
         balClient.runMain("test", new String[]{"annotation-access"}, null,
                 new String[]{}, new LogLeecher[]{clientLeecher}, projectPath);

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/annotation-access/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/annotation-access/tests/main_test.bal
@@ -56,3 +56,30 @@ function testTestConstructTestAnnotAccess() {
 function testTestSrcConstructSrcAnnotAccess() {
     test:assertEquals(getFooAnnotId(), 100);
 }
+
+type MyAnnotation record {
+    string foo;
+};
+
+annotation MyAnnotation serviceAnnotation on service, class;
+
+service object {} ser =
+@serviceAnnotation{
+    foo: "serviceAnnotation"
+}
+service object {
+    int i = 1234;
+
+    remote function xyz() {
+
+    }
+};
+
+@test:Config {}
+public function testServiceAnnotReordering() {
+    typedesc<any> td = typeof ser;
+
+    MyAnnotation? x = td.@serviceAnnotation;
+    test:assertTrue(x is MyAnnotation);
+    test:assertEquals(x, <MyAnnotation> {foo: "serviceAnnotation"});
+}


### PR DESCRIPTION
## Purpose
Adds a test for the scenario fixed in https://github.com/ballerina-platform/ballerina-lang/pull/27438.

Testerina tests are disabled atm, but adding this test so that it will run when the tests are enabled. Tests were also run locally.

Partially addresses https://github.com/ballerina-platform/ballerina-lang/issues/16555

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
