### PR TITLE
[Debugger] Remove uber jar creation from debug server build 

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -44,7 +44,7 @@ configurations {
     debugAdapterLauncher {
         transitive false
     }
-    debugAdapterDistribution {
+    debugAdapterLib {
         transitive false
     }
     docerina
@@ -124,8 +124,10 @@ dependencies {
     langserverLib project(':language-server:language-server-stdio-launcher')
     langserverLib project(':language-server:language-server-cli')
     langserverLib project(':language-server:language-server-core')
-    debugAdapterDistribution project(':debug-adapter:debug-adapter-core')
-    debugAdapterDistribution project(':debug-adapter:debug-adapter-cli')
+
+    debugAdapterLib project(path: ':debug-adapter:debug-adapter-core', configuration: 'libs')
+    debugAdapterLib project(':debug-adapter:debug-adapter-cli')
+    debugAdapterLib project(':debug-adapter:debug-adapter-core')
 
     balSource project(path: ':jballerina', configuration: 'source')
 
@@ -312,6 +314,7 @@ def copyLangServerBinSpec = {
         into(path + 'lib/tools/lang-server/launcher')
     }
 }
+
 def copyDebugAdapterLauncher = {
     path -> copySpec {
         from('resources/debug-adapter-launcher.sh')
@@ -320,9 +323,9 @@ def copyDebugAdapterLauncher = {
     }
 }
 
-def copydebugAdapterDistributionSpec = {
+def copyDebugAdapterLibsSpec = {
     path -> copySpec {
-        from configurations.debugAdapterDistribution
+        from configurations.debugAdapterLib
         into(path + 'lib/tools/debug-adapter/lib')
      }
 }
@@ -416,7 +419,7 @@ task createZip(type: Zip) {
     with copyDataMapperLibsSpec(basePath)
     with copyLangServerBinSpec(basePath)
     with copyBallerinaZipSpec(basePath)
-    with copydebugAdapterDistributionSpec(basePath)
+    with copyDebugAdapterLibsSpec(basePath)
     with copyDebugAdapterLauncher(basePath)
     with apiDocsSpec(basePath)
     with copyStaticSpec(basePath)
@@ -440,7 +443,7 @@ task updateBalHome(type: Copy) {
     with copyDataMapperLibsSpec(installDir)
     with copyLangServerBinSpec(installDir)
     with copyBallerinaZipSpec(installDir)
-    with copydebugAdapterDistributionSpec(installDir)
+    with copyDebugAdapterLibsSpec(installDir)
     with copyDebugAdapterLauncher(installDir)
     with apiDocsSpec(installDir)
     with copyStaticSpec(installDir)
@@ -466,7 +469,7 @@ task createDistribution(type: Copy) {
     with copyDataMapperLibsSpec("")
     with copyLangServerBinSpec("")
     with copyBallerinaZipSpec("")
-    with copydebugAdapterDistributionSpec("")
+    with copyDebugAdapterLibsSpec("")
     with copyDebugAdapterLauncher("")
     with apiDocsSpec("")
     with copyStaticSpec("")

--- a/misc/debug-adapter/modules/debug-adapter-core/build.gradle
+++ b/misc/debug-adapter/modules/debug-adapter-core/build.gradle
@@ -1,36 +1,38 @@
 apply from: "$rootDir/gradle/javaProjectWithExtBalo.gradle"
-apply plugin: 'com.github.johnrengelman.shadow'
 
 repositories {
     mavenCentral()
 }
 
+configurations {
+    dist {
+        transitive false
+    }
+    dependency {
+        transitive false
+    }
+    libs
+}
+
 dependencies {
-    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.7.1'
     implementation project(':ballerina-lang')
     implementation project(':ballerina-parser')
     implementation project(':ballerina-tools-api')
     implementation project(':ballerina-runtime')
     implementation 'org.apache.commons:commons-compress:1.18'
+    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.7.1'
+
+    dependency 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.7.1'
+    dependency 'org.apache.commons:commons-compress:1.18'
 }
 
-shadowJar {
-    configurations = [project.configurations.runtimeClasspath]
-    dependencies {
-        exclude('META-INF/*.SF')
-        exclude('META-INF/*.DSA')
-        exclude('META-INF/*.RSA')
-    }
+task createZip(type: Zip) {
+    dependsOn createBalHome
 }
 
-jar {
-    enabled = false
-    dependsOn(shadowJar { classifier = null })
-    manifest {
-        attributes(
-                'Main-Class': 'org.ballerinalang.debugadapter.DebugAdapterLauncher'
-        )
-    }
+artifacts {
+    dist file: file(createZip.archiveFile), builtBy: createZip
+    libs configurations.dependency.files
 }
 
 createJavadoc {
@@ -41,4 +43,3 @@ createJavadoc {
 description = 'Ballerina - Debug Adapter - Debug Adaptor Core'
 
 ext.moduleName = 'ballerina.debug.adapter.core'
-

--- a/misc/debug-adapter/modules/debug-adapter-core/build.gradle
+++ b/misc/debug-adapter/modules/debug-adapter-core/build.gradle
@@ -19,11 +19,13 @@ dependencies {
     implementation project(':ballerina-parser')
     implementation project(':ballerina-tools-api')
     implementation project(':ballerina-runtime')
-    implementation 'org.apache.commons:commons-compress:1.18'
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.7.1'
+    implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc.debug:0.7.1'
+    implementation 'com.github.zafarkhaja:java-semver:0.9.0'
 
     dependency 'org.eclipse.lsp4j:org.eclipse.lsp4j.debug:0.7.1'
-    dependency 'org.apache.commons:commons-compress:1.18'
+    dependency 'org.eclipse.lsp4j:org.eclipse.lsp4j.jsonrpc.debug:0.7.1'
+    dependency 'com.github.zafarkhaja:java-semver:0.9.0'
 }
 
 task createZip(type: Zip) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/module-info.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/module-info.java
@@ -2,7 +2,6 @@ module ballerina.debug.adapter.core {
     requires org.eclipse.lsp4j.debug;
     requires jdk.jdi;
     requires slf4j.api;
-    requires org.apache.commons.compress;
     requires io.ballerina.lang;
     requires io.ballerina.tools.api;
     requires io.ballerina.parser;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JBallerinaDebugServer.java
@@ -33,7 +33,6 @@ import io.ballerina.projects.directory.BuildProject;
 import io.ballerina.projects.directory.ProjectLoader;
 import io.ballerina.projects.directory.SingleFileProject;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
-import org.apache.commons.compress.utils.IOUtils;
 import org.ballerinalang.debugadapter.evaluation.ExpressionEvaluator;
 import org.ballerinalang.debugadapter.jdi.JdiProxyException;
 import org.ballerinalang.debugadapter.jdi.LocalVariableProxyImpl;
@@ -110,6 +109,7 @@ import static org.ballerinalang.debugadapter.evaluation.utils.EvaluationUtils.ST
 import static org.ballerinalang.debugadapter.utils.PackageUtils.BAL_FILE_EXT;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.GENERATED_VAR_PREFIX;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.INIT_CLASS_NAME;
+import static org.ballerinalang.debugadapter.utils.PackageUtils.closeQuietly;
 import static org.ballerinalang.debugadapter.utils.PackageUtils.getRectifiedSourcePath;
 import static org.ballerinalang.debugadapter.variable.VariableUtils.removeRedundantQuotes;
 import static org.eclipse.lsp4j.debug.OutputEventArgumentsCategory.STDERR;
@@ -487,8 +487,8 @@ public class JBallerinaDebugServer implements IDebugProtocolServer {
         if (terminateDebuggee) {
             new TerminatorFactory().getTerminator(OSUtils.getOperatingSystem()).terminate();
         }
-        IOUtils.closeQuietly(launchedErrorStream);
-        IOUtils.closeQuietly(launchedStdoutStream);
+        closeQuietly(launchedErrorStream);
+        closeQuietly(launchedStdoutStream);
         if (launchedProcess != null) {
             launchedProcess.destroy();
         }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/terminator/TerminatorMac.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/terminator/TerminatorMac.java
@@ -16,12 +16,11 @@
 
 package org.ballerinalang.debugadapter.terminator;
 
-import org.apache.commons.compress.utils.IOUtils;
-
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+
+import static org.ballerinalang.debugadapter.utils.PackageUtils.closeQuietly;
 
 /**
  * Launcher Terminator Implementation for Mac.
@@ -65,9 +64,7 @@ public class TerminatorMac extends TerminatorUnix {
         } catch (Throwable e) {
 //            LOGGER.error("Launcher was unable to find the process ID for " + PROCESS_IDENTIFIER + ".");
         } finally {
-            if (reader != null) {
-                IOUtils.closeQuietly(reader);
-            }
+            closeQuietly(reader);
         }
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/terminator/TerminatorUnix.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/terminator/TerminatorUnix.java
@@ -16,11 +16,11 @@
 
 package org.ballerinalang.debugadapter.terminator;
 
-import org.apache.commons.compress.utils.IOUtils;
-
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
+
+import static org.ballerinalang.debugadapter.utils.PackageUtils.closeQuietly;
 
 /**
  * Launcher Terminator Implementation for Unix.
@@ -67,9 +67,7 @@ public class TerminatorUnix implements Terminator {
         } catch (Throwable e) {
 //            LOGGER.error("Launcher was unable to find the process ID for " + PROCESS_IDENTIFIER + ".");
         } finally {
-            if (reader != null) {
-                IOUtils.closeQuietly(reader);
-            }
+            closeQuietly(reader);
         }
     }
 
@@ -113,9 +111,7 @@ public class TerminatorUnix implements Terminator {
         } catch (Throwable e) {
 //            LOGGER.error("Launcher was unable to find parent for process:" + pid + ".");
         } finally {
-            if (reader != null) {
-                IOUtils.closeQuietly(reader);
-            }
+            closeQuietly(reader);
         }
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/utils/PackageUtils.java
@@ -32,7 +32,9 @@ import org.ballerinalang.debugadapter.SuspendedContext;
 import org.ballerinalang.debugadapter.evaluation.EvaluationException;
 import org.ballerinalang.debugadapter.evaluation.EvaluationExceptionKind;
 
+import java.io.Closeable;
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -229,6 +231,20 @@ public class PackageUtils {
             return replaceSeparators(path);
         } catch (Exception e) {
             return referenceType.name();
+        }
+    }
+
+    /**
+     * Closes the given Closeable and swallows any IOException that may occur.
+     *
+     * @param c Closeable to close, can be null.
+     */
+    public static void closeQuietly(final Closeable c) {
+        if (c != null) {
+            try {
+                c.close();
+            } catch (final IOException ignored) { // NOPMD
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
This PR fixes https://github.com/ballerina-platform/ballerina-lang/issues/27607.

## Remarks
However, After removing the uber jar creation from the debug server core build, Project API usages inside the debug server throw  `ClassNotFoundException`s. After some debugging it could be observed that these exceptions are thrown due to the missing library `com.github.zafarkhaja:java-semver` although this dependency is already declared as a compile time + runtime dependency in the project API module.

As an temporary fix, we have added this missing library as a dependency in the debug server core build and these redundant declarations should be removed once the issue(https://github.com/ballerina-platform/ballerina-lang/issues/27610) is fixed.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [x] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
