### PR TITLE
Move Observaiblity ST Collection to a JBallerinaBackend constructor

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
@@ -30,12 +30,6 @@ import io.ballerina.tools.text.LineRange;
 class PositionUtil {
 
     static boolean withinBlock(LinePosition cursorPos, Location symbolPosition) {
-        /*
-        Temporary null check added
-         */
-        if (symbolPosition == null) {
-            return false;
-        }
         int startLine = symbolPosition.lineRange().startLine().line();
         int endLine = symbolPosition.lineRange().endLine().line();
         int startColumn = symbolPosition.lineRange().startLine().offset();
@@ -51,10 +45,7 @@ class PositionUtil {
     }
 
     static boolean withinRange(LineRange specifiedRange, Location nodePosition) {
-        /*
-        Temporary null check added
-         */
-        if (nodePosition == null || !nodePosition.lineRange().filePath().equals(specifiedRange.filePath())) {
+        if (!nodePosition.lineRange().filePath().equals(specifiedRange.filePath())) {
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -112,6 +112,13 @@ public class JBallerinaBackend extends CompilerBackend {
         // TODO The following line is a temporary solution to cleanup the TesterinaRegistry
         TesterinaRegistry.reset();
 
+        // TODO: Move to a compiler extension once Compiler revamp is complete
+        if (packageContext.compilationOptions().observabilityIncluded()) {
+            ObservabilitySymbolCollector observabilitySymbolCollector
+                    = ObservabilitySymbolCollectorRunner.getInstance(compilerContext);
+            observabilitySymbolCollector.process(packageContext.project());
+        }
+
         // Trigger code generation
         performCodeGen();
     }
@@ -517,7 +524,6 @@ public class JBallerinaBackend extends CompilerBackend {
             if (packageContext.compilationOptions().observabilityIncluded()) {
                 ObservabilitySymbolCollector observabilitySymbolCollector
                         = ObservabilitySymbolCollectorRunner.getInstance(compilerContext);
-                observabilitySymbolCollector.process(packageContext.project());
                 observabilitySymbolCollector.writeToExecutable(executableFilePath);
             }
         } catch (IOException e) {


### PR DESCRIPTION
## Purpose
> Move Observaiblity ST Collection to a JBallerinaBackend constructor

Related to #27510

## Approach
> Move Observaiblity ST Collection to a JBallerinaBackend constructor

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
