### PR TITLE
Remove compiler.api.impl from exported modules list

### DIFF
--- a/compiler/ballerina-lang/src/main/java/module-info.java
+++ b/compiler/ballerina-lang/src/main/java/module-info.java
@@ -17,7 +17,6 @@ module io.ballerina.lang {
     requires java.semver;
     exports io.ballerina.compiler.api;
     exports io.ballerina.compiler.api.symbols;
-    exports io.ballerina.compiler.api.impl;
     exports org.wso2.ballerinalang.compiler.util;
     exports org.ballerinalang.toml.model;
     exports org.wso2.ballerinalang.util;

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -21,8 +21,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
-import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -309,8 +309,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
 //                        listPropJson.add((Boolean) listPropItem);
 //                    }
 //                }
-            } else if (prop instanceof BallerinaModuleID) {
-                BallerinaModuleID ballerinaModuleID = (BallerinaModuleID) prop;
+            } else if (prop instanceof ModuleID) {
+                ModuleID ballerinaModuleID = (ModuleID) prop;
                 JsonObject moduleIdJson = new JsonObject();
                 moduleIdJson.addProperty("orgName", ballerinaModuleID.orgName());
                 moduleIdJson.addProperty("moduleName", ballerinaModuleID.moduleName());

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -20,7 +20,7 @@ package org.ballerinalang.docgen.docs;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
+import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.util.ProjectConstants;
@@ -414,7 +414,7 @@ public class BallerinaDocGenerator {
                 syntaxTreeMap.put(document.name(), document.syntaxTree());
             });
             ModuleDoc moduleDoc = new ModuleDoc(moduleMd == null ? null : moduleMd.toAbsolutePath(), resources,
-                    syntaxTreeMap, (BallerinaSemanticModel) module.getCompilation().getSemanticModel());
+                    syntaxTreeMap, module.getCompilation().getSemanticModel());
             moduleDocMap.put(moduleName, moduleDoc);
         }
         return moduleDocMap;
@@ -439,7 +439,7 @@ public class BallerinaDocGenerator {
 
         List<Module> moduleDocs = new ArrayList<>();
         for (Map.Entry<String, ModuleDoc> moduleDoc : docsMap.entrySet()) {
-            BallerinaSemanticModel model = moduleDoc.getValue().semanticModel;
+            SemanticModel model = moduleDoc.getValue().semanticModel;
             Module module = new Module();
             module.id = moduleDoc.getKey();
             module.orgName = orgName;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
@@ -17,7 +17,7 @@
  */
 package org.ballerinalang.docgen.generator.model;
 
-import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
+import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.docgen.docs.utils.BallerinaDocUtils;
@@ -41,7 +41,7 @@ public class ModuleDoc {
     public final String description;
     public final String summary;
     public final Map<String, SyntaxTree> syntaxTreeMap;
-    public final BallerinaSemanticModel semanticModel;
+    public final SemanticModel semanticModel;
     public final List<Path> resources;
 
     /**
@@ -54,7 +54,7 @@ public class ModuleDoc {
      * @throws IOException on error.
      */
     public ModuleDoc(Path descriptionPath, List<Path> resources, Map<String, SyntaxTree> syntaxTreeMap,
-                     BallerinaSemanticModel semanticModel) throws IOException {
+                     SemanticModel semanticModel) throws IOException {
         this.description = getDescription(descriptionPath);
         this.summary = getSummary(descriptionPath);
         this.resources = resources;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
-import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
+import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -115,7 +115,7 @@ public class Type {
     private Type() {
     }
 
-    public static Type fromNode(Node node, BallerinaSemanticModel semanticModel, String fileName) {
+    public static Type fromNode(Node node, SemanticModel semanticModel, String fileName) {
         Type type = new Type();
         if (node instanceof SimpleNameReferenceNode) {
             SimpleNameReferenceNode simpleNameReferenceNode = (SimpleNameReferenceNode) node;


### PR DESCRIPTION
## Purpose
$subject. This is to make users rely solely on the APIs provided. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
