### PR TITLE
Remove singleton instance of PackageHolder in Observability Symbol Collector

### DIFF
--- a/misc/observability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
+++ b/misc/observability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
@@ -71,6 +71,7 @@ public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolC
     private static final PrintStream out = System.out;
 
     private boolean isObservabilityIncluded = false;
+    private final PackageHolder packageHolder = new PackageHolder();
 
     @Override
     public void process(Project project) {
@@ -79,7 +80,6 @@ public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolC
             return;
         }
         Package currentPackage = project.currentPackage();
-        PackageHolder packageHolder = PackageHolder.getInstance();
         packageHolder.setOrg(currentPackage.packageOrg().toString());
         packageHolder.setName(currentPackage.packageName().toString());
         packageHolder.setVersion(currentPackage.packageVersion().toString());
@@ -103,7 +103,7 @@ public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolC
             Files.createDirectories(syntaxTreeDirPath);
 
             // Writing Syntax Tree Json
-            String syntaxTreeDataString = generateCanonicalJsonString(PackageHolder.getInstance());
+            String syntaxTreeDataString = generateCanonicalJsonString(packageHolder);
             Files.write(syntaxTreeDirPath.resolve(SYNTAX_TREE_FILE_NAME),
                     syntaxTreeDataString.getBytes(StandardCharsets.UTF_8));
 

--- a/misc/observability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/model/PackageHolder.java
+++ b/misc/observability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/model/PackageHolder.java
@@ -31,24 +31,15 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class PackageHolder {
 
-    private static final PackageHolder INSTANCE = new PackageHolder();
-
     private String org;
     private String name;
     private String version;
     private final Map<String, ModuleHolder> modulesMap = new ConcurrentHashMap<>();
 
-    private PackageHolder() {   // Prevent initialization
-    }
-
     public void addSyntaxTree(ModuleDescriptor moduleDescriptor, String documentName, JsonElement syntaxTreeJson) {
         String moduleName = moduleDescriptor.name().toString();
         ModuleHolder moduleHolder = this.modulesMap.computeIfAbsent(moduleName, k -> new ModuleHolder(moduleName));
         moduleHolder.addSyntaxTree(documentName, syntaxTreeJson);
-    }
-
-    public static PackageHolder getInstance() {
-        return INSTANCE;
     }
 
     public Map<String, ModuleHolder> getModules() {


### PR DESCRIPTION
## Purpose
> Remove singleton instance of PackageHolder in Observability Symbol Collector

## Approach
> Observability symbol collector instance is kept within the compiler context. Since keeping singleton objects are not a good practice, the Package Holder was made part of the Default Observability Symbol collector so that it becomes part of the compiler context.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
