### PR TITLE
Add Test API support for configurable variables

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
@@ -57,7 +57,6 @@ import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.S
  */
 public class ConfigTomlParser {
 
-
     private ConfigTomlParser() {
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
@@ -26,7 +26,6 @@ import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.internal.configurable.exceptions.TomlException;
 import io.ballerina.runtime.internal.types.BIntersectionType;
-import io.ballerina.runtime.internal.util.RuntimeUtils;
 import io.ballerina.runtime.internal.values.ArrayValueImpl;
 import io.ballerina.runtime.internal.values.ListInitialValueEntry;
 import io.ballerina.toml.semantic.TomlType;
@@ -40,7 +39,6 @@ import io.ballerina.toml.semantic.ast.TopLevelNode;
 import java.math.BigDecimal;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -59,24 +57,25 @@ import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.S
  */
 public class ConfigTomlParser {
 
-    static final Path CONFIG_FILE_PATH = Paths.get(RuntimeUtils.USER_DIR).resolve(CONFIG_FILE_NAME);
 
     private ConfigTomlParser() {
     }
 
-    private static TomlTableNode getConfigurationData() throws TomlException {
-        if (!Files.exists(CONFIG_FILE_PATH)) {
+    private static TomlTableNode getConfigurationData(Path filePath) throws TomlException {
+        Path configFilePath = filePath.resolve(CONFIG_FILE_NAME);
+        if (!Files.exists(configFilePath)) {
             throw new TomlException("Configuration toml file `" + CONFIG_FILE_NAME + "` is not found");
         }
-        ConfigToml configToml = new ConfigToml(CONFIG_FILE_PATH);
+        ConfigToml configToml = new ConfigToml(configFilePath);
         return configToml.tomlAstNode();
     }
 
-    public static void populateConfigMap(Map<Module, VariableKey[]> configurationData) throws TomlException {
+    public static void populateConfigMap(Path filePath, Map<Module, VariableKey[]> configurationData)
+            throws TomlException {
         if (configurationData.isEmpty()) {
             return;
         }
-        TomlTableNode tomlNode = getConfigurationData();
+        TomlTableNode tomlNode = getConfigurationData(filePath);
         if (tomlNode.entries().isEmpty()) {
             //No values provided at toml file
             return;
@@ -87,6 +86,9 @@ public class ConfigTomlParser {
             TomlTableNode orgNode = orgName.equals(ANON_ORG) ? tomlNode : extractOrganizationNode(tomlNode, orgName);
             TomlTableNode moduleNode = moduleName.equals(DEFAULT_MODULE) ? orgNode : extractModuleNode(orgNode,
                     moduleName);
+            if (moduleNode == null) {
+                continue;
+            }
             for (VariableKey key : moduleEntry.getValue()) {
                 if (!moduleNode.entries().containsKey(key.variable)) {
                     //It is an optional configurable variable

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
@@ -85,9 +85,6 @@ public class ConfigTomlParser {
             TomlTableNode orgNode = orgName.equals(ANON_ORG) ? tomlNode : extractOrganizationNode(tomlNode, orgName);
             TomlTableNode moduleNode = moduleName.equals(DEFAULT_MODULE) ? orgNode : extractModuleNode(orgNode,
                     moduleName);
-            if (moduleNode == null) {
-                continue;
-            }
             for (VariableKey key : moduleEntry.getValue()) {
                 if (!moduleNode.entries().containsKey(key.variable)) {
                     //It is an optional configurable variable

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/launch/LaunchUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/launch/LaunchUtils.java
@@ -136,9 +136,9 @@ public class LaunchUtils {
         }
     }
 
-    public static void initConfigurableVariables(Map<Module, VariableKey[]> configurationData) {
+    public static void initConfigurableVariables(Path filePath, Map<Module, VariableKey[]> configurationData) {
         try {
-            ConfigTomlParser.populateConfigMap(configurationData);
+            ConfigTomlParser.populateConfigMap(filePath, configurationData);
         } catch (TomlException exception) {
             throw ErrorCreator.createError(StringUtils.fromString(exception.getMessage()));
         }

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -341,6 +341,7 @@ public class RunTestsTask implements Task {
         String mainClassName = TesterinaConstants.TESTERINA_LAUNCHER_CLASS_NAME;
         String orgName = module.packageInstance().packageOrg().toString();
         String packageName = module.packageInstance().packageName().toString();
+        String moduleName = module.isDefaultModule() ? "" : module.moduleName().moduleNamePart();
 
         String jacocoAgentJarPath = Paths.get(System.getProperty(BALLERINA_HOME)).resolve(BALLERINA_HOME_BRE)
                 .resolve(BALLERINA_HOME_LIB).resolve(TesterinaConstants.AGENT_FILE_NAME).toString();
@@ -369,6 +370,7 @@ public class RunTestsTask implements Task {
             cmdArgs.add(target.path().toString());
             cmdArgs.add(orgName);
             cmdArgs.add(packageName);
+            cmdArgs.add(moduleName);
             ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
             Process proc = processBuilder.start();
             return proc.waitFor();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -277,6 +277,7 @@ public class JvmConstants {
     public static final String RECORD_INIT_WRAPPER_NAME = "$init";
     public static final String LISTENER_REGISTRY_VARIABLE = "$listenerRegistry";
     public static final String CONFIGURE_INIT = "$configureInit";
+    public static final String PARSE_TOML_METHOD = "$parseConfigTOML";
     public static final String CONFIGURATION_CLASS_NAME = "$ConfigurationMapper";
     public static final String POPULATE_CONFIG_DATA_METHOD = "$populateConfigurationData";
     public static final String CONFIG_DATA = "$configurationData";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -145,7 +145,6 @@ public class JvmConstants {
     public static final String MODULE = "io/ballerina/runtime/api/Module";
     public static final String CURRENT_MODULE_VAR_NAME = "$moduleName";
     public static final String B_STRING_VAR_PREFIX = "$bString";
-    public static final String CONFIG_VARIABLE = "io/ballerina/runtime/api/internal/configurable/ConfigurableVariable";
     public static final String VARIABLE_KEY = "io/ballerina/runtime/internal/configurable/VariableKey";
     public static final String TYPE_ID_SET = "io/ballerina/runtime/internal/types/BTypeIdSet";
     public static final String TYPE_ID = "io/ballerina/runtime/internal/types/BTypeIdSet$TypeId";
@@ -203,6 +202,8 @@ public class JvmConstants {
     public static final String COLLECTION = "java/util/Collection";
     public static final String NUMBER = "java/lang/Number";
     public static final String HASH_MAP = "java/util/HashMap";
+    public static final String PATH = "java/nio/file/Path";
+    public static final String PATHS = "java/nio/file/Paths";
 
     // service objects, annotation processing related classes
     public static final String ANNOTATION_UTILS = "io/ballerina/runtime/internal/AnnotationUtils";
@@ -278,6 +279,7 @@ public class JvmConstants {
     public static final String CONFIGURE_INIT = "$configureInit";
     public static final String CONFIGURATION_CLASS_NAME = "$ConfigurationMapper";
     public static final String POPULATE_CONFIG_DATA_METHOD = "$populateConfigurationData";
+    public static final String CONFIG_DATA = "$configurationData";
 
 
     // scheduler related constants

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -277,10 +277,8 @@ public class JvmConstants {
     public static final String RECORD_INIT_WRAPPER_NAME = "$init";
     public static final String LISTENER_REGISTRY_VARIABLE = "$listenerRegistry";
     public static final String CONFIGURE_INIT = "$configureInit";
-    public static final String PARSE_TOML_METHOD = "$parseConfigTOML";
-    public static final String CONFIGURATION_CLASS_NAME = "$ConfigurationMapper";
+    public static final String CONFIGURATION_CLASS_NAME = "$configurationMapper";
     public static final String POPULATE_CONFIG_DATA_METHOD = "$populateConfigurationData";
-    public static final String CONFIG_DATA = "$configurationData";
 
 
     // scheduler related constants

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmPackageGen.java
@@ -418,9 +418,9 @@ public class JvmPackageGen {
 
         // enrich current package with package initializers
         initMethodGen.enrichPkgWithInitializers(jvmClassMapping, moduleInitClass, module, flattenedModuleImports);
-        JvmBStringConstantsGen stringConstantsGen =  new JvmBStringConstantsGen(module);
-        configMethodGen.generateConfigInit(flattenedModuleImports, module, moduleInitClass, stringConstantsGen,
-                                           jarEntries);
+        JvmBStringConstantsGen stringConstantsGen = new JvmBStringConstantsGen(module);
+        configMethodGen.generateConfigMapper(flattenedModuleImports, module, moduleInitClass, stringConstantsGen,
+                jarEntries);
 
         // generate the shutdown listener class.
         new ShutDownListenerGen().generateShutdownSignalListener(moduleInitClass, jarEntries);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/ConfigMethodGen.java
@@ -20,7 +20,6 @@ package org.wso2.ballerinalang.compiler.bir.codegen.methodgen;
 
 import org.ballerinalang.model.elements.PackageID;
 import org.objectweb.asm.ClassWriter;
-import org.objectweb.asm.FieldVisitor;
 import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.wso2.ballerinalang.compiler.bir.codegen.BallerinaClassWriter;
@@ -36,7 +35,6 @@ import java.util.Map;
 
 import static org.objectweb.asm.ClassWriter.COMPUTE_FRAMES;
 import static org.objectweb.asm.Opcodes.AASTORE;
-import static org.objectweb.asm.Opcodes.ACC_FINAL;
 import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
 import static org.objectweb.asm.Opcodes.ACC_STATIC;
@@ -55,19 +53,19 @@ import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
 import static org.objectweb.asm.Opcodes.INVOKESTATIC;
 import static org.objectweb.asm.Opcodes.NEW;
 import static org.objectweb.asm.Opcodes.POP;
-import static org.objectweb.asm.Opcodes.PUTSTATIC;
 import static org.objectweb.asm.Opcodes.RETURN;
 import static org.objectweb.asm.Opcodes.V1_8;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURATION_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURE_INIT;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIG_DATA;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CURRENT_MODULE_VAR_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.HASH_MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.JVM_INIT_METHOD;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.LAUNCH_UTILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MAP;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.MODULE_INIT_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATH;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.POPULATE_CONFIG_DATA_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE;
@@ -87,18 +85,6 @@ public class ConfigMethodGen {
         ClassWriter cw = new BallerinaClassWriter(COMPUTE_FRAMES);
         cw.visit(V1_8, ACC_PUBLIC | ACC_SUPER, innerClassName, null, OBJECT, null);
 
-        FieldVisitor fv = cw.visitField(ACC_PRIVATE | ACC_FINAL | ACC_STATIC, CONFIG_DATA, String.format("L" +
-                        "%s;", MAP), String.format("L%s<L%s;[L%s;>;", MAP, MODULE, VARIABLE_KEY), null);
-        fv.visitEnd();
-
-        generateConfigInit(cw, imprtMods, pkg.packageID);
-        populateConfigDataMethod(cw, moduleInitClass, pkg, new JvmTypeGen(stringConstantsGen));
-        generateStaticInitializer(cw);
-        cw.visitEnd();
-        jarEntries.put(innerClassName + ".class", cw.toByteArray());
-    }
-
-    private void generateConfigInit(ClassWriter cw, List<PackageID> imprtMods, PackageID packageID) {
         MethodVisitor mv = cw.visitMethod(ACC_PRIVATE, JVM_INIT_METHOD, "()V", null, null);
         mv.visitCode();
         mv.visitVarInsn(ALOAD, 0);
@@ -107,26 +93,30 @@ public class ConfigMethodGen {
         mv.visitMaxs(0, 0);
         mv.visitEnd();
 
-        mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, CONFIGURE_INIT, "()V", null, null);
+        generateConfigInit(cw, imprtMods, pkg.packageID);
+        populateConfigDataMethod(cw, moduleInitClass, pkg, new JvmTypeGen(stringConstantsGen));
+        cw.visitEnd();
+        jarEntries.put(innerClassName + ".class", cw.toByteArray());
+    }
+
+    private void generateConfigInit(ClassWriter cw, List<PackageID> imprtMods, PackageID packageID) {
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, CONFIGURE_INIT, "(L" + PATH + ";)V", null, null);
         mv.visitCode();
+
+        mv.visitTypeInsn(NEW, HASH_MAP);
+        mv.visitInsn(DUP);
+        mv.visitMethodInsn(INVOKESPECIAL, HASH_MAP, JVM_INIT_METHOD, "()V", false);
+        mv.visitVarInsn(ASTORE, 1);
 
         for (PackageID id : imprtMods) {
             generateInvokeConfiguration(mv, id);
         }
 
         generateInvokeConfiguration(mv, packageID);
-        mv.visitInsn(RETURN);
-        mv.visitMaxs(0, 0);
-        mv.visitEnd();
-    }
-
-    private void generateStaticInitializer(ClassWriter cw) {
-        MethodVisitor mv = cw.visitMethod(ACC_STATIC, "<clinit>", "()V", null, null);
-        mv.visitCode();
-        mv.visitTypeInsn(NEW, HASH_MAP);
-        mv.visitInsn(DUP);
-        mv.visitMethodInsn(INVOKESPECIAL, HASH_MAP, JVM_INIT_METHOD, "()V", false);
-        mv.visitFieldInsn(PUTSTATIC, innerClassName, CONFIG_DATA, String.format("L%s;", MAP));
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitVarInsn(ALOAD, 1);
+        mv.visitMethodInsn(INVOKESTATIC, LAUNCH_UTILS, "initConfigurableVariables",
+                String.format("(L%s;L%s;)V", PATH, MAP), false);
         mv.visitInsn(RETURN);
         mv.visitMaxs(0, 0);
         mv.visitEnd();
@@ -138,15 +128,15 @@ public class ConfigMethodGen {
 
         mv.visitMethodInsn(INVOKESTATIC, moduleClass, POPULATE_CONFIG_DATA_METHOD,
                 String.format("()[L%s;", VARIABLE_KEY), false);
-        mv.visitVarInsn(ASTORE, 0);
+        mv.visitVarInsn(ASTORE, 2);
 
-        mv.visitVarInsn(ALOAD, 0);
+        mv.visitVarInsn(ALOAD, 2);
         mv.visitInsn(ARRAYLENGTH);
         Label elseLabel = new Label();
         mv.visitJumpInsn(IFEQ, elseLabel);
-        mv.visitFieldInsn(GETSTATIC, innerClassName, CONFIG_DATA, String.format("L%s;", MAP));
+        mv.visitVarInsn(ALOAD, 1);
         mv.visitFieldInsn(GETSTATIC, initClass, CURRENT_MODULE_VAR_NAME, String.format("L%s;", MODULE));
-        mv.visitVarInsn(ALOAD, 0);
+        mv.visitVarInsn(ALOAD, 2);
 
         mv.visitMethodInsn(INVOKEINTERFACE, MAP, "put", String.format("(L%s;L%s;)L%s;", OBJECT, OBJECT, OBJECT), true);
         mv.visitInsn(POP);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -63,7 +63,6 @@ import static org.objectweb.asm.Opcodes.RETURN;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURATION_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURE_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
-import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PARSE_TOML_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATH;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATHS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RUNTIME_UTILS;
@@ -169,15 +168,12 @@ public class MainMethodGen {
 
     private void invokeConfigInit(MethodVisitor mv, PackageID packageID) {
         String configClass = JvmCodeGenUtil.getModuleLevelClassName(packageID, CONFIGURATION_CLASS_NAME);
-        mv.visitVarInsn(ALOAD, 0);
-        mv.visitMethodInsn(INVOKESTATIC, configClass, CONFIGURE_INIT, "()V", false);
-
         mv.visitFieldInsn(GETSTATIC, RUNTIME_UTILS, "USER_DIR", "L" + STRING_VALUE + ";");
         mv.visitInsn(ICONST_0);
         mv.visitTypeInsn(ANEWARRAY, STRING_VALUE);
         mv.visitMethodInsn(INVOKESTATIC, PATHS, "get",
                 String.format("(L%s;[L%s;)L%s;", STRING_VALUE, STRING_VALUE, PATH), false);
-        mv.visitMethodInsn(INVOKESTATIC, configClass, PARSE_TOML_METHOD, "(L" + PATH + ";)V", false);
+        mv.visitMethodInsn(INVOKESTATIC, configClass, CONFIGURE_INIT, "(L" + PATH + ";)V", false);
     }
 
     private void generateJavaCompatibilityCheck(MethodVisitor mv) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -50,6 +50,7 @@ import static org.objectweb.asm.Opcodes.BIPUSH;
 import static org.objectweb.asm.Opcodes.CHECKCAST;
 import static org.objectweb.asm.Opcodes.DUP;
 import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
 import static org.objectweb.asm.Opcodes.ICONST_0;
 import static org.objectweb.asm.Opcodes.ICONST_1;
 import static org.objectweb.asm.Opcodes.IFNULL;
@@ -62,6 +63,10 @@ import static org.objectweb.asm.Opcodes.RETURN;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURATION_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURE_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATH;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATHS;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RUNTIME_UTILS;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 
 /**
  * Generates Jvm byte code for the main method.
@@ -165,6 +170,13 @@ public class MainMethodGen {
         String configClass = JvmCodeGenUtil.getModuleLevelClassName(packageID, CONFIGURATION_CLASS_NAME);
         mv.visitVarInsn(ALOAD, 0);
         mv.visitMethodInsn(INVOKESTATIC, configClass, CONFIGURE_INIT, "()V", false);
+
+        mv.visitFieldInsn(GETSTATIC, RUNTIME_UTILS, "USER_DIR", "L" + STRING_VALUE + ";");
+        mv.visitInsn(ICONST_0);
+        mv.visitTypeInsn(ANEWARRAY, STRING_VALUE);
+        mv.visitMethodInsn(INVOKESTATIC, PATHS, "get",
+                String.format("(L%s;[L%s;)L%s;", STRING_VALUE, STRING_VALUE, PATH), false);
+        mv.visitMethodInsn(INVOKESTATIC, configClass, "$parseConfigTOML", "(L" + PATH + ";)V", false);
     }
 
     private void generateJavaCompatibilityCheck(MethodVisitor mv) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MainMethodGen.java
@@ -63,6 +63,7 @@ import static org.objectweb.asm.Opcodes.RETURN;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURATION_CLASS_NAME;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CONFIGURE_INIT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.OBJECT;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PARSE_TOML_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATH;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.PATHS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.RUNTIME_UTILS;
@@ -176,7 +177,7 @@ public class MainMethodGen {
         mv.visitTypeInsn(ANEWARRAY, STRING_VALUE);
         mv.visitMethodInsn(INVOKESTATIC, PATHS, "get",
                 String.format("(L%s;[L%s;)L%s;", STRING_VALUE, STRING_VALUE, PATH), false);
-        mv.visitMethodInsn(INVOKESTATIC, configClass, "$parseConfigTOML", "(L" + PATH + ";)V", false);
+        mv.visitMethodInsn(INVOKESTATIC, configClass, PARSE_TOML_METHOD, "(L" + PATH + ";)V", false);
     }
 
     private void generateJavaCompatibilityCheck(MethodVisitor mv) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -19,6 +19,8 @@
 package org.ballerinalang.test.runtime;
 
 import com.google.gson.Gson;
+
+import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.BooleanType;
 import io.ballerina.runtime.api.types.ByteType;
@@ -81,6 +83,7 @@ public class BTestRunner {
     private static final String TEST_INIT_FUNCTION_NAME = ".<testinit>";
     private static final String TEST_START_FUNCTION_NAME = ".<teststart>";
     private static final String TEST_STOP_FUNCTION_NAME = ".<teststop>";
+    public static final String CONFIGURATION_CLASS_NAME = "$ConfigurationMapper";
 
     private PrintStream errStream;
     private PrintStream outStream;
@@ -266,6 +269,15 @@ public class BTestRunner {
         } catch (Throwable e) {
             throw new BallerinaTestException("failed to load init class :" + initClassName);
         }
+        Class<?> configClazz;
+        String configClassName = TesterinaUtils
+                .getQualifiedClassName(suite.getOrgName(), suite.getPackageID(), suite.getVersion(),
+                        CONFIGURATION_CLASS_NAME);
+        try {
+            configClazz = classLoader.loadClass(configClassName);
+        } catch (Throwable e) {
+            throw new BallerinaTestException("failed to load configuration class :" + configClassName);
+        }
         Scheduler scheduler = new Scheduler(4, false);
         Scheduler initScheduler = new Scheduler(4, false);
         Class<?> testInitClazz = null;
@@ -288,7 +300,7 @@ public class BTestRunner {
         tReport.setReportRequired(suite.isReportRequired());
         // Initialize the test suite.
         // This will init and start the test module.
-        startSuite(suite, initScheduler, initClazz, testInitClazz, hasTestablePackage);
+        startSuite(suite, initScheduler, initClazz, testInitClazz, configClazz, hasTestablePackage);
         // Run Before suite functions
         executeBeforeSuiteFunctions(suite, classLoader, scheduler, shouldSkip, shouldSkipAfterSuite);
         // Run Tests
@@ -553,11 +565,17 @@ public class BTestRunner {
     }
 
     private void startSuite(TestSuite suite, Scheduler initScheduler, Class<?> initClazz, Class<?> testInitClazz,
-                            boolean hasTestablePackage) {
-        TesterinaFunction init = new TesterinaFunction(initClazz, INIT_FUNCTION_NAME, initScheduler);
-        TesterinaFunction start = new TesterinaFunction(initClazz, START_FUNCTION_NAME, initScheduler);
+                            Class<?> configClazz, boolean hasTestablePackage) {
+        TesterinaFunction init = new TesterinaFunction(initClazz, suite.getInitFunctionName(), initScheduler);
+        TesterinaFunction start = new TesterinaFunction(initClazz, suite.getStartFunctionName(), initScheduler);
+        TesterinaFunction configInit = new TesterinaFunction(configClazz, "$configureInit", initScheduler);
         // As the init function we need to use $moduleInit to initialize all the dependent modules
         // properly.
+
+        invokeConfigFunction(configInit, new Class[]{}, new Object[]{});
+        configInit.setName("$parseConfigTOML");
+        invokeConfigFunction(configInit, new Class[]{Path.class}, new Object[]{getConfigPath(suite)});
+
         init.setName("$moduleInit");
         Object response = init.invoke();
         if (response instanceof Throwable) {
@@ -591,6 +609,23 @@ public class BTestRunner {
         immortalThread.start();
     }
 
+    private void invokeConfigFunction(TesterinaFunction function, Class[] argClasses, Object[] args) {
+        Object response = function.directInvoke(argClasses, args);
+        if (response instanceof Throwable) {
+            throw new BallerinaTestException("Configurable initialization for test suite failed due to " +
+                    response.toString(), (Throwable) response);
+        }
+    }
+
+    private Path getConfigPath(TestSuite testSuite) {
+        String moduleName = testSuite.getModuleName();
+        Path configFilePath = Paths.get(testSuite.getSourceRootPath());
+        if (!moduleName.equals("")) {
+            configFilePath = configFilePath.resolve(ProjectConstants.MODULES_ROOT).resolve(moduleName);
+        }
+        return configFilePath.resolve(ProjectConstants.TEST_DIR_NAME);
+    }
+
     private void stopSuite(TestSuite suite, Scheduler scheduler, Class<?> initClazz, Class<?> testInitClazz,
                            boolean hasTestablePackage) {
         TesterinaFunction stop = new TesterinaFunction(initClazz, STOP_FUNCTION_NAME, scheduler);
@@ -602,7 +637,8 @@ public class BTestRunner {
             testStop.invoke();
         }
         stop.setName("$moduleStop");
-        stop.directInvoke(new Class<?>[]{Scheduler.ListenerRegistry.class});
+        stop.directInvoke(new Class<?>[]{Scheduler.ListenerRegistry.class},
+                new Object[]{scheduler.getListenerRegistry()});
     }
 
     private Object invokeTestFunction(TestSuite suite, String functionName, ClassLoader classLoader,

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -19,7 +19,6 @@
 package org.ballerinalang.test.runtime;
 
 import com.google.gson.Gson;
-
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.runtime.api.types.ArrayType;
 import io.ballerina.runtime.api.types.BooleanType;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
@@ -50,6 +50,7 @@ public class Main {
             //convert the json string back to object
             Gson gson = new Gson();
             TestSuite response = gson.fromJson(br, TestSuite.class);
+            response.setModuleName(args[args.length - 1]);
             startTestSuit(Paths.get(response.getSourceRootPath()), response, jsonTmpSummaryPath);
         }
     }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestSuite.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TestSuite.java
@@ -31,6 +31,7 @@ public class TestSuite {
     private String orgName;
     private String version;
     private String packageName;
+    private String moduleName;
     private String packageId;
 
     private String initFunctionName;
@@ -85,6 +86,14 @@ public class TestSuite {
 
     public void setOrgName(String orgName) {
         this.orgName = orgName;
+    }
+
+    public String getModuleName() {
+        return moduleName;
+    }
+
+    public void setModuleName(String moduleName) {
+        this.moduleName = moduleName;
     }
 
     public String getVersion() {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaFunction.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/TesterinaFunction.java
@@ -64,8 +64,8 @@ public class TesterinaFunction {
      * @param types of the function parameters
      * @return output
      */
-    public Object directInvoke(Class[] types) {
-        return run(programFile, bFunctionName, scheduler, types);
+    public Object directInvoke(Class[] types, Object[] args) {
+        return run(programFile, bFunctionName, types, args);
     }
 
     public String getName() {
@@ -84,12 +84,11 @@ public class TesterinaFunction {
         this.groups = groups;
     }
 
-    private static Object run(Class<?> initClazz, String name, Scheduler scheduler,
-                              Class[] paramTypes) {
+    private static Object run(Class<?> initClazz, String name, Class[] paramTypes, Object[] args) {
         String funcName = cleanupFunctionName(name);
         try {
             final Method method = initClazz.getDeclaredMethod(funcName, paramTypes);
-            return method.invoke(null, scheduler.getListenerRegistry());
+            return method.invoke(null, args);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
             throw new BallerinaTestException("Failed to invoke the function '" +
                                                      funcName + " due to " + e.getMessage());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -66,6 +66,15 @@ public class ConfigurableTest extends BaseTest {
     }
 
     @Test
+    public void testBallerinaTestAPIWithConfigurableVariables() throws BallerinaTestException {
+        Path projectPath = Paths.get(testFileLocation, "testProject").toAbsolutePath();
+        LogLeecher runLeecher = new LogLeecher("Tests passed");
+        bMainInstance.runMain("test", new String[]{"configPkg"}, null, new String[]{},
+                new LogLeecher[]{runLeecher}, projectPath.toString());
+        runLeecher.waitForText(5000);
+    }
+
+    @Test
     public void testSingleBalFileWithConfigurables() throws BallerinaTestException {
         Path filePath = Paths.get(testFileLocation, "configTest.bal").toAbsolutePath();
         LogLeecher runLeecher = new LogLeecher("Tests passed");

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -68,7 +68,7 @@ public class ConfigurableTest extends BaseTest {
     @Test
     public void testBallerinaTestAPIWithConfigurableVariables() throws BallerinaTestException {
         Path projectPath = Paths.get(testFileLocation, "testProject").toAbsolutePath();
-        LogLeecher runLeecher = new LogLeecher("Tests passed");
+        LogLeecher runLeecher = new LogLeecher("4 passing");
         bMainInstance.runMain("test", new String[]{"configPkg"}, null, new String[]{},
                 new LogLeecher[]{runLeecher}, projectPath.toString());
         runLeecher.waitForText(5000);

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/Ballerina.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/Ballerina.toml
@@ -1,0 +1,9 @@
+[package]
+org= "testOrg"
+name= "configPkg"
+version= "0.1.0"
+
+[build-options]
+observability-included=true
+
+[dependencies]

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/main.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/main.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+configurable int intVar = 3;
+configurable float floatVar = 12.8;
+configurable string stringVar = ?;
+configurable boolean booleanVar = ?;
+
+public function main() {
+	 //Do nothing
+}
+
+function getAverage() returns float {
+    return <float>(intVar + floatVar) / 2;
+}
+
+function getString() returns string {
+    return stringVar;
+}
+
+function getBoolean() returns boolean {
+    return booleanVar;
+}
+

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/main.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+configurable int intVar = ?;
+configurable float floatVar = 9.5;
+configurable string stringVar = "hello";
+configurable boolean booleanVar = ?;
+
+public function getAverage() returns float {
+    return <float>(intVar + floatVar) / 2;
+}
+
+public function getString() returns string {
+    return stringVar;
+}
+
+public function getBoolean() returns boolean {
+    return booleanVar;
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/tests/configuration.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/tests/configuration.toml
@@ -1,0 +1,10 @@
+[testOrg.configPkg.util.foo]
+intVar = 41
+floatVar = 3.6
+stringVar = "test string"
+booleanVar = true
+testInt = 22
+testFloat = 12.4
+testString = "configurable variable inside test source"
+testBoolean = true
+

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/tests/module_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/tests/module_test.bal
@@ -21,26 +21,28 @@ configurable float testFloat = 9.5;
 configurable string testString = "hello";
 configurable boolean testBoolean = ?;
 
+@test:Config {}
+function testAverage() {
+    float res = getAverage();
+    test:assertEquals(res, 22.3);
+}
 
 @test:Config {}
- function testAverage() {
-    float res = getAverage();
+function testStringValue() {
+    string res = getString();
+    test:assertEquals(res, "test string");
+}
+
+@test:Config {}
+function testBooleanValue() {
+    boolean res = getBoolean();
+    test:assertEquals(res, true);
+}
+
+@test:Config {}
+function testInternalVariables() {
     test:assertEquals(testInt, 22);
     test:assertEquals(testFloat, 12.4);
-    test:assertEquals(res, 22.3);
- }
- 
-@test:Config {}
- function testString() {
-    string res = getString();
     test:assertEquals(testString, "configurable variable inside test source");
-    test:assertEquals(res, "test string");
- }
-
-@test:Config {}
- function testBoolean() {
-    boolean res = getBoolean();
     test:assertEquals(testBoolean, true);
-    test:assertEquals(res, true);
- }
-
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/tests/module_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/modules/util.foo/tests/module_test.bal
@@ -1,0 +1,46 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+configurable int testInt = ?;
+configurable float testFloat = 9.5;
+configurable string testString = "hello";
+configurable boolean testBoolean = ?;
+
+
+@test:Config {}
+ function testAverage() {
+    float res = getAverage();
+    test:assertEquals(testInt, 22);
+    test:assertEquals(testFloat, 12.4);
+    test:assertEquals(res, 22.3);
+ }
+ 
+@test:Config {}
+ function testString() {
+    string res = getString();
+    test:assertEquals(testString, "configurable variable inside test source");
+    test:assertEquals(res, "test string");
+ }
+
+@test:Config {}
+ function testBoolean() {
+    boolean res = getBoolean();
+    test:assertEquals(testBoolean, true);
+    test:assertEquals(res, true);
+ }
+

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/tests/configuration.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/tests/configuration.toml
@@ -1,0 +1,10 @@
+[testOrg.configPkg]
+intVar = 45
+floatVar = 3.5
+stringVar = "abc"
+booleanVar = false
+testInt = 24
+testFloat = 77.2
+testString = "configurable variable test"
+testBoolean = true
+

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/tests/main_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/tests/main_test.bal
@@ -28,15 +28,15 @@ configurable boolean testBoolean = ?;
  }
  
 @test:Config {}
- function testString() {
+ function testStringValue() {
     string res = getString();
     test:assertEquals(res, "abc");
  }
 
 @test:Config {}
- function testBoolean() {
+ function testBooleanValue() {
     boolean res = getBoolean();
-    test:assertEquals(res, true);
+    test:assertEquals(res, false);
  }
 
 @test:Config {}
@@ -44,5 +44,5 @@ configurable boolean testBoolean = ?;
     test:assertEquals(testInt, 24);
     test:assertEquals(testFloat, 77.2);
     test:assertEquals(testString, "configurable variable test");
-    test:assertEquals(testBoolean, false);
+    test:assertEquals(testBoolean, true);
  }

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/tests/main_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configPkg/tests/main_test.bal
@@ -1,0 +1,48 @@
+ // Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+ 
+configurable int testInt = ?;
+configurable float testFloat = 66.8;
+configurable string testString = "test";
+configurable boolean testBoolean = ?;
+
+@test:Config {}
+ function testAverage() {
+    float res = getAverage();
+    test:assertEquals(res, 24.25);
+ }
+ 
+@test:Config {}
+ function testString() {
+    string res = getString();
+    test:assertEquals(res, "abc");
+ }
+
+@test:Config {}
+ function testBoolean() {
+    boolean res = getBoolean();
+    test:assertEquals(res, true);
+ }
+
+@test:Config {}
+ function testInternalVariables() {
+    test:assertEquals(testInt, 24);
+    test:assertEquals(testFloat, 77.2);
+    test:assertEquals(testString, "configurable variable test");
+    test:assertEquals(testBoolean, false);
+ }

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configuration.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testProject/configuration.toml
@@ -1,0 +1,11 @@
+[testOrg.configPkg]
+intVar = 42
+floatVar = 3.5
+stringVar = "abc"
+booleanVar = true
+
+[testOrg.configPkg.util.foo]
+intVar = 24
+floatVar = 4.8
+stringVar = "world"
+booleanVar = false


### PR DESCRIPTION
## Purpose
Ballerina test API was previously not supported configurable variables feature.  
This PR contains the implementation for this support. 

Fixes #27491 

## Approach

- The TOML parser is modified to have a `Path` argument that conveys the location of the `configuration.toml`
- The current directory path is code generated to be called at runtime
- Implementation done to call the configuration init method at Testerina and specify the toml file path according to test.
       -  The TOML file must be located in every module’s test directory, including for the root module

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
