### PR TITLE
Introduce PackageDiagnostic class to expose diagnostics related to a package compilation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -129,7 +129,8 @@ public class JBallerinaBackend extends CompilerBackend {
         List<Diagnostic> diagnostics = new ArrayList<>();
         for (ModuleContext moduleContext : pkgResolution.topologicallySortedModuleList()) {
             moduleContext.generatePlatformSpecificCode(compilerContext, this);
-            diagnostics.addAll(moduleContext.diagnostics());
+            moduleContext.diagnostics().forEach(diagnostic ->
+                    diagnostics.add(new PackageDiagnostic(diagnostic, moduleContext.moduleName())));
         }
 
         this.diagnosticResult = new DefaultDiagnosticResult(diagnostics);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/JBallerinaBackend.java
@@ -20,6 +20,7 @@ package io.ballerina.projects;
 import io.ballerina.projects.environment.PackageCache;
 import io.ballerina.projects.environment.ProjectEnvironment;
 import io.ballerina.projects.internal.DefaultDiagnosticResult;
+import io.ballerina.projects.internal.PackageDiagnostic;
 import io.ballerina.projects.internal.jballerina.JarWriter;
 import io.ballerina.projects.util.ProjectUtils;
 import io.ballerina.tools.diagnostics.Diagnostic;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilation.java
@@ -98,7 +98,8 @@ public class ModuleCompilation {
             Package pkg = packageCache.getPackageOrThrow(sortedModuleId.packageId());
             ModuleContext moduleContext = pkg.module(sortedModuleId).moduleContext();
             moduleContext.compile(compilerContext);
-            diagnostics.addAll(moduleContext.diagnostics());
+            moduleContext.diagnostics().forEach(diagnostic ->
+                    diagnostics.add(new PackageDiagnostic(diagnostic, moduleContext.moduleName())));
         }
 
         // Create an immutable list

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilation.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
 import io.ballerina.projects.environment.PackageCache;
 import io.ballerina.projects.environment.ProjectEnvironment;
 import io.ballerina.projects.internal.DefaultDiagnosticResult;
+import io.ballerina.projects.internal.PackageDiagnostic;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -134,7 +134,8 @@ public class PackageCompilation {
         List<Diagnostic> diagnostics = new ArrayList<>();
         for (ModuleContext moduleContext : packageResolution.topologicallySortedModuleList()) {
             moduleContext.compile(compilerContext);
-            diagnostics.addAll(moduleContext.diagnostics());
+            moduleContext.diagnostics().forEach(diagnostic ->
+                    diagnostics.add(new PackageDiagnostic(diagnostic, moduleContext.moduleName())));
         }
 
         addOtherDiagnostics(diagnostics);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.impl.BallerinaSemanticModel;
 import io.ballerina.projects.CompilerBackend.TargetPlatform;
 import io.ballerina.projects.environment.ProjectEnvironment;
 import io.ballerina.projects.internal.DefaultDiagnosticResult;
+import io.ballerina.projects.internal.PackageDiagnostic;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageDiagnostic.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageDiagnostic.java
@@ -1,0 +1,123 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package io.ballerina.projects;
+
+import io.ballerina.projects.util.ProjectConstants;
+import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.tools.diagnostics.properties.DiagnosticProperty;
+import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static io.ballerina.projects.util.ProjectConstants.TEST_DIR_NAME;
+
+/**
+ * Decorator for diagnostics exposed via the Project API.
+ * All diagnostics in a package will be enriched with this before exposing via the project API classes.
+ *
+ * @since 2.0.0
+ */
+public class PackageDiagnostic extends Diagnostic {
+    private final Diagnostic diagnostic;
+    private final Location location;
+
+    public PackageDiagnostic(Diagnostic diagnostic, ModuleName moduleName) {
+        this.diagnostic = diagnostic;
+        String filePath;
+        if (!moduleName.isDefaultModuleName()) {
+            Path modulePath = Paths.get(ProjectConstants.MODULES_ROOT).resolve(moduleName.moduleNamePart());
+            LineRange lineRange = this.diagnostic.location().lineRange();
+            filePath = modulePath.resolve(lineRange.filePath()).toString();
+        } else {
+            filePath = diagnostic.location().lineRange().filePath();
+        }
+        this.location = new DiagnosticLocation(filePath, this.diagnostic.location());
+    }
+
+    @Override
+    public Location location() {
+        return this.location;
+    }
+
+    @Override
+    public DiagnosticInfo diagnosticInfo() {
+        return this.diagnostic.diagnosticInfo();
+    }
+
+    @Override
+    public String message() {
+        return this.diagnostic.message();
+    }
+
+    @Override
+    public List<DiagnosticProperty<?>> properties() {
+        return this.diagnostic.properties();
+    }
+
+    @Override
+    public String toString() {
+        return diagnosticInfo().severity().toString() + " ["
+                + this.location.lineRange().filePath() + ":" + this.location.lineRange() + "] " + message();
+    }
+
+    /*
+    * Inner class to create the modified Location containing the
+    * filepath relative to the project.
+    */
+    private static class DiagnosticLocation implements Location {
+
+        private final LineRange lineRange;
+        private final TextRange textRange;
+
+        public DiagnosticLocation(String filePath, Location location) {
+            LineRange lineRange = location.lineRange();
+            int startLine = lineRange.startLine().line(),
+                    endLine = lineRange.endLine().line(),
+                    startColumn = lineRange.startLine().offset(),
+                    endColumn = lineRange.endLine().offset();
+
+            // replace hardcoded string "tests/" to match the OS
+            filePath = filePath.replace(TEST_DIR_NAME + "/", TEST_DIR_NAME + File.separator);
+            this.lineRange = LineRange.from(filePath, LinePosition.from(startLine, startColumn),
+                    LinePosition.from(endLine, endColumn));
+            this.textRange = location.textRange();
+        }
+
+        @Override
+        public LineRange lineRange() {
+            return lineRange;
+        }
+
+        @Override
+        public TextRange textRange() {
+            return textRange;
+        }
+
+        @Override
+        public String toString() {
+            return lineRange.toString() + textRange.toString();
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDiagnostic.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/PackageDiagnostic.java
@@ -15,8 +15,9 @@
  *  specific language governing permissions and limitations
  *  under the License.
  */
-package io.ballerina.projects;
+package io.ballerina.projects.internal;
 
+import io.ballerina.projects.ModuleName;
 import io.ballerina.projects.util.ProjectConstants;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticInfo;

--- a/project-api/project-api-test/src/test/resources/test_proj_pkg_compilation/modules/services/tests/svc_tests.bal
+++ b/project-api/project-api-test/src/test/resources/test_proj_pkg_compilation/modules/services/tests/svc_tests.bal
@@ -1,2 +1,4 @@
+import myproject.storage
+
 public function testServices() {
 }

--- a/project-api/project-api-test/src/test/resources/test_proj_pkg_compilation/tests/main_tests.bal
+++ b/project-api/project-api-test/src/test/resources/test_proj_pkg_compilation/tests/main_tests.bal
@@ -1,2 +1,4 @@
+import myproject.services
+
 public function testRunMain() {
 }


### PR DESCRIPTION
## Purpose
> Introduces the PackageDiagnostics class which is used as the public API for accessing the diagnostics of a package compilation. 

Fixes #27231 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
