### PR TITLE
Cache the public type symbols for internal types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2569,6 +2569,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
         invokableSymbol.type = new BInvokableType(paramTypes, restType, invokableNode.returnTypeNode.type, null);
         invokableSymbol.type.tsymbol = functionTypeSymbol;
+        invokableSymbol.type.tsymbol.type = invokableSymbol.type;
     }
 
     private void defineSymbol(Location pos, BSymbol symbol) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeCacheTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeCacheTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.FieldSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.tools.text.LinePosition;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static org.testng.Assert.assertNotSame;
+import static org.testng.Assert.assertSame;
+
+/**
+ * Test cases for verifying that type caching works.
+ *
+ * @since 2.0.0
+ */
+public class TypeCacheTest {
+
+    private SemanticModel model;
+    private final String fileName = "type_cache_test.bal";
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/type_cache_test.bal");
+    }
+
+    @Test
+    public void testRecords() {
+        TypeDefinitionSymbol personDefSymbol =
+                (TypeDefinitionSymbol) model.symbol(fileName, LinePosition.from(30, 5)).get();
+        TypeSymbol personTypedesc = personDefSymbol.typeDescriptor();
+        List<FieldSymbol> personFields = ((RecordTypeSymbol) personTypedesc).fieldDescriptors();
+        FieldSymbol parentField = personFields.stream().filter(field -> "parent".equals(field.name())).findAny().get();
+        TypeSymbol type = ((UnionTypeSymbol) parentField.typeDescriptor()).memberTypeDescriptors().get(0);
+
+        assertSame(personTypedesc, ((TypeReferenceTypeSymbol) type).typeDescriptor());
+
+        TypeDefinitionSymbol employeeDefSymbol =
+                (TypeDefinitionSymbol) model.symbol(fileName, LinePosition.from(36, 5)).get();
+        TypeSymbol typeInclusion = ((RecordTypeSymbol) employeeDefSymbol.typeDescriptor()).typeInclusions().get(0);
+
+        assertSame(personTypedesc, ((TypeReferenceTypeSymbol) typeInclusion).typeDescriptor());
+
+        List<FieldSymbol> empFields = ((RecordTypeSymbol) employeeDefSymbol.typeDescriptor()).fieldDescriptors();
+        FieldSymbol designationType =
+                empFields.stream().filter(field -> "designation".equals(field.name())).findAny().get();
+        FieldSymbol nameType =
+                personFields.stream().filter(field -> "name".equals(field.name())).findAny().get();
+
+        assertSame(nameType.typeDescriptor(), designationType.typeDescriptor());
+    }
+
+    @Test(enabled = false)
+    public void testObjectsAndClasses() {
+        ClassSymbol personClzSymbol =
+                (ClassSymbol) model.symbol(fileName, LinePosition.from(16, 6)).get();
+        VariableSymbol personVar =
+                (VariableSymbol) model.symbol(fileName, LinePosition.from(42, 14)).get();
+        assertSame(personClzSymbol, ((TypeReferenceTypeSymbol) personVar.typeDescriptor()).typeDescriptor());
+    }
+
+    @Test
+    public void testFunctionTypes() {
+        FunctionSymbol fnAdd =
+                (FunctionSymbol) model.symbol(fileName, LinePosition.from(46, 9)).get();
+        FunctionSymbol fnAdd2 =
+                (FunctionSymbol) model.symbol(fileName, LinePosition.from(43, 14)).get();
+        assertSame(fnAdd.typeDescriptor(), fnAdd2.typeDescriptor());
+
+        FunctionSymbol fnSum1 =
+                (FunctionSymbol) model.symbol(fileName, LinePosition.from(48, 9)).get();
+        FunctionSymbol fnSum2 =
+                (FunctionSymbol) model.symbol(fileName, LinePosition.from(48, 9)).get();
+
+        // Due to the issue with overridden equals() in BInvokableType, this equivalent function type to the above
+        // one doesn't get cached. Hence not the same typedesc.
+        assertNotSame(fnSum1.typeDescriptor(), fnSum2.typeDescriptor());
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type_cache_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type_cache_test.bal
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class PersonClz {
+    string fname;
+    string lname;
+
+    public function init(string fname, string lname) {
+        self.fname = fname;
+        self.lname = lname;
+    }
+
+    public function getFullName() returns string {
+        return self.fname + " " + self.lname;
+    }
+}
+
+type Person record {|
+    string name;
+    int age;
+    Person? parent;
+|};
+
+type Employee record {|
+    *Person;
+    string designation;
+|};
+
+function test() {
+    PersonClz person = new("John", "Doe");
+    int sum = add(10, 20);
+}
+
+function add(int x, int y) returns int => x + y;
+
+function sum(int x, int y) returns int => x + y;

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -33,6 +33,7 @@
             <class name="io.ballerina.semantic.api.test.TestSourcesTest" />
             <class name="io.ballerina.semantic.api.test.SymbolLookupTest" />
             <class name="io.ballerina.semantic.api.test.SymbolPositionTest" />
+            <class name="io.ballerina.semantic.api.test.TypeCacheTest" />
             <class name="io.ballerina.semantic.api.test.TypedescriptorTest" />
             <class name="io.ballerina.semantic.api.test.WorkspaceSymbolLookupTest" />
             <class name="io.ballerina.semantic.api.test.ServiceSemanticAPITest" />


### PR DESCRIPTION
## Purpose
This PR adds a caching mechanism for the public type symbols so that we won't be creating the same type symbol over and over again for a given internal type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
