### PR TITLE
[Testerina] Support function pointers in Config annotations

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/ballerina/annotations.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/annotations.bal
@@ -28,7 +28,7 @@ public type TestConfig record {
     function() returns (any) dataProvider?;
     function() returns (any) before?;
     function() returns (any) after?;
-    string[] dependsOn = [];
+    (function() returns (any))[] dependsOn?;
 };
 
 # Configuration of the function to be mocked.

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/annotations.bal
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/annotations.bal
@@ -25,9 +25,9 @@
 public type TestConfig record {
     boolean enable = true;
     string[] groups = [];
-    string dataProvider = "";
-    string before = "";
-    string after = "";
+    function() returns (any) dataProvider?;
+    function() returns (any) before?;
+    function() returns (any) after?;
     string[] dependsOn = [];
 };
 

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/basic-project/tests/hello_world_test.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/basic-project/tests/hello_world_test.bal
@@ -28,8 +28,8 @@ function beforeFunc() {}
 # Test function
 
 @test:Config {
-    before: "beforeFunc",
-    after: "afterFunc"
+    before: beforeFunc,
+    after: afterFunc
 }
 function testFunction() {
     test:assertTrue(true, msg = "Failed!");

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/breakpoint-tests/tests/main_test.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/breakpoint-tests/tests/main_test.bal
@@ -29,8 +29,8 @@ function beforeFunc() {
 
 # Test function
 @test:Config {
-    before: "beforeFunc",
-    after: "afterFunc"
+    before: beforeFunc,
+    after: afterFunc
 }
 function testMain() {
     main();
@@ -38,7 +38,7 @@ function testMain() {
 }
 
 @test:Config {
-    dependsOn: ["testMain"]
+    dependsOn: [testMain]
 }
 function testFunction() {
     test:when(intAddMockFn).call("mockAdd");

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/MissingFunctionsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/MissingFunctionsTestCase.java
@@ -42,8 +42,7 @@ public class MissingFunctionsTestCase extends BaseTestCase {
 
     @Test
     public void testMissingBeforeFunction() throws BallerinaTestException {
-        String errMsg = "error: Cannot find the specified before function : [beforeFunc-nonExist] for testerina " +
-                "function : [beforeFuncNegative]";
+        String errMsg = "ERROR [before-func-negative.bal:(22:13,22:31)] undefined symbol 'beforeFuncNonExist'";
         LogLeecher clientLeecher = new LogLeecher(errMsg, ERROR);
         balClient.runMain("test", new String[]{"before-func-negative.bal"}, null, new String[]{},
                 new LogLeecher[]{clientLeecher}, projectPath);
@@ -52,8 +51,7 @@ public class MissingFunctionsTestCase extends BaseTestCase {
 
     @Test
     public void testMissingAfterFunction() throws BallerinaTestException {
-        String errMsg = "error: Cannot find the specified after function : [afterFunc-nonExist] for testerina " +
-                "function : [afterFuncNegative]";
+        String errMsg = "ERROR [after-func-negative.bal:(22:12,22:29)] undefined symbol 'afterFuncNonExist'";
         LogLeecher clientLeecher = new LogLeecher(errMsg, ERROR);
         balClient.runMain("test", new String[]{"after-func-negative.bal"}, null, new String[]{},
                 new LogLeecher[]{clientLeecher}, projectPath);

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/MissingFunctionsTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/MissingFunctionsTestCase.java
@@ -60,7 +60,7 @@ public class MissingFunctionsTestCase extends BaseTestCase {
 
     @Test
     public void testMissingDependsOnFunction() throws BallerinaTestException {
-        String errMsg = "error: Cannot find the specified dependsOn function : non-existing";
+        String errMsg = "ERROR [depends-on-negative.bal:(22:17,22:28)] undefined symbol 'nonExisting'";
         LogLeecher clientLeecher = new LogLeecher(errMsg, ERROR);
         balClient.runMain("test", new String[]{"depends-on-negative.bal"}, null, new String[]{},
                 new LogLeecher[]{clientLeecher}, projectPath);

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/annotations/tests/config-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/annotations/tests/config-test.bal
@@ -42,7 +42,7 @@ function cleanup () {
 }
 
 @test:Config{
-    before: "init"
+    before: init
 }
 function testBefore () {
     test:assertTrue(i == 1, msg = "Expected i to be 1, but i = "+i.toString());
@@ -50,8 +50,8 @@ function testBefore () {
 }
 
 @test:Config{
-    before: "init", 
-    after: "cleanup"
+    before: init,
+    after: cleanup
 }
 function test1 () {
     test:assertTrue(i == 1, msg = "Expected i to be 1, but i = "+i.toString());
@@ -66,7 +66,7 @@ function testAfter () {
 }
 
 @test:Config{
-    after: "cleanup"
+    after: cleanup
 }
 function test2 () {
     reset();

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/annotations/tests/config-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/annotations/tests/config-test.bal
@@ -58,7 +58,7 @@ function test1 () {
 }
 
 @test:Config{
-    dependsOn: ["test1"]
+    dependsOn: [test1]
 }
 function testAfter () {
     test:assertTrue(i == 0, msg = "Expected i to be 0, but i = "+i.toString());
@@ -74,7 +74,7 @@ function test2 () {
 }
 
 @test:Config{
-    dependsOn: ["test2"]
+    dependsOn: [test2]
 }
 function testAfterAlone () {
     test:assertTrue(i == 0, msg = "Expected i to be 0, but i = "+i.toString());
@@ -92,7 +92,7 @@ function test4 () {
 }
 
 @test:Config{
-    dependsOn: ["test3", "test4", "test5"]
+    dependsOn: [test3, test4, test5]
 }
 function testDependsOn1 () {
     test:assertTrue(j == 3, msg = "Expected j to be 3, but j = " +j.toString());

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/annotations/tests/data-provider-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/annotations/tests/data-provider-test.bal
@@ -17,7 +17,7 @@
 import ballerina/test;
 
 @test:Config{
-    dataProvider:"dataGen"
+    dataProvider: dataGen
 }
 function stringDataProviderTest (string fValue, string sValue, string result) returns error? {
 
@@ -36,7 +36,7 @@ function dataGen() returns (string[][]) {
 }
 
 @test:Config{
-    dataProvider:"dataGen2"
+    dataProvider: dataGen2
 }
 function stringDataProviderTest2 (string fValue, string sValue, string result) returns error? {
             
@@ -55,7 +55,7 @@ function dataGen2() returns (string[][]) {
 }
 
 @test:Config{
-    dataProvider:"dataGen3"
+    dataProvider: dataGen3
 }
 function jsonDataProviderTest (json fValue, json sValue, json result) {
     json a = {"a": "a"};
@@ -71,7 +71,7 @@ function dataGen3() returns (json[][]) {
 }
 
 @test:Config{
-    dataProvider:"dataGen4"
+    dataProvider: dataGen4
 }
 function tupleDataProviderTest ([int, int, [int, int]] result) {
     int a = 10;

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/before-after/tests/before-after-func.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/before-after/tests/before-after-func.bal
@@ -41,7 +41,7 @@ public function afterFunc() {
 
 // 2nd function
 @test:Config {
-    dependsOn:["testFunc"]
+    dependsOn: [testFunc]
 }
 public function testFunc2() {
     test:assertEquals(testString, "beforetestafter");

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/before-after/tests/before-after-func.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/before-after/tests/before-after-func.bal
@@ -27,8 +27,8 @@ function beforeFunc() {
 
 // 2nd function
 @test:Config {
-    before:"beforeFunc",
-    after:"afterFunc"
+    before: beforeFunc,
+    after: afterFunc
 }
 public function testFunc() {
     testString += "test";

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/before-each-after-each/tests/before-each-after-each.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/before-each-after-each/tests/before-each-after-each.bal
@@ -40,7 +40,7 @@ public function afterEachFunc() {
 
 // 2nd function
 @test:Config {
-    dependsOn:["testFunc"]
+    dependsOn: [testFunc]
 }
 public function testFunc2() {
     test:assertEquals(testString, "beforeEachtestafterEachbeforeEach");
@@ -48,7 +48,7 @@ public function testFunc2() {
 
 // 2nd function
 @test:Config {
-    dependsOn:["testFunc2"]
+    dependsOn: [testFunc2]
 }
 public function testFunc3() {
     test:assertEquals(testString, "beforeEachtestafterEachbeforeEachafterEachbeforeEach");

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/depends-on/tests/depends-on-with-before.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/depends-on/tests/depends-on-with-before.bal
@@ -35,7 +35,7 @@ public function testWithBefore2() {
 
 // 1st function
 @test:Config {
-    before: "before",
+    before: before,
     dependsOn: ["test4"] // added to preserve order of test execution 
 }
 public function testWithBefore1() {

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/depends-on/tests/depends-on-with-before.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/depends-on/tests/depends-on-with-before.bal
@@ -27,7 +27,7 @@ function before() {
 
 // 2nd function
 @test:Config {
-    dependsOn:["testWithBefore1"]
+    dependsOn: [testWithBefore1]
 }
 public function testWithBefore2() {
     testStr = testStr + "test2";
@@ -36,7 +36,7 @@ public function testWithBefore2() {
 // 1st function
 @test:Config {
     before: before,
-    dependsOn: ["test4"] // added to preserve order of test execution 
+    dependsOn: [test4] // added to preserve order of test execution
 }
 public function testWithBefore1() {
     testStr = testStr + "test1";
@@ -44,7 +44,7 @@ public function testWithBefore1() {
 
 // 3rd function
 @test:Config {
-    dependsOn:["testWithBefore2"]
+    dependsOn: [testWithBefore2]
 }
 public function testWithBefore3() {
     testStr = testStr + "test3";
@@ -52,7 +52,7 @@ public function testWithBefore3() {
 
 // Last function
 @test:Config {
-    dependsOn:["testWithBefore3"]
+    dependsOn: [testWithBefore3]
 }
 public function testWithBefore4() {
     test:assertEquals(testStr, "beforetest1test2test3", msg = "Order is not correct");

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/depends-on/tests/depends-on.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/depends-on/tests/depends-on.bal
@@ -23,7 +23,7 @@ string testString = "";
 
 // 2nd function
 @test:Config {
-    dependsOn:["test1"]
+    dependsOn: [test1]
 }
 public function test2() {
     testString = testString + "test2";
@@ -37,7 +37,7 @@ public function test1() {
 
 // 3rd function
 @test:Config {
-    dependsOn:["test2"]
+    dependsOn: [test2]
 }
 public function test3() {
     testString = testString + "test3";
@@ -45,7 +45,7 @@ public function test3() {
 
 // Last function
 @test:Config {
-    dependsOn:["test3"]
+    dependsOn: [test3]
 }
 public function test4() {
     test:assertEquals(testString, "test1test2test3", msg = "Order is not correct");

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/function-mocking-tests/tests/main_test.bal
@@ -94,8 +94,7 @@ public function mockFloatAdd(float a, float b) returns (float) {
 // TESTS
 //
 
-@test:Config {
-}
+@test:Config {}
 public function call_Test1() {
     // IntAdd
     test:when(mock_intAdd).call("mockIntAdd1");
@@ -111,8 +110,7 @@ public function call_Test1() {
      test:assertEquals(floatAdd(10.6, 4.5), 6.1);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function call_Test2() {
     // Set which function to call
     test:when(mock_intAdd).call("mockIntAdd1");
@@ -127,29 +125,25 @@ public function call_Test2() {
     test:assertEquals(intAdd(10, 6), 4);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function call_Test3() {
     test:when(mock_intAdd).call("invalidMockFunction");
     test:assertEquals(intAdd(10, 6), 4);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function call_Test4() {
     test:when(mock_intAdd).call("mockIntAdd3");
     test:assertEquals(intAdd(10, 6), 4);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function call_Test5() {
     test:when(mock_intAdd).call("mockIntAdd4");
     test:assertEquals(intAdd(10, 6), 4);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function call_Test6() {
     TestClass testClass = new();
     test:when(mock_intAdd).call("mockIntAdd1");
@@ -169,8 +163,7 @@ public function call_Test8() {
     test:assertEquals(intAdd3(1, 3, 5), -9);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function thenReturn_Test1() {
     test:when(mock_intAdd).thenReturn(5);
     test:assertEquals(intAdd(10, 4), 5);
@@ -182,8 +175,7 @@ public function thenReturn_Test1() {
     test:assertEquals(floatAdd(10, 5), 10.5);
 }
 
-@test:Config {
-}
+@test:Config {}
 public function withArguments_Test1() {
     test:when(mock_intAdd).withArguments(20, 14).thenReturn(100);
     test:assertEquals(intAdd(20, 14), 100);
@@ -192,8 +184,7 @@ public function withArguments_Test1() {
     test:assertEquals(stringAdd("string1"), "test");
 }
 
-@test:Config {
-}
+@test:Config {}
 public function callOriginal_Test1() {
     // IntAdd
     test:when(mock_intAdd).callOriginal();

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/interops/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/interops/tests/main_test.bal
@@ -16,8 +16,7 @@
 
 import ballerina/test;
 
-@test:Config {
-}
+@test:Config {}
 function testInteropWithRestArgs() {
     string formattedString = formatFruits();
     test:assertEquals(formattedString, "mango and banana");

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/path-verification/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/path-verification/tests/main_test.bal
@@ -56,7 +56,7 @@ function afterSuiteFunc() {
 
 # Second Test function
 @test:Config {
-    dependsOn : ["testFunction"]
+    dependsOn : [testFunction]
 }
 function testFunction2() {
     test:assertEquals(testString, "beforeSuiteFuncbeforeFunctestafterFunc");

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/path-verification/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/path-verification/tests/main_test.bal
@@ -34,8 +34,8 @@ function beforeFunc() {
 # Test function
 
 @test:Config {
-    before: "beforeFunc",
-    after: "afterFunc"
+    before: beforeFunc,
+    after: afterFunc
 }
 function testFunction() {
     testString += "test";

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/test-report-tests/tests/main_test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/test-report-tests/tests/main_test.bal
@@ -25,7 +25,7 @@ function testMain() {
 }
 
 @test:Config {
-    dependsOn: ["testMain"]
+    dependsOn: [testMain]
 }
 function testFunction() {
     test:assertTrue(true, msg = "Failed!");

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/grouping/before-groups-after-groups-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/grouping/before-groups-after-groups-test.bal
@@ -64,7 +64,7 @@ function testFunction() {
 
 @test:Config {
     groups: ["g1"],
-    dependsOn:["testFunction"]
+    dependsOn: [testFunction]
 }
 function testFunction2() {
     a += "8";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/grouping/before-groups-after-groups-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/grouping/before-groups-after-groups-test.bal
@@ -55,8 +55,8 @@ function beforeFunc() {
 
 # Test function
 @test:Config {
-    before: "beforeFunc",
-    after: "afterFunc"
+    before: beforeFunc,
+    after: afterFunc
 }
 function testFunction() {
     a += "4";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/grouping/before-groups-after-groups-test2.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/grouping/before-groups-after-groups-test2.bal
@@ -46,7 +46,7 @@ function testFunction() {
 
 @test:Config {
     groups: ["g1"],
-    dependsOn:["testFunction"]
+    dependsOn: [testFunction]
 }
 function testFunction2() {
     a += "3";
@@ -54,7 +54,7 @@ function testFunction2() {
 
 @test:Config {
     groups : ["g2"],
-    dependsOn:["testFunction2"]
+    dependsOn: [testFunction2]
 }
 function testFunction3() {
     a += "5";
@@ -67,7 +67,7 @@ function testFunction4() {
 
 @test:Config {
     groups : ["g2"],
-    dependsOn:["testFunction4"]
+    dependsOn: [testFunction4]
 }
 function testFunction5() {
     a += "8";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/invalid-data-providers/invalid-data-provider-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/invalid-data-providers/invalid-data-provider-test.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 // tests an invalid data provider
 
 @test:Config{
-    dataProvider:"invalidDataGen"
+    dataProvider: invalidDataGen
 }
 function testInvalidDataProvider(string result) {
     int|error resultErr = trap result.cloneWithType(int);

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/invalid-data-providers/invalid-data-provider-test2.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/invalid-data-providers/invalid-data-provider-test2.bal
@@ -18,7 +18,7 @@ import ballerina/test;
 
 // tests an invalid data provider
 @test:Config{
-    dataProvider:"invalidDataGen2"
+    dataProvider: invalidDataGen2
 }
 function testInvalidDataProvider2(string fValue, string sValue, string result) {
 

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/invalid-data-providers/invalid-data-provider-test3.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/invalid-data-providers/invalid-data-provider-test3.bal
@@ -18,7 +18,7 @@ import ballerina/test;
 
 // tests an invalid tuple data provider
 @test:Config{
-    dataProvider:"invalidDataGen3"
+    dataProvider: invalidDataGen3
 }
 function testInvalidTupleDataProvider ([string, string, [string, string]] result) {
 

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/missing-functions/after-func-negative.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/missing-functions/after-func-negative.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 // Tests the behaviour when a non-exesting function is provided as the after function
 
 @test:Config {
-    after:"afterFunc-nonExist"
+    after: afterFuncNonExist
 }
 public function afterFuncNegative() {
 }

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/missing-functions/before-func-negative.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/missing-functions/before-func-negative.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 // Tests the behaviour when a non-exesting function is provided as the before function
 
 @test:Config {
-    before:"beforeFunc-nonExist"
+    before: beforeFuncNonExist
 }
 public function beforeFuncNegative() {
 }

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/missing-functions/depends-on-negative.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/missing-functions/depends-on-negative.bal
@@ -19,7 +19,7 @@ import ballerina/test;
 // Tests the behaviour when a non-existing function is provided as the dependsOn function
 
 @test:Config {
-    dependsOn:["non-existing"]
+    dependsOn: [nonExisting]
 }
 public function test2() {
 }

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/single-test-execution/single-test-execution.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/single-test-execution/single-test-execution.bal
@@ -39,7 +39,7 @@ public function afterEachFunc() {
 
 // 2nd function
 @test:Config {
-    dependsOn:["testFunc"]
+    dependsOn: [testFunc]
 }
 public function testFunc2() {
     test:assertEquals(testString, "beforeEachtestafterEachbeforeEach");
@@ -56,7 +56,7 @@ public function testDisabledFunc() {
 
 // Test Dependent on disabled function
 @test:Config {
-    dependsOn: ["testDisabledFunc"]
+    dependsOn: [testDisabledFunc]
 }
 public function testDependentDisabledFunc() {
     test:assertEquals(testString, "beforeEachdisabledafterEachbeforeEach");

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/dependson-skip-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/dependson-skip-test.bal
@@ -28,21 +28,21 @@ public function test1() {
 
 // This test should fail and the consecutive depends on tests will be skipped
 @test:Config {
-    dependsOn:["test1"]
+    dependsOn: [test1]
 }
 public function test2() {
     int i = 12/0;
 }
 
 @test:Config {
-    dependsOn:["test2"]
+    dependsOn: [test2]
 }
 public function test3() {
     j = j+1;
 }
 
 @test:Config {
-    dependsOn:["test3"]
+    dependsOn: [test3]
 }
 public function test4() {
     j = j+1;

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-after-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-after-fails.bal
@@ -32,7 +32,7 @@ public function afterFunc() {
 
 // This test should pass
 @test:Config {
-    after: "afterFunc"
+    after: afterFunc
 }
 public function test1() {
     a = a + "test";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-after-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-after-fails.bal
@@ -40,7 +40,7 @@ public function test1() {
 
 // This should be skipped
 @test:Config {
-    dependsOn:["test1"]
+    dependsOn: [test1]
 }
 public function test2() {
     a = a + "test2";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-before-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-before-fails.bal
@@ -37,7 +37,7 @@ public function test1() {
 
 // Independent function which passes
 @test:Config {
-    dependsOn: ["test1"]
+    dependsOn: [test1]
 }
 public function test2() {
     a = a + "test2";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-before-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-before-fails.bal
@@ -29,7 +29,7 @@ public function before() {
 }
 
 @test:Config {
-    before:"before"
+    before: before
 }
 public function test1() {
     a = a + "test1";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeGroups-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeGroups-fails.bal
@@ -45,7 +45,7 @@ function testFunction() {
 
 @test:Config {
     groups: ["g1"],
-    dependsOn: ["testFunction"]
+    dependsOn: [testFunction]
 }
 function testFunction2() {
     a += "3";
@@ -53,7 +53,7 @@ function testFunction2() {
 
 @test:Config {
     groups : ["g2"],
-    dependsOn: ["testFunction2"]
+    dependsOn: [testFunction2]
 }
 function testFunction3() {
     a += "5";
@@ -61,7 +61,7 @@ function testFunction3() {
 
 @test:Config {
     groups : ["g1", "g2"],
-    dependsOn: ["testFunction3"]
+    dependsOn: [testFunction3]
 }
 function testFunction4() {
     a += "6";
@@ -69,7 +69,7 @@ function testFunction4() {
 
 @test:Config {
     groups : ["g2"],
-    dependsOn: ["testFunction4"]
+    dependsOn: [testFunction4]
 }
 function testFunction5() {
     a += "8";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeSuite-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeSuite-fails.bal
@@ -53,8 +53,8 @@ public function afterFunc() {
 }
 
 @test:Config {
-    before: "beforeFunc",
-    after: "afterFunc"
+    before: beforeFunc,
+    after: afterFunc
 }
 public function test1() {
     a = a + "test1";

--- a/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeSuite-fails.bal
+++ b/tests/testerina-integration-test/src/test/resources/single-file-tests/skip-tests/skip-when-beforeSuite-fails.bal
@@ -61,7 +61,7 @@ public function test1() {
 }
 
 @test:Config {
-    dependsOn:["test1"]
+    dependsOn: [test1]
 }
 public function test2() {
     a = a + "test2";


### PR DESCRIPTION
## Purpose
Support function pointers in Testerina config annotation

This converts the following implementation of `test:Config` : 

```
@test:Config {
    before : <"functionName">
}
```

To 

```
@test:Config {
    before : <functionPointer>
}
```

This applies to before, after and dependsOn

Fixes #27722

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
