### PR TITLE
Add Missing Jars for toml parser

### DIFF
--- a/distribution/zip/jballerina-tools/build.gradle
+++ b/distribution/zip/jballerina-tools/build.gradle
@@ -79,6 +79,7 @@ dependencies {
     dist 'me.tongfei:progressbar:0.7.4'
     dist 'org.jline:jline:3.11.0'
     dist 'org.wso2.orbit.org.antlr:antlr4-runtime:4.5.1.wso2v1'
+    dist 'org.apache.commons:commons-text:1.9'
 
     // Following dependencies are required for kraal library
     dist 'org.jetbrains.kotlin:kotlin-stdlib:1.3.31'


### PR DESCRIPTION
## Purpose
Earlier Toml parser was bundled to debug adapter. Since these modules are decoupled now, in order to avoid making the toml parser fat jar, the dependency required by toml parser is added to bre libs.