### PR TITLE
Add overloaded version of symbol() which accepts syntax tree nodes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -19,6 +19,7 @@ package io.ballerina.compiler.api;
 
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
@@ -46,11 +47,24 @@ public interface SemanticModel {
     /**
      * Lookup the symbol at the given location.
      *
-     * @param fileName  path for the file in which we need to look up symbols, relative to the source root path
+     * @param fileName path for the file in which we need to look up symbols, relative to the source root path
      * @param position text position in the source
      * @return {@link Symbol} in the given location
      */
     Optional<Symbol> symbol(String fileName, LinePosition position);
+
+    /**
+     * Looks up the symbol for the specified syntax tree node. This will only return a symbol if the provided node is a
+     * construct in the language for which we associate names. e.g., functions, variables, function calls, type
+     * definitions etc.
+     * <p>
+     * One can also provide just the relevant portion of a particular construct to get the symbol. e.g., binding pattern
+     * node of a variable declaration node, function name node of a function definition node
+     *
+     * @param node The syntax tree node of which the symbol is required
+     * @return {@link Symbol} for the given node
+     */
+    Optional<Symbol> symbol(Node node);
 
     /**
      * Retrieves the symbols of module-scoped constructs in the semantic model.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -59,7 +59,7 @@ public interface SemanticModel {
      * definitions etc.
      * <p>
      * One can also provide just the relevant portion of a particular construct to get the symbol. e.g., binding pattern
-     * node of a variable declaration node, function name node of a function definition node
+     * node of a variable declaration node, function name node of a function definition node.
      *
      * @param node The syntax tree node of which the symbol is required
      * @return {@link Symbol} for the given node

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -73,12 +73,14 @@ public class BallerinaSemanticModel implements SemanticModel {
     private final CompilerContext compilerContext;
     private final SymbolFactory symbolFactory;
     private final TypesFactory typesFactory;
+    private final SymbolTable symbolTable;
 
     public BallerinaSemanticModel(BLangPackage bLangPackage, CompilerContext context) {
         this.compilerContext = context;
         this.bLangPackage = bLangPackage;
         this.symbolFactory = SymbolFactory.getInstance(context);
         this.typesFactory = TypesFactory.getInstance(context);
+        this.symbolTable = SymbolTable.getInstance(context);
     }
 
     /**
@@ -126,7 +128,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         SymbolFinder symbolFinder = new SymbolFinder();
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
 
-        if (symbolAtCursor == null) {
+        if (symbolAtCursor == null || symbolAtCursor == symbolTable.notFoundSymbol) {
             return Optional.empty();
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -148,7 +148,7 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Optional.empty();
         }
 
-        Optional<Location> nodeIdentifierLocation = node.apply(new SyntaxNodeLocationMapper());
+        Optional<Location> nodeIdentifierLocation = node.apply(new SyntaxNodeToLocationMapper());
 
         if (nodeIdentifierLocation.isEmpty()) {
             return Optional.empty();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.api.impl.symbols.BallerinaTypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
@@ -137,6 +138,22 @@ public class BallerinaSemanticModel implements SemanticModel {
 
         return Optional.ofNullable(symbolFactory.getBCompiledSymbol(symbolAtCursor, symbolAtCursor.name.value));
 
+    }
+
+    @Override
+    public Optional<Symbol> symbol(Node node) {
+        if (node == null) {
+            return Optional.empty();
+        }
+
+        Optional<Location> nodeIdentifierLocation = node.apply(new SyntaxNodeLocationMapper());
+
+        if (nodeIdentifierLocation.isEmpty()) {
+            return Optional.empty();
+        }
+
+        return symbol(nodeIdentifierLocation.get().lineRange().filePath(),
+                      nodeIdentifierLocation.get().lineRange().startLine());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -144,10 +144,6 @@ public class BallerinaSemanticModel implements SemanticModel {
 
     @Override
     public Optional<Symbol> symbol(Node node) {
-        if (node == null) {
-            return Optional.empty();
-        }
-
         Optional<Location> nodeIdentifierLocation = node.apply(new SyntaxNodeToLocationMapper());
 
         if (nodeIdentifierLocation.isEmpty()) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -295,6 +295,7 @@ class SymbolFinder extends BaseVisitor {
             return;
         }
 
+        lookupNodes(typeDefinition.annAttachments);
         lookupNode(typeDefinition.typeNode);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeLocationMapper.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.EnumMemberNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.IdentifierToken;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ImportPrefixNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
@@ -45,6 +46,7 @@ import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
@@ -69,22 +71,22 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
 
     @Override
     public Optional<Location> transform(AnnotationDeclarationNode annotationDeclarationNode) {
-        return Optional.of(annotationDeclarationNode.annotationTag().location());
+        return annotationDeclarationNode.annotationTag().apply(this);
     }
 
     @Override
     public Optional<Location> transform(ClassDefinitionNode classDefinitionNode) {
-        return Optional.of(classDefinitionNode.className().location());
+        return classDefinitionNode.className().apply(this);
     }
 
     @Override
     public Optional<Location> transform(ConstantDeclarationNode constantDeclarationNode) {
-        return Optional.of(constantDeclarationNode.variableName().location());
+        return constantDeclarationNode.variableName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(EnumDeclarationNode enumDeclarationNode) {
-        return Optional.of(enumDeclarationNode.identifier().location());
+        return enumDeclarationNode.identifier().apply(this);
     }
 
     @Override
@@ -94,22 +96,22 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
 
     @Override
     public Optional<Location> transform(RecordFieldNode recordFieldNode) {
-        return Optional.of(recordFieldNode.fieldName().location());
+        return recordFieldNode.fieldName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(RecordFieldWithDefaultValueNode recordFieldWithDefaultValueNode) {
-        return Optional.of(recordFieldWithDefaultValueNode.fieldName().location());
+        return recordFieldWithDefaultValueNode.fieldName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(ObjectFieldNode objectFieldNode) {
-        return Optional.of(objectFieldNode.fieldName().location());
+        return objectFieldNode.fieldName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(FunctionDefinitionNode functionDefinitionNode) {
-        return Optional.of(functionDefinitionNode.functionName().location());
+        return functionDefinitionNode.functionName().apply(this);
     }
 
     @Override
@@ -118,7 +120,7 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
             return Optional.empty();
         }
 
-        return Optional.of(defaultableParameterNode.paramName().get().location());
+        return defaultableParameterNode.paramName().get().apply(this);
     }
 
     @Override
@@ -127,7 +129,7 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
             return Optional.empty();
         }
 
-        return Optional.of(requiredParameterNode.paramName().get().location());
+        return requiredParameterNode.paramName().get().apply(this);
     }
 
     @Override
@@ -136,37 +138,36 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
             return Optional.empty();
         }
 
-        return Optional.of(restParameterNode.paramName().get().location());
+        return restParameterNode.paramName().get().apply(this);
     }
 
     @Override
     public Optional<Location> transform(FunctionCallExpressionNode functionCallExpressionNode) {
-        return Optional.of(functionCallExpressionNode.functionName().location());
+        return functionCallExpressionNode.functionName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(MethodDeclarationNode methodDeclarationNode) {
-        return Optional.of(methodDeclarationNode.methodName().location());
+        return methodDeclarationNode.methodName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(MethodCallExpressionNode methodCallExpressionNode) {
-        return Optional.of(methodCallExpressionNode.methodName().location());
+        return methodCallExpressionNode.methodName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(RemoteMethodCallActionNode remoteMethodCallActionNode) {
-        return Optional.of(remoteMethodCallActionNode.methodName().location());
+        return remoteMethodCallActionNode.methodName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(ImportDeclarationNode importDeclarationNode) {
         if (importDeclarationNode.prefix().isPresent()) {
-            return Optional.of(importDeclarationNode.prefix().get().location());
+            return importDeclarationNode.prefix().get().apply(this);
         }
 
-        return Optional.of(
-                importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1).location());
+        return importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1).apply(this);
     }
 
     @Override
@@ -176,17 +177,17 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
 
     @Override
     public Optional<Location> transform(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
-        return Optional.of(qualifiedNameReferenceNode.identifier().location());
+        return qualifiedNameReferenceNode.identifier().apply(this);
     }
 
     @Override
     public Optional<Location> transform(SimpleNameReferenceNode simpleNameReferenceNode) {
-        return Optional.of(simpleNameReferenceNode.name().location());
+        return simpleNameReferenceNode.name().apply(this);
     }
 
     @Override
     public Optional<Location> transform(TypeDefinitionNode typeDefinitionNode) {
-        return Optional.of(typeDefinitionNode.typeName().location());
+        return typeDefinitionNode.typeName().apply(this);
     }
 
     @Override
@@ -211,12 +212,12 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
 
     @Override
     public Optional<Location> transform(CaptureBindingPatternNode captureBindingPatternNode) {
-        return Optional.of(captureBindingPatternNode.variableName().location());
+        return captureBindingPatternNode.variableName().apply(this);
     }
 
     @Override
     public Optional<Location> transform(NamedWorkerDeclarationNode namedWorkerDeclarationNode) {
-        return Optional.of(namedWorkerDeclarationNode.workerName().location());
+        return namedWorkerDeclarationNode.workerName().apply(this);
     }
 
     @Override
@@ -225,7 +226,7 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
             return Optional.empty();
         }
 
-        return Optional.of(xmlNamespaceDeclarationNode.namespacePrefix().get().location());
+        return xmlNamespaceDeclarationNode.namespacePrefix().get().apply(this);
     }
 
     @Override
@@ -234,7 +235,17 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
             return Optional.empty();
         }
 
-        return Optional.of(moduleXMLNamespaceDeclarationNode.namespacePrefix().get().location());
+        return moduleXMLNamespaceDeclarationNode.namespacePrefix().get().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(Token token) {
+        return Optional.of(token.location());
+    }
+
+    @Override
+    public Optional<Location> transform(IdentifierToken identifier) {
+        return Optional.of(identifier.location());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeLocationMapper.java
@@ -1,0 +1,244 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.impl;
+
+import io.ballerina.compiler.syntax.tree.AnnotationDeclarationNode;
+import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumMemberNode;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ImportPrefixNode;
+import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.MethodDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModuleXMLNamespaceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.NamedWorkerDeclarationNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeTransformer;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.RecordFieldNode;
+import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
+import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.RestParameterNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.XMLNamespaceDeclarationNode;
+import io.ballerina.tools.diagnostics.Location;
+
+import java.util.Optional;
+
+/**
+ * A util class for mapping a given syntax node to the syntax node associated with its symbol (i.e., the name node)
+ *
+ * @since 2.0.0
+ */
+public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>> {
+
+    // Nodes relevant for symbol()
+
+    @Override
+    public Optional<Location> transform(AnnotationNode annotationNode) {
+        return annotationNode.annotReference().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(AnnotationDeclarationNode annotationDeclarationNode) {
+        return Optional.of(annotationDeclarationNode.annotationTag().location());
+    }
+
+    @Override
+    public Optional<Location> transform(ClassDefinitionNode classDefinitionNode) {
+        return Optional.of(classDefinitionNode.className().location());
+    }
+
+    @Override
+    public Optional<Location> transform(ConstantDeclarationNode constantDeclarationNode) {
+        return Optional.of(constantDeclarationNode.variableName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(EnumDeclarationNode enumDeclarationNode) {
+        return Optional.of(enumDeclarationNode.identifier().location());
+    }
+
+    @Override
+    public Optional<Location> transform(EnumMemberNode enumMemberNode) {
+        return Optional.of(enumMemberNode.identifier().location());
+    }
+
+    @Override
+    public Optional<Location> transform(RecordFieldNode recordFieldNode) {
+        return Optional.of(recordFieldNode.fieldName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(RecordFieldWithDefaultValueNode recordFieldWithDefaultValueNode) {
+        return Optional.of(recordFieldWithDefaultValueNode.fieldName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(ObjectFieldNode objectFieldNode) {
+        return Optional.of(objectFieldNode.fieldName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(FunctionDefinitionNode functionDefinitionNode) {
+        return Optional.of(functionDefinitionNode.functionName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(DefaultableParameterNode defaultableParameterNode) {
+        if (defaultableParameterNode.paramName().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(defaultableParameterNode.paramName().get().location());
+    }
+
+    @Override
+    public Optional<Location> transform(RequiredParameterNode requiredParameterNode) {
+        if (requiredParameterNode.paramName().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(requiredParameterNode.paramName().get().location());
+    }
+
+    @Override
+    public Optional<Location> transform(RestParameterNode restParameterNode) {
+        if (restParameterNode.paramName().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(restParameterNode.paramName().get().location());
+    }
+
+    @Override
+    public Optional<Location> transform(FunctionCallExpressionNode functionCallExpressionNode) {
+        return Optional.of(functionCallExpressionNode.functionName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(MethodDeclarationNode methodDeclarationNode) {
+        return Optional.of(methodDeclarationNode.methodName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(MethodCallExpressionNode methodCallExpressionNode) {
+        return Optional.of(methodCallExpressionNode.methodName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(RemoteMethodCallActionNode remoteMethodCallActionNode) {
+        return Optional.of(remoteMethodCallActionNode.methodName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(ImportDeclarationNode importDeclarationNode) {
+        if (importDeclarationNode.prefix().isPresent()) {
+            return Optional.of(importDeclarationNode.prefix().get().location());
+        }
+
+        return Optional.of(
+                importDeclarationNode.moduleName().get(importDeclarationNode.moduleName().size() - 1).location());
+    }
+
+    @Override
+    public Optional<Location> transform(ImportPrefixNode importPrefixNode) {
+        return Optional.of(importPrefixNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
+        return Optional.of(qualifiedNameReferenceNode.identifier().location());
+    }
+
+    @Override
+    public Optional<Location> transform(SimpleNameReferenceNode simpleNameReferenceNode) {
+        return Optional.of(simpleNameReferenceNode.name().location());
+    }
+
+    @Override
+    public Optional<Location> transform(TypeDefinitionNode typeDefinitionNode) {
+        return Optional.of(typeDefinitionNode.typeName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(VariableDeclarationNode variableDeclarationNode) {
+        return variableDeclarationNode.typedBindingPattern().bindingPattern().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
+        return moduleVariableDeclarationNode.typedBindingPattern().bindingPattern().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(LetVariableDeclarationNode letVariableDeclarationNode) {
+        return letVariableDeclarationNode.typedBindingPattern().bindingPattern().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(TypedBindingPatternNode typedBindingPatternNode) {
+        return typedBindingPatternNode.bindingPattern().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(CaptureBindingPatternNode captureBindingPatternNode) {
+        return Optional.of(captureBindingPatternNode.variableName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(NamedWorkerDeclarationNode namedWorkerDeclarationNode) {
+        return Optional.of(namedWorkerDeclarationNode.workerName().location());
+    }
+
+    @Override
+    public Optional<Location> transform(XMLNamespaceDeclarationNode xmlNamespaceDeclarationNode) {
+        if (xmlNamespaceDeclarationNode.namespacePrefix().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(xmlNamespaceDeclarationNode.namespacePrefix().get().location());
+    }
+
+    @Override
+    public Optional<Location> transform(ModuleXMLNamespaceDeclarationNode moduleXMLNamespaceDeclarationNode) {
+        if (moduleXMLNamespaceDeclarationNode.namespacePrefix().isEmpty()) {
+            return Optional.empty();
+        }
+
+        return Optional.of(moduleXMLNamespaceDeclarationNode.namespacePrefix().get().location());
+    }
+
+    @Override
+    protected Optional<Location> transformSyntaxNode(Node node) {
+        return Optional.empty();
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeLocationMapper.java
@@ -172,7 +172,7 @@ public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>
 
     @Override
     public Optional<Location> transform(ImportPrefixNode importPrefixNode) {
-        return Optional.of(importPrefixNode.location());
+        return importPrefixNode.prefix().apply(this);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -56,11 +56,11 @@ import io.ballerina.tools.diagnostics.Location;
 import java.util.Optional;
 
 /**
- * A util class for mapping a given syntax node to the syntax node associated with its symbol (i.e., the name node)
+ * A util class for mapping a given syntax node to the syntax node associated with its symbol (i.e., the name node).
  *
  * @since 2.0.0
  */
-public class SyntaxNodeLocationMapper extends NodeTransformer<Optional<Location>> {
+public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Location>> {
 
     // Nodes relevant for symbol()
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -903,7 +903,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
         // Generate a name for the anonymous object
         String genName = anonymousModelHelper.getNextAnonymousTypeKey(packageID);
-        IdentifierNode anonTypeGenName = createIdentifier(pos, genName);
+        IdentifierNode anonTypeGenName = createIdentifier(symTable.builtinPos, genName);
         bLTypeDef.setName(anonTypeGenName);
         bLTypeDef.flagSet.add(Flag.PUBLIC);
         bLTypeDef.flagSet.add(Flag.ANONYMOUS);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
@@ -61,9 +61,15 @@ public class SymbolByAnnotationTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 4);
+    }
+
     private void assertSymbol(Node node, SemanticModel model) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), ANNOTATION);
         assertEquals(symbol.get().name(), "v1");
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.AnnotationDeclarationNode;
+import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given an annotation decl or an annotation.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByAnnotationTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_annotation_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(AnnotationDeclarationNode annotationDeclarationNode) {
+                assertSymbol(annotationDeclarationNode.annotationTag(), model);
+                assertSymbol(annotationDeclarationNode, model);
+            }
+
+            @Override
+            public void visit(AnnotationNode annotationNode) {
+                assertSymbol(annotationNode, model);
+                assertSymbol(annotationNode.annotReference(), model);
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), ANNOTATION);
+        assertEquals(symbol.get().name(), "v1");
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
@@ -72,7 +72,7 @@ public class SymbolByClassTest extends SymbolByNodeTest {
 
             @Override
             public void visit(FunctionDefinitionNode functionDefinitionNode) {
-                if (functionDefinitionNode.parent().kind() == SyntaxKind.CLASS_DEFINITION) {
+                if (functionDefinitionNode.kind() == SyntaxKind.OBJECT_METHOD_DEFINITION) {
                     assertSymbol(functionDefinitionNode, model, METHOD, functionDefinitionNode.functionName().text());
                     return;
                 }
@@ -94,9 +94,15 @@ public class SymbolByClassTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 13);
+    }
+
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a class.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByClassTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_class_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(ClassDefinitionNode classDefinitionNode) {
+                assertSymbol(classDefinitionNode, model);
+                assertSymbol(classDefinitionNode.className(), model);
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), CLASS);
+        assertEquals(symbol.get().name(), "Person");
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a constant.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByConstantTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_constant_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(ConstantDeclarationNode constantDeclarationNode) {
+                assertSymbol(constantDeclarationNode, model);
+                assertSymbol(constantDeclarationNode.variableName(), model);
+            }
+
+            @Override
+            public void visit(VariableDeclarationNode variableDeclarationNode) {
+                assertSymbol(variableDeclarationNode.initializer().get(), model);
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), CONSTANT);
+        assertEquals(symbol.get().name(), "PI");
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
@@ -60,9 +60,15 @@ public class SymbolByConstantTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
     private void assertSymbol(Node node, SemanticModel model) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), CONSTANT);
         assertEquals(symbol.get().name(), "PI");
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
@@ -53,6 +53,10 @@ public class SymbolByEnumTest extends SymbolByNodeTest {
             public void visit(EnumDeclarationNode enumDeclarationNode) {
                 assertSymbol(enumDeclarationNode, model, ENUM, "Colour");
                 assertSymbol(enumDeclarationNode.identifier(), model, ENUM, "Colour");
+
+                for (Node node : enumDeclarationNode.enumMemberList()) {
+                    node.accept(this);
+                }
             }
 
             @Override
@@ -67,9 +71,15 @@ public class SymbolByEnumTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 6);
+    }
+
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
+import io.ballerina.compiler.syntax.tree.EnumMemberNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
+import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given an enum or enum fields.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByEnumTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_enum_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(EnumDeclarationNode enumDeclarationNode) {
+                assertSymbol(enumDeclarationNode, model, ENUM, "Colour");
+                assertSymbol(enumDeclarationNode.identifier(), model, ENUM, "Colour");
+            }
+
+            @Override
+            public void visit(EnumMemberNode enumMemberNode) {
+                assertSymbol(enumMemberNode, model, CONSTANT, enumMemberNode.identifier().text());
+            }
+
+            @Override
+            public void visit(VariableDeclarationNode variableDeclarationNode) {
+                assertSymbol(variableDeclarationNode.initializer().get(), model, CONSTANT, "RED");
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.RestParameterNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a function/param nodes etc.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByFunctionTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_function_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(FunctionDefinitionNode functionDefinitionNode) {
+                assertSymbol(functionDefinitionNode, model, FUNCTION, functionDefinitionNode.functionName().text());
+                assertSymbol(functionDefinitionNode.functionName(), model, FUNCTION,
+                             functionDefinitionNode.functionName().text());
+            }
+
+            @Override
+            public void visit(RequiredParameterNode requiredParameterNode) {
+                assertSymbol(requiredParameterNode, model, VARIABLE, "a");
+                assertSymbol(requiredParameterNode.paramName().get(), model, VARIABLE, "a");
+            }
+
+            @Override
+            public void visit(DefaultableParameterNode defaultableParameterNode) {
+                assertSymbol(defaultableParameterNode, model, VARIABLE, "b");
+                assertSymbol(defaultableParameterNode.paramName().get(), model, VARIABLE, "b");
+            }
+
+            @Override
+            public void visit(RestParameterNode restParameterNode) {
+                assertSymbol(restParameterNode, model, VARIABLE, "c");
+                assertSymbol(restParameterNode.paramName().get(), model, VARIABLE, "c");
+            }
+
+            @Override
+            public void visit(VariableDeclarationNode variableDeclarationNode) {
+                assertSymbol(variableDeclarationNode.initializer().get(), model, FUNCTION, "foo");
+            }
+
+            @Override
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertSymbol(functionCallExpressionNode, model, FUNCTION, "foo");
+                assertSymbol(functionCallExpressionNode.functionName(), model, FUNCTION, "foo");
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
@@ -58,6 +58,9 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
                 assertSymbol(functionDefinitionNode, model, FUNCTION, functionDefinitionNode.functionName().text());
                 assertSymbol(functionDefinitionNode.functionName(), model, FUNCTION,
                              functionDefinitionNode.functionName().text());
+
+                functionDefinitionNode.functionSignature().accept(this);
+                functionDefinitionNode.functionBody().accept(this);
             }
 
             @Override
@@ -81,6 +84,7 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
             @Override
             public void visit(VariableDeclarationNode variableDeclarationNode) {
                 assertSymbol(variableDeclarationNode.initializer().get(), model, FUNCTION, "foo");
+                variableDeclarationNode.initializer().get().accept(this);
             }
 
             @Override
@@ -91,9 +95,15 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 13);
+    }
+
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
@@ -37,7 +37,7 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.MODULE;
 import static org.testng.Assert.assertEquals;
 
 /**
- * Test cases for looking up a symbol given a record def/record fields.
+ * Test cases for looking up a symbol given a module import/prefix.
  *
  * @since 2.0.0
  */
@@ -78,9 +78,15 @@ public class SymbolByImportTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.MODULE;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a record def/record fields.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByImportTest extends SymbolByNodeTest {
+
+    @BeforeClass
+    public void setup() {
+        CompileResult compileResult = BCompileUtil.compileAndCacheBalo("test-src/testproject");
+        if (compileResult.getErrorCount() != 0) {
+            Arrays.stream(compileResult.getDiagnostics()).forEach(System.out::println);
+            Assert.fail("Compilation contains error");
+        }
+    }
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_import_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(ImportDeclarationNode importDeclarationNode) {
+                if (importDeclarationNode.prefix().isEmpty()) {
+                    assertSymbol(importDeclarationNode, model, MODULE, "testproject");
+                } else {
+                    assertSymbol(importDeclarationNode, model, MODULE, "lang.int");
+                }
+            }
+
+            @Override
+            public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
+                assertSymbol(qualifiedNameReferenceNode.modulePrefix(), model, MODULE, "testproject");
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByNodeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByNodeTest.java
@@ -34,6 +34,8 @@ import org.testng.annotations.Test;
  */
 public abstract class SymbolByNodeTest {
 
+    private int assertCount = 0;
+
     @Test
     public void testLookup() {
         Project project = BCompileUtil.loadProject(getTestSourcePath());
@@ -43,9 +45,20 @@ public abstract class SymbolByNodeTest {
         SyntaxTree syntaxTree = currentPackage.getDefaultModule().document(docId).syntaxTree();
         SemanticModel model = currentPackage.getCompilation().getSemanticModel(defaultModuleId);
         syntaxTree.rootNode().accept(getNodeVisitor(model));
+        verifyAssertCount();
     }
 
     abstract String getTestSourcePath();
 
     abstract NodeVisitor getNodeVisitor(SemanticModel model);
+
+    abstract void verifyAssertCount();
+
+    void incrementAssertCount() {
+        this.assertCount++;
+    }
+
+    int getAssertCount() {
+        return this.assertCount;
+    }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByNodeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByNodeTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Base test class for tests for finding symbols given a node.
+ *
+ * @since 2.0.0
+ */
+public abstract class SymbolByNodeTest {
+
+    @Test
+    public void testLookup() {
+        Project project = BCompileUtil.loadProject(getTestSourcePath());
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        DocumentId docId = currentPackage.getDefaultModule().documentIds().iterator().next();
+        SyntaxTree syntaxTree = currentPackage.getDefaultModule().document(docId).syntaxTree();
+        SemanticModel model = currentPackage.getCompilation().getSemanticModel(defaultModuleId);
+        syntaxTree.rootNode().accept(getNodeVisitor(model));
+    }
+
+    abstract String getTestSourcePath();
+
+    abstract NodeVisitor getNodeVisitor(SemanticModel model);
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given an object.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByObjectTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_object_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(TypeDefinitionNode typeDefinitionNode) {
+                assertSymbol(typeDefinitionNode, model, TYPE_DEFINITION, typeDefinitionNode.typeName().text());
+                assertSymbol(typeDefinitionNode.typeName(), model, TYPE_DEFINITION,
+                             typeDefinitionNode.typeName().text());
+            }
+
+            @Override
+            public void visit(ObjectFieldNode objectFieldNode) {
+                assertSymbol(objectFieldNode, model, VARIABLE, objectFieldNode.fieldName().text());
+                assertSymbol(objectFieldNode.fieldName(), model, VARIABLE, objectFieldNode.fieldName().text());
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
@@ -20,6 +20,7 @@ package io.ballerina.semantic.api.test.symbolbynode;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.MethodDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
@@ -28,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static org.testng.Assert.assertEquals;
@@ -54,6 +56,8 @@ public class SymbolByObjectTest extends SymbolByNodeTest {
                 assertSymbol(typeDefinitionNode, model, TYPE_DEFINITION, typeDefinitionNode.typeName().text());
                 assertSymbol(typeDefinitionNode.typeName(), model, TYPE_DEFINITION,
                              typeDefinitionNode.typeName().text());
+
+                typeDefinitionNode.typeDescriptor().accept(this);
             }
 
             @Override
@@ -61,12 +65,23 @@ public class SymbolByObjectTest extends SymbolByNodeTest {
                 assertSymbol(objectFieldNode, model, VARIABLE, objectFieldNode.fieldName().text());
                 assertSymbol(objectFieldNode.fieldName(), model, VARIABLE, objectFieldNode.fieldName().text());
             }
+
+            @Override
+            public void visit(MethodDeclarationNode methodDeclarationNode) {
+                assertSymbol(methodDeclarationNode, model, METHOD, methodDeclarationNode.methodName().text());
+            }
         };
+    }
+
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 14);
     }
 
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.RecordFieldNode;
+import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
+import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a record def/record fields.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByRecordTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_record_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(TypeDefinitionNode typeDefinitionNode) {
+                assertSymbol(typeDefinitionNode, model, TYPE_DEFINITION, typeDefinitionNode.typeName().text());
+                assertSymbol(typeDefinitionNode.typeName(), model, TYPE_DEFINITION,
+                             typeDefinitionNode.typeName().text());
+            }
+
+            @Override
+            public void visit(RecordFieldNode recordFieldNode) {
+                assertSymbol(recordFieldNode, model, VARIABLE, recordFieldNode.fieldName().text());
+                assertSymbol(recordFieldNode.fieldName(), model, VARIABLE, recordFieldNode.fieldName().text());
+            }
+
+            @Override
+            public void visit(RecordFieldWithDefaultValueNode recordFieldWithDefaultValueNode) {
+                assertSymbol(recordFieldWithDefaultValueNode, model, VARIABLE,
+                             recordFieldWithDefaultValueNode.fieldName().text());
+                assertSymbol(recordFieldWithDefaultValueNode.fieldName(), model, VARIABLE,
+                             recordFieldWithDefaultValueNode.fieldName().text());
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), kind);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
@@ -73,9 +73,15 @@ public class SymbolByRecordTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 6);
+    }
+
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclNegativeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclNegativeTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -51,11 +52,13 @@ public class SymbolByVarDeclNegativeTest extends SymbolByNodeTest {
             @Override
             public void visit(VariableDeclarationNode variableDeclarationNode) {
                 assertEmptySymbol(model, variableDeclarationNode);
+                variableDeclarationNode.typedBindingPattern().accept(this);
             }
 
             @Override
             public void visit(TypedBindingPatternNode typedBindingPatternNode) {
                 assertEmptySymbol(model, typedBindingPatternNode);
+                typedBindingPatternNode.bindingPattern().accept(this);
             }
 
             @Override
@@ -70,8 +73,14 @@ public class SymbolByVarDeclNegativeTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 6);
+    }
+
     private void assertEmptySymbol(SemanticModel model, Node node) {
         Optional<Symbol> symbol = model.symbol(node);
         assertTrue(symbol.isEmpty());
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclNegativeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclNegativeTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.syntax.tree.ListBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.MappingBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for looking up a symbol given a var decl node.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByVarDeclNegativeTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/var_decl_symbol_negative_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(VariableDeclarationNode variableDeclarationNode) {
+                assertEmptySymbol(model, variableDeclarationNode);
+            }
+
+            @Override
+            public void visit(TypedBindingPatternNode typedBindingPatternNode) {
+                assertEmptySymbol(model, typedBindingPatternNode);
+            }
+
+            @Override
+            public void visit(ListBindingPatternNode listBindingPatternNode) {
+                assertEmptySymbol(model, listBindingPatternNode);
+            }
+
+            @Override
+            public void visit(MappingBindingPatternNode mappingBindingPatternNode) {
+                assertEmptySymbol(model, mappingBindingPatternNode);
+            }
+        };
+    }
+
+    private void assertEmptySymbol(SemanticModel model, Node node) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertTrue(symbol.isEmpty());
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a var decl node.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByVarDeclTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/var_decl_symbol_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        Map<String, Object[]> expVarDetails = new HashMap<>();
+        expVarDetails.put("x", new Object[]{"x", INT});
+        expVarDetails.put("y", new Object[]{"y", FLOAT});
+        expVarDetails.put("z", new Object[]{"z", INT});
+
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
+                Optional<Symbol> symbol = model.symbol(moduleVariableDeclarationNode);
+                assertSymbol(symbol.get(), "x", INT);
+            }
+
+            @Override
+            public void visit(VariableDeclarationNode variableDeclarationNode) {
+                Optional<Symbol> symbol = model.symbol(variableDeclarationNode);
+                assertSymbol(symbol.get(), "y", FLOAT);
+            }
+
+            @Override
+            public void visit(LetVariableDeclarationNode letVariableDeclarationNode) {
+                Optional<Symbol> symbol = model.symbol(letVariableDeclarationNode);
+                assertSymbol(symbol.get(), "z", INT);
+            }
+
+            @Override
+            public void visit(TypedBindingPatternNode typedBindingPatternNode) {
+                Optional<Symbol> symbol = model.symbol(typedBindingPatternNode);
+                Object[] expVals = expVarDetails.get(symbol.get().name());
+                assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
+            }
+
+            @Override
+            public void visit(CaptureBindingPatternNode captureBindingPatternNode) {
+                Optional<Symbol> symbol = model.symbol(captureBindingPatternNode);
+                Object[] expVals = expVarDetails.get(symbol.get().name());
+                assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
+            }
+        };
+    }
+
+    private void assertSymbol(Symbol symbol, String name, TypeDescKind typeKind) {
+        assertEquals(symbol.kind(), VARIABLE);
+        assertEquals(symbol.name(), name);
+        assertEquals(((VariableSymbol) symbol).typeDescriptor().typeKind(), typeKind);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
@@ -64,18 +64,24 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
             public void visit(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
                 Optional<Symbol> symbol = model.symbol(moduleVariableDeclarationNode);
                 assertSymbol(symbol.get(), "x", INT);
+
+                moduleVariableDeclarationNode.typedBindingPattern().accept(this);
             }
 
             @Override
             public void visit(VariableDeclarationNode variableDeclarationNode) {
                 Optional<Symbol> symbol = model.symbol(variableDeclarationNode);
                 assertSymbol(symbol.get(), "y", FLOAT);
+
+                variableDeclarationNode.typedBindingPattern().accept(this);
             }
 
             @Override
             public void visit(LetVariableDeclarationNode letVariableDeclarationNode) {
                 Optional<Symbol> symbol = model.symbol(letVariableDeclarationNode);
                 assertSymbol(symbol.get(), "z", INT);
+
+                letVariableDeclarationNode.typedBindingPattern().accept(this);
             }
 
             @Override
@@ -83,6 +89,8 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
                 Optional<Symbol> symbol = model.symbol(typedBindingPatternNode);
                 Object[] expVals = expVarDetails.get(symbol.get().name());
                 assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
+
+                typedBindingPatternNode.bindingPattern().accept(this);
             }
 
             @Override
@@ -94,9 +102,15 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 9);
+    }
+
     private void assertSymbol(Symbol symbol, String name, TypeDescKind typeKind) {
         assertEquals(symbol.kind(), VARIABLE);
         assertEquals(symbol.name(), name);
         assertEquals(((VariableSymbol) symbol).typeDescriptor().typeKind(), typeKind);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
@@ -62,25 +63,19 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
 
             @Override
             public void visit(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
-                Optional<Symbol> symbol = model.symbol(moduleVariableDeclarationNode);
-                assertSymbol(symbol.get(), "x", INT);
-
+                assertSymbol(moduleVariableDeclarationNode, model, "x", INT);
                 moduleVariableDeclarationNode.typedBindingPattern().accept(this);
             }
 
             @Override
             public void visit(VariableDeclarationNode variableDeclarationNode) {
-                Optional<Symbol> symbol = model.symbol(variableDeclarationNode);
-                assertSymbol(symbol.get(), "y", FLOAT);
-
+                assertSymbol(variableDeclarationNode, model, "y", FLOAT);
                 variableDeclarationNode.typedBindingPattern().accept(this);
             }
 
             @Override
             public void visit(LetVariableDeclarationNode letVariableDeclarationNode) {
-                Optional<Symbol> symbol = model.symbol(letVariableDeclarationNode);
-                assertSymbol(symbol.get(), "z", INT);
-
+                assertSymbol(letVariableDeclarationNode, model, "z", INT);
                 letVariableDeclarationNode.typedBindingPattern().accept(this);
             }
 
@@ -112,5 +107,10 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
         assertEquals(symbol.name(), name);
         assertEquals(((VariableSymbol) symbol).typeDescriptor().typeKind(), typeKind);
         incrementAssertCount();
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, String name, TypeDescKind typeKind) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertSymbol(symbol.get(), name, typeKind);
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.NamedWorkerDeclarationNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for looking up a symbol given a record def/record fields.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByWorkerTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_worker_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(NamedWorkerDeclarationNode namedWorkerDeclarationNode) {
+                assertSymbol(namedWorkerDeclarationNode, model, namedWorkerDeclarationNode.workerName().text());
+                assertSymbol(namedWorkerDeclarationNode.workerName(), model,
+                             namedWorkerDeclarationNode.workerName().text());
+            }
+
+            @Override
+            public void visit(SimpleNameReferenceNode simpleNameReferenceNode) {
+                assertSymbol(simpleNameReferenceNode, model, simpleNameReferenceNode.name().text());
+                assertSymbol(simpleNameReferenceNode.name(), model, simpleNameReferenceNode.name().text());
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), SymbolKind.WORKER);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
@@ -31,7 +31,7 @@ import java.util.Optional;
 import static org.testng.Assert.assertEquals;
 
 /**
- * Test cases for looking up a symbol given a record def/record fields.
+ * Test cases for looking up a symbol given a worker.
  *
  * @since 2.0.0
  */
@@ -52,6 +52,7 @@ public class SymbolByWorkerTest extends SymbolByNodeTest {
                 assertSymbol(namedWorkerDeclarationNode, model, namedWorkerDeclarationNode.workerName().text());
                 assertSymbol(namedWorkerDeclarationNode.workerName(), model,
                              namedWorkerDeclarationNode.workerName().text());
+
             }
 
             @Override
@@ -62,9 +63,15 @@ public class SymbolByWorkerTest extends SymbolByNodeTest {
         };
     }
 
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 6);
+    }
+
     private void assertSymbol(Node node, SemanticModel model, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), SymbolKind.WORKER);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
@@ -62,14 +62,21 @@ public class SymbolByXMLNSTest extends SymbolByNodeTest {
                 } else {
                     Optional<Symbol> symbol = model.symbol(moduleXMLNamespaceDeclarationNode);
                     assertTrue(symbol.isEmpty());
+                    incrementAssertCount();
                 }
             }
         };
+    }
+
+    @Override
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 5);
     }
 
     private void assertSymbol(Node node, SemanticModel model, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), SymbolKind.XMLNS);
         assertEquals(symbol.get().name(), name);
+        incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbolbynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.syntax.tree.ModuleXMLNamespaceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.XMLNamespaceDeclarationNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for looking up a symbol given an XML namespace.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class SymbolByXMLNSTest extends SymbolByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/symbol-by-node/symbol_by_xmlns_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(XMLNamespaceDeclarationNode xmlNamespaceDeclarationNode) {
+                assertSymbol(xmlNamespaceDeclarationNode, model, "ns1");
+                assertSymbol(xmlNamespaceDeclarationNode.namespacePrefix().get(), model, "ns1");
+            }
+
+            @Override
+            public void visit(ModuleXMLNamespaceDeclarationNode moduleXMLNamespaceDeclarationNode) {
+                if (moduleXMLNamespaceDeclarationNode.namespacePrefix().isPresent()) {
+                    assertSymbol(moduleXMLNamespaceDeclarationNode, model, "ns0");
+                    assertSymbol(moduleXMLNamespaceDeclarationNode.namespacePrefix().get(), model, "ns0");
+                } else {
+                    Optional<Symbol> symbol = model.symbol(moduleXMLNamespaceDeclarationNode);
+                    assertTrue(symbol.isEmpty());
+                }
+            }
+        };
+    }
+
+    private void assertSymbol(Node node, SemanticModel model, String name) {
+        Optional<Symbol> symbol = model.symbol(node);
+        assertEquals(symbol.get().kind(), SymbolKind.XMLNS);
+        assertEquals(symbol.get().name(), name);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_annotation_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_annotation_test.bal
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Annot record {
+    string foo;
+    int bar?;
+};
+
+public const annotation Annot v1 on source type, class, service, annotation, var, const, worker;
+
+@v1 {
+    foo: strValue,
+    bar: 1
+}
+public type T1 record {
+    string name;
+};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_class_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_class_test.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+class Person {
+    string name;
+    int age;
+
+    function init(string name, int age) {
+        self.name = name;
+        self.age = age;
+    }
+
+    function getName() returns string => self.name;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_class_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_class_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-class Person {
+client class Person {
     string name;
     int age;
 
@@ -24,4 +24,12 @@ class Person {
     }
 
     function getName() returns string => self.name;
+
+    remote function getAge() returns int => self.age;
+}
+
+function test() {
+    Person p = new("John Doe", 25);
+    string s = p.getName();
+    int a = p->getAge();
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_constant_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_constant_test.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public const PI = 3.14;
+
+function test() {
+    float f = PI;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_enum_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_enum_test.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+enum Colour {
+    RED, GREEN, BLUE
+}
+
+function testEnum() {
+    string red = RED;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_function_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_function_test.bal
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function foo(int a, string b = "hello", float... c) returns string {
+    return b + " world!";
+}
+
+function test() {
+    string s = foo(10, 20, 30);
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_import_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_import_test.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import testorg/testproject;
+import ballerina/lang.'int as ints;
+
+function testAnonTypes() {
+    int sum = testproject:add(10, 20);
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_object_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_object_test.bal
@@ -1,0 +1,35 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Person object {
+    string name;
+    int age;
+
+    function getName() returns string;
+
+    function getAge() returns int;
+};
+
+function test() {
+    object {
+        string name;
+        int age;
+
+        function getName() returns string;
+
+        function getAge() returns int;
+    } person;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_record_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_record_test.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Person record {|
+    string name;
+    int age = 10;
+|};
+
+function test() {
+    record {|
+        string name;
+        int age = 20;
+    |} person;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_worker_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_worker_test.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function test() {
+    worker w1 {
+      int i = 40;
+      i -> w2;
+
+      float x = 12.34;
+      x ->> w2;
+
+      var res = flush w2;
+    }
+
+    worker w2 returns int {
+      int j = 25;
+      j = <- w1;
+
+      float y = <- w1;
+      return j;
+    }
+
+    int ret = wait w2;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_xmlns_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_xmlns_test.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+xmlns "http://ballerina.io/a";
+xmlns "http://ballerina.io/b" as ns0;
+
+function test() {
+    xmlns "http://ballerina.io/c" as ns1;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/var_decl_symbol_negative_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/var_decl_symbol_negative_test.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+type Person record {
+    string name;
+    int age;
+};
+
+function test() {
+    [string, int, string] [name, age, address] = ["Jack Smith", 23, "380 Lakewood Dr. Desoto, TX 75115"];
+    Person {name, age} = getPerson();
+}
+
+function getPerson() returns Person => {name: "Jack Smith", age: 23, "occupation": "Software Engineer"};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/var_decl_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/var_decl_symbol_test.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+int x = 10;
+
+function test() {
+    float y = 12.34;
+    _ = let int z = 4 in 3 * x;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -52,6 +52,7 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByClassTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByConstantTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByEnumTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByObjectTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByRecordTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -52,6 +52,7 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByClassTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByConstantTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByEnumTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByRecordTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
         </classes>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -58,6 +58,7 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByRecordTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByWorkerTest" />
         </classes>
     </test>
 </suite>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -50,6 +50,8 @@
 
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByAnnotationTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByClassTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByConstantTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByEnumTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
         </classes>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -52,6 +52,7 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByClassTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByConstantTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByEnumTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByFunctionTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByObjectTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByRecordTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -59,6 +59,7 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByWorkerTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByXMLNSTest" />
         </classes>
     </test>
 </suite>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -53,6 +53,7 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByConstantTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByEnumTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByFunctionTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByImportTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByObjectTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByRecordTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -47,6 +47,9 @@
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInTestsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInWorkersTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.XMLRefsTest" />
+
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
         </classes>
     </test>
 </suite>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -49,6 +49,7 @@
             <class name="io.ballerina.semantic.api.test.allreferences.XMLRefsTest" />
 
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByAnnotationTest" />
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByClassTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
         </classes>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -48,6 +48,7 @@
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInWorkersTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.XMLRefsTest" />
 
+            <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByAnnotationTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
         </classes>


### PR DESCRIPTION
## Purpose
This PR adds an overloaded version of `symbol()` which accepts syntax tree nodes as the param instead of a position. 

This PR addresses a part of #27724

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
