### PR TITLE
Base classloader returned by `makeClassLoader` should be the context classloader

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropValidator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/InteropValidator.java
@@ -164,8 +164,9 @@ public class InteropValidator {
     }
 
     private ClassLoader makeClassLoader(Set<Path> moduleDependencies) {
+        ClassLoader baseClassLoader = Thread.currentThread().getContextClassLoader();
         if (moduleDependencies == null || moduleDependencies.size() == 0) {
-            return Thread.currentThread().getContextClassLoader();
+            return baseClassLoader;
         }
         List<URL> dependentJars = new ArrayList<>();
         for (Path dependency : moduleDependencies) {
@@ -175,7 +176,7 @@ public class InteropValidator {
                 // ignore
             }
         }
-        return new URLClassLoader(dependentJars.toArray(new URL[]{}), ClassLoader.getPlatformClassLoader());
+        return new URLClassLoader(dependentJars.toArray(new URL[]{}), baseClassLoader);
     }
 
     /**


### PR DESCRIPTION
## Purpose

Classloaders used in `makeClassLoader` method are changed conditional depending on whether the module dependencies are set. However, the classloader returned if the module dependencies are not set is the context class loader while the classloader returned if the module dependencies are set is a classloader which is a child of platform classloader. This conditional behavior causes some libraries available while module dependencies are not set to be unavailable when module dependencies are set. Ballerina shell project depends on the class loader returned to be the context classloader. So, the classloader returned if the module dependencies are set should be a child of context classloader.

## Approach

If module dependencies are set, return a classloader extending the context classloader. (instead of the platform classloader)

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
