### PR TITLE
Unify language server instance with own utility instances

### DIFF
--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DocumentServiceContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/DocumentServiceContext.java
@@ -28,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 
 /**
- * Represents the language server context.
+ * Represents the language server document service context.
  *
  * @since 2.0.0
  */
@@ -84,4 +84,11 @@ public interface DocumentServiceContext {
      * @return {@link Module}
      */
     Optional<Module> currentModule();
+
+    /**
+     * Get the language server context.
+     * 
+     * @return {@link LanguageServerContext}
+     */
+    LanguageServerContext languageServercontext();
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageExtension.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageExtension.java
@@ -46,11 +46,12 @@ public interface LanguageExtension<I, O, C extends DocumentServiceContext> {
     /**
      * Execute the operation and output the result.
      *
-     * @param inputParams input params for the opration
-     * @param context language server context
+     * @param inputParams input params for the operation
+     * @param context language server operation context
+     * @param serverContext language server context
      * @return {@link O} output of the operation
      * @throws Throwable while executing. Here we throw the Throwable rather than a narrower exception since the
      *                   executor has to handle the exceptions accordingly.
      */
-    O execute(I inputParams, C context) throws Throwable;
+    O execute(I inputParams, C context, LanguageServerContext serverContext) throws Throwable;
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageServerContext.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/LanguageServerContext.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  *  WSO2 Inc. licenses this file to you under the Apache License,
  *  Version 2.0 (the "License"); you may not use this file except
@@ -17,33 +17,25 @@
  */
 package org.ballerinalang.langserver.commons;
 
-import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
-
 /**
- * Represents the language server workspace service context.
+ * Language server context holding the common utility instances of an associated language server instance.
  *
  * @since 2.0.0
  */
-public interface WorkspaceServiceContext {
+public interface LanguageServerContext {
+
+    <V> void put(LanguageServerContext.Key<V> key, V value);
+
+    <V> V get(LanguageServerContext.Key<V> key);
+
+    <V> void put(Class<V> clazz, V value);
+
+    <V> V get(Class<V> clazz);
 
     /**
-     * Get the workspace manager instance.
-     *
-     * @return {@link WorkspaceManager} instance for the language server
+     * @param <K> key
+     * @since 2.0.0
      */
-    WorkspaceManager workspace();
-
-    /**
-     * Get the operation.
-     *
-     * @return {@link LSOperation}
-     */
-    LSOperation operation();
-
-    /**
-     * Get the language server context.
-     *
-     * @return {@link LanguageServerContext}
-     */
-    LanguageServerContext languageServercontext();
+    class Key<K> {
+    }
 }

--- a/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/codeaction/spi/LSCodeActionProvider.java
+++ b/language-server/modules/langserver-commons/src/main/java/org/ballerinalang/langserver/commons/codeaction/spi/LSCodeActionProvider.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.commons.codeaction.spi;
 
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.codeaction.CodeActionNodeType;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.Diagnostic;
@@ -43,7 +44,7 @@ public interface LSCodeActionProvider {
      *
      * @return True if code action is enabled, False otherwise
      */
-    default boolean isEnabled() {
+    default boolean isEnabled(LanguageServerContext serverContext) {
         return true;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/module-info.java
+++ b/language-server/modules/langserver-core/src/main/java/module-info.java
@@ -1,5 +1,9 @@
 module io.ballerina.language.server.core {
     uses org.ballerinalang.langserver.commons.LanguageExtension;
+    uses org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider;
+    uses org.ballerinalang.langserver.commons.codelenses.spi.LSCodeLensesProvider;
+    uses org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
+    uses org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
     exports org.ballerinalang.langserver;
     exports org.ballerinalang.langserver.util.references;
     exports org.ballerinalang.langserver.common.utils;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -84,17 +84,17 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
 
     private BallerinaLanguageServer(LanguageServerContext serverContext) {
         super(serverContext);
-        this.textService = new BallerinaTextDocumentService(this, workspaceManager, lsContext);
-        this.workspaceService = new BallerinaWorkspaceService(this, workspaceManager, lsContext);
-        this.ballerinaDocumentService = new BallerinaDocumentServiceImpl(workspaceManager, lsContext);
-        this.ballerinaConnectorService = new BallerinaConnectorServiceImpl(lsContext);
+        this.textService = new BallerinaTextDocumentService(this, workspaceManager, this.serverContext);
+        this.workspaceService = new BallerinaWorkspaceService(this, workspaceManager, this.serverContext);
+        this.ballerinaDocumentService = new BallerinaDocumentServiceImpl(workspaceManager, this.serverContext);
+        this.ballerinaConnectorService = new BallerinaConnectorServiceImpl(this.serverContext);
         this.ballerinaProjectService = new BallerinaProjectServiceImpl();
-        this.ballerinaExampleService = new BallerinaExampleServiceImpl(lsContext);
+        this.ballerinaExampleService = new BallerinaExampleServiceImpl(this.serverContext);
         this.ballerinaTraceService = new BallerinaTraceServiceImpl(this);
         this.ballerinaTraceListener = new Listener(this.ballerinaTraceService);
         this.ballerinaSymbolService = new BallerinaSymbolServiceImpl();
 
-        LSAnnotationCache.getInstance(lsContext).initiate();
+        LSAnnotationCache.getInstance(this.serverContext).initiate();
     }
 
     public ExtendedLanguageClient getClient() {
@@ -104,7 +104,7 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
         final SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions(Arrays.asList("(", ","));
-        final List<String> commandList = LSCommandExecutorProvidersHolder.getInstance(this.lsContext).getCommandsList();
+        final List<String> commandList = LSCommandExecutorProvidersHolder.getInstance(this.serverContext).getCommandsList();
         final ExecuteCommandOptions executeCommandOptions = new ExecuteCommandOptions(commandList);
         final CompletionOptions completionOptions = new CompletionOptions();
         completionOptions.setTriggerCharacters(Arrays.asList(":", ".", ">", "@"));
@@ -209,7 +209,7 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     @Override
     public void connect(ExtendedLanguageClient languageClient) {
         this.client = languageClient;
-        LSClientLogger.getInstance(this.lsContext).initialize(this.client, this.lsContext);
+        LSClientLogger.getInstance(this.serverContext).initialize(this.client, this.serverContext);
     }
 
     public BallerinaSymbolService getBallerinaSymbolService() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -17,11 +17,12 @@ package org.ballerinalang.langserver;
 
 import com.google.gson.Gson;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClientAware;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
-import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
+import org.ballerinalang.langserver.contexts.LanguageServerContextImpl;
 import org.ballerinalang.langserver.extensions.AbstractExtendedLanguageServer;
 import org.ballerinalang.langserver.extensions.ExtendedLanguageServer;
 import org.ballerinalang.langserver.extensions.ballerina.connector.BallerinaConnectorService;
@@ -38,7 +39,6 @@ import org.ballerinalang.langserver.extensions.ballerina.traces.BallerinaTraceSe
 import org.ballerinalang.langserver.extensions.ballerina.traces.BallerinaTraceServiceImpl;
 import org.ballerinalang.langserver.extensions.ballerina.traces.Listener;
 import org.ballerinalang.langserver.extensions.ballerina.traces.ProviderOptions;
-import org.ballerinalang.langserver.workspace.BallerinaWorkspaceManager;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
 import org.eclipse.lsp4j.InitializeParams;
@@ -79,22 +79,22 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     private int shutdown = 1;
 
     public BallerinaLanguageServer() {
-        this(new BallerinaWorkspaceManager());
+        this(new LanguageServerContextImpl());
     }
 
-    public BallerinaLanguageServer(WorkspaceManager workspaceManager) {
-        super(workspaceManager);
-        this.textService = new BallerinaTextDocumentService(this, workspaceManager);
-        this.workspaceService = new BallerinaWorkspaceService(this, workspaceManager);
-        this.ballerinaDocumentService = new BallerinaDocumentServiceImpl(workspaceManager);
-        this.ballerinaConnectorService = new BallerinaConnectorServiceImpl();
+    private BallerinaLanguageServer(LanguageServerContext serverContext) {
+        super(serverContext);
+        this.textService = new BallerinaTextDocumentService(this, workspaceManager, lsContext);
+        this.workspaceService = new BallerinaWorkspaceService(this, workspaceManager, lsContext);
+        this.ballerinaDocumentService = new BallerinaDocumentServiceImpl(workspaceManager, lsContext);
+        this.ballerinaConnectorService = new BallerinaConnectorServiceImpl(lsContext);
         this.ballerinaProjectService = new BallerinaProjectServiceImpl();
-        this.ballerinaExampleService = new BallerinaExampleServiceImpl();
+        this.ballerinaExampleService = new BallerinaExampleServiceImpl(lsContext);
         this.ballerinaTraceService = new BallerinaTraceServiceImpl(this);
         this.ballerinaTraceListener = new Listener(this.ballerinaTraceService);
         this.ballerinaSymbolService = new BallerinaSymbolServiceImpl();
 
-        LSAnnotationCache.initiate();
+        LSAnnotationCache.getInstance(lsContext).initiate();
     }
 
     public ExtendedLanguageClient getClient() {
@@ -104,7 +104,7 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
         final SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions(Arrays.asList("(", ","));
-        final List<String> commandList = LSCommandExecutorProvidersHolder.getInstance().getCommandsList();
+        final List<String> commandList = LSCommandExecutorProvidersHolder.getInstance(this.lsContext).getCommandsList();
         final ExecuteCommandOptions executeCommandOptions = new ExecuteCommandOptions(commandList);
         final CompletionOptions completionOptions = new CompletionOptions();
         completionOptions.setTriggerCharacters(Arrays.asList(":", ".", ">", "@"));
@@ -209,7 +209,7 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     @Override
     public void connect(ExtendedLanguageClient languageClient) {
         this.client = languageClient;
-        LSClientLogger.initialize(this.client);
+        LSClientLogger.getInstance(this.lsContext).initialize(this.client, this.lsContext);
     }
 
     public BallerinaSymbolService getBallerinaSymbolService() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaLanguageServer.java
@@ -104,7 +104,8 @@ public class BallerinaLanguageServer extends AbstractExtendedLanguageServer
     public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
         final InitializeResult res = new InitializeResult(new ServerCapabilities());
         final SignatureHelpOptions signatureHelpOptions = new SignatureHelpOptions(Arrays.asList("(", ","));
-        final List<String> commandList = LSCommandExecutorProvidersHolder.getInstance(this.serverContext).getCommandsList();
+        final List<String> commandList = LSCommandExecutorProvidersHolder.getInstance(this.serverContext)
+                .getCommandsList();
         final ExecuteCommandOptions executeCommandOptions = new ExecuteCommandOptions(commandList);
         final CompletionOptions completionOptions = new CompletionOptions();
         completionOptions.setTriggerCharacters(Arrays.asList(":", ".", ">", "@"));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -33,6 +33,7 @@ import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.FoldingRangeContext;
 import org.ballerinalang.langserver.commons.HoverContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.SignatureContext;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
@@ -88,9 +89,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import static org.ballerinalang.langserver.LSClientLogger.logError;
-import static org.ballerinalang.langserver.LSClientLogger.notifyUser;
-
 /**
  * Text document service implementation for ballerina.
  */
@@ -98,10 +96,16 @@ class BallerinaTextDocumentService implements TextDocumentService {
     private final BallerinaLanguageServer languageServer;
     private LSClientCapabilities clientCapabilities;
     private final WorkspaceManager workspaceManager;
+    private final LanguageServerContext serverContext;
+    private final LSClientLogger clientLogger;
 
-    BallerinaTextDocumentService(BallerinaLanguageServer languageServer, WorkspaceManager workspaceManager) {
+    BallerinaTextDocumentService(BallerinaLanguageServer languageServer,
+                                 WorkspaceManager workspaceManager,
+                                 LanguageServerContext serverContext) {
         this.workspaceManager = workspaceManager;
         this.languageServer = languageServer;
+        this.serverContext = serverContext;
+        this.clientLogger = LSClientLogger.getInstance(this.serverContext);
     }
 
     /**
@@ -120,15 +124,16 @@ class BallerinaTextDocumentService implements TextDocumentService {
             CompletionContext context = ContextBuilder.buildCompletionContext(fileUri,
                     this.workspaceManager,
                     this.clientCapabilities.getTextDocCapabilities().getCompletion(),
+                    this.serverContext,
                     position.getPosition());
             try {
-                return LangExtensionDelegator.instance().completion(position, context);
+                return LangExtensionDelegator.instance().completion(position, context, this.serverContext);
             } catch (CompletionContextNotSupportedException e) {
                 // Ignore the exception
             } catch (Throwable e) {
                 // Note: Not catching UserErrorException separately to avoid flooding error msgs popups
                 String msg = "Operation 'text/completion' failed!";
-                logError(msg, e, position.getTextDocument(), position.getPosition());
+                this.clientLogger.logError(msg, e, position.getTextDocument(), position.getPosition());
             }
 
             return Either.forLeft(Collections.emptyList());
@@ -140,14 +145,14 @@ class BallerinaTextDocumentService implements TextDocumentService {
         return CompletableFuture.supplyAsync(() -> {
             String fileUri = position.getTextDocument().getUri();
             HoverContext context = ContextBuilder
-                    .buildHoverContext(fileUri, this.workspaceManager, position.getPosition());
+                    .buildHoverContext(fileUri, this.workspaceManager, this.serverContext, position.getPosition());
             Hover hover;
             try {
                 hover = HoverUtil.getHover(context);
             } catch (Throwable e) {
                 // Note: Not catching UserErrorException separately to avoid flooding error msgs popups
                 String msg = "Operation 'text/hover' failed!";
-                logError(msg, e, position.getTextDocument(), position.getPosition());
+                this.clientLogger.logError(msg, e, position.getTextDocument(), position.getPosition());
                 hover = HoverUtil.getDefaultHoverObject();
             }
 
@@ -169,6 +174,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
             SignatureContext context = ContextBuilder.buildSignatureContext(uri,
                     this.workspaceManager,
                     this.clientCapabilities.getTextDocCapabilities().getSignatureHelp(),
+                    this.serverContext,
                     position.getPosition());
             try {
                 // Find token at cursor position
@@ -217,11 +223,11 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 signatureHelp.setSignatures(signatures);
                 return signatureHelp;
             } catch (UserErrorException e) {
-                notifyUser("Signature Help", e);
+                this.clientLogger.notifyUser("Signature Help", e);
                 return new SignatureHelp();
             } catch (Throwable e) {
                 String msg = "Operation 'text/signature' failed!";
-                logError(msg, e, position.getTextDocument(), position.getPosition());
+                this.clientLogger.logError(msg, e, position.getTextDocument(), position.getPosition());
                 return new SignatureHelp();
             }
         });
@@ -234,14 +240,15 @@ class BallerinaTextDocumentService implements TextDocumentService {
             try {
                 DocumentServiceContext defContext = ContextBuilder.buildBaseContext(position.getTextDocument().getUri(),
                         this.workspaceManager,
-                        LSContextOperation.TXT_DEFINITION);
+                        LSContextOperation.TXT_DEFINITION,
+                        this.serverContext);
                 return Either.forLeft(DefinitionUtil.getDefinition(defContext, position.getPosition()));
             } catch (UserErrorException e) {
-                notifyUser("Goto Definition", e);
+                this.clientLogger.notifyUser("Goto Definition", e);
                 return Either.forLeft(Collections.emptyList());
             } catch (Throwable e) {
                 String msg = "Operation 'text/definition' failed!";
-                logError(msg, e, position.getTextDocument(), position.getPosition());
+                this.clientLogger.logError(msg, e, position.getTextDocument(), position.getPosition());
                 return Either.forLeft(Collections.emptyList());
             }
         });
@@ -260,11 +267,11 @@ class BallerinaTextDocumentService implements TextDocumentService {
             try {
                 return new ArrayList<>();
             } catch (UserErrorException e) {
-                notifyUser("Find References", e);
+                this.clientLogger.notifyUser("Find References", e);
                 return new ArrayList<>();
             } catch (Throwable e) {
                 String msg = "Operation 'text/references' failed!";
-                logError(msg, e, params.getTextDocument(), params.getPosition());
+                this.clientLogger.logError(msg, e, params.getTextDocument(), params.getPosition());
                 return new ArrayList<>();
             }
         });
@@ -284,11 +291,11 @@ class BallerinaTextDocumentService implements TextDocumentService {
             try {
                 return new ArrayList<>();
             } catch (UserErrorException e) {
-                notifyUser("Document Symbols", e);
+                this.clientLogger.notifyUser("Document Symbols", e);
                 return new ArrayList<>();
             } catch (Throwable e) {
                 String msg = "Operation 'text/documentSymbol' failed!";
-                logError(msg, e, params.getTextDocument(), (Position) null);
+                this.clientLogger.logError(msg, e, params.getTextDocument(), (Position) null);
                 return new ArrayList<>();
             }
         });
@@ -299,16 +306,17 @@ class BallerinaTextDocumentService implements TextDocumentService {
         return CompletableFuture.supplyAsync(() -> {
             String fileUri = params.getTextDocument().getUri();
             try {
-                CodeActionContext context = ContextBuilder.buildCodeActionContext(fileUri, workspaceManager, params);
-                return LangExtensionDelegator.instance().codeActions(params, context).stream()
+                CodeActionContext context = ContextBuilder.buildCodeActionContext(fileUri, workspaceManager,
+                        this.serverContext, params);
+                return LangExtensionDelegator.instance().codeActions(params, context, this.serverContext).stream()
                         .map((Function<CodeAction, Either<Command, CodeAction>>) Either::forRight)
                         .collect(Collectors.toList());
             } catch (UserErrorException e) {
-                notifyUser("Code Action", e);
+                this.clientLogger.notifyUser("Code Action", e);
             } catch (Throwable e) {
                 String msg = "Operation 'text/codeAction' failed!";
                 Range range = params.getRange();
-                logError(msg, e, params.getTextDocument(), range.getStart(), range.getEnd());
+                this.clientLogger.logError(msg, e, params.getTextDocument(), range.getStart(), range.getEnd());
             }
             return Collections.emptyList();
         });
@@ -318,7 +326,7 @@ class BallerinaTextDocumentService implements TextDocumentService {
     public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
         return CompletableFuture.supplyAsync(() -> {
             List<CodeLens> lenses;
-            if (!LSCodeLensesProviderHolder.getInstance().isEnabled()) {
+            if (!LSCodeLensesProviderHolder.getInstance(this.serverContext).isEnabled()) {
                 // Disabled ballerina codeLens feature
                 clientCapabilities.getTextDocCapabilities().setCodeLens(null);
                 // Skip code lenses if codeLens disabled
@@ -335,17 +343,17 @@ class BallerinaTextDocumentService implements TextDocumentService {
 
             DocumentServiceContext codeLensContext = ContextBuilder.buildBaseContext(fileUri,
                     this.workspaceManager,
-                    LSContextOperation.TXT_CODE_LENS);
+                    LSContextOperation.TXT_CODE_LENS, this.serverContext);
 
             try {
                 lenses = CodeLensUtil.getCodeLenses(codeLensContext);
                 return lenses;
             } catch (UserErrorException e) {
-                notifyUser("Code Lens", e);
+                this.clientLogger.notifyUser("Code Lens", e);
                 // Source compilation failed, serve from cache
             } catch (Throwable e) {
                 String msg = "Operation 'text/codeLens' failed!";
-                logError(msg, e, params.getTextDocument(), (Position) null);
+                this.clientLogger.logError(msg, e, params.getTextDocument(), (Position) null);
                 // Source compilation failed, serve from cache
             }
 
@@ -382,11 +390,11 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 textEdit = new TextEdit(range, formattedSource);
                 return Collections.singletonList(textEdit);
             } catch (UserErrorException | FormatterException e) {
-                notifyUser("Formatting", e);
+                this.clientLogger.notifyUser("Formatting", e);
                 return Collections.singletonList(textEdit);
             } catch (Throwable e) {
                 String msg = "Operation 'text/formatting' failed!";
-                logError(msg, e, params.getTextDocument(), (Position) null);
+                this.clientLogger.logError(msg, e, params.getTextDocument(), (Position) null);
                 return Collections.singletonList(textEdit);
             }
         });
@@ -427,11 +435,11 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 textEdit = new TextEdit(updateRange, formattedTree.toSourceCode());
                 return Collections.singletonList(textEdit);
             } catch (UserErrorException | FormatterException e) {
-                notifyUser("Formatting", e);
+                this.clientLogger.notifyUser("Formatting", e);
                 return Collections.singletonList(textEdit);
             } catch (Throwable e) {
                 String msg = "Operation 'text/formatting' failed!";
-                logError(msg, e, params.getTextDocument(), (Position) null);
+                this.clientLogger.logError(msg, e, params.getTextDocument(), (Position) null);
                 return Collections.singletonList(textEdit);
             }
         });
@@ -442,15 +450,16 @@ class BallerinaTextDocumentService implements TextDocumentService {
         String fileUri = params.getTextDocument().getUri();
         try {
             DocumentServiceContext context = ContextBuilder.buildBaseContext(fileUri, this.workspaceManager,
-                    LSContextOperation.TXT_DID_OPEN);
+                    LSContextOperation.TXT_DID_OPEN, this.serverContext);
             this.workspaceManager.didOpen(context.filePath(), params);
-            LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_OPEN.getName() +
+            this.clientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_OPEN.getName() +
                     "' {fileUri: '" + fileUri + "'} opened}");
-            DiagnosticsHelper.getInstance().compileAndSendDiagnostics(this.languageServer.getClient(), context);
+            DiagnosticsHelper diagnosticsHelper = DiagnosticsHelper.getInstance(this.serverContext);
+            diagnosticsHelper.compileAndSendDiagnostics(this.languageServer.getClient(), context);
         } catch (Throwable e) {
             String msg = "Operation 'text/didOpen' failed!";
             TextDocumentIdentifier identifier = new TextDocumentIdentifier(params.getTextDocument().getUri());
-            logError(msg, e, identifier, (Position) null);
+            this.clientLogger.logError(msg, e, identifier, (Position) null);
         }
     }
 
@@ -461,19 +470,21 @@ class BallerinaTextDocumentService implements TextDocumentService {
             // Update content
             DocumentServiceContext context = ContextBuilder.buildBaseContext(fileUri,
                     this.workspaceManager,
-                    LSContextOperation.TXT_DID_CHANGE);
+                    LSContextOperation.TXT_DID_CHANGE,
+                    this.serverContext);
             // Note: If the source is a cached stdlib source or path does not exist, then return early and ignore
             if (CommonUtil.isCachedExternalSource(fileUri)) {
                 // TODO: Check whether still we need this check
                 return;
             }
             workspaceManager.didChange(context.filePath(), params);
-            LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CHANGE.getName() +
+            this.clientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CHANGE.getName() +
                     "' {fileUri: '" + fileUri + "'} updated}");
-            DiagnosticsHelper.getInstance().compileAndSendDiagnostics(this.languageServer.getClient(), context);
+            DiagnosticsHelper diagnosticsHelper = DiagnosticsHelper.getInstance(this.serverContext);
+            diagnosticsHelper.compileAndSendDiagnostics(this.languageServer.getClient(), context);
         } catch (Throwable e) {
             String msg = "Operation 'text/didChange' failed!";
-            logError(msg, e, params.getTextDocument(), (Position) null);
+            this.clientLogger.logError(msg, e, params.getTextDocument(), (Position) null);
         }
     }
 
@@ -483,13 +494,14 @@ class BallerinaTextDocumentService implements TextDocumentService {
         try {
             DocumentServiceContext context = ContextBuilder.buildBaseContext(fileUri,
                     this.workspaceManager,
-                    LSContextOperation.TXT_DID_CLOSE);
+                    LSContextOperation.TXT_DID_CLOSE,
+                    this.serverContext);
             workspaceManager.didClose(context.filePath(), params);
-            LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CLOSE.getName() +
+            this.clientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CLOSE.getName() +
                     "' {fileUri: '" + fileUri + "'} closed}");
         } catch (Throwable e) {
             String msg = "Operation 'text/didClose' failed!";
-            logError(msg, e, params.getTextDocument(), (Position) null);
+            this.clientLogger.logError(msg, e, params.getTextDocument(), (Position) null);
         }
     }
 
@@ -504,11 +516,13 @@ class BallerinaTextDocumentService implements TextDocumentService {
                 FoldingRangeContext foldingRangeContext = ContextBuilder.buildFoldingRangeContext(
                         params.getTextDocument().getUri(),
                         this.workspaceManager,
+                        this.serverContext,
                         this.clientCapabilities.getTextDocCapabilities().getFoldingRange().getLineFoldingOnly());
                 return FoldingRangeProvider.getFoldingRange(foldingRangeContext);
             } catch (Throwable e) {
                 String msg = "Operation 'text/foldingRange' failed!";
-                logError(msg, e, new TextDocumentIdentifier(params.getTextDocument().getUri()), (Position) null);
+                this.clientLogger.logError(msg, e, new TextDocumentIdentifier(params.getTextDocument().getUri()),
+                        (Position) null);
                 return Collections.emptyList();
             }
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaWorkspaceService.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver;
 import com.google.gson.JsonObject;
 import org.ballerinalang.langserver.command.LSCommandExecutorProvidersHolder;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.command.LSCommandExecutorException;
 import org.ballerinalang.langserver.commons.command.spi.LSCommandExecutor;
@@ -35,22 +36,24 @@ import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static org.ballerinalang.langserver.LSClientLogger.logError;
-import static org.ballerinalang.langserver.LSClientLogger.notifyUser;
-
 /**
  * Workspace service implementation for Ballerina.
  */
 public class BallerinaWorkspaceService implements WorkspaceService {
     private final BallerinaLanguageServer languageServer;
-    private final LSClientConfigHolder configHolder = LSClientConfigHolder.getInstance();
+    private final LSClientConfigHolder configHolder;
     private LSClientCapabilities clientCapabilities;
     private final WorkspaceManager workspaceManager;
+    private final LanguageServerContext serverContext;
+    private final LSClientLogger clientLogger;
 
-
-    BallerinaWorkspaceService(BallerinaLanguageServer languageServer, WorkspaceManager workspaceManager) {
+    BallerinaWorkspaceService(BallerinaLanguageServer languageServer, WorkspaceManager workspaceManager,
+                              LanguageServerContext serverContext) {
         this.languageServer = languageServer;
         this.workspaceManager = workspaceManager;
+        this.serverContext = serverContext;
+        this.configHolder = LSClientConfigHolder.getInstance(this.serverContext);
+        this.clientLogger = LSClientLogger.getInstance(this.serverContext);
     }
 
     public void setClientCapabilities(LSClientCapabilities clientCapabilities) {
@@ -84,23 +87,24 @@ public class BallerinaWorkspaceService implements WorkspaceService {
     public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
         return CompletableFuture.supplyAsync(() -> {
             ExecuteCommandContext context = ContextBuilder.buildExecuteCommandContext(this.workspaceManager,
+                    this.serverContext,
                     params.getArguments(),
                     this.clientCapabilities,
                     this.languageServer);
 
             try {
-                Optional<LSCommandExecutor> executor = LSCommandExecutorProvidersHolder.getInstance()
+                Optional<LSCommandExecutor> executor = LSCommandExecutorProvidersHolder.getInstance(this.serverContext)
                         .getCommandExecutor(params.getCommand());
                 if (executor.isPresent()) {
                     return executor.get().execute(context);
                 }
             } catch (UserErrorException e) {
-                notifyUser("Execute Command", e);
+                this.clientLogger.notifyUser("Execute Command", e);
             } catch (Throwable e) {
                 String msg = "Operation 'workspace/executeCommand' failed!";
-                logError(msg, e, null, (Position) null);
+                this.clientLogger.logError(msg, e, null, (Position) null);
             }
-            logError("Operation 'workspace/executeCommand' failed!",
+            this.clientLogger.logError("Operation 'workspace/executeCommand' failed!",
                     new LSCommandExecutorException("No command executor found for '" + params.getCommand() + "'"),
                     null, (Position) null);
             return false;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
@@ -44,26 +44,25 @@ import java.util.stream.Collectors;
  * @since 0.970.0
  */
 public class LSAnnotationCache {
-
-    private static final Map<ModuleID, List<AnnotationSymbol>> typeAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> classAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> objectAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> functionAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> objectMethodAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> resourceAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> parameterAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> returnAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> serviceAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> listenerAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> annotationAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> externalAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> varAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> constAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> workerAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> fieldAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> recordFieldAnnotations = new HashMap<>();
-    private static final Map<ModuleID, List<AnnotationSymbol>> objectFieldAnnotations = new HashMap<>();
-    private static final List<PackageID> processedPackages = new ArrayList<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> typeAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> classAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> objectAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> functionAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> objectMethodAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> resourceAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> parameterAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> returnAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> serviceAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> listenerAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> annotationAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> externalAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> varAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> constAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> workerAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> fieldAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> recordFieldAnnotations = new HashMap<>();
+    private final Map<ModuleID, List<AnnotationSymbol>> objectFieldAnnotations = new HashMap<>();
+    private final List<PackageID> processedPackages = new ArrayList<>();
 
     private static final LanguageServerContext.Key<LSAnnotationCache> LS_ANNOTATION_CACHE_KEY =
             new LanguageServerContext.Key<>();
@@ -214,7 +213,7 @@ public class LSAnnotationCache {
      *
      * @param pkg BLang Package Symbol to load annotations
      */
-    private static void loadAnnotationsFromPackage(Package pkg) {
+    private void loadAnnotationsFromPackage(Package pkg) {
         for (Module module : pkg.modules()) {
             List<AnnotationSymbol> annotList = module.getCompilation().getSemanticModel().moduleLevelSymbols().stream()
                     .filter(symbol -> symbol.kind() == io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION)
@@ -285,7 +284,7 @@ public class LSAnnotationCache {
         }
     }
 
-    private static List<Scope.ScopeEntry> extractAnnotationDefinitions(Map<Name, Scope.ScopeEntry> scopeEntries) {
+    private List<Scope.ScopeEntry> extractAnnotationDefinitions(Map<Name, Scope.ScopeEntry> scopeEntries) {
         return scopeEntries.values().stream()
                 .filter(scopeEntry -> scopeEntry.symbol.kind == SymbolKind.ANNOTATION)
                 .collect(Collectors.toList());
@@ -297,7 +296,7 @@ public class LSAnnotationCache {
                 .anyMatch(processedPkgId -> processedPkgId.toString().equals(packageID.toString()));
     }
 
-    private static Map<String, Package> loadPackagesMap(LanguageServerContext context) {
+    private Map<String, Package> loadPackagesMap(LanguageServerContext context) {
         Map<String, Package> staticPackages = new HashMap<>();
 
         // Annotation cache will only load the sk packages initially and the others will load in the runtime
@@ -327,11 +326,11 @@ public class LSAnnotationCache {
         return staticPackages;
     }
 
-    private static void loadAnnotations(List<Package> packageList) {
-        packageList.forEach(LSAnnotationCache::loadAnnotationsFromPackage);
+    private void loadAnnotations(List<Package> packageList) {
+        packageList.forEach(this::loadAnnotationsFromPackage);
     }
 
-    private static void addAttachment(AnnotationSymbol annotationSymbol,
+    private void addAttachment(AnnotationSymbol annotationSymbol,
                                       Map<ModuleID, List<AnnotationSymbol>> map) {
         // TODO: Check the map contains is valid
         if (map.containsKey(annotationSymbol.moduleID())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSPackageLoader.java
@@ -25,6 +25,7 @@ import io.ballerina.projects.environment.PackageRepository;
 import io.ballerina.projects.environment.ResolutionRequest;
 import io.ballerina.projects.internal.environment.BallerinaDistribution;
 import io.ballerina.projects.internal.environment.DefaultEnvironment;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -36,10 +37,12 @@ import java.util.Optional;
  * Loads the Ballerina builtin core and builtin packages.
  */
 public class LSPackageLoader {
+    private static final LanguageServerContext.Key<LSPackageLoader> LS_PACKAGE_LOADER_KEY =
+            new LanguageServerContext.Key<>();
 
-    private static final List<Package> distRepoPackages = getPackagesFromDistRepo();
+    private List<Package> distRepoPackages;
 
-    private static List<Package> getPackagesFromDistRepo() {
+    private List<Package> getPackagesFromDistRepo() {
         DefaultEnvironment environment = new DefaultEnvironment();
         // Creating a Ballerina distribution instance
         BallerinaDistribution ballerinaDistribution = BallerinaDistribution.from(environment);
@@ -74,7 +77,21 @@ public class LSPackageLoader {
      *
      * @return {@link List} of distribution repo packages
      */
-    public static List<Package> getDistributionRepoPackages() {
-        return distRepoPackages;
+    public List<Package> getDistributionRepoPackages() {
+        return this.distRepoPackages;
+    }
+
+    public static LSPackageLoader getInstance(LanguageServerContext context) {
+        LSPackageLoader lsPackageLoader = context.get(LS_PACKAGE_LOADER_KEY);
+        if (lsPackageLoader == null) {
+            lsPackageLoader = new LSPackageLoader(context);
+        }
+
+        return lsPackageLoader;
+    }
+
+    private LSPackageLoader(LanguageServerContext context) {
+        distRepoPackages = this.getPackagesFromDistRepo();
+        context.put(LS_PACKAGE_LOADER_KEY, this);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LangExtensionDelegator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LangExtensionDelegator.java
@@ -25,6 +25,7 @@ import org.ballerinalang.langserver.commons.DiagnosticsExtension;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.FormattingExtension;
 import org.ballerinalang.langserver.commons.LanguageExtension;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CompletionItem;
@@ -81,12 +82,14 @@ public class LangExtensionDelegator {
      * @return {@link Either} completion results
      * @throws Throwable while executing the extension
      */
-    public Either<List<CompletionItem>, CompletionList> completion(CompletionParams params, CompletionContext context)
+    public Either<List<CompletionItem>, CompletionList> completion(CompletionParams params,
+                                                                   CompletionContext context,
+                                                                   LanguageServerContext serverContext)
             throws Throwable {
         List<CompletionItem> completionItems = new ArrayList<>();
         for (CompletionExtension ext : completionExtensions) {
             if (ext.validate(params)) {
-                completionItems.addAll(ext.execute(params, context));
+                completionItems.addAll(ext.execute(params, context, serverContext));
             }
         }
 
@@ -100,12 +103,14 @@ public class LangExtensionDelegator {
      * @return {@link List} of text edits
      * @throws Throwable while executing the extension
      */
-    public List<? extends TextEdit> formatting(DocumentFormattingParams params, DocumentServiceContext context)
+    public List<? extends TextEdit> formatting(DocumentFormattingParams params,
+                                               DocumentServiceContext context,
+                                               LanguageServerContext serverContext)
             throws Throwable {
         List<TextEdit> textEdits = new ArrayList<>();
         for (FormattingExtension ext : formatExtensions) {
             if (ext.validate(params)) {
-                textEdits.addAll(ext.execute(params, context));
+                textEdits.addAll(ext.execute(params, context, serverContext));
             }
         }
 
@@ -119,12 +124,13 @@ public class LangExtensionDelegator {
      * @return {@link List} of text edits
      * @throws Throwable while executing the extension
      */
-    public List<? extends CodeAction> codeActions(CodeActionParams params, CodeActionContext context)
+    public List<? extends CodeAction> codeActions(CodeActionParams params, CodeActionContext context,
+                                                  LanguageServerContext serverContext)
             throws Throwable {
         List<CodeAction> actions = new ArrayList<>();
         for (CodeActionExtension ext : codeActionsExtensions) {
             if (ext.validate(params)) {
-                actions.addAll(ext.execute(params, context));
+                actions.addAll(ext.execute(params, context, serverContext));
             }
         }
 
@@ -138,11 +144,13 @@ public class LangExtensionDelegator {
      * @return {@link PublishDiagnosticsParams} diagnostic params calculated
      * @throws Throwable while executing the extension
      */
-    public List<PublishDiagnosticsParams> diagnostics(String uri, DocumentServiceContext context) throws Throwable {
+    public List<PublishDiagnosticsParams> diagnostics(String uri,
+                                                      DocumentServiceContext context,
+                                                      LanguageServerContext serverContext) throws Throwable {
         List<PublishDiagnosticsParams> diagnosticsParams = new ArrayList<>();
         for (DiagnosticsExtension ext : diagExtensions) {
             if (ext.validate(uri)) {
-                diagnosticsParams.addAll(ext.execute(uri, context));
+                diagnosticsParams.addAll(ext.execute(uri, context, serverContext));
             }
         }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/BallerinaCodeActionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/BallerinaCodeActionExtension.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langserver.codeaction;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.CodeActionExtension;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionParams;
 
@@ -39,7 +40,9 @@ public class BallerinaCodeActionExtension implements CodeActionExtension {
     }
 
     @Override
-    public List<? extends CodeAction> execute(CodeActionParams inputParams, CodeActionContext context) {
+    public List<? extends CodeAction> execute(CodeActionParams inputParams,
+                                              CodeActionContext context,
+                                              LanguageServerContext serverContext) {
         return CodeActionRouter.getAvailableCodeActions(context);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionProvidersHolder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionProvidersHolder.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.langserver.codeaction;
 
+import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.codeaction.CodeActionNodeType;
 import org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider;
 
@@ -35,18 +37,25 @@ import java.util.stream.Collectors;
 public class CodeActionProvidersHolder {
     private static final Map<CodeActionNodeType, List<LSCodeActionProvider>> nodeBasedProviders = new HashMap<>();
     private static final List<LSCodeActionProvider> diagnosticsBasedProviders = new ArrayList<>();
-    private static final CodeActionProvidersHolder INSTANCE = new CodeActionProvidersHolder();
+    private static final LanguageServerContext.Key<CodeActionProvidersHolder> CODE_ACTION_PROVIDERS_HOLDER_KEY =
+            new LanguageServerContext.Key<>();
 
     /**
      * Returns the instance of Holder.
      *
      * @return code action provider holder instance
      */
-    public static CodeActionProvidersHolder getInstance() {
-        return INSTANCE;
+    public static CodeActionProvidersHolder getInstance(LanguageServerContext serverContext) {
+        CodeActionProvidersHolder codeActionProvidersHolder = serverContext.get(CODE_ACTION_PROVIDERS_HOLDER_KEY);
+        if (codeActionProvidersHolder == null) {
+            codeActionProvidersHolder = new CodeActionProvidersHolder(serverContext);
+        }
+
+        return codeActionProvidersHolder;
     }
 
-    private CodeActionProvidersHolder() {
+    private CodeActionProvidersHolder(LanguageServerContext serverContext) {
+        serverContext.put(CODE_ACTION_PROVIDERS_HOLDER_KEY, this);
         ServiceLoader<LSCodeActionProvider> serviceLoader = ServiceLoader.load(LSCodeActionProvider.class);
         for (CodeActionNodeType nodeType : CodeActionNodeType.values()) {
             nodeBasedProviders.put(nodeType, new ArrayList<>());
@@ -69,10 +78,10 @@ public class CodeActionProvidersHolder {
      * @param nodeType node type
      * @return node based providers
      */
-    List<LSCodeActionProvider> getActiveNodeBasedProviders(CodeActionNodeType nodeType) {
+    List<LSCodeActionProvider> getActiveNodeBasedProviders(CodeActionNodeType nodeType, CodeActionContext ctx) {
         if (nodeBasedProviders.containsKey(nodeType)) {
             return nodeBasedProviders.get(nodeType).stream()
-                    .filter(LSCodeActionProvider::isEnabled)
+                    .filter(provider -> provider.isEnabled(ctx.languageServercontext()))
                     .sorted(Comparator.comparingInt(LSCodeActionProvider::priority))
                     .collect(Collectors.toList());
         }
@@ -84,9 +93,9 @@ public class CodeActionProvidersHolder {
      *
      * @return diagnostic based providers
      */
-    List<LSCodeActionProvider> getActiveDiagnosticsBasedProviders() {
+    List<LSCodeActionProvider> getActiveDiagnosticsBasedProviders(CodeActionContext ctx) {
         return diagnosticsBasedProviders.stream()
-                .filter(LSCodeActionProvider::isEnabled)
+                .filter(provider -> provider.isEnabled(ctx.languageServercontext()))
                 .sorted(Comparator.comparingInt(LSCodeActionProvider::priority))
                 .collect(Collectors.toList());
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
@@ -49,8 +49,10 @@ public class CodeActionRouter {
      * @return list of code actions
      */
     public static List<CodeAction> getAvailableCodeActions(CodeActionContext ctx) {
+        LSClientLogger clientLogger = LSClientLogger.getInstance(ctx.languageServercontext());
         List<CodeAction> codeActions = new ArrayList<>();
-        CodeActionProvidersHolder codeActionProvidersHolder = CodeActionProvidersHolder.getInstance();
+        CodeActionProvidersHolder codeActionProvidersHolder
+                = CodeActionProvidersHolder.getInstance(ctx.languageServercontext());
 
         // Get available node-type based code-actions
         SyntaxTree syntaxTree = ctx.workspace().syntaxTree(ctx.filePath()).orElseThrow();
@@ -65,7 +67,7 @@ public class CodeActionRouter {
 
             PositionDetails posDetails = CodeActionPositionDetails.from(matchedNode.get(), null, matchedTypeSymbol);
             ctx.setPositionDetails(posDetails);
-            codeActionProvidersHolder.getActiveNodeBasedProviders(matchedNodeType).forEach(provider -> {
+            codeActionProvidersHolder.getActiveNodeBasedProviders(matchedNodeType, ctx).forEach(provider -> {
                 try {
                     List<CodeAction> codeActionsOut = provider.getNodeBasedCodeActions(ctx);
                     if (codeActionsOut != null) {
@@ -73,7 +75,7 @@ public class CodeActionRouter {
                     }
                 } catch (Exception e) {
                     String msg = "CodeAction '" + provider.getClass().getSimpleName() + "' failed!";
-                    LSClientLogger.logError(msg, e, null, (Position) null);
+                    clientLogger.logError(msg, e, null, (Position) null);
                 }
             });
         }
@@ -84,7 +86,7 @@ public class CodeActionRouter {
             for (Diagnostic diagnostic : cursorDiagnostics) {
                 PositionDetails positionDetails = computePositionDetails(diagnostic.getRange(), syntaxTree, ctx);
                 ctx.setPositionDetails(positionDetails);
-                codeActionProvidersHolder.getActiveDiagnosticsBasedProviders().forEach(provider -> {
+                codeActionProvidersHolder.getActiveDiagnosticsBasedProviders(ctx).forEach(provider -> {
                     try {
                         List<CodeAction> codeActionsOut = provider.getDiagBasedCodeActions(diagnostic, ctx);
                         if (codeActionsOut != null) {
@@ -92,7 +94,7 @@ public class CodeActionRouter {
                         }
                     } catch (Exception e) {
                         String msg = "CodeAction '" + provider.getClass().getSimpleName() + "' failed!";
-                        LSClientLogger.logError(msg, e, null, (Position) null);
+                        clientLogger.logError(msg, e, null, (Position) null);
                     }
                 });
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractCodeActionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AbstractCodeActionProvider.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.codeaction.providers;
 
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.codeaction.CodeActionNodeType;
 import org.ballerinalang.langserver.commons.codeaction.spi.LSCodeActionProvider;
 import org.eclipse.lsp4j.CodeAction;
@@ -41,7 +42,7 @@ public abstract class AbstractCodeActionProvider implements LSCodeActionProvider
     protected boolean isNodeTypeBased;
 
     @Override
-    public boolean isEnabled() {
+    public boolean isEnabled(LanguageServerContext serverContext) {
         return true;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/CreateFunctionCodeAction.java
@@ -22,6 +22,7 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.command.executors.CreateFunctionExecutor;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -45,7 +46,7 @@ public class CreateFunctionCodeAction extends AbstractCodeActionProvider {
     private static final String UNDEFINED_FUNCTION = "undefined function";
 
     @Override
-    public boolean isEnabled() {
+    public boolean isEnabled(LanguageServerContext serverContext) {
         //TODO: Need to get return type of the function invocation blocked due to #27211
         return false;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/ImportModuleCodeAction.java
@@ -26,6 +26,7 @@ import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvi
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -63,7 +64,9 @@ public class ImportModuleCodeAction extends AbstractCodeActionProvider {
         String diagnosticMessage = diagnostic.getMessage();
         String packageAlias = diagnosticMessage.substring(diagnosticMessage.indexOf("'") + 1,
                 diagnosticMessage.lastIndexOf("'"));
-        List<Package> packagesList = new ArrayList<>(LSPackageLoader.getDistributionRepoPackages());
+        LanguageServerContext serverContext = context.languageServercontext();
+        List<Package> packagesList =
+                new ArrayList<>(LSPackageLoader.getInstance(serverContext).getDistributionRepoPackages());
 
         packagesList.stream()
                 .filter(pkgEntry -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/PullModuleCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/imports/PullModuleCodeAction.java
@@ -20,6 +20,7 @@ import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvi
 import org.ballerinalang.langserver.command.executors.PullModuleExecutor;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -42,7 +43,7 @@ public class PullModuleCodeAction extends AbstractCodeActionProvider {
     private static final String UNRESOLVED_MODULE = "cannot resolve module";
 
     @Override
-    public boolean isEnabled() {
+    public boolean isEnabled(LanguageServerContext serverContext) {
         //TODO: disabled since offline is yet to be supported through project api
         return false;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/CodeLensUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/CodeLensUtil.java
@@ -41,7 +41,8 @@ public class CodeLensUtil {
      */
     public static List<CodeLens> getCodeLenses(DocumentServiceContext codeLensContext) {
         List<CodeLens> lenses = new ArrayList<>();
-        List<LSCodeLensesProvider> providers = LSCodeLensesProviderHolder.getInstance().getProviders();
+        List<LSCodeLensesProvider> providers = LSCodeLensesProviderHolder
+                .getInstance(codeLensContext.languageServercontext()).getProviders();
         for (LSCodeLensesProvider provider : providers) {
             try {
                 lenses.addAll(provider.getLenses(codeLensContext));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/LSCodeLensesProviderHolder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/LSCodeLensesProviderHolder.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.codelenses;
 
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.codelenses.spi.LSCodeLensesProvider;
 import org.ballerinalang.langserver.config.ClientConfigListener;
 import org.ballerinalang.langserver.config.LSClientConfig;
@@ -26,25 +27,26 @@ import java.util.ServiceLoader;
 
 /**
  * Loads and provides the Code Lenses Providers.
- * 
+ *
  * @since 0.990.3
  */
 public class LSCodeLensesProviderHolder {
-
     private static final List<LSCodeLensesProvider> providers = new ArrayList<>();
+    private static final LanguageServerContext.Key<LSCodeLensesProviderHolder> CODE_LENSES_PROVIDER_HOLDER_KEY =
+            new LanguageServerContext.Key<>();
 
-    private static final LSCodeLensesProviderHolder INSTANCE = new LSCodeLensesProviderHolder();
 
     private boolean isEnabled = true;
 
-    private LSCodeLensesProviderHolder() {
+    private LSCodeLensesProviderHolder(LanguageServerContext serverContext) {
+        serverContext.put(CODE_LENSES_PROVIDER_HOLDER_KEY, this);
         ServiceLoader<LSCodeLensesProvider> providers = ServiceLoader.load(LSCodeLensesProvider.class);
         for (LSCodeLensesProvider executor : providers) {
             if (executor != null && executor.isEnabled()) {
                 LSCodeLensesProviderHolder.providers.add(executor);
             }
         }
-        LSClientConfigHolder.getInstance().register(new ClientConfigListener() {
+        LSClientConfigHolder.getInstance(serverContext).register(new ClientConfigListener() {
             @Override
             public void didChangeConfig(LSClientConfig oldConfig, LSClientConfig newConfig) {
                 isEnabled = newConfig.getCodeLens().getAll().isEnabled();
@@ -52,8 +54,13 @@ public class LSCodeLensesProviderHolder {
         });
     }
 
-    public static LSCodeLensesProviderHolder getInstance() {
-        return INSTANCE;
+    public static LSCodeLensesProviderHolder getInstance(LanguageServerContext serverContext) {
+        LSCodeLensesProviderHolder lsCodeLensesProviderHolder = serverContext.get(CODE_LENSES_PROVIDER_HOLDER_KEY);
+        if (lsCodeLensesProviderHolder == null) {
+            lsCodeLensesProviderHolder = new LSCodeLensesProviderHolder(serverContext);
+        }
+        
+        return lsCodeLensesProviderHolder;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/providers/DocsCodeLensesProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codelenses/providers/DocsCodeLensesProvider.java
@@ -31,9 +31,6 @@ import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.command.CommandArgument;
-import org.ballerinalang.langserver.config.ClientConfigListener;
-import org.ballerinalang.langserver.config.LSClientConfig;
-import org.ballerinalang.langserver.config.LSClientConfigHolder;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.Position;
@@ -53,12 +50,13 @@ import java.util.Optional;
 public class DocsCodeLensesProvider extends AbstractCodeLensesProvider {
     public DocsCodeLensesProvider() {
         super("docs.CodeLenses");
-        LSClientConfigHolder.getInstance().register(new ClientConfigListener() {
-            @Override
-            public void didChangeConfig(LSClientConfig oldConfig, LSClientConfig newConfig) {
-                isEnabled = newConfig.getCodeLens().getDocs().isEnabled();
-            }
-        });
+        // TODO: Fix me
+//        LSClientConfigHolder.getInstance().register(new ClientConfigListener() {
+//            @Override
+//            public void didChangeConfig(LSClientConfig oldConfig, LSClientConfig newConfig) {
+//                isEnabled = newConfig.getCodeLens().getDocs().isEnabled();
+//            }
+//        });
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/PullModuleExecutor.java
@@ -84,7 +84,7 @@ public class PullModuleExecutor implements LSCommandExecutor {
             String ballerinaCmd = Paths.get(CommonUtil.BALLERINA_CMD).toString();
             ProcessBuilder processBuilder = new ProcessBuilder(ballerinaCmd, "pull", moduleName);
             LanguageClient client = context.getLanguageClient();
-            DiagnosticsHelper diagnosticsHelper = DiagnosticsHelper.getInstance();
+            DiagnosticsHelper diagnosticsHelper = DiagnosticsHelper.getInstance(context.languageServercontext());
             try {
                 notifyClient(client, MessageType.Info, "Pulling '" + moduleName + "' from the Ballerina Central...");
                 Process process = processBuilder.start();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/BallerinaCompletionExtension.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/BallerinaCompletionExtension.java
@@ -21,6 +21,7 @@ import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.CompletionExtension;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.completions.util.CompletionUtil;
 import org.ballerinalang.langserver.contexts.BallerinaCompletionContextImpl;
 import org.eclipse.lsp4j.CompletionItem;
@@ -42,9 +43,11 @@ public class BallerinaCompletionExtension implements CompletionExtension {
     }
 
     @Override
-    public List<CompletionItem> execute(CompletionParams inputParams, CompletionContext context)
+    public List<CompletionItem> execute(CompletionParams inputParams,
+                                        CompletionContext context,
+                                        LanguageServerContext serverContext)
             throws Throwable {
-        BallerinaCompletionContext bcContext = new BallerinaCompletionContextImpl(context);
+        BallerinaCompletionContext bcContext = new BallerinaCompletionContextImpl(context, serverContext);
         return CompletionUtil.getCompletionItems(bcContext);
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -259,7 +259,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                     return new SymbolCompletionItem(ctx, null, item);
                 }).collect(Collectors.toList());
 
-        List<Package> packages = LSPackageLoader.getDistributionRepoPackages();
+        List<Package> packages = LSPackageLoader.getInstance(ctx.languageServercontext()).getDistributionRepoPackages();
         // TODO: Refactor to match the latest project structure
 //        packages.addAll(LSPackageLoader.getCurrentProjectModules(currentPkg, ctx));
         packages.forEach(pkg -> {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
@@ -106,7 +106,7 @@ public class AnnotationNodeContext extends AbstractCompletionProvider<Annotation
         if (moduleEntry.isEmpty()) {
             List<LSCompletionItem> completionItems = new ArrayList<>();
             // Import statement has not been added. Hence try resolving from the annotation cache
-            LSAnnotationCache.getInstance().getAnnotationsInModule(context, alias, kind)
+            LSAnnotationCache.getInstance(context.languageServercontext()).getAnnotationsInModule(context, alias, kind)
                     .forEach((key, value) -> value.forEach(annotation -> {
                         completionItems.add(AnnotationUtil.getAnnotationItem(annotation, context));
                     }));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportDeclarationNodeContext.java
@@ -30,6 +30,7 @@ import io.ballerina.projects.ProjectKind;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.LSPackageLoader;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.SnippetCompletionItem;
 import org.ballerinalang.langserver.completions.StaticCompletionItem;
@@ -180,9 +181,9 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
     private ArrayList<LSCompletionItem> orgNameContextCompletions(BallerinaCompletionContext ctx) {
         List<String> orgNames = new ArrayList<>();
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
-        List<Package> packagesList = LSPackageLoader.getDistributionRepoPackages();
+        List<Package> pkgList = LSPackageLoader.getInstance(ctx.languageServercontext()).getDistributionRepoPackages();
 
-        packagesList.forEach(pkg -> {
+        pkgList.forEach(pkg -> {
             String orgName = pkg.packageOrg().value();
             String pkgName = pkg.packageName().value();
             String fullPkgNameLabel = orgName + SLASH + pkgName;
@@ -266,7 +267,8 @@ public class ImportDeclarationNodeContext extends AbstractCompletionProvider<Imp
                                                                      String orgName) {
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
         List<String> pkgNameLabels = new ArrayList<>();
-        List<Package> packageList = LSPackageLoader.getDistributionRepoPackages();
+        LanguageServerContext serverContext = context.languageServercontext();
+        List<Package> packageList = LSPackageLoader.getInstance(serverContext).getDistributionRepoPackages();
         packageList.forEach(ballerinaPackage -> {
             if (isPreDeclaredLangLib(ballerinaPackage)) {
                 return;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImportOrgNameNodeContext.java
@@ -58,7 +58,8 @@ public class ImportOrgNameNodeContext extends AbstractCompletionProvider<ImportO
             throw new AssertionError("ModuleName cannot be empty");
         }
 
-        List<Package> packagesList = new ArrayList<>(LSPackageLoader.getDistributionRepoPackages());
+        List<Package> packagesList =
+                new ArrayList<>(LSPackageLoader.getInstance(ctx.languageServercontext()).getDistributionRepoPackages());
         ArrayList<LSCompletionItem> completionItems = moduleNameContextCompletions(ctx, orgName, packagesList);
         this.sort(ctx, node, completionItems);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/config/LSClientConfigHolder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/config/LSClientConfigHolder.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.config;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 
 import java.lang.reflect.Type;
 import java.util.ArrayList;
@@ -26,8 +27,9 @@ import java.util.List;
  * This class is holding the latest client configuration.
  */
 public class LSClientConfigHolder {
-    private static final LSClientConfigHolder INSTANCE = new LSClientConfigHolder();
     private final Gson gson = new Gson();
+    private static final LanguageServerContext.Key<LSClientConfigHolder> CLIENT_CONFIG_HOLDER_KEY =
+            new LanguageServerContext.Key<>();
 
     private final List<ClientConfigListener> listeners = new ArrayList<>();
 
@@ -35,11 +37,17 @@ public class LSClientConfigHolder {
     private LSClientConfig clientConfig = LSClientConfig.getDefault();
     private JsonElement clientConfigJson = gson.toJsonTree(this.clientConfig).getAsJsonObject();
 
-    private LSClientConfigHolder() {
+    private LSClientConfigHolder(LanguageServerContext serverContext) {
+        serverContext.put(CLIENT_CONFIG_HOLDER_KEY, this);
     }
 
-    public static LSClientConfigHolder getInstance() {
-        return INSTANCE;
+    public static LSClientConfigHolder getInstance(LanguageServerContext serverContext) {
+        LSClientConfigHolder lsClientConfigHolder = serverContext.get(CLIENT_CONFIG_HOLDER_KEY);
+        if (lsClientConfigHolder == null) {
+            lsClientConfigHolder = new LSClientConfigHolder(serverContext);
+        }
+
+        return lsClientConfigHolder;
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractWorkspaceServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractWorkspaceServiceContext.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.langserver.contexts;
 
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.WorkspaceServiceContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 
@@ -32,14 +33,24 @@ public class AbstractWorkspaceServiceContext implements WorkspaceServiceContext 
 
     private final WorkspaceManager workspaceManager;
 
-    AbstractWorkspaceServiceContext(LSOperation operation, WorkspaceManager wsManager) {
+    private final LanguageServerContext languageServerContext;
+
+    AbstractWorkspaceServiceContext(LSOperation operation,
+                                    WorkspaceManager wsManager,
+                                    LanguageServerContext serverContext) {
         this.operation = operation;
         this.workspaceManager = wsManager;
+        this.languageServerContext = serverContext;
     }
 
     @Override
     public LSOperation operation() {
         return this.operation;
+    }
+
+    @Override
+    public LanguageServerContext languageServercontext() {
+        return this.languageServerContext;
     }
 
     @Override
@@ -56,14 +67,16 @@ public class AbstractWorkspaceServiceContext implements WorkspaceServiceContext 
     protected abstract static class AbstractContextBuilder<T extends AbstractContextBuilder<T>> {
         protected final LSOperation operation;
         protected WorkspaceManager wsManager;
+        protected LanguageServerContext serverContext;
 
         /**
          * Context Builder constructor.
          *
          * @param lsOperation LS Operation for the particular invocation
          */
-        public AbstractContextBuilder(LSOperation lsOperation) {
+        public AbstractContextBuilder(LSOperation lsOperation, LanguageServerContext serverContext) {
             this.operation = lsOperation;
+            this.serverContext = serverContext;
         }
 
         public T withWorkspaceManager(WorkspaceManager workspaceManager) {
@@ -72,7 +85,7 @@ public class AbstractWorkspaceServiceContext implements WorkspaceServiceContext 
         }
 
         public WorkspaceServiceContext build() {
-            return new AbstractWorkspaceServiceContext(this.operation, this.wsManager);
+            return new AbstractWorkspaceServiceContext(this.operation, this.wsManager, this.serverContext);
         }
 
         public abstract T self();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaCompletionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BallerinaCompletionContextImpl.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.CompletionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -37,12 +38,13 @@ public class BallerinaCompletionContextImpl extends CompletionContextImpl implem
     private Token tokenAtCursor;
     private NonTerminalNode nodeAtCursor;
 
-    public BallerinaCompletionContextImpl(CompletionContext context) {
+    public BallerinaCompletionContextImpl(CompletionContext context, LanguageServerContext serverContext) {
         super(context.operation(),
                 context.fileUri(),
                 context.workspace(),
                 context.getCapabilities(),
-                context.getCursorPosition());
+                context.getCursorPosition(),
+                serverContext);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BaseContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/BaseContextImpl.java
@@ -19,6 +19,7 @@ package org.ballerinalang.langserver.contexts;
 
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 
 /**
@@ -28,8 +29,11 @@ import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
  */
 public class BaseContextImpl extends AbstractDocumentServiceContext {
 
-    BaseContextImpl(LSOperation operation, String fileUri, WorkspaceManager wsManager) {
-        super(operation, fileUri, wsManager);
+    BaseContextImpl(LSOperation operation,
+                    String fileUri,
+                    WorkspaceManager wsManager,
+                    LanguageServerContext serverContext) {
+        super(operation, fileUri, wsManager, serverContext);
     }
 
     /**
@@ -44,12 +48,13 @@ public class BaseContextImpl extends AbstractDocumentServiceContext {
          *
          * @param lsOperation LS Operation for the particular invocation
          */
-        public BaseContextBuilder(LSOperation lsOperation) {
-            super(lsOperation);
+        public BaseContextBuilder(LSOperation lsOperation,
+                                  LanguageServerContext serverContext) {
+            super(lsOperation, serverContext);
         }
 
         public DocumentServiceContext build() {
-            return new BaseContextImpl(this.operation, this.fileUri, this.wsManager);
+            return new BaseContextImpl(this.operation, this.fileUri, this.wsManager, this.serverContext);
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CodeActionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CodeActionContextImpl.java
@@ -22,6 +22,7 @@ import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.codeaction.spi.PositionDetails;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -46,8 +47,9 @@ public class CodeActionContextImpl extends AbstractDocumentServiceContext implem
     public CodeActionContextImpl(LSOperation operation,
                                  String fileUri,
                                  WorkspaceManager wsManager,
-                                 CodeActionParams params) {
-        super(operation, fileUri, wsManager);
+                                 CodeActionParams params,
+                                 LanguageServerContext serverContext) {
+        super(operation, fileUri, wsManager, serverContext);
         this.params = params;
     }
 
@@ -58,7 +60,7 @@ public class CodeActionContextImpl extends AbstractDocumentServiceContext implem
             int col = params.getRange().getStart().getCharacter();
             this.cursorPosition = new Position(line, col);
         }
-        
+
         return this.cursorPosition;
     }
 
@@ -96,8 +98,9 @@ public class CodeActionContextImpl extends AbstractDocumentServiceContext implem
 
         private final CodeActionParams params;
 
-        public CodeActionContextBuilder(CodeActionParams params) {
-            super(LSContextOperation.TXT_CODE_ACTION);
+        public CodeActionContextBuilder(CodeActionParams params,
+                                        LanguageServerContext serverContext) {
+            super(LSContextOperation.TXT_CODE_ACTION, serverContext);
             this.params = params;
         }
 
@@ -105,7 +108,8 @@ public class CodeActionContextImpl extends AbstractDocumentServiceContext implem
             return new CodeActionContextImpl(this.operation,
                     this.fileUri,
                     this.wsManager,
-                    this.params);
+                    this.params,
+                    this.serverContext);
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CompletionContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/CompletionContextImpl.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langserver.contexts;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.Position;
@@ -39,8 +40,9 @@ public class CompletionContextImpl extends AbstractDocumentServiceContext implem
                           String fileUri,
                           WorkspaceManager wsManager,
                           CompletionCapabilities capabilities,
-                          Position cursorPosition) {
-        super(operation, fileUri, wsManager);
+                          Position cursorPosition,
+                          LanguageServerContext serverContext) {
+        super(operation, fileUri, wsManager, serverContext);
         this.capabilities = capabilities;
         this.cursorPosition = cursorPosition;
     }
@@ -81,8 +83,8 @@ public class CompletionContextImpl extends AbstractDocumentServiceContext implem
         /**
          * Context Builder constructor.
          */
-        public CompletionContextBuilder() {
-            super(LSContextOperation.TXT_COMPLETION);
+        public CompletionContextBuilder(LanguageServerContext serverContext) {
+            super(LSContextOperation.TXT_COMPLETION, serverContext);
         }
 
         /**
@@ -110,7 +112,8 @@ public class CompletionContextImpl extends AbstractDocumentServiceContext implem
                     this.fileUri,
                     this.wsManager,
                     this.capabilities,
-                    this.cursor);
+                    this.cursor,
+                    this.serverContext);
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ContextBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ContextBuilder.java
@@ -25,6 +25,7 @@ import org.ballerinalang.langserver.commons.DocumentServiceContext;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
 import org.ballerinalang.langserver.commons.FoldingRangeContext;
 import org.ballerinalang.langserver.commons.HoverContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.SignatureContext;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
@@ -50,11 +51,13 @@ public class ContextBuilder {
      * @param uri              file uri
      * @param workspaceManager workspace manager instance
      * @param operation        language server operation
+     * @param serverContext    language server context
      * @return {@link DocumentServiceContext} base context generated
      */
     public static DocumentServiceContext buildBaseContext(String uri, WorkspaceManager workspaceManager,
-                                                          LSContextOperation operation) {
-        return new BaseContextImpl.BaseContextBuilder(operation)
+                                                          LSContextOperation operation,
+                                                          LanguageServerContext serverContext) {
+        return new BaseContextImpl.BaseContextBuilder(operation, serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
                 .build();
@@ -66,13 +69,16 @@ public class ContextBuilder {
      * @param uri              file uri
      * @param workspaceManager workspace manager instance
      * @param capabilities     completion capabilities
+     * @param serverContext    language server context
+     * @param position         cursor position where the completion triggered
      * @return {@link DocumentServiceContext} base context generated
      */
     public static CompletionContext buildCompletionContext(String uri,
                                                            WorkspaceManager workspaceManager,
                                                            CompletionCapabilities capabilities,
+                                                           LanguageServerContext serverContext,
                                                            Position position) {
-        return new CompletionContextImpl.CompletionContextBuilder()
+        return new CompletionContextImpl.CompletionContextBuilder(serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
                 .withCapabilities(capabilities)
@@ -86,14 +92,16 @@ public class ContextBuilder {
      * @param uri              file uri
      * @param workspaceManager workspace manager instance
      * @param capabilities     signature help capabilities
+     * @param serverContext    language server context
      * @param position         cursor position
      * @return {@link SignatureContext} generated signature context
      */
     public static SignatureContext buildSignatureContext(String uri,
                                                          WorkspaceManager workspaceManager,
                                                          SignatureHelpCapabilities capabilities,
+                                                         LanguageServerContext serverContext,
                                                          Position position) {
-        return new SignatureContextImpl.SignatureContextBuilder()
+        return new SignatureContextImpl.SignatureContextBuilder(serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
                 .withCapabilities(capabilities)
@@ -106,13 +114,15 @@ public class ContextBuilder {
      *
      * @param uri              file uri
      * @param workspaceManager workspace manager instance
+     * @param serverContext    language server context
      * @param params           code action parameters
      * @return {@link CodeActionContext} generated signature context
      */
     public static CodeActionContext buildCodeActionContext(String uri,
                                                            WorkspaceManager workspaceManager,
+                                                           LanguageServerContext serverContext,
                                                            CodeActionParams params) {
-        return new CodeActionContextImpl.CodeActionContextBuilder(params)
+        return new CodeActionContextImpl.CodeActionContextBuilder(params, serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
                 .build();
@@ -123,10 +133,15 @@ public class ContextBuilder {
      *
      * @param uri              file uri
      * @param workspaceManager workspace manager instance
+     * @param serverContext    language server context
+     * @param position         cursor position where the hover request executed
      * @return {@link HoverContext} generated hover context
      */
-    public static HoverContext buildHoverContext(String uri, WorkspaceManager workspaceManager, Position position) {
-        return new HoverContextImpl.HoverContextBuilder()
+    public static HoverContext buildHoverContext(String uri,
+                                                 WorkspaceManager workspaceManager,
+                                                 LanguageServerContext serverContext,
+                                                 Position position) {
+        return new HoverContextImpl.HoverContextBuilder(serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
                 .withPosition(position)
@@ -140,10 +155,12 @@ public class ContextBuilder {
      * @return {@link ExecuteCommandContext} generated command execution context
      */
     public static ExecuteCommandContext buildExecuteCommandContext(WorkspaceManager workspaceManager,
+                                                                   LanguageServerContext serverContext,
                                                                    List<Object> arguments,
                                                                    LSClientCapabilities clientCapabilities,
                                                                    BallerinaLanguageServer languageServer) {
-        return new ExecuteCommandContextImpl.ExecuteCommandContextBuilder(arguments, clientCapabilities, languageServer)
+        return new ExecuteCommandContextImpl.ExecuteCommandContextBuilder(serverContext,
+                arguments, clientCapabilities, languageServer)
                 .withWorkspaceManager(workspaceManager)
                 .build();
     }
@@ -153,12 +170,14 @@ public class ContextBuilder {
      *
      * @param uri              file uri
      * @param workspaceManager workspace manager instance
+     * @param serverContext    language server context
      * @param lineFoldingOnly  if line folding only or not
      * @return {@link FoldingRangeContext} generated folding range context
      */
     public static FoldingRangeContext buildFoldingRangeContext(String uri, WorkspaceManager workspaceManager,
+                                                               LanguageServerContext serverContext,
                                                                boolean lineFoldingOnly) {
-        return new FoldingRangeContextImpl.FoldingRangeContextBuilder(lineFoldingOnly)
+        return new FoldingRangeContextImpl.FoldingRangeContextBuilder(lineFoldingOnly, serverContext)
                 .withFileUri(uri)
                 .withWorkspaceManager(workspaceManager)
                 .build();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ExecuteCommandContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/ExecuteCommandContextImpl.java
@@ -20,6 +20,7 @@ package org.ballerinalang.langserver.contexts;
 import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.ExecuteCommandContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.capability.LSClientCapabilities;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.services.LanguageClient;
@@ -41,10 +42,11 @@ public class ExecuteCommandContextImpl extends AbstractWorkspaceServiceContext i
     private final BallerinaLanguageServer languageServer;
 
     ExecuteCommandContextImpl(WorkspaceManager wsManager,
+                              LanguageServerContext serverContext,
                               List<Object> arguments,
                               LSClientCapabilities clientCapabilities,
                               BallerinaLanguageServer languageServer) {
-        super(LSContextOperation.WS_EXEC_CMD, wsManager);
+        super(LSContextOperation.WS_EXEC_CMD, wsManager, serverContext);
         this.arguments = arguments;
         this.clientCapabilities = clientCapabilities;
         this.languageServer = languageServer;
@@ -82,14 +84,18 @@ public class ExecuteCommandContextImpl extends AbstractWorkspaceServiceContext i
         private final LSClientCapabilities clientCapabilities;
 
         private final BallerinaLanguageServer languageServer;
+        
+        private final LanguageServerContext serverContext;
 
         /**
          * Context Builder constructor.
          */
-        public ExecuteCommandContextBuilder(List<Object> arguments,
+        public ExecuteCommandContextBuilder(LanguageServerContext serverContext,
+                                            List<Object> arguments,
                                             LSClientCapabilities clientCapabilities,
                                             BallerinaLanguageServer languageServer) {
-            super(LSContextOperation.WS_EXEC_CMD);
+            super(LSContextOperation.WS_EXEC_CMD, serverContext);
+            this.serverContext = serverContext;
             this.arguments = arguments;
             this.clientCapabilities = clientCapabilities;
             this.languageServer = languageServer;
@@ -98,6 +104,7 @@ public class ExecuteCommandContextImpl extends AbstractWorkspaceServiceContext i
         public ExecuteCommandContext build() {
             return new ExecuteCommandContextImpl(
                     this.wsManager,
+                    this.serverContext,
                     this.arguments,
                     this.clientCapabilities,
                     this.languageServer);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/FoldingRangeContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/FoldingRangeContextImpl.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.contexts;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.FoldingRangeContext;
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 
 /**
@@ -29,8 +30,12 @@ public class FoldingRangeContextImpl extends AbstractDocumentServiceContext impl
 
     private final boolean lineFoldingOnly;
 
-    FoldingRangeContextImpl(LSOperation operation, String uri, WorkspaceManager wsManager, boolean lineFoldingOnly) {
-        super(operation, uri, wsManager);
+    FoldingRangeContextImpl(LSOperation operation,
+                            String uri,
+                            WorkspaceManager wsManager,
+                            boolean lineFoldingOnly,
+                            LanguageServerContext serverContext) {
+        super(operation, uri, wsManager, serverContext);
         this.lineFoldingOnly = lineFoldingOnly;
     }
 
@@ -46,13 +51,17 @@ public class FoldingRangeContextImpl extends AbstractDocumentServiceContext impl
 
         private final boolean lineFoldingOnly;
 
-        public FoldingRangeContextBuilder(boolean lineFoldingOnly) {
-            super(LSContextOperation.TXT_FOLDING_RANGE);
+        public FoldingRangeContextBuilder(boolean lineFoldingOnly, LanguageServerContext serverContext) {
+            super(LSContextOperation.TXT_FOLDING_RANGE, serverContext);
             this.lineFoldingOnly = lineFoldingOnly;
         }
 
         public FoldingRangeContext build() {
-            return new FoldingRangeContextImpl(this.operation, this.fileUri, this.wsManager, this.lineFoldingOnly);
+            return new FoldingRangeContextImpl(this.operation,
+                    this.fileUri,
+                    this.wsManager,
+                    this.lineFoldingOnly,
+                    this.serverContext);
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/HoverContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/HoverContextImpl.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.syntax.tree.Token;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.HoverContext;
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.Position;
 
@@ -40,8 +41,9 @@ public class HoverContextImpl extends AbstractDocumentServiceContext implements 
     HoverContextImpl(LSOperation operation,
                      String fileUri,
                      WorkspaceManager wsManager,
-                     Position cursorPosition) {
-        super(operation, fileUri, wsManager);
+                     Position cursorPosition,
+                     LanguageServerContext serverContext) {
+        super(operation, fileUri, wsManager, serverContext);
         this.cursorPosition = cursorPosition;
     }
 
@@ -73,15 +75,16 @@ public class HoverContextImpl extends AbstractDocumentServiceContext implements 
         
         private Position cursorPosition;
 
-        public HoverContextBuilder() {
-            super(LSContextOperation.TXT_HOVER);
+        public HoverContextBuilder(LanguageServerContext serverContext) {
+            super(LSContextOperation.TXT_HOVER, serverContext);
         }
 
         public HoverContext build() {
             return new HoverContextImpl(this.operation,
                     this.fileUri,
                     this.wsManager,
-                    this.cursorPosition);
+                    this.cursorPosition,
+                    this.serverContext);
         }
         
         public HoverContextBuilder withPosition(Position cursorPosition) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/LanguageServerContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/LanguageServerContextImpl.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.contexts;
+
+import org.ballerinalang.langserver.commons.LanguageServerContext;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Language server context holding the common utility instances of an associated language server instance.
+ *
+ * @since 2.0.0
+ */
+public class LanguageServerContextImpl implements LanguageServerContext {
+    private Map<LanguageServerContext.Key<?>, Object> props = new HashMap<>();
+    private Map<Class<?>, Object> objects = new HashMap<>();
+
+    public LanguageServerContextImpl() {
+    }
+
+    public <V> void put(LanguageServerContext.Key<V> key, V value) {
+        props.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> V get(LanguageServerContext.Key<V> key) {
+        return (V) props.get(key);
+    }
+
+    public <V> void put(Class<V> clazz, V value) {
+        objects.put(clazz, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    public <V> V get(Class<V> clazz) {
+        return (V) objects.get(clazz);
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/SignatureContextImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/SignatureContextImpl.java
@@ -19,6 +19,7 @@ package org.ballerinalang.langserver.contexts;
 
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.LSOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.SignatureContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.Position;
@@ -39,8 +40,9 @@ public class SignatureContextImpl extends AbstractDocumentServiceContext impleme
                          String fileUri,
                          WorkspaceManager wsManager,
                          SignatureHelpCapabilities capabilities,
-                         Position cursorPos) {
-        super(operation, fileUri, wsManager);
+                         Position cursorPos,
+                         LanguageServerContext serverContext) {
+        super(operation, fileUri, wsManager, serverContext);
         this.capabilities = capabilities;
         this.cursorPos = cursorPos;
     }
@@ -78,8 +80,8 @@ public class SignatureContextImpl extends AbstractDocumentServiceContext impleme
         private SignatureHelpCapabilities capabilities;
         private Position position;
 
-        public SignatureContextBuilder() {
-            super(LSContextOperation.TXT_SIGNATURE);
+        public SignatureContextBuilder(LanguageServerContext serverContext) {
+            super(LSContextOperation.TXT_SIGNATURE, serverContext);
         }
 
         /**
@@ -107,7 +109,8 @@ public class SignatureContextImpl extends AbstractDocumentServiceContext impleme
                     this.fileUri,
                     this.wsManager,
                     this.capabilities,
-                    this.position);
+                    this.position,
+                    this.serverContext);
         }
 
         @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
@@ -44,7 +44,7 @@ import java.util.Optional;
  * @since 0.983.0
  */
 public class DiagnosticsHelper {
-    private final List<Diagnostic> EMPTY_DIAGNOSTIC_LIST = new ArrayList<>(0);
+    private final List<Diagnostic> emptyDiagnosticList = new ArrayList<>(0);
     private static final LanguageServerContext.Key<DiagnosticsHelper> DIAGNOSTICS_HELPER_KEY =
             new LanguageServerContext.Key<>();
     /**
@@ -88,7 +88,7 @@ public class DiagnosticsHelper {
         // Clear old entries with an empty list
         lastDiagnosticMap.forEach((key, value) -> {
             if (!diagnosticMap.containsKey(key)) {
-                client.publishDiagnostics(new PublishDiagnosticsParams(key, EMPTY_DIAGNOSTIC_LIST));
+                client.publishDiagnostics(new PublishDiagnosticsParams(key, emptyDiagnosticList));
             }
         });
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
@@ -21,6 +21,7 @@ import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.client.ExtendedLanguageClient;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.Diagnostic;
@@ -44,17 +45,24 @@ import java.util.Optional;
  */
 public class DiagnosticsHelper {
     private static final List<Diagnostic> EMPTY_DIAGNOSTIC_LIST = new ArrayList<>(0);
-    private static final DiagnosticsHelper INSTANCE = new DiagnosticsHelper();
+    private static final LanguageServerContext.Key<DiagnosticsHelper> DIAGNOSTICS_HELPER_KEY =
+            new LanguageServerContext.Key<>();
     /**
      * Holds last sent diagnostics for the purpose of clear-off when publishing new diagnostics.
      */
     private Map<String, List<Diagnostic>> lastDiagnosticMap;
 
-    public static DiagnosticsHelper getInstance() {
-        return INSTANCE;
+    public static DiagnosticsHelper getInstance(LanguageServerContext serverContext) {
+        DiagnosticsHelper diagnosticsHelper = serverContext.get(DIAGNOSTICS_HELPER_KEY);
+        if (diagnosticsHelper == null) {
+            diagnosticsHelper = new DiagnosticsHelper(serverContext);
+        }
+
+        return diagnosticsHelper;
     }
 
-    private DiagnosticsHelper() {
+    private DiagnosticsHelper(LanguageServerContext serverContext) {
+        serverContext.put(DIAGNOSTICS_HELPER_KEY, this);
         this.lastDiagnosticMap = new HashMap<>();
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/diagnostic/DiagnosticsHelper.java
@@ -44,7 +44,7 @@ import java.util.Optional;
  * @since 0.983.0
  */
 public class DiagnosticsHelper {
-    private static final List<Diagnostic> EMPTY_DIAGNOSTIC_LIST = new ArrayList<>(0);
+    private final List<Diagnostic> EMPTY_DIAGNOSTIC_LIST = new ArrayList<>(0);
     private static final LanguageServerContext.Key<DiagnosticsHelper> DIAGNOSTICS_HELPER_KEY =
             new LanguageServerContext.Key<>();
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/AbstractExtendedLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/AbstractExtendedLanguageServer.java
@@ -48,11 +48,11 @@ public abstract class AbstractExtendedLanguageServer implements LanguageServer, 
     private Map<String, JsonRpcMethod> supportedMethods;
     private final Multimap<String, Endpoint> extensionServices = LinkedListMultimap.create();
     protected final WorkspaceManager workspaceManager;
-    protected final LanguageServerContext lsContext;
+    protected final LanguageServerContext serverContext;
 
     public AbstractExtendedLanguageServer(LanguageServerContext serverContext) {
         this.workspaceManager = BallerinaWorkspaceManager.getInstance(serverContext);
-        this.lsContext = serverContext;
+        this.serverContext = serverContext;
         ServiceLoader<ExtendedLanguageServerService> serviceLoader = ServiceLoader.load(
                 ExtendedLanguageServerService.class);
         for (ExtendedLanguageServerService service : serviceLoader) {
@@ -78,7 +78,7 @@ public abstract class AbstractExtendedLanguageServer implements LanguageServer, 
                         if (supportedMethods.containsKey(entry.getKey())) {
                             String msg = "The json rpc method '" + entry.getKey()
                                     + "' can not be an extension as it is already defined in the LSP standard.";
-                            LSClientLogger.getInstance(this.lsContext)
+                            LSClientLogger.getInstance(this.serverContext)
                                     .logError(msg, new RuntimeException(msg), null, (Position) null);
                         } else {
                             JsonRpcMethod existing = extensions.put(entry.getKey(), entry.getValue());
@@ -86,7 +86,7 @@ public abstract class AbstractExtendedLanguageServer implements LanguageServer, 
                                 String msg = "An incompatible LSP extension '" + entry.getKey()
                                         + "' has already been registered. Using 1 ignoring 2. \n1 : " +
                                         existing + " \n2 : " + entry.getValue();
-                                LSClientLogger.getInstance(this.lsContext)
+                                LSClientLogger.getInstance(this.serverContext)
                                         .logError(msg, new RuntimeException(msg), null, (Position) null);
                                 extensions.put(entry.getKey(), existing);
                             } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/AbstractExtendedLanguageServer.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/AbstractExtendedLanguageServer.java
@@ -18,8 +18,11 @@ package org.ballerinalang.langserver.extensions;
 import com.google.common.base.Objects;
 import com.google.common.collect.LinkedListMultimap;
 import com.google.common.collect.Multimap;
+import org.ballerinalang.langserver.LSClientLogger;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.service.spi.ExtendedLanguageServerService;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
+import org.ballerinalang.langserver.workspace.BallerinaWorkspaceManager;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.jsonrpc.Endpoint;
 import org.eclipse.lsp4j.jsonrpc.json.JsonRpcMethod;
@@ -34,8 +37,6 @@ import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletableFuture;
 
-import static org.ballerinalang.langserver.LSClientLogger.logError;
-
 /**
  * Provides capabilities for the extended language server services.
  *
@@ -47,9 +48,11 @@ public abstract class AbstractExtendedLanguageServer implements LanguageServer, 
     private Map<String, JsonRpcMethod> supportedMethods;
     private final Multimap<String, Endpoint> extensionServices = LinkedListMultimap.create();
     protected final WorkspaceManager workspaceManager;
+    protected final LanguageServerContext lsContext;
 
-    public AbstractExtendedLanguageServer(WorkspaceManager workspaceManager) {
-        this.workspaceManager = workspaceManager;
+    public AbstractExtendedLanguageServer(LanguageServerContext serverContext) {
+        this.workspaceManager = BallerinaWorkspaceManager.getInstance(serverContext);
+        this.lsContext = serverContext;
         ServiceLoader<ExtendedLanguageServerService> serviceLoader = ServiceLoader.load(
                 ExtendedLanguageServerService.class);
         for (ExtendedLanguageServerService service : serviceLoader) {
@@ -75,14 +78,16 @@ public abstract class AbstractExtendedLanguageServer implements LanguageServer, 
                         if (supportedMethods.containsKey(entry.getKey())) {
                             String msg = "The json rpc method '" + entry.getKey()
                                     + "' can not be an extension as it is already defined in the LSP standard.";
-                            logError(msg, new RuntimeException(msg), null, (Position) null);
+                            LSClientLogger.getInstance(this.lsContext)
+                                    .logError(msg, new RuntimeException(msg), null, (Position) null);
                         } else {
                             JsonRpcMethod existing = extensions.put(entry.getKey(), entry.getValue());
                             if (existing != null && !Objects.equal(existing, entry.getValue())) {
                                 String msg = "An incompatible LSP extension '" + entry.getKey()
                                         + "' has already been registered. Using 1 ignoring 2. \n1 : " +
                                         existing + " \n2 : " + entry.getValue();
-                                logError(msg, new RuntimeException(msg), null, (Position) null);
+                                LSClientLogger.getInstance(this.lsContext)
+                                        .logError(msg, new RuntimeException(msg), null, (Position) null);
                                 extensions.put(entry.getKey(), existing);
                             } else {
                                 Endpoint endpoint = ServiceEndpoints.toEndpoint(ext);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
@@ -44,7 +44,9 @@ import io.ballerina.projects.balo.BaloProject;
 import io.ballerina.projects.repos.TempDirCompilationCache;
 import org.ballerinalang.compiler.BLangCompilerException;
 import org.ballerinalang.diagramutil.DiagramUtil;
+import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.exception.LSConnectorException;
 import org.ballerinalang.model.elements.PackageID;
 import org.eclipse.lsp4j.Position;
@@ -68,8 +70,6 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
-import static org.ballerinalang.langserver.LSClientLogger.logError;
-
 /**
  * Implementation of the BallerinaConnectorService.
  *
@@ -83,10 +83,12 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
             .resolve("balo");
     private String connectorConfig;
     private final ConnectorExtContext connectorExtContext;
+    private final LSClientLogger clientLogger;
 
-    public BallerinaConnectorServiceImpl() {
+    public BallerinaConnectorServiceImpl(LanguageServerContext serverContext) {
         this.connectorExtContext = new ConnectorExtContext();
         connectorConfig = System.getenv(DEFAULT_CONNECTOR_FILE_KEY);
+        this.clientLogger = LSClientLogger.getInstance(serverContext);
         if (connectorConfig == null) {
             connectorConfig = System.getProperty(DEFAULT_CONNECTOR_FILE_KEY);
         }
@@ -99,7 +101,7 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
             return CompletableFuture.supplyAsync(() -> response);
         } catch (IOException e) {
             String msg = "Operation 'ballerinaConnector/connectors' failed!";
-            logError(msg, e, null, (Position) null);
+            this.clientLogger.logError(msg, e, null, (Position) null);
         }
 
         return CompletableFuture.supplyAsync(BallerinaConnectorsResponse::new);
@@ -189,7 +191,7 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
                 String msg = "Operation 'ballerinaConnector/connector' for " + cacheableKey + ":" +
                         request.getName() + " failed!";
                 error = e.getMessage();
-                logError(msg, e, null, (Position) null);
+                this.clientLogger.logError(msg, e, null, (Position) null);
             }
         }
         BallerinaConnectorResponse response = new BallerinaConnectorResponse(request.getOrg(), request.getModule(),
@@ -360,7 +362,7 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
                 String msg = "Operation 'ballerinaConnector/record' for " + cacheableKey + ":" +
                         request.getName() + " failed!";
                 error = e.getMessage();
-                logError(msg, e, null, (Position) null);
+                this.clientLogger.logError(msg, e, null, (Position) null);
             }
 
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -19,7 +19,9 @@ import com.google.gson.JsonElement;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import org.ballerinalang.diagramutil.DiagramUtil;
+import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.eclipse.lsp4j.Position;
 
@@ -27,19 +29,18 @@ import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
-import static org.ballerinalang.langserver.LSClientLogger.logError;
-
 /**
  * Implementation of Ballerina Document extension for Language Server.
  *
  * @since 0.981.2
  */
 public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
-
     private final WorkspaceManager workspaceManager;
+    private final LSClientLogger clientLogger;
 
-    public BallerinaDocumentServiceImpl(WorkspaceManager workspaceManager) {
+    public BallerinaDocumentServiceImpl(WorkspaceManager workspaceManager, LanguageServerContext serverContext) {
         this.workspaceManager = workspaceManager;
+        this.clientLogger = LSClientLogger.getInstance(serverContext);
     }
 
     @Override
@@ -72,7 +73,7 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
         } catch (Throwable e) {
             reply.setParseSuccess(false);
             String msg = "Operation 'ballerinaDocument/syntaxTree' failed!";
-            logError(msg, e, request.getDocumentIdentifier(), (Position) null);
+            this.clientLogger.logError(msg, e, request.getDocumentIdentifier(), (Position) null);
         }
         return CompletableFuture.supplyAsync(() -> reply);
     }
@@ -99,7 +100,7 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
         } catch (Throwable e) {
             reply.setParseSuccess(false);
             String msg = "Operation 'ballerinaDocument/syntaxTreeModify' failed!";
-            logError(msg, e, request.getDocumentIdentifier(), (Position) null);
+            this.clientLogger.logError(msg, e, request.getDocumentIdentifier(), (Position) null);
         }
         return CompletableFuture.supplyAsync(() -> reply);
     }
@@ -124,7 +125,7 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
         } catch (Throwable e) {
             reply.setParseSuccess(false);
             String msg = "Operation 'ballerinaDocument/ast' failed!";
-            logError(msg, e, request.getDocumentIdentifier(), (Position) null);
+            this.clientLogger.logError(msg, e, request.getDocumentIdentifier(), (Position) null);
         }
         return CompletableFuture.supplyAsync(() -> reply);
     }
@@ -142,7 +143,7 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
                 project.setPath(projectRoot.toString());
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaDocument/project' failed!";
-                logError(msg, e, params.getDocumentIdentifier(), (Position) null);
+                this.clientLogger.logError(msg, e, params.getDocumentIdentifier(), (Position) null);
             }
             return project;
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/example/BallerinaExampleServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/example/BallerinaExampleServiceImpl.java
@@ -18,7 +18,9 @@ package org.ballerinalang.langserver.extensions.ballerina.example;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
+import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 
@@ -32,20 +34,21 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import static org.ballerinalang.langserver.LSClientLogger.logError;
-
 /**
  * Ballerina example service.
  *
  * @since 0.981.2
  */
 public class BallerinaExampleServiceImpl implements BallerinaExampleService {
-
     private static final String BBE_DEF_JSON = "index.json";
-
     private static final String EXAMPLES_DIR = "examples";
+    private static final Type EXAMPLE_CATEGORY_TYPE = new TypeToken<List<BallerinaExampleCategory>>() {
+    }.getType();
+    private final LSClientLogger clientLogger;
 
-    private static final Type EXAMPLE_CATEGORY_TYPE = new TypeToken<List<BallerinaExampleCategory>>() { }.getType();
+    public BallerinaExampleServiceImpl(LanguageServerContext serverContext) {
+        this.clientLogger = LSClientLogger.getInstance(serverContext);
+    }
 
     @Override
     public CompletableFuture<BallerinaExampleListResponse> list(BallerinaExampleListRequest request) {
@@ -61,7 +64,7 @@ public class BallerinaExampleServiceImpl implements BallerinaExampleService {
                 response.setSamples(data);
             } catch (Throwable e) {
                 String msg = "Operation 'ballerinaExample/list' failed!";
-                logError(msg, e, new TextDocumentIdentifier(bbeJSONPath.toString()), (Position) null);
+                this.clientLogger.logError(msg, e, new TextDocumentIdentifier(bbeJSONPath.toString()), (Position) null);
                 response.setSamples(new ArrayList<>());
             }
             return response;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/symbol/BallerinaSymbolServiceImpl.java
@@ -15,9 +15,6 @@
  */
 package org.ballerinalang.langserver.extensions.ballerina.symbol;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -28,8 +25,6 @@ import java.util.concurrent.CompletableFuture;
  * @since 0.981.2
  */
 public class BallerinaSymbolServiceImpl implements BallerinaSymbolService {
-
-    private static final Logger logger = LoggerFactory.getLogger(BallerinaSymbolServiceImpl.class);
 
     @Override
     public CompletableFuture<BallerinaEndpointsResponse> endpoints() {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/workspace/BallerinaWorkspaceManager.java
@@ -37,6 +37,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.LSContextOperation;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentManager;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
@@ -67,14 +68,28 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
     /**
      * Cache mapping of document path to source root.
      */
-    private static final Map<Path, Path> pathToSourceRootCache;
+    private final Map<Path, Path> pathToSourceRootCache;
+    private static final LanguageServerContext.Key<BallerinaWorkspaceManager> WORKSPACE_MANAGER_KEY =
+            new LanguageServerContext.Key<>();
+    private final LSClientLogger clientLogger;
 
-    static {
+    private BallerinaWorkspaceManager(LanguageServerContext serverContext) {
+        serverContext.put(WORKSPACE_MANAGER_KEY, this);
+        this.clientLogger = LSClientLogger.getInstance(serverContext);
         Cache<Path, Path> cache = CacheBuilder.newBuilder()
                 .expireAfterWrite(10, TimeUnit.MINUTES)
                 .maximumSize(1000)
                 .build();
-        pathToSourceRootCache = cache.asMap();
+        this.pathToSourceRootCache = cache.asMap();
+    }
+
+    public static BallerinaWorkspaceManager getInstance(LanguageServerContext serverContext) {
+        BallerinaWorkspaceManager workspaceManager = serverContext.get(WORKSPACE_MANAGER_KEY);
+        if (workspaceManager == null) {
+            workspaceManager = new BallerinaWorkspaceManager(serverContext);
+        }
+
+        return workspaceManager;
     }
 
     @Override
@@ -303,7 +318,7 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         if (project.get().kind() == ProjectKind.SINGLE_FILE_PROJECT) {
             Path projectRoot = project.get().sourceRoot();
             sourceRootToProject.remove(projectRoot);
-            LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CLOSE.getName() +
+            clientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_CLOSE.getName() +
                     "' {project: '" + projectRoot.toUri().toString() +
                     "' kind: '" + project.get().kind().name().toLowerCase(Locale.getDefault()) +
                     "'} removed}");
@@ -376,7 +391,7 @@ public class BallerinaWorkspaceManager implements WorkspaceManager {
         } else {
             project = SingleFileProject.load(projectRoot, options);
         }
-        LSClientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_OPEN.getName() +
+        clientLogger.logTrace("Operation '" + LSContextOperation.TXT_DID_OPEN.getName() +
                 "' {project: '" + projectRoot.toUri().toString() + "' kind: '" +
                 project.kind().name().toLowerCase(Locale.getDefault()) + "'} created}");
         return ProjectPair.from(project);

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/AbstractCodeActionTest.java
@@ -22,7 +22,9 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
+import org.ballerinalang.langserver.contexts.LanguageServerContextImpl;
 import org.ballerinalang.langserver.util.FileUtils;
 import org.ballerinalang.langserver.util.TestUtil;
 import org.ballerinalang.langserver.workspace.BallerinaWorkspaceManager;
@@ -56,7 +58,10 @@ public abstract class AbstractCodeActionTest {
 
     private final Path sourcesPath = new File(getClass().getClassLoader().getResource("codeaction").getFile()).toPath();
 
-    private static final WorkspaceManager workspaceManager = new BallerinaWorkspaceManager();
+    private static final WorkspaceManager workspaceManager
+            = BallerinaWorkspaceManager.getInstance(new LanguageServerContextImpl());
+    
+    private static final LanguageServerContext serverContext = new LanguageServerContextImpl();
 
     @BeforeClass
     public void init() throws Exception {
@@ -72,8 +77,9 @@ public abstract class AbstractCodeActionTest {
         TestUtil.openDocument(serviceEndpoint, sourcePath);
 
         // Filter diagnostics for the cursor position
-        List<Diagnostic> diags = new ArrayList<>(
-                CodeActionUtil.toDiagnostics(TestUtil.compileAndGetDiagnostics(sourcePath, workspaceManager)));
+        List<io.ballerina.tools.diagnostics.Diagnostic> diagnostics
+                = TestUtil.compileAndGetDiagnostics(sourcePath, workspaceManager, serverContext);
+        List<Diagnostic> diags = new ArrayList<>(CodeActionUtil.toDiagnostics(diagnostics));
         Position pos = new Position(configJsonObject.get("line").getAsInt(),
                                     configJsonObject.get("character").getAsInt());
         diags = diags.stream().

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/diagnostics/DiagnosticsTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/diagnostics/DiagnosticsTest.java
@@ -23,7 +23,9 @@ import com.google.gson.JsonParser;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
+import org.ballerinalang.langserver.contexts.LanguageServerContextImpl;
 import org.ballerinalang.langserver.diagnostic.DiagnosticsHelper;
 import org.ballerinalang.langserver.util.FileUtils;
 import org.ballerinalang.langserver.util.TestUtil;
@@ -59,7 +61,9 @@ public class DiagnosticsTest {
 
     private final Gson gson = new Gson();
 
-    private final BallerinaWorkspaceManager workspaceManager = new BallerinaWorkspaceManager();
+    private final LanguageServerContext serverContext = new LanguageServerContextImpl();
+    
+    private final BallerinaWorkspaceManager workspaceManager = BallerinaWorkspaceManager.getInstance(serverContext);
 
     @BeforeClass
     public void init() {
@@ -96,9 +100,9 @@ public class DiagnosticsTest {
     String getResponse(JsonObject configJsonObject) {
         Path sourcePath = testRoot.resolve(configJsonObject.get("source").getAsString());
         DocumentServiceContext serviceContext = ContextBuilder.buildBaseContext(sourcePath.toUri().toString(),
-                this.workspaceManager, LSContextOperation.TXT_DID_OPEN);
+                this.workspaceManager, LSContextOperation.TXT_DID_OPEN, this.serverContext);
         workspaceManager.didOpen(sourcePath, null);
-        Map<String, List<Diagnostic>> diagnostics = DiagnosticsHelper.getInstance()
+        Map<String, List<Diagnostic>> diagnostics = DiagnosticsHelper.getInstance(serverContext)
                 .getBallerinaDiagnostics(serviceContext);
 
         return gson.toJson(diagnostics).replace("\r\n", "\n").replace("\\r\\n", "\\n");

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -26,6 +26,7 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -456,13 +457,16 @@ public class TestUtil {
         return GSON.toJson(jsonrpcResponse).replace("\r\n", "\n").replace("\\r\\n", "\\n");
     }
 
-    public static List<Diagnostic> compileAndGetDiagnostics(Path sourcePath, WorkspaceManager workspaceManager)
+    public static List<Diagnostic> compileAndGetDiagnostics(Path sourcePath,
+                                                            WorkspaceManager workspaceManager,
+                                                            LanguageServerContext serverContext)
             throws IOException {
         List<Diagnostic> diagnostics = new ArrayList<>();
 
         DocumentServiceContext context = ContextBuilder.buildBaseContext(sourcePath.toUri().toString(),
                 workspaceManager,
-                LSContextOperation.TXT_DID_OPEN);
+                LSContextOperation.TXT_DID_OPEN,
+                serverContext);
         DidOpenTextDocumentParams params = new DidOpenTextDocumentParams();
         TextDocumentItem textDocument = new TextDocumentItem();
         textDocument.setUri(sourcePath.toUri().toString());

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/workspace/TestWorkspaceManager.java
@@ -19,6 +19,7 @@ package org.ballerinalang.langserver.workspace;
 
 import io.ballerina.projects.Document;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
+import org.ballerinalang.langserver.contexts.LanguageServerContextImpl;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
@@ -42,7 +43,8 @@ import java.util.Optional;
 public class TestWorkspaceManager {
     private static final Path RESOURCE_DIRECTORY = Paths.get("src/test/resources/project");
     private final String dummyContent = "function foo() {\n}";
-    private final BallerinaWorkspaceManager workspaceManager = new BallerinaWorkspaceManager();
+    private final BallerinaWorkspaceManager workspaceManager
+            = BallerinaWorkspaceManager.getInstance(new LanguageServerContextImpl());
 
     @Test(dataProvider = "workspace-data-provider")
     public void testOpenDocument(Path filePath) throws IOException {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeAction.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeAction.java
@@ -22,6 +22,7 @@ import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvi
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.config.LSClientConfigHolder;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -58,14 +59,13 @@ public class AIDataMapperCodeAction extends AbstractCodeActionProvider {
         }
         return actions;
     }
-
-
+    
     /**
      * {@inheritDoc}
      */
     @Override
-    public boolean isEnabled() {
-        return LSClientConfigHolder.getInstance()
+    public boolean isEnabled(LanguageServerContext serverContext) {
+        return LSClientConfigHolder.getInstance(serverContext)
                 .getConfigAs(ClientExtendedConfigImpl.class).getDataMapper().isEnabled();
     }
 

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/DataMapperTestUtils.java
@@ -21,7 +21,9 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
+import org.ballerinalang.langserver.contexts.LanguageServerContextImpl;
 import org.ballerinalang.langserver.workspace.BallerinaWorkspaceManager;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.Diagnostic;
@@ -44,7 +46,8 @@ public class DataMapperTestUtils {
     private static JsonParser parser = new JsonParser();
     private static Path sourcesPath = new File(DataMapperTestUtils.class.getClassLoader().getResource("codeaction")
             .getFile()).toPath();
-    private static final WorkspaceManager workspaceManager = new BallerinaWorkspaceManager();
+    private static final LanguageServerContext serverContext = new LanguageServerContextImpl();
+    private static final WorkspaceManager workspaceManager = BallerinaWorkspaceManager.getInstance(serverContext);
 
 
     /**
@@ -76,8 +79,9 @@ public class DataMapperTestUtils {
         TestUtil.openDocument(serviceEndpoint, sourcePath);
 
         // Filter diagnostics for the cursor position
-        List<Diagnostic> diags = new ArrayList<>(
-                CodeActionUtil.toDiagnostics(TestUtil.compileAndGetDiagnostics(sourcePath, workspaceManager)));
+        List<io.ballerina.tools.diagnostics.Diagnostic> diagnostics
+                = TestUtil.compileAndGetDiagnostics(sourcePath, workspaceManager, serverContext);
+        List<Diagnostic> diags = new ArrayList<>(CodeActionUtil.toDiagnostics(diagnostics));
         Position pos = new Position(configJsonObject.get("line").getAsInt(),
                 configJsonObject.get("character").getAsInt());
         diags = diags.stream().

--- a/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/TestUtil.java
+++ b/misc/ballerinalang-data-mapper/src/test/java/org/ballerinalang/datamapper/util/TestUtil.java
@@ -25,6 +25,7 @@ import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.langserver.BallerinaLanguageServer;
 import org.ballerinalang.langserver.LSContextOperation;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
+import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -188,13 +189,15 @@ public class TestUtil {
         return GSON.toJson(jsonrpcResponse).replace("\r\n", "\n").replace("\\r\\n", "\\n");
     }
 
-    public static List<Diagnostic> compileAndGetDiagnostics(Path sourcePath, WorkspaceManager workspaceManager)
-            throws IOException {
+    public static List<Diagnostic> compileAndGetDiagnostics(Path sourcePath,
+                                                            WorkspaceManager workspaceManager,
+                                                            LanguageServerContext serverContext) throws IOException {
         List<Diagnostic> diagnostics = new ArrayList<>();
 
         DocumentServiceContext context = ContextBuilder.buildBaseContext(sourcePath.toUri().toString(),
                 workspaceManager,
-                LSContextOperation.TXT_DID_OPEN);
+                LSContextOperation.TXT_DID_OPEN,
+                serverContext);
         DidOpenTextDocumentParams params = new DidOpenTextDocumentParams();
         TextDocumentItem textDocument = new TextDocumentItem();
         textDocument.setUri(sourcePath.toUri().toString());


### PR DESCRIPTION
## Purpose
With this, the utility helpers such as DiagnosticsHelper, AnnotationCache which we singleton implementations earlier, converted to instance helpers in order to allow multiple RPC server to be run on a single JVM without sharing inter server information.

## Approach
> Introduced `LanguageServerContext` to maintain the instances (Modified Multiton)

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
