### PR TITLE
Add a temporary fix for skipping Graph QL Listener symbol

### DIFF
--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -202,6 +202,10 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
         if (symbol == null) {
             return JsonNull.INSTANCE;
         }
+        if (symbol.moduleID() != null && "ballerina".equals(symbol.moduleID().orgName())
+                && "graphql".equals(symbol.moduleID().moduleName()) && "Listener".equals(symbol.name())) {
+            return JsonNull.INSTANCE;
+        }
 
         Set<Method> methods = ClassUtils.getAllInterfaces(symbol.getClass()).stream()
                 .flatMap(aClass -> Arrays.stream(aClass.getMethods()))


### PR DESCRIPTION
## Purpose
> Add a temporary fix for skipping Graph QL Listener symbol. Related to #27510

## Approach
> Since the recursively going through symbols in graph QL listener causes a stack overflow exception, graphql:Listener had been skipped as a temporary fix.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
