### PR TITLE
Add clean cache method to avoid orgName/pkgName caching issues

### DIFF
--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
@@ -34,7 +34,6 @@ import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -267,10 +266,5 @@ public class PackageResolutionTests {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_m_with_unstable_dep");
         BuildProject buildProject = BuildProject.load(projectDirPath);
         buildProject.currentPackage().getResolution();
-    }
-
-    @AfterClass
-    public void tearDown() {
-        BCompileUtil.cleanBaloCache();
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/PackageResolutionTests.java
@@ -34,6 +34,7 @@ import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
@@ -181,7 +182,7 @@ public class PackageResolutionTests {
         jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALO, balrPath);
 
         // Load the balr file now.
-        BaloProject baloProject = BaloProject.loadProject(BCompileUtil.getTestProjectEnvironmentBuilder(), balrPath);
+        BaloProject baloProject = BaloProject.loadProject(BCompileUtil.testProjectEnvironmentBuilder(), balrPath);
         PackageResolution resolution = baloProject.currentPackage().getResolution();
 
         // Dependency graph should contain only one entry
@@ -266,5 +267,10 @@ public class PackageResolutionTests {
         Path projectDirPath = RESOURCE_DIRECTORY.resolve("package_m_with_unstable_dep");
         BuildProject buildProject = BuildProject.load(projectDirPath);
         buildProject.currentPackage().getResolution();
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBaloWriter.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBaloWriter.java
@@ -33,6 +33,7 @@ import io.ballerina.projects.internal.model.Target;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -365,5 +366,10 @@ public class TestBaloWriter {
     @AfterMethod
     public void cleanUp() {
         TestUtils.deleteDirectory(new File(String.valueOf(BALO_PATH)));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBaloWriter.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBaloWriter.java
@@ -33,7 +33,6 @@ import io.ballerina.projects.internal.model.Target;
 import io.ballerina.projects.util.ProjectUtils;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -366,10 +365,5 @@ public class TestBaloWriter {
     @AfterMethod
     public void cleanUp() {
         TestUtils.deleteDirectory(new File(String.valueOf(BALO_PATH)));
-    }
-
-    @AfterClass
-    public void tearDown() {
-        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -29,6 +29,7 @@ import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -132,5 +133,10 @@ public class SymbolBIRTest {
 //                {26, 12, "foo"}, // TODO: issue #25841
                 {31, 20, "getName"},
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
@@ -18,7 +18,7 @@
 
 package io.ballerina.semantic.api.test.allreferences;
 
-import org.ballerinalang.test.balo.BaloCreator;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -36,8 +36,7 @@ public class FindModulePrefixRefsTest extends FindAllReferencesTest {
 
     @BeforeClass
     public void setup() {
-        BaloCreator.cleanCacheDirectories();
-        BaloCreator.createAndSetupBalo("test-src/test-project", "testorg", "baz");
+        BCompileUtil.compileAndCacheBalo("test-src/test-project");
         super.setup();
     }
 
@@ -72,6 +71,6 @@ public class FindModulePrefixRefsTest extends FindAllReferencesTest {
 
     @AfterClass
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/test-project", "testorg", "baz");
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/CompilerPluginTest.java
+++ b/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/CompilerPluginTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -109,5 +110,10 @@ public class CompilerPluginTest {
                 Assert.assertEquals(actualEventSet.contains(expectedEvent), true,
                         "The " + kind.name + " '" + expectedEvent.nodeName + "' is not processed")
         );
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -190,7 +190,7 @@ public class BCompileUtil {
     public static void cleanBaloCache() {
         Path testCompilationCachePath = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
         if (testCompilationCachePath.toFile().exists()) {
-            BFileUtil.delete(testCompilationCachePath);
+            BFileUtil.deletePackageCache(testCompilationCachePath);
         }
     }
 }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BCompileUtil.java
@@ -28,6 +28,7 @@ import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.projects.environment.EnvironmentBuilder;
 import io.ballerina.projects.repos.FileSystemCache;
 import io.ballerina.projects.util.ProjectUtils;
+import org.ballerinalang.test.util.BFileUtil;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -88,7 +89,7 @@ public class BCompileUtil {
         Path sourceRoot = testSourcesDirectory.resolve(sourcePath.getParent());
 
         Path projectPath = Paths.get(sourceRoot.toString(), sourceFileName);
-        Project project = ProjectLoader.loadProject(projectPath, getTestProjectEnvironmentBuilder());
+        Project project = ProjectLoader.loadProject(projectPath, testProjectEnvironmentBuilder());
 
         if (isSingleFileProject(project)) {
             throw new RuntimeException("single file project is given for compilation at " + project.sourceRoot());
@@ -131,7 +132,7 @@ public class BCompileUtil {
         Files.copy(srcPath, targetPath, StandardCopyOption.REPLACE_EXISTING);
     }
 
-    public static ProjectEnvironmentBuilder getTestProjectEnvironmentBuilder() {
+    public static ProjectEnvironmentBuilder testProjectEnvironmentBuilder() {
         ProjectEnvironmentBuilder environmentBuilder = ProjectEnvironmentBuilder.getBuilder(
                 EnvironmentBuilder.buildDefault());
         return environmentBuilder.addCompilationCacheFactory(TestCompilationCache::from);
@@ -183,6 +184,13 @@ public class BCompileUtil {
         private static TestCompilationCache from(Project project) {
             Path testCompilationCachePath = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
             return new TestCompilationCache(project, testCompilationCachePath);
+        }
+    }
+
+    public static void cleanBaloCache() {
+        Path testCompilationCachePath = testBuildDirectory.resolve(DIST_CACHE_DIRECTORY);
+        if (testCompilationCachePath.toFile().exists()) {
+            BFileUtil.delete(testCompilationCachePath);
         }
     }
 }

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -123,7 +123,7 @@ public class BFileUtil {
     }
 
     /**
-     * Delete the distribution package cache directory and files from give location.
+     * Delete the distribution package cache directory and files from given location, excluding the system balos.
      *
      * @param path Path to the package cache
      */
@@ -140,7 +140,8 @@ public class BFileUtil {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     if (Files.exists(file)) {
-                        if (file.toString().matches(patternToExclude)) {
+                        String path = file.toString().replaceAll("\\\\", "/");
+                        if (path.matches(patternToExclude)) {
                             return FileVisitResult.CONTINUE;
                         }
                         Files.delete(file);
@@ -151,7 +152,8 @@ public class BFileUtil {
                 @Override
                 public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
                     if (Files.exists(dir)) {
-                        if (dir.toString().matches(patternToExclude)) {
+                        String path = dir.toString().replaceAll("\\\\", "/");
+                        if (path.matches(patternToExclude)) {
                             return FileVisitResult.CONTINUE;
                         }
                         Files.list(dir).forEach(BFileUtil::delete);

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/util/BFileUtil.java
@@ -112,6 +112,7 @@ public class BFileUtil {
                 public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
                     if (Files.exists(dir)) {
                         Files.list(dir).forEach(BFileUtil::delete);
+                        Files.delete(dir);
                     }
                     return FileVisitResult.CONTINUE;
                 }
@@ -120,6 +121,50 @@ public class BFileUtil {
             throw new BLangRuntimeException("error occurred while deleting '" + path + "'", e);
         }
     }
+
+    /**
+     * Delete the distribution package cache directory and files from give location.
+     *
+     * @param path Path to the package cache
+     */
+    public static void deletePackageCache(Path path) {
+        final String patternToExclude = ".*repo/balo/ballerina.*|.*repo/cache/ballerina.*|.*repo|.*cache|.*balo";
+        try {
+            Files.walkFileTree(path, new SimpleFileVisitor<Path>() {
+
+                @Override
+                public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+                    if (Files.exists(file)) {
+                        if (file.toString().matches(patternToExclude)) {
+                            return FileVisitResult.CONTINUE;
+                        }
+                        Files.delete(file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+                    if (Files.exists(dir)) {
+                        if (dir.toString().matches(patternToExclude)) {
+                            return FileVisitResult.CONTINUE;
+                        }
+                        Files.list(dir).forEach(BFileUtil::delete);
+                        Files.delete(dir);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+        } catch (IOException e) {
+            throw new BLangRuntimeException("error occurred while deleting '" + path + "'", e);
+        }
+    }
+
 
     /**
      * Provides Qualified Class Name.

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/annotation/AnnotationTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/annotation/AnnotationTests.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -78,5 +79,10 @@ public class AnnotationTests {
         Assert.assertEquals(returns.length, 1);
         Assert.assertNotNull(returns[0]);
         Assert.assertTrue(returns[0].stringValue().contains("/bar"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInBaloTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -1142,5 +1143,10 @@ public class MapConstantEqualityInBaloTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testSimpleNilMapReferenceEqualityInDifferentMap");
         Assert.assertNotNull(returns[0]);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInDifferentBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInDifferentBaloTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -1144,5 +1145,10 @@ public class MapConstantEqualityInDifferentBaloTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testSimpleNilMapReferenceEqualityInDifferentMap");
         Assert.assertNotNull(returns[0]);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantInBaloTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -264,5 +265,10 @@ public class MapConstantInBaloTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testConstInAnnotations");
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "{s:\"Ballerina\", i:100, m:{\"mKey\":\"mValue\"}}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantPanicInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantPanicInBaloTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -289,5 +290,10 @@ public class MapConstantPanicInBaloTest {
             expectedExceptionsMessageRegExp = ".*modification not allowed on readonly value.*")
     public void updateConstantNilMapValueInArrayWithNewKey() {
         BRunUtil.invoke(compileResult, "updateConstantNilMapValueInArrayWithNewKey");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantAccessInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantAccessInBaloTest.java
@@ -26,7 +26,6 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.ballerinalang.test.balo.BaloCreator;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantAccessInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantAccessInBaloTest.java
@@ -159,6 +159,6 @@ public class SimpleConstantAccessInBaloTest {
 
     @AfterClass
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantBaloNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantBaloNegativeTests.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -63,5 +64,10 @@ public class SimpleConstantBaloNegativeTests {
                 " 'string'", offset += 9, 28);
         BAssertUtil.validateError(compileResult, index, "incompatible types: expected 'Ballerina rocks', found " +
                 "'string'", offset += 7, 31);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/documentation/DocumentationTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.model.elements.MarkdownDocAttachment;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
@@ -109,5 +110,10 @@ public class DocumentationTest {
 
         Assert.assertNotNull(annotationSymbol.markdownDocumentation);
         Assert.assertEquals(markdownDocumentation.description, "Documentation for Test annotation");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/FunctionSignatureInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/FunctionSignatureInBaloTest.java
@@ -25,7 +25,6 @@ import org.ballerinalang.core.model.values.BValueArray;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.ballerinalang.test.balo.BaloCreator;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/FunctionSignatureInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/functions/FunctionSignatureInBaloTest.java
@@ -392,6 +392,6 @@ public class FunctionSignatureInBaloTest {
 
     @AfterClass
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/globalvar/GlobalVarFunctionInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/globalvar/GlobalVarFunctionInBaloTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -167,5 +168,10 @@ public class GlobalVarFunctionInBaloTest {
         Assert.assertEquals(((BInteger) returns[4]).intValue(), 3);
         Assert.assertEquals(((BInteger) returns[5]).intValue(), 3);
         Assert.assertEquals(((BInteger) returns[6]).intValue(), 2);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/listener/ListenerBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/listener/ListenerBaloTest.java
@@ -21,7 +21,6 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.ballerinalang.test.balo.BaloCreator;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/listener/ListenerBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/listener/ListenerBaloTest.java
@@ -50,6 +50,6 @@ public class ListenerBaloTest {
 
     @AfterClass(enabled = false)
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_listener", "listenerProject", "bee");
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/listener/ListenerBaloTestExtPackage.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/listener/ListenerBaloTestExtPackage.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.balo.listener;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,6 +40,11 @@ public class ListenerBaloTestExtPackage {
     @Test(description = "Test access listener in different package")
     public void testListenerObjectDefinedInDifferentPackage() {
         BRunUtil.invoke(compileResult, "getStartAndAttachCount");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -589,4 +590,9 @@ public class ObjectInBaloTest {
 //                                          "non-public fields or methods",
 //                                  42, 6);
 //    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectIncludeOverrideBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectIncludeOverrideBaloTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.balo.object;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -49,5 +50,10 @@ public class ObjectIncludeOverrideBaloTest {
     @Test
     public void testObjectWithOverriddenFieldsAndMethods() {
         BRunUtil.invoke(result, "testObjectWithOverriddenFieldsAndMethods");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ReadOnlyObjectBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ReadOnlyObjectBaloTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.balo.object;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
@@ -55,5 +56,10 @@ public class ReadOnlyObjectBaloTest {
         validateError(result, index++, "invalid intersection type: cannot have a 'readonly' intersection with a " +
                 "'readonly object'", 20, 5);
         assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/RemoteObjectBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/RemoteObjectBaloTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -50,5 +51,10 @@ public class RemoteObjectBaloTest {
         result = BRunUtil.invoke(compileResult, "testNewEP", new BValue[]{new BString("done")});
         Assert.assertEquals(result.length, 1);
         Assert.assertEquals(result[0].stringValue(), "donedone");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ServiceObjectBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ServiceObjectBaloTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.balo.object;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,5 +45,10 @@ public class ServiceObjectBaloTest {
     @Test
     public void testServiceClassBalo() {
         BRunUtil.invoke(result, "testServiceObjectValue");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/readonly/SelectivelyImmutableTypeBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/readonly/SelectivelyImmutableTypeBaloTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.balo.readonly;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -84,5 +85,10 @@ public class SelectivelyImmutableTypeBaloTest {
                 ".0:MyConfig'", 88, 5);
 
         assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
@@ -171,6 +171,6 @@ public class ClosedRecordTypeReferenceTest {
 
     @AfterClass
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
@@ -29,7 +29,6 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.ballerinalang.test.balo.BaloCreator;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -170,5 +171,10 @@ public class OpenRecordTypeReferenceTest {
     @Test()
     public void testCreatingRecordWithOverriddenFields() {
         BRunUtil.invoke(compileResult, "testCreatingRecordWithOverriddenFields");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/RecordInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/RecordInBaloTest.java
@@ -22,7 +22,6 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.ballerinalang.test.balo.BaloCreator;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/RecordInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/RecordInBaloTest.java
@@ -61,6 +61,6 @@ public class RecordInBaloTest {
 
     @AfterClass
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project/", "testorg", "records");
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -119,5 +120,10 @@ public class ErrorTypeTest {
                 "incompatible types: expected 'testorg/errors:1.0.0:NewPostDefinedError', " +
                         "found 'testorg/errors:1.0.0:PostDefinedError'", 28, 32);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/FiniteTypeTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -305,6 +306,11 @@ public class FiniteTypeTest {
                 {"testFiniteTypesAsUnionsAsBroaderTypes_1"},
                 {"testFiniteTypesAsUnionsAsBroaderTypes_2"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/NeverTypeBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/NeverTypeBaloTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -67,5 +68,10 @@ public class NeverTypeBaloTest {
     @Test
     public void testNeverWithKeyLessTable() {
         BRunUtil.invoke(result, "testNeverWithKeyLessTable");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ObjectSubtypingTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ObjectSubtypingTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -121,5 +122,10 @@ public class ObjectSubtypingTest {
         validateError(result, i++, "uninitialized field 'intField1'", 27, 5);
         validateError(result, i++, "uninitialized field 'intField2'", 28, 5);
         assertEquals(result.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        BCompileUtil.cleanBaloCache();
     }
 }


### PR DESCRIPTION
## Purpose
Added a cleanup cache method to avoid orgName/pkgName caching issues with unit tests compilations.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
