### PR TITLE
Enable module execution flow test

### DIFF
--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/execution/ModuleExecutionFlowTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/execution/ModuleExecutionFlowTests.java
@@ -142,7 +142,7 @@ public class ModuleExecutionFlowTests {
                 "basic:TestListener listener __gracefulStop called, service name - basic";
 
         String expectedErrorString = "error: panicked while starting module 'dependent'\n" +
-                "\tat test.basic.0_1_0.TestListener:__start(main.bal:40)";
+                "\tat testorg.start_stop_failing_project:start(basic.bal:35)";
         Assert.assertEquals(output.consoleOutput, expectedConsoleString, "evaluated to invalid value");
         Assert.assertEquals(output.errorOutput, expectedErrorString, "evaluated to invalid value");
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/execution/start_stop_failing_project/modules/basic/basic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/execution/start_stop_failing_project/modules/basic/basic.bal
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/java;
+
+function init() {
+	println("Initializing module 'basic'");
+}
+
+public class TestListener {
+
+    private string name = "";
+
+    public function init(string name){
+        self.name = name;
+    }
+
+    public function 'start() returns error? {
+        println("basic:TestListener listener __start called, service name - " + self.name);
+        if (self.name == "dependent") {
+            println("listener __start panicked for service name - " + self.name);
+            error sampleErr = error("panicked while starting module 'dependent'");
+            panic sampleErr;
+        }
+    }
+
+    public function gracefulStop() returns error? {
+        println("basic:TestListener listener __gracefulStop called, service name - " + self.name);
+        if (self.name == "dependent") {
+            println("listener __gracefulStop panicked, service name - " + self.name);
+            error sampleErr = error("panicked while stopping module 'dependent'");
+            panic sampleErr;
+        }
+        return ();
+    }
+
+    public function immediateStop() returns error? {
+        println("basic:TestListener listener __immediateStop called, service name - " + self.name);
+        return ();
+    }
+
+    public function attach(service object {} s, string[]? name) returns error? {
+        println("basic:TestListener listener __attach called, service name - " + self.name);
+    }
+
+    public function detach(service object {} s) returns error? {
+        println("basic:TestListener listener __detach called, service name - " + self.name);
+    }
+}
+
+listener TestListener testListner = new TestListener("basic");
+
+public function println(string value) {
+    handle strValue = java:fromString(value);
+    handle stdout1 = stdout();
+    printlnInternal(stdout1, strValue);
+}
+
+function stdout() returns handle = @java:FieldGet {
+    name: "out",
+    'class: "java/lang/System"
+} external;
+
+function printlnInternal(handle receiver, handle strValue)  = @java:Method {
+    name: "println",
+    'class: "java/io/PrintStream",
+    paramTypes: ["java.lang.String"]
+} external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/execution/start_stop_failing_project/modules/dependent/dependent.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/execution/start_stop_failing_project/modules/dependent/dependent.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -15,15 +15,13 @@
 // under the License.
 
 import start_stop_failing_project.basic;
-import start_stop_failing_project.dependent;
 
 function init() {
-	basic:println("Initializing module 'current'");
+	basic:println("Initializing module 'dependent'");
 }
 
-public function main() {
-    dependent:sample();
-    basic:println("main function invoked for current module");
+public function sample() {
+
 }
 
-listener basic:TestListener ep = new basic:TestListener("current");
+listener basic:TestListener ep = new basic:TestListener("dependent");

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -234,11 +234,6 @@
 
             <!-- Disabled tests related to ProjectAPI change -->
             <!-- ########################## START ############################# -->
-            <class name="org.ballerinalang.test.execution.ModuleExecutionFlowTests">
-                <methods>
-                    <exclude name="testModuleStartAndStopPanic"/>
-                </methods>
-            </class>
             <class name="org.ballerinalang.test.taintchecking.TaintedStatusPropagationTest">
                 <methods>
                     <exclude name="testParameterStatusWithNativeInvocations"/>


### PR DESCRIPTION
## Purpose
Re-enable the module execution flow unit test that is disbled after the Project API changes

part of #27446 

## Approach
Modify proper module structure for test project

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
