### PR TITLE
Restrict type() return types of expressions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -43,6 +43,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
@@ -204,11 +205,11 @@ public class BallerinaSemanticModel implements SemanticModel {
         NodeFinder nodeFinder = new NodeFinder();
         BLangNode node = nodeFinder.lookup(compilationUnit, range);
 
-        if (node == null) {
-            return Optional.empty();
+        if (node instanceof BLangExpression) {
+            return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
         }
 
-        return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
+        return Optional.empty();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -76,6 +76,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangObjectConstructorExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangRawTemplateLiteral;
@@ -194,7 +195,8 @@ class NodeFinder extends BaseVisitor {
         this.enclosingNode = null;
 
         for (TopLevelNode node : nodes) {
-            if (!PositionUtil.withinRange(this.range, node.getPosition()) || isLambdaFunction(node)) {
+            if (!PositionUtil.withinRange(this.range, node.getPosition()) || isLambdaFunction(node)
+                    || isClassDefForObjectConstructor(node)) {
                 continue;
             }
 
@@ -234,7 +236,7 @@ class NodeFinder extends BaseVisitor {
 
         node.accept(this);
 
-        if (this.enclosingNode == null && !node.internal) {
+        if (this.enclosingNode == null && !node.internal && this.range.equals(node.pos.lineRange())) {
             this.enclosingNode = node;
         }
     }
@@ -902,7 +904,15 @@ class NodeFinder extends BaseVisitor {
         lookupNode(classDefinition.initFunction);
         lookupNodes(classDefinition.functions);
         lookupNodes(classDefinition.typeRefs);
-        setEnclosingNode(classDefinition, classDefinition.name.pos);
+
+        if (!classDefinition.flagSet.contains(Flag.OBJECT_CTOR)) {
+            setEnclosingNode(classDefinition, classDefinition.name.pos);
+        }
+    }
+
+    @Override
+    public void visit(BLangObjectConstructorExpression objConstructorExpr) {
+        lookupNode(objConstructorExpr.classNode);
     }
 
     @Override
@@ -1188,5 +1198,13 @@ class NodeFinder extends BaseVisitor {
 
         BLangFunction func = (BLangFunction) node;
         return func.flagSet.contains(Flag.LAMBDA);
+    }
+
+    private boolean isClassDefForObjectConstructor(TopLevelNode node) {
+        if (node.getKind() != NodeKind.CLASS_DEFN) {
+            return false;
+        }
+
+        return ((BLangClassDefinition) node).flagSet.contains(Flag.OBJECT_CTOR);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2159,15 +2159,20 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         switch (kind) {
             case XML_TEMPLATE_EXPRESSION:
                 SyntaxKind contentKind = expressionNode.content().get(0).kind();
+                BLangNode expr;
                 switch (contentKind) {
                     case XML_COMMENT:
                     case XML_PI:
                     case XML_ELEMENT:
                     case XML_EMPTY_ELEMENT:
-                        return createExpression(expressionNode.content().get(0));
+                        expr = createExpression(expressionNode.content().get(0));
+                        break;
                     default:
-                        return createXMLLiteral(expressionNode);
+                        expr = createXMLLiteral(expressionNode);
+                        break;
                 }
+                expr.pos = getPosition(expressionNode);
+                return expr;
             case STRING_TEMPLATE_EXPRESSION:
                 return createStringTemplateLiteral(expressionNode.content(), getPosition(expressionNode));
             case RAW_TEMPLATE_EXPRESSION:

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -33,6 +33,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
@@ -53,6 +54,8 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Tests for the checking the types of expressions.
@@ -83,27 +86,32 @@ public class ExpressionTypeTest {
                 {17, 44, 17, 46, NIL},
                 {17, 48, 17, 53, STRING},
                 {18, 13, 18, 17, NIL},
+                {113, 16, 113, 20, BOOLEAN}
         };
     }
 
     @Test
     public void testByteLiteral() {
-        TypeSymbol type = getExprType(19, 13, 19, 42);
+        TypeSymbol type = getExprType(19, 15, 19, 44);
         assertEquals(type.typeKind(), ARRAY);
         assertEquals(((ArrayTypeSymbol) type).memberTypeDescriptor().typeKind(), BYTE);
+
+        Optional<TypeSymbol> optType = getOptionalType(19, 13, 19, 42);
+        assertTrue(optType.isEmpty());
     }
 
-    @Test(dataProvider = "TemplateExprProvider")
-    public void testTemplateExprs(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
-        assertType(sLine, sCol, eLine, eCol, kind);
+    @Test
+    public void testStringTemplateExpr() {
+        assertType(23, 15, 23, 36, STRING);
     }
 
-    @DataProvider(name = "TemplateExprProvider")
-    public Object[][] getTemplateExprPos() {
-        return new Object[][]{
-                {23, 15, 23, 36, STRING},
-                {24, 12, 24, 45, XML},
-        };
+    @Test
+    public void testXMLTemplateExpr() {
+        TypeSymbol type = getExprType(24, 12, 24, 45);
+
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.name(), "Element");
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), XML);
     }
 
     @Test
@@ -254,13 +262,16 @@ public class ExpressionTypeTest {
         return new Object[][]{
                 {72, 12, 72, 15, INT},
                 {73, 12, 73, 23, INT},
-                {73, 17, 73, 23, INT},
+                {73, 17, 73, 23, null},
+                {73, 12, 73, 19, INT},
                 {74, 12, 74, 23, INT},
                 {75, 16, 75, 22, BOOLEAN},
                 {76, 17, 76, 22, STRING},
                 {78, 8, 78, 20, BOOLEAN},
                 {78, 8, 78, 10, ANYDATA},
-                {78, 14, 78, 20, STRING},
+                {78, 14, 78, 20, null},
+                {78, 8, 78, 30, BOOLEAN},
+                {78, 24, 78, 30, BOOLEAN},
         };
     }
 
@@ -316,19 +327,30 @@ public class ExpressionTypeTest {
         return new Object[][]{
                 {109, 4, 109, 10, UNION},
                 {109, 4, 109, 9, UNION},
-                {112, 15, 112, 27, STRING},
+                {112, 15, 112, 27, null},
                 {112, 15, 112, 26, STRING}
         };
     }
 
     private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
-        TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
-        assertEquals(type.typeKind(), kind);
+        Optional<TypeSymbol> type = getOptionalType(sLine, sCol, eLine, eCol);
+
+        if (type.isPresent()) {
+            assertEquals(type.get().typeKind(), kind);
+        } else {
+            assertNull(kind, "Type symbol not found, but expected a type symbol of kind: " + kind);
+        }
     }
 
     private TypeSymbol getExprType(int sLine, int sCol, int eLine, int eCol) {
         LinePosition start = LinePosition.from(sLine, sCol);
         LinePosition end = LinePosition.from(eLine, eCol);
         return model.type("expressions_test.bal", LineRange.from("expressions_test.bal", start, end)).get();
+    }
+
+    private Optional<TypeSymbol> getOptionalType(int sLine, int sCol, int eLine, int eCol) {
+        LinePosition start = LinePosition.from(sLine, sCol);
+        LinePosition end = LinePosition.from(eLine, eCol);
+        return model.type("expressions_test.bal", LineRange.from("expressions_test.bal", start, end));
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -111,6 +111,7 @@ function testFunctionCall() {
 
     PersonObj p = new("Pubudu");
     string s = p.getName();
+    boolean b = true;
 }
 
 // utils


### PR DESCRIPTION
## Purpose
Currently, `type()` returns type type of any node, if there's a node in the given range. This PR restricts this to return only the types of expressions.

Fix #27432 

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
