### PR TITLE
Restrict the Observability Control Flow Instrumentation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/CodeGenerator.java
@@ -75,7 +75,7 @@ public class CodeGenerator {
 
         // Desugar BIR to include the observations
         JvmObservabilityGen jvmObservabilityGen = new JvmObservabilityGen(packageCache, symbolTable);
-        jvmObservabilityGen.instrumentPackage(packageSymbol.bir, packageSymbol.entryPointExists);
+        jvmObservabilityGen.instrumentPackage(packageSymbol.bir);
 
         dlog.setCurrentPackageId(packageSymbol.pkgID);
         final JvmPackageGen jvmPackageGen = new JvmPackageGen(symbolTable, packageCache, dlog);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -154,11 +154,12 @@ class JvmObservabilityGen {
             boolean isService = (typeDef.type.flags & Flags.SERVICE) == Flags.SERVICE;
             for (int i = 0; i < typeDef.attachedFuncs.size(); i++) {
                 BIRFunction func = typeDef.attachedFuncs.get(i);
-
-                if ((func.flags & Flags.RESOURCE) == Flags.RESOURCE) {
-                    rewriteControlFlowInvocation(func, pkg);
-                } else if ((func.flags & Flags.REMOTE) == Flags.REMOTE) {
-                    rewriteControlFlowInvocation(func, pkg);
+                if (isService) {
+                    if ((func.flags & Flags.RESOURCE) == Flags.RESOURCE) {
+                        rewriteControlFlowInvocation(func, pkg);
+                    } else if ((func.flags & Flags.REMOTE) == Flags.REMOTE) {
+                        rewriteControlFlowInvocation(func, pkg);
+                    }
                 }
                 rewriteAsyncInvocations(func, typeDef, pkg);
                 rewriteObservableFunctionInvocations(func, pkg);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -109,9 +109,6 @@ class JvmObservabilityGen {
     private static final String FUNC_BODY_INSTRUMENTATION_TYPE = "funcBody";
     private static final Location COMPILE_TIME_CONST_POS =
             new BLangDiagnosticLocation(null, -1, -1, -1, -1);
-    private static final String INIT_FUNCTION_SUFFIX = ".<init>";
-    private static final String START_FUNCTION_SUFFIX = ".<start>";
-    private static final String STOP_FUNCTION_SUFFIX = ".<stop>";
 
     private final PackageCache packageCache;
     private final SymbolTable symbolTable;
@@ -134,19 +131,13 @@ class JvmObservabilityGen {
      * Instrument the package by rewriting the BIR to add relevant Observability related instructions.
      *
      * @param pkg The package to instrument
-     * @param entryPointExists The boolean to check if the pkg has entry points
      */
-    void instrumentPackage(BIRPackage pkg, boolean entryPointExists) {
+    void instrumentPackage(BIRPackage pkg) {
         for (int i = 0; i < pkg.functions.size(); i++) {
             BIRFunction func = pkg.functions.get(i);
 
-            // If there is an entry point in the package, then we instrument with control flow checkpoints
-            if (entryPointExists) {
-                if (!(func.name.value.equalsIgnoreCase(INIT_FUNCTION_SUFFIX) ||
-                        func.name.value.equalsIgnoreCase(START_FUNCTION_SUFFIX) ||
-                        func.name.value.equalsIgnoreCase(STOP_FUNCTION_SUFFIX))) {
-                    rewriteControlFlowInvocation(func, pkg);
-                }
+            if (ENTRY_POINT_MAIN_METHOD_NAME.equals(func.name.value)) {
+                rewriteControlFlowInvocation(func, pkg);
             }
             rewriteAsyncInvocations(func, null, pkg);
             rewriteObservableFunctionInvocations(func, pkg);
@@ -164,13 +155,10 @@ class JvmObservabilityGen {
             for (int i = 0; i < typeDef.attachedFuncs.size(); i++) {
                 BIRFunction func = typeDef.attachedFuncs.get(i);
 
-                // Instrumenting the control flow of attached functions
-                if (entryPointExists) {
-                    if (!(func.name.value.equalsIgnoreCase(INIT_FUNCTION_SUFFIX) ||
-                            func.name.value.equalsIgnoreCase(START_FUNCTION_SUFFIX) ||
-                            func.name.value.equalsIgnoreCase(STOP_FUNCTION_SUFFIX))) {
-                        rewriteControlFlowInvocation(func, pkg);
-                    }
+                if ((func.flags & Flags.RESOURCE) == Flags.RESOURCE) {
+                    rewriteControlFlowInvocation(func, pkg);
+                } else if ((func.flags & Flags.REMOTE) == Flags.REMOTE) {
+                    rewriteControlFlowInvocation(func, pkg);
                 }
                 rewriteAsyncInvocations(func, typeDef, pkg);
                 rewriteObservableFunctionInvocations(func, pkg);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -155,9 +155,8 @@ class JvmObservabilityGen {
             for (int i = 0; i < typeDef.attachedFuncs.size(); i++) {
                 BIRFunction func = typeDef.attachedFuncs.get(i);
                 if (isService) {
-                    if ((func.flags & Flags.RESOURCE) == Flags.RESOURCE) {
-                        rewriteControlFlowInvocation(func, pkg);
-                    } else if ((func.flags & Flags.REMOTE) == Flags.REMOTE) {
+                    if ((func.flags & Flags.RESOURCE) == Flags.RESOURCE ||
+                            (func.flags & Flags.REMOTE) == Flags.REMOTE) {
                         rewriteControlFlowInvocation(func, pkg);
                     }
                 }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -50,7 +50,6 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
         final String span6Position = FILE_NAME + ":38:16";
         final String entryPointFunctionModule = "intg_tests/tracing_tests:0.0.1";
         final String entryPointFunctionPosition = "01_main_function.bal:19:1";
-        // TODO : Need to fix the position offset 55:43 (col 43 is not found in the source-code)
         final List<BMockSpan.BMockSpanEvent> expectedCheckpoints = Arrays.asList(
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":20:5"),
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":22:13"),
@@ -61,8 +60,6 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":38:16"),
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":39:11"),
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":44:43"),
-                new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":53:43"),
-                new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":53:43"),
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":44:43"),
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":54:31"),
                 new BMockSpan.BMockSpanEvent(entryPointFunctionModule, FILE_NAME + ":55:5"),


### PR DESCRIPTION
## Purpose
With this PR observability control flow instrumentation have been restricted to `main method`, `resource` and `remote` functions.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
