### PR TITLE
Generate jacoco coverage report for Project API integration tests

### DIFF
--- a/project-api/project-api-test/build.gradle
+++ b/project-api/project-api-test/build.gradle
@@ -63,11 +63,29 @@ test {
     dependsOn ':ballerina-lang:build'
     dependsOn createTestDistributionCache
     dependsOn createTestBre
-    
+    finalizedBy jacocoTestReport
+
     useTestNG() {
         suites 'src/test/resources/testng.xml'
     }
 }
+
+task jacocoMergeTest(type: JacocoMerge) {
+    dependsOn ':ballerina-lang:build'
+    String langProjectBuildDir = project(":ballerina-lang").buildDir
+    destinationFile = file("$buildDir/jacoco/all-test.exec")
+    executionData = files("$buildDir/jacoco/test.exec", "$langProjectBuildDir/jacoco/test.exec")
+}
+
+jacocoTestReport.doFirst{
+    String langProjectDir = project(":ballerina-lang").projectDir
+    String langProjectBuildDir = project(":ballerina-lang").buildDir
+    classDirectories = files("$langProjectBuildDir/classes/java/main/io/ballerina/projects")
+    sourceDirectories = files("$langProjectDir/src/main/java")
+    executionData = files("$buildDir/jacoco/all-test.exec")
+}
+
+jacocoTestReport.dependsOn(jacocoMergeTest)
 
 ext.moduleName = 'io.ballerina.projects.test'
 

--- a/project-api/project-api-test/build.gradle
+++ b/project-api/project-api-test/build.gradle
@@ -14,6 +14,8 @@
  * limitations under the License.
  *
  */
+import org.apache.tools.ant.taskdefs.condition.Os
+
 apply plugin: 'base'
 apply from: "$rootDir/gradle/javaProject.gradle"
 apply from: "$rootDir/gradle/ballerinaLangLibLoad.gradle"
@@ -63,7 +65,10 @@ test {
     dependsOn ':ballerina-lang:build'
     dependsOn createTestDistributionCache
     dependsOn createTestBre
-    finalizedBy jacocoTestReport
+
+    if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+        finalizedBy jacocoTestReport
+    }
 
     useTestNG() {
         suites 'src/test/resources/testng.xml'
@@ -78,11 +83,11 @@ task jacocoMergeTest(type: JacocoMerge) {
 }
 
 jacocoTestReport.doFirst{
-    String langProjectDir = project(":ballerina-lang").projectDir
-    String langProjectBuildDir = project(":ballerina-lang").buildDir
-    classDirectories = files("$langProjectBuildDir/classes/java/main/io/ballerina/projects")
-    sourceDirectories = files("$langProjectDir/src/main/java")
-    executionData = files("$buildDir/jacoco/all-test.exec")
+        String langProjectDir = project(":ballerina-lang").projectDir
+        String langProjectBuildDir = project(":ballerina-lang").buildDir
+        classDirectories = files("$langProjectBuildDir/classes/java/main/io/ballerina/projects")
+        sourceDirectories = files("$langProjectDir/src/main/java")
+        executionData = files("$buildDir/jacoco/all-test.exec")
 }
 
 jacocoTestReport.dependsOn(jacocoMergeTest)


### PR DESCRIPTION
## Purpose
> Generate jacoco coverage report for Project API integration test.

## Remarks
> With theese changes, the Jacoco coverage report will be created in the follwing path.
`<project-api-test-gradle-module>/build/reports/jacoco/test/html/index.html`

Sample: 
![image](https://user-images.githubusercontent.com/18344003/102755274-2b8fd780-4394-11eb-805f-3f6a3cab2da2.png)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
