### PR TITLE
Splitting workers to do actual concurrent access,

### DIFF
--- a/examples/locks/locks.bal
+++ b/examples/locks/locks.bal
@@ -26,6 +26,10 @@ type Counter object {
 Counter counterObj = new;
 
 function process() {
+
+    @strand {
+        thread: "any"
+    }
     worker w1 {
         counterObj.update();
         // Locks the shared `counter` variable and increments the `counter`.
@@ -36,6 +40,10 @@ function process() {
             }
         }
     }
+
+    @strand {
+        thread: "any"
+    }
     worker w2 {
         counterObj.update();
         foreach var i in 1 ... 1000 {
@@ -45,6 +53,10 @@ function process() {
             }
         }
     }
+
+    @strand {
+        thread: "any"
+    }
     worker w3 {
         counterObj.update();
         foreach var i in 1 ... 1000 {
@@ -53,6 +65,10 @@ function process() {
                 counter = counter + 1;
             }
         }
+    }
+
+    @strand {
+        thread: "any"
     }
     worker w4 {
         counterObj.update();


### PR DESCRIPTION
## Purpose
> Since w1, w2, w3 and w4 are running on the same physical thread of the parent strand, these workers don't do concurrent updates to counter/counterObj, therefor removing the lock won't change the output of this program, so the example is not explaining the actual purpose of the lock.

## Approach
> Adding @strand{thread:"any"} annotation will allow wokers to perform simultaneously, this way we can simulate concurrent updates to counter/counterObj.