### PR TITLE
Replace the string filename param with Document param

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -39,11 +39,11 @@ public interface SemanticModel {
     /**
      * Lookup the visible symbols at the given location.
      *
-     * @param srcFile  The source file document in which to look up the position
-     * @param position text position in the source
+     * @param sourceFile The source file document in which to look up the position
+     * @param position   text position in the source
      * @return {@link List} of visible symbols in the given location
      */
-    List<Symbol> visibleSymbols(Document srcFile, LinePosition position);
+    List<Symbol> visibleSymbols(Document sourceFile, LinePosition position);
 
     /**
      * Lookup the symbol at the given location.
@@ -87,11 +87,11 @@ public interface SemanticModel {
      * If there's an identifier associated with a symbol at the specified cursor position, finds all the references of
      * the specified symbol within the relevant scope.
      *
-     * @param fileName name of the file in which to look up the specified position
-     * @param position a cursor position in the source
+     * @param sourceFile The source file document in which to look up the position
+     * @param position   a cursor position in the source
      * @return A {@link List} of line ranges of all the references
      */
-    List<Location> references(String fileName, LinePosition position);
+    List<Location> references(Document sourceFile, LinePosition position);
 
     /**
      * Retrieves the type of the expression in the specified text range. If it's not a valid expression, returns an

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.api;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
@@ -47,11 +48,12 @@ public interface SemanticModel {
     /**
      * Lookup the symbol at the given location.
      *
-     * @param fileName path for the file in which we need to look up symbols, relative to the source root path
+     *
+     * @param sourceFile The source file document in which to look up the position
      * @param position text position in the source
      * @return {@link Symbol} in the given location
      */
-    Optional<Symbol> symbol(String fileName, LinePosition position);
+    Optional<Symbol> symbol(Document sourceFile, LinePosition position);
 
     /**
      * Looks up the symbol for the specified syntax tree node. This will only return a symbol if the provided node is a
@@ -99,7 +101,7 @@ public interface SemanticModel {
      * @param range    the text range of the expression
      * @return the type of the expression
      */
-    Optional<TypeSymbol> type(String fileName, LineRange range);
+    Optional<TypeSymbol> type(LineRange range);
 
     /**
      * Get the diagnostics within the given text Span.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -48,12 +48,11 @@ public interface SemanticModel {
     /**
      * Lookup the symbol at the given location.
      *
-     *
-     * @param sourceFile The source file document in which to look up the position
-     * @param position text position in the source
+     * @param sourceDocument The source file document in which to look up the position
+     * @param position       text position in the source
      * @return {@link Symbol} in the given location
      */
-    Optional<Symbol> symbol(Document sourceFile, LinePosition position);
+    Optional<Symbol> symbol(Document sourceDocument, LinePosition position);
 
     /**
      * Looks up the symbol for the specified syntax tree node. This will only return a symbol if the provided node is a
@@ -87,11 +86,11 @@ public interface SemanticModel {
      * If there's an identifier associated with a symbol at the specified cursor position, finds all the references of
      * the specified symbol within the relevant scope.
      *
-     * @param sourceFile The source file document in which to look up the position
+     * @param sourceDocument The source file document in which to look up the position
      * @param position   a cursor position in the source
      * @return A {@link List} of line ranges of all the references
      */
-    List<Location> references(Document sourceFile, LinePosition position);
+    List<Location> references(Document sourceDocument, LinePosition position);
 
     /**
      * Retrieves the type of the expression in the specified text range. If it's not a valid expression, returns an

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -39,11 +39,11 @@ public interface SemanticModel {
     /**
      * Lookup the visible symbols at the given location.
      *
-     * @param fileName  path for the file in which we need to look up symbols, relative to the source root path
+     * @param srcFile  The source file document in which to look up the position
      * @param position text position in the source
      * @return {@link List} of visible symbols in the given location
      */
-    List<Symbol> visibleSymbols(String fileName, LinePosition position);
+    List<Symbol> visibleSymbols(Document srcFile, LinePosition position);
 
     /**
      * Lookup the symbol at the given location.
@@ -97,7 +97,6 @@ public interface SemanticModel {
      * Retrieves the type of the expression in the specified text range. If it's not a valid expression, returns an
      * empty {@link Optional} value!.
      *
-     * @param fileName path for the file with the expression
      * @param range    the text range of the expression
      * @return the type of the expression
      */

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -124,8 +124,8 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public Optional<Symbol> symbol(Document sourceFile, LinePosition position) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceFile);
+    public Optional<Symbol> symbol(Document sourceDocument, LinePosition position) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceDocument);
         return lookupSymbol(compilationUnit, position);
     }
 
@@ -182,8 +182,8 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public List<Location> references(Document sourceFile, LinePosition position) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceFile);
+    public List<Location> references(Document sourceDocument, LinePosition position) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceDocument);
         SymbolFinder symbolFinder = new SymbolFinder();
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -88,8 +88,8 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public List<Symbol> visibleSymbols(String fileName, LinePosition linePosition) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(fileName);
+    public List<Symbol> visibleSymbols(Document srcFile, LinePosition linePosition) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(srcFile);
         BPackageSymbol moduleSymbol = getModuleSymbol(compilationUnit);
         SymbolTable symbolTable = SymbolTable.getInstance(this.compilerContext);
         SymbolEnv pkgEnv = symbolTable.pkgEnvMap.get(moduleSymbol);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.impl.symbols.TypesFactory;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
@@ -123,8 +124,8 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public Optional<Symbol> symbol(String fileName, LinePosition position) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(fileName);
+    public Optional<Symbol> symbol(Document sourceFile, LinePosition position) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceFile);
         SymbolFinder symbolFinder = new SymbolFinder();
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
 
@@ -286,6 +287,10 @@ public class BallerinaSemanticModel implements SemanticModel {
     private boolean isImportedSymbol(BSymbol symbol) {
         return symbol.origin == COMPILED_SOURCE &&
                 (Symbols.isFlagOn(symbol.flags, Flags.PUBLIC) || symbol.getKind() == SymbolKind.PACKAGE);
+    }
+
+    private BLangCompilationUnit getCompilationUnit(Document srcFile) {
+        return getCompilationUnit(srcFile.name());
     }
 
     private BLangCompilationUnit getCompilationUnit(String srcFile) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -182,8 +182,8 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
-    public List<Location> references(String fileName, LinePosition position) {
-        BLangCompilationUnit compilationUnit = getCompilationUnit(fileName);
+    public List<Location> references(Document sourceFile, LinePosition position) {
+        BLangCompilationUnit compilationUnit = getCompilationUnit(sourceFile);
         SymbolFinder symbolFinder = new SymbolFinder();
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -48,6 +48,8 @@ import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.Token;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
+import io.ballerina.compiler.syntax.tree.TypeReferenceNode;
+import io.ballerina.compiler.syntax.tree.TypeReferenceTypeDescNode;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.XMLNamespaceDeclarationNode;
@@ -236,6 +238,16 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
         }
 
         return moduleXMLNamespaceDeclarationNode.namespacePrefix().get().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(TypeReferenceTypeDescNode typeReferenceTypeDescNode) {
+        return typeReferenceTypeDescNode.typeRef().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(TypeReferenceNode typeReferenceNode) {
+        return typeReferenceNode.typeName().apply(this);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
@@ -20,6 +20,7 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.Document;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;
@@ -59,11 +60,10 @@ public class CodeActionRouter {
         Optional<NonTerminalNode> matchedNode = CodeActionUtil.getTopLevelNode(ctx.cursorPosition(), syntaxTree);
         CodeActionNodeType matchedNodeType = CodeActionUtil.codeActionNodeType(matchedNode.orElse(null));
         SemanticModel semanticModel = ctx.workspace().semanticModel(ctx.filePath()).orElseThrow();
-        String relPath = ctx.workspace().relativePath(ctx.filePath()).orElseThrow();
         if (matchedNode.isPresent() && matchedNodeType != CodeActionNodeType.NONE) {
             Range range = CommonUtil.toRange(matchedNode.get().lineRange());
             Node expressionNode = CodeActionUtil.largestExpressionNode(matchedNode.get(), range);
-            TypeSymbol matchedTypeSymbol = semanticModel.type(relPath, expressionNode.lineRange()).orElse(null);
+            TypeSymbol matchedTypeSymbol = semanticModel.type(expressionNode.lineRange()).orElse(null);
 
             PositionDetails posDetails = CodeActionPositionDetails.from(matchedNode.get(), null, matchedTypeSymbol);
             ctx.setPositionDetails(posDetails);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionRouter.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import io.ballerina.projects.Document;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.CodeActionContext;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -312,11 +312,11 @@ public class CodeActionUtil {
                                                          CodeActionContext context) {
         // Find Cursor node
         NonTerminalNode cursorNode = CommonUtil.findNode(range, syntaxTree);
-        Optional<Document> srcFile = context.workspace().document(context.filePath());
+        Document srcFile = context.workspace().document(context.filePath()).orElseThrow();
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
 
         Optional<Pair<NonTerminalNode, Symbol>> nodeAndSymbol = getMatchedNodeAndSymbol(cursorNode, range,
-                                                                                        semanticModel, srcFile.get());
+                                                                                        semanticModel, srcFile);
         Symbol matchedSymbol;
         NonTerminalNode matchedNode;
         Optional<TypeSymbol> matchedExprTypeSymbol;
@@ -399,14 +399,9 @@ public class CodeActionUtil {
 
         List<TextEdit> edits = new ArrayList<>();
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        Optional<Document> document = context.workspace().document(context.filePath());
-
-        if (document.isEmpty()) {
-            return Collections.emptyList();
-        }
-
+        Document document = context.workspace().document(context.filePath()).orElseThrow();
         Optional<Symbol> optEnclosedFuncSymbol =
-                semanticModel.symbol(document.get(), enclosedFunc.get().functionName().lineRange().startLine());
+                semanticModel.symbol(document, enclosedFunc.get().functionName().lineRange().startLine());
 
         String returnText = "";
         Range returnRange = null;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/AddCheckCodeAction.java
@@ -134,8 +134,7 @@ public class AddCheckCodeAction extends TypeGuardCodeAction {
 
     private boolean containsErrorMemberType(CodeActionContext context, ExpressionNode expressionNode) {
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        Optional<TypeSymbol> typeSymbol = semanticModel.type(expressionNode.location().lineRange().filePath(),
-                                                             expressionNode.lineRange());
+        Optional<TypeSymbol> typeSymbol = semanticModel.type(expressionNode.lineRange());
         if (typeSymbol.isEmpty() || typeSymbol.get().typeKind() != TypeDescKind.UNION) {
             return false;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/TypeGuardCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/TypeGuardCodeAction.java
@@ -157,8 +157,8 @@ public class TypeGuardCodeAction extends AbstractCodeActionProvider {
     private Optional<VariableSymbol> getVariableSymbol(CodeActionContext context, Node matchedNode) {
         AssignmentStatementNode assignmentStmtNode = (AssignmentStatementNode) matchedNode;
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        Optional<Document> srcFile = context.workspace().document(context.filePath());
-        Optional<Symbol> symbol = semanticModel.symbol(srcFile.get(),
+        Document srcFile = context.workspace().document(context.filePath()).orElseThrow();
+        Optional<Symbol> symbol = semanticModel.symbol(srcFile,
                                                        assignmentStmtNode.varRef().lineRange().startLine());
         if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.VARIABLE) {
             return Optional.empty();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/TypeGuardCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/TypeGuardCodeAction.java
@@ -34,6 +34,7 @@ import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.TypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.Document;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.ballerinalang.annotation.JavaSPIService;
@@ -156,8 +157,9 @@ public class TypeGuardCodeAction extends AbstractCodeActionProvider {
     private Optional<VariableSymbol> getVariableSymbol(CodeActionContext context, Node matchedNode) {
         AssignmentStatementNode assignmentStmtNode = (AssignmentStatementNode) matchedNode;
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        String relPath = context.workspace().relativePath(context.filePath()).orElseThrow();
-        Optional<Symbol> symbol = semanticModel.symbol(relPath, assignmentStmtNode.varRef().lineRange().startLine());
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
+        Optional<Symbol> symbol = semanticModel.symbol(srcFile.get(),
+                                                       assignmentStmtNode.varRef().lineRange().startLine());
         if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.VARIABLE) {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
@@ -78,8 +78,8 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
 
         // Get parameter symbol
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        Optional<Document> srcFile = context.workspace().document(context.filePath());
-        Optional<Symbol> optParamSymbol = semanticModel.symbol(srcFile.get(),
+        Document srcFile = context.workspace().document(context.filePath()).orElseThrow();
+        Optional<Symbol> optParamSymbol = semanticModel.symbol(srcFile,
                                                                initializer.get().lineRange().startLine());
         if (optParamSymbol.isEmpty() || optParamSymbol.get().kind() != SymbolKind.VARIABLE) {
             return Collections.emptyList();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
@@ -77,8 +78,9 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
 
         // Get parameter symbol
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        String relPath = context.workspace().relativePath(context.filePath()).orElseThrow();
-        Optional<Symbol> optParamSymbol = semanticModel.symbol(relPath, initializer.get().lineRange().startLine());
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
+        Optional<Symbol> optParamSymbol = semanticModel.symbol(srcFile.get(),
+                                                               initializer.get().lineRange().startLine());
         if (optParamSymbol.isEmpty() || optParamSymbol.get().kind() != SymbolKind.VARIABLE) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
@@ -116,8 +116,8 @@ public class TypeCastCodeAction extends AbstractCodeActionProvider {
     protected Optional<VariableSymbol> getVariableSymbol(CodeActionContext context, Node matchedNode) {
         AssignmentStatementNode assignmentStmtNode = (AssignmentStatementNode) matchedNode;
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        Optional<Document> srcFile = context.workspace().document(context.filePath());
-        Optional<Symbol> symbol = semanticModel.symbol(srcFile.get(),
+        Document srcFile = context.workspace().document(context.filePath()).orElseThrow();
+        Optional<Symbol> symbol = semanticModel.symbol(srcFile,
                                                        assignmentStmtNode.varRef().lineRange().startLine());
         if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.VARIABLE) {
             return Optional.empty();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/TypeCastCodeAction.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
@@ -115,8 +116,9 @@ public class TypeCastCodeAction extends AbstractCodeActionProvider {
     protected Optional<VariableSymbol> getVariableSymbol(CodeActionContext context, Node matchedNode) {
         AssignmentStatementNode assignmentStmtNode = (AssignmentStatementNode) matchedNode;
         SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
-        String relPath = context.workspace().relativePath(context.filePath()).orElseThrow();
-        Optional<Symbol> symbol = semanticModel.symbol(relPath, assignmentStmtNode.varRef().lineRange().startLine());
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
+        Optional<Symbol> symbol = semanticModel.symbol(srcFile.get(),
+                                                       assignmentStmtNode.varRef().lineRange().startLine());
         if (symbol.isEmpty() || symbol.get().kind() != SymbolKind.VARIABLE) {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocumentationGenerator.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocumentationGenerator.java
@@ -117,31 +117,19 @@ public class DocumentationGenerator {
         return Optional.empty();
     }
 
-    public static Optional<Symbol> getDocumentableSymbol(NonTerminalNode node, SemanticModel semanticModel,
-                                                         String fileName) {
+    public static Optional<Symbol> getDocumentableSymbol(NonTerminalNode node, SemanticModel semanticModel) {
         switch (node.kind()) {
             case FUNCTION_DEFINITION:
-            case OBJECT_METHOD_DEFINITION: {
-                FunctionDefinitionNode functionDefNode = (FunctionDefinitionNode) node;
-                return semanticModel.symbol(fileName, functionDefNode.functionName().lineRange().startLine());
-            }
-            case METHOD_DECLARATION: {
-                MethodDeclarationNode methodDeclrNode = (MethodDeclarationNode) node;
-                return semanticModel.symbol(fileName, methodDeclrNode.methodName().lineRange().startLine());
-            }
+            case OBJECT_METHOD_DEFINITION:
+            case METHOD_DECLARATION:
 //            case SERVICE_DECLARATION: {
 //                ServiceDeclarationNode serviceDeclrNode = (ServiceDeclarationNode) node;
 //                return semanticModel.symbol(fileName, serviceDeclrNode.typeDescriptor().map(s->s.lineRange()
 //                .startLine()).);
 //            }
-            case TYPE_DEFINITION: {
-                TypeDefinitionNode typeDefNode = (TypeDefinitionNode) node;
-                return semanticModel.symbol(fileName, typeDefNode.typeName().lineRange().startLine());
-            }
-            case CLASS_DEFINITION: {
-                ClassDefinitionNode classDefNode = (ClassDefinitionNode) node;
-                return semanticModel.symbol(fileName, classDefNode.className().lineRange().startLine());
-            }
+            case TYPE_DEFINITION:
+            case CLASS_DEFINITION:
+                return semanticModel.symbol(node);
             default:
                 break;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/CreateFunctionExecutor.java
@@ -104,8 +104,7 @@ public class CreateFunctionExecutor implements LSCommandExecutor {
             return new LSCommandExecutorException("Couldn't find a matching node");
         }
         SemanticModel semanticModel = context.workspace().semanticModel(filePath.get()).orElseThrow();
-        String relPath = context.workspace().relativePath(filePath.get()).orElseThrow();
-        TypeSymbol matchedTypeSymbol = semanticModel.type(relPath, identifier.lineRange()).orElse(null);
+        TypeSymbol matchedTypeSymbol = semanticModel.type(identifier.lineRange()).orElse(null);
         if (matchedTypeSymbol == null) {
             return Collections.emptyList();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/UpdateDocumentationExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/UpdateDocumentationExecutor.java
@@ -89,8 +89,7 @@ public class UpdateDocumentationExecutor implements LSCommandExecutor {
             node = ((ModulePartNode) node).members().get(0);
         }
         SemanticModel semanticModel = ctx.workspace().semanticModel(filePath.get()).orElseThrow();
-        Optional<Symbol> documentableSymbol = getDocumentableSymbol(node, semanticModel,
-                                                                    filePath.get().toFile().getName());
+        Optional<Symbol> documentableSymbol = getDocumentableSymbol(node, semanticModel);
 
         Optional<DocAttachmentInfo> docAttachmentInfo = getDocumentationEditForNode(node);
         if (docAttachmentInfo.isPresent() && documentableSymbol.isPresent()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/contexts/AbstractDocumentServiceContext.java
@@ -105,13 +105,15 @@ public class AbstractDocumentServiceContext implements DocumentServiceContext {
     public List<Symbol> visibleSymbols(Position position) {
         if (this.visibleSymbols == null) {
             Optional<SemanticModel> semanticModel = this.workspaceManager.semanticModel(this.filePath);
-            Optional<String> relativePath = this.workspaceManager.relativePath(filePath);
-            if (semanticModel.isEmpty() || relativePath.isEmpty()) {
+            Optional<Document> srcFile = this.workspaceManager.document(filePath);
+
+            if (semanticModel.isEmpty() || srcFile.isEmpty()) {
                 return Collections.emptyList();
             }
-            // TODO: file uri here should be the relative file URI
-            visibleSymbols = semanticModel.get().visibleSymbols(relativePath.get(),
-                    LinePosition.from(position.getLine(), position.getCharacter()));
+
+            visibleSymbols = semanticModel.get().visibleSymbols(srcFile.get(),
+                                                                LinePosition.from(position.getLine(),
+                                                                                  position.getCharacter()));
         }
 
         return visibleSymbols;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
@@ -202,28 +202,24 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
     private void populateConnectorFunctionParamRecords(Node parameterNode, SemanticModel semanticModel,
                                                        Map<String, TypeDefinitionNode> jsonRecords,
                                                        Map<String, JsonElement> connectorRecords) {
-        Optional<TypeSymbol> paramType = semanticModel
-                .type(parameterNode.syntaxTree().filePath(), parameterNode.lineRange());
+        Optional<TypeSymbol> paramType = semanticModel.type(parameterNode.lineRange());
         if (paramType.isPresent()) {
             if (paramType.get().typeKind() == TypeDescKind.UNION) {
                 String parameterTypeName = "";
                 if (parameterNode instanceof RequiredParameterNode) {
-                    Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode.syntaxTree().filePath(),
-                            ((RequiredParameterNode) parameterNode).paramName().get().lineRange().startLine());
+                    Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode);
                     if (paramSymbol.isPresent()) {
                         parameterTypeName = String.format("%s:%s", paramSymbol.get().moduleID(),
                                 ((RequiredParameterNode) parameterNode).typeName());
                     }
                 } else if (parameterNode instanceof DefaultableParameterNode) {
-                    Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode.syntaxTree().filePath(),
-                            ((DefaultableParameterNode) parameterNode).paramName().get().lineRange().startLine());
+                    Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode);
                     if (paramSymbol.isPresent()) {
                         parameterTypeName = String.format("%s:%s", paramSymbol.get().moduleID(),
                                 ((DefaultableParameterNode) parameterNode).typeName());
                     }
                 } else if (parameterNode instanceof RestParameterNode) {
-                    Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode.syntaxTree().filePath(),
-                            ((RestParameterNode) parameterNode).paramName().get().lineRange().startLine());
+                    Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode);
                     if (paramSymbol.isPresent()) {
                         parameterTypeName = String.format("%s:%s", paramSymbol.get().moduleID(),
                                 ((RestParameterNode) parameterNode).typeName());
@@ -282,10 +278,9 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
 
             Optional<Symbol> fieldType;
             if (field instanceof TypeReferenceNode) {
-                fieldType = semanticModel.symbol(field.syntaxTree().filePath(),
-                        ((TypeReferenceNode) field).typeName().lineRange().startLine());
+                fieldType = semanticModel.symbol(((TypeReferenceNode) field).typeName());
             } else {
-                fieldType = semanticModel.symbol(field.syntaxTree().filePath(), field.lineRange().startLine());
+                fieldType = semanticModel.symbol(field);
             }
 
             if (fieldType.isPresent() && fieldType.get() instanceof TypeReferenceTypeSymbol) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
@@ -75,13 +75,15 @@ public class ConnectorNodeVisitor extends NodeVisitor {
     public void visit(ClassDefinitionNode classDefinitionNode) {
         Optional<Symbol> symbol = this.semanticModel.symbol(classDefinitionNode);
 
-        if (symbol.isPresent()) {
-            ClassSymbol classSymbol = (ClassSymbol) symbol.get();
-            boolean isClient = classSymbol.qualifiers().contains(Qualifier.CLIENT);
+        if (symbol.isEmpty()) {
+            return;
+        }
 
-            if (isClient) {
-                this.connectors.add(classDefinitionNode);
-            }
+        ClassSymbol classSymbol = (ClassSymbol) symbol.get();
+        boolean isClient = classSymbol.qualifiers().contains(Qualifier.CLIENT);
+
+        if (isClient) {
+            this.connectors.add(classDefinitionNode);
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
@@ -18,7 +18,7 @@
 package org.ballerinalang.langserver.extensions.ballerina.connector;
 
 import io.ballerina.compiler.api.SemanticModel;
-import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
@@ -73,28 +73,20 @@ public class ConnectorNodeVisitor extends NodeVisitor {
     }
 
     public void visit(ClassDefinitionNode classDefinitionNode) {
-        String fileName = classDefinitionNode.syntaxTree().filePath();
-        Optional<TypeSymbol> typeSymbol = this.semanticModel.type(fileName,
-                classDefinitionNode.className().lineRange());
+        Optional<Symbol> symbol = this.semanticModel.symbol(classDefinitionNode);
 
-        if (typeSymbol.isPresent()) {
-            TypeSymbol rawType = getRawType(typeSymbol.get());
-            if (rawType.typeKind() == TypeDescKind.OBJECT) {
-                ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) rawType;
+        if (symbol.isPresent()) {
+            ClassSymbol classSymbol = (ClassSymbol) symbol.get();
+            boolean isClient = classSymbol.qualifiers().contains(Qualifier.CLIENT);
 
-                boolean isClient = objectTypeSymbol.qualifiers().contains(Qualifier.CLIENT);
-                if (isClient) {
-                    this.connectors.add(classDefinitionNode);
-                }
-
+            if (isClient) {
+                this.connectors.add(classDefinitionNode);
             }
         }
     }
 
     public void visit(TypeDefinitionNode typeDefinitionNode) {
-        String fileName = typeDefinitionNode.syntaxTree().filePath();
-        Optional<Symbol> typeSymbol = this.semanticModel.symbol(fileName,
-                typeDefinitionNode.typeName().lineRange().startLine());
+        Optional<Symbol> typeSymbol = this.semanticModel.symbol(typeDefinitionNode);
 
         if (typeSymbol.isPresent() && typeSymbol.get() instanceof TypeDefinitionSymbol) {
             TypeSymbol rawType = getRawType(((TypeDefinitionSymbol) typeSymbol.get()).typeDescriptor());

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -17,7 +17,7 @@ package org.ballerinalang.langserver.extensions.ballerina.document;
 
 import com.google.gson.JsonElement;
 import io.ballerina.compiler.api.SemanticModel;
-import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.Document;
 import org.ballerinalang.diagramutil.DiagramUtil;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -53,9 +53,8 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
         }
 
         try {
-            // Get the syntax tree for the document.
-            Optional<SyntaxTree> syntaxTree = this.workspaceManager.syntaxTree(filePath.get());
-            if (syntaxTree.isEmpty()) {
+            Optional<Document> srcFile = this.workspaceManager.document(filePath.get());
+            if (srcFile.isEmpty()) {
                 return CompletableFuture.supplyAsync(() -> reply);
             }
 
@@ -63,11 +62,10 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
             Optional<SemanticModel> semanticModel = this.workspaceManager.semanticModel(filePath.get());
 
             // Get the generated syntax tree JSON with type info.
-            JsonElement jsonSyntaxTree = DiagramUtil
-                    .getSyntaxTreeJSON(syntaxTree.get(), semanticModel.get());
+            JsonElement jsonSyntaxTree = DiagramUtil.getSyntaxTreeJSON(srcFile.get(), semanticModel.get());
 
             // Preparing the response.
-            reply.setSource(syntaxTree.get().toSourceCode());
+            reply.setSource(srcFile.get().syntaxTree().toSourceCode());
             reply.setSyntaxTree(jsonSyntaxTree);
             reply.setParseSuccess(reply.getSyntaxTree() != null);
         } catch (Throwable e) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
@@ -199,11 +199,12 @@ public class BallerinaTreeModifyUtil {
         }
 
         Optional<SemanticModel> semanticModel = workspaceManager.semanticModel(compilationPath);
-        if (semanticModel.isEmpty()) {
+        Optional<Document> srcFile = workspaceManager.document(compilationPath);
+        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
             throw new JSONGenerationException("Modification error");
         }
-        UnusedSymbolsVisitor unusedSymbolsVisitor = new UnusedSymbolsVisitor(oldSyntaxTree.get().filePath(),
-                semanticModel.get(), deleteRange);
+        UnusedSymbolsVisitor unusedSymbolsVisitor =
+                new UnusedSymbolsVisitor(srcFile.get(), semanticModel.get(), deleteRange);
         unusedSymbolsVisitor.visit((ModulePartNode) oldSyntaxTree.get().rootNode());
 
         TextDocument oldTextDocument = oldSyntaxTree.get().textDocument();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTreeModifyUtil.java
@@ -243,17 +243,17 @@ public class BallerinaTreeModifyUtil {
         newSyntaxTree = Formatter.format(newSyntaxTree);
 
         SemanticModel newSemanticModel = updateWorkspaceDocument(compilationPath, newSyntaxTree.toSourceCode(),
-                workspaceManager);
+                                                                 workspaceManager);
 
-        Optional<SyntaxTree> formattedSyntaxTree = workspaceManager.syntaxTree(compilationPath);
-        if (formattedSyntaxTree.isEmpty()) {
+        Optional<Document> formattedSrcFile = workspaceManager.document(compilationPath);
+        if (formattedSrcFile.isEmpty()) {
             throw new JSONGenerationException("Modification error");
         }
 
-        JsonElement syntaxTreeJson = DiagramUtil.getSyntaxTreeJSON(formattedSyntaxTree.get(), newSemanticModel);
+        JsonElement syntaxTreeJson = DiagramUtil.getSyntaxTreeJSON(formattedSrcFile.get(), newSemanticModel);
         JsonObject jsonTreeWithSource = new JsonObject();
         jsonTreeWithSource.add("tree", syntaxTreeJson);
-        jsonTreeWithSource.addProperty("source", formattedSyntaxTree.get().toSourceCode());
+        jsonTreeWithSource.addProperty("source", formattedSrcFile.get().syntaxTree().toSourceCode());
 
         return jsonTreeWithSource;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
@@ -78,8 +78,6 @@ public class BallerinaTriggerModifyUtil {
             oldSyntaxTree.get();
         }
 
-        String fileName = compilationPath.toFile().getName();
-
         TextDocument oldTextDocument = oldSyntaxTree.get().textDocument();
 
         List<TextEdit> edits =
@@ -92,11 +90,12 @@ public class BallerinaTriggerModifyUtil {
         TextDocument newTextDoc = oldTextDocument.apply(textDocumentChange);
         SyntaxTree updatedSyntaxTree = SyntaxTree.from(newTextDoc);
         SemanticModel updatedSemanticModel = updateWorkspaceDocument(compilationPath, updatedSyntaxTree.toSourceCode(),
-                workspaceManager);
+                                                                     workspaceManager);
+        Document srcFile = workspaceManager.document(compilationPath).orElseThrow();
 
         //remove unused imports
-        UnusedSymbolsVisitor unusedSymbolsVisitor = new UnusedSymbolsVisitor(fileName, updatedSemanticModel,
-                new HashMap<>());
+        UnusedSymbolsVisitor unusedSymbolsVisitor = new UnusedSymbolsVisitor(srcFile, updatedSemanticModel,
+                                                                             new HashMap<>());
         unusedSymbolsVisitor.visit((ModulePartNode) updatedSyntaxTree.rootNode());
 
         if (!unusedSymbolsVisitor.getUnusedImports().isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaTriggerModifyUtil.java
@@ -113,16 +113,16 @@ public class BallerinaTriggerModifyUtil {
         String formattedSource = Formatter.format(syntaxTree).toSourceCode();
 
         SemanticModel newSemanticModel = updateWorkspaceDocument(compilationPath, formattedSource,
-                workspaceManager);
-        Optional<SyntaxTree> formattedSyntaxTree = workspaceManager.syntaxTree(compilationPath);
-        if (formattedSyntaxTree.isEmpty()) {
+                                                                 workspaceManager);
+        Optional<Document> formattedSrcFile = workspaceManager.document(compilationPath);
+        if (formattedSrcFile.isEmpty()) {
             throw new JSONGenerationException("Modification error");
         }
 
-        JsonElement syntaxTreeJson = DiagramUtil.getSyntaxTreeJSON(formattedSyntaxTree.get(), newSemanticModel);
+        JsonElement syntaxTreeJson = DiagramUtil.getSyntaxTreeJSON(formattedSrcFile.get(), newSemanticModel);
         JsonObject jsonTreeWithSource = new JsonObject();
         jsonTreeWithSource.add("tree", syntaxTreeJson);
-        jsonTreeWithSource.addProperty("source", formattedSyntaxTree.get().toSourceCode());
+        jsonTreeWithSource.addProperty("source", formattedSrcFile.get().syntaxTree().toSourceCode());
         return jsonTreeWithSource;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/visitor/UnusedSymbolsVisitor.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.SeparatedNodeList;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.langserver.extensions.ballerina.document.ASTModification;
@@ -46,14 +47,14 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     private Map<LineRange, ASTModification> deleteRanges;
     private Map<LineRange, ASTModification> toBeDeletedRanges = new HashMap<>();
     private SemanticModel semanticModel;
-    private String fileName;
+    private Document srcFile;
 
-    public UnusedSymbolsVisitor(String fileName, SemanticModel semanticModel, Map<LineRange,
-            ASTModification> deleteRanges) {
+    public UnusedSymbolsVisitor(Document srcFile, SemanticModel semanticModel,
+                                Map<LineRange, ASTModification> deleteRanges) {
         this.semanticModel = semanticModel;
         this.deleteRanges = deleteRanges;
         this.toBeDeletedRanges.putAll(deleteRanges);
-        this.fileName = fileName;
+        this.srcFile = srcFile;
     }
 
     private void addUnusedImportNode(ImportDeclarationNode importDeclarationNode) {
@@ -104,7 +105,7 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     }
 
     private void moveUnusedtoUsedImport(LineRange lineRange, ImportDeclarationNode importDeclarationNode) {
-        List<Location> locations = this.semanticModel.references(fileName, lineRange.startLine());
+        List<Location> locations = this.semanticModel.references(srcFile, lineRange.startLine());
         boolean availableOutSideDeleteRange = false;
         for (Location location : locations) {
             if (isWithinLineRange(importDeclarationNode.lineRange(), location.lineRange())) {
@@ -127,7 +128,7 @@ public class UnusedSymbolsVisitor extends NodeVisitor {
     private void decideVariablesToBeDeleted(LineRange lineRange) {
         LineRange deleteRange = getDeleteRange(lineRange);
         if (deleteRange != null) {
-            List<Location> locations = this.semanticModel.references(fileName, lineRange.startLine());
+            List<Location> locations = this.semanticModel.references(srcFile, lineRange.startLine());
             for (Location location : locations) {
                 if (isWithinLineRange(deleteRange, location.lineRange())) {
                     continue;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -29,6 +29,7 @@ import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.langserver.common.constants.ContextConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -56,15 +57,15 @@ public class HoverUtil {
      * @return {@link Hover} Hover content
      */
     public static Hover getHover(HoverContext context) {
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
         Optional<SemanticModel> semanticModel = context.workspace().semanticModel(context.filePath());
-        if (semanticModel.isEmpty()) {
+        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
             return HoverUtil.getDefaultHoverObject();
         }
 
         Position cursorPosition = context.getCursorPosition();
         LinePosition linePosition = LinePosition.from(cursorPosition.getLine(), cursorPosition.getCharacter());
-        String relPath = context.workspace().relativePath(context.filePath()).orElseThrow();
-        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(relPath, linePosition);
+        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(), linePosition);
         if (symbolAtCursor.isEmpty()) {
             return HoverUtil.getDefaultHoverObject();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -87,7 +87,7 @@ public class HoverUtil {
             case TYPE:
                 if (((TypeSymbol) symbolAtCursor.get()).typeKind() == TypeDescKind.TYPE_REFERENCE) {
                     return getTypeRefHoverMarkupContent((TypeReferenceTypeSymbol) symbolAtCursor.get(),
-                                                        semanticModel.get(), relPath);
+                                                        semanticModel.get(), srcFile.get());
                 }
                 return getDefaultHoverObject();
             default:
@@ -204,8 +204,8 @@ public class HoverUtil {
     }
 
     private static Hover getTypeRefHoverMarkupContent(TypeReferenceTypeSymbol typeSymbol, SemanticModel model,
-                                                      String fileName) {
-        Optional<Symbol> associatedDef = model.symbol(fileName, typeSymbol.location().lineRange().startLine());
+                                                      Document srcFile) {
+        Optional<Symbol> associatedDef = model.symbol(srcFile, typeSymbol.location().lineRange().startLine());
 
         if (associatedDef.isEmpty()) {
             return getDefaultHoverObject();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/DefinitionUtil.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.util.definition;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
 import io.ballerina.tools.text.LinePosition;
@@ -45,14 +46,15 @@ public class DefinitionUtil {
      * @return {@link List} List of definition locations
      */
     public static List<Location> getDefinition(DocumentServiceContext context, Position position) {
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
         Optional<SemanticModel> semanticModel = context.workspace().semanticModel(context.filePath());
 
-        if (semanticModel.isEmpty()) {
+        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
             return Collections.emptyList();
         }
-        String relPath = context.workspace().relativePath(context.filePath()).orElseThrow();
+
         LinePosition linePosition = LinePosition.from(position.getLine(), position.getCharacter());
-        Optional<Symbol> symbol = semanticModel.get().symbol(relPath, linePosition);
+        Optional<Symbol> symbol = semanticModel.get().symbol(srcFile.get(), linePosition);
 
         if (symbol.isEmpty()) {
             return Collections.emptyList();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.util.references;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.Document;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
@@ -40,18 +41,19 @@ public class ReferencesUtil {
     }
 
     public static List<Location> getReferences(PositionedOperationContext context) {
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
         Optional<SemanticModel> semanticModel = context.workspace().semanticModel(context.filePath());
         List<Location> locations = new ArrayList<>();
 
-        if (semanticModel.isEmpty()) {
+        if (semanticModel.isEmpty() || srcFile.isEmpty()) {
             return locations;
         }
 
-        String relPath = context.workspace().relativePath(context.filePath()).orElseThrow();
         Position position = context.getCursorPosition();
         Optional<Project> project = context.workspace().project(context.filePath());
-        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(relPath, LinePosition.from(position.getLine(),
-                position.getCharacter()));
+        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
+                                                                     LinePosition.from(position.getLine(),
+                                                                                       position.getCharacter()));
 
         if (project.isEmpty() || symbolAtCursor.isEmpty()) {
             return locations;

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -161,7 +161,7 @@ class AIDataMapperCodeActionUtil {
         Optional<Document> srcFile = context.workspace().document(context.filePath());
 
         if (srcFile.isEmpty()) {
-            return ""; // TODO: Check with Isuru whether this is ok
+            return "";
         }
 
         SemanticModel model = context.workspace().semanticModel(context.filePath()).get();

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -106,7 +106,6 @@ class AIDataMapperCodeActionUtil {
         // Insert function call in the code where error is found
         Range newTextRange = CommonUtil.toRange(diagnostic.location().lineRange());
 
-        String filePath = context.filePath().getFileName().toString();
         Optional<Document> srcFile = context.workspace().document(context.filePath());
 
         if (srcFile.isEmpty()) {

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.TextDocument;
@@ -49,6 +50,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 
 /**
@@ -105,9 +107,15 @@ class AIDataMapperCodeActionUtil {
         Range newTextRange = CommonUtil.toRange(diagnostic.location().lineRange());
 
         String filePath = context.filePath().getFileName().toString();
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
+
+        if (srcFile.isEmpty()) {
+            return fEdits;
+        }
+
         LinePosition linePosition = LinePosition.from(context.cursorPosition().getLine(), context.cursorPosition().
                 getCharacter());
-        String symbolAtCursor = semanticModel.symbol(filePath, linePosition).get().name();
+        String symbolAtCursor = semanticModel.symbol(srcFile.get(), linePosition).get().name();
 
         String generatedFunctionName =
                 String.format("map%sTo%s(%s)", foundTypeRight, foundTypeLeft, symbolAtCursor);
@@ -151,10 +159,17 @@ class AIDataMapperCodeActionUtil {
 
 
         // Schema 1
-        List<FieldSymbol> rightSchemaFields = SymbolUtil.getTypeDescForRecordSymbol(context.workspace().
-                semanticModel(context.filePath()).get().symbol(context.filePath().getFileName().toString(),
-                LinePosition.from(context.cursorPosition().getLine(), context.cursorPosition().getCharacter())).
-                get()).fieldDescriptors();
+        Optional<Document> srcFile = context.workspace().document(context.filePath());
+
+        if (srcFile.isEmpty()) {
+            return ""; // TODO: Check with Isuru whether this is ok
+        }
+
+        SemanticModel model = context.workspace().semanticModel(context.filePath()).get();
+        LinePosition cursorPos = LinePosition.from(context.cursorPosition().getLine(),
+                                                   context.cursorPosition().getCharacter());
+        List<FieldSymbol> rightSchemaFields =
+                SymbolUtil.getTypeDescForRecordSymbol(model.symbol(srcFile.get(), cursorPos).get()).fieldDescriptors();
         JsonObject rightSchema = (JsonObject) recordToJSON(rightSchemaFields);
 
         rightRecordJSON.addProperty(SCHEMA, foundTypeRight);

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -159,11 +159,6 @@ class AIDataMapperCodeActionUtil {
 
         // Schema 1
         Optional<Document> srcFile = context.workspace().document(context.filePath());
-
-        if (srcFile.isEmpty()) {
-            return "";
-        }
-
         SemanticModel model = context.workspace().semanticModel(context.filePath()).get();
         LinePosition cursorPos = LinePosition.from(context.cursorPosition().getLine(),
                                                    context.cursorPosition().getCharacter());

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
@@ -89,7 +89,7 @@ public class LangLibUtils {
         SemanticModel semanticContext = context.getDebugCompiler().getSemanticInfo();
         LinePosition position = LinePosition.from(context.getLineNumber(), 0);
 
-        return semanticContext.visibleSymbols(context.getFileNameWithExt().get(), position)
+        return semanticContext.visibleSymbols(context.getDocument(), position)
                 .stream()
                 .filter(symbol -> symbol.kind() == MODULE
                         && symbol.moduleID().orgName().equals(LANG_LIB_ORG)

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/DiagramUtil.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/DiagramUtil.java
@@ -58,7 +58,7 @@ public class DiagramUtil {
         JsonElement syntaxTreeJson;
         try {
             SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(
-                    classDefinitionNode.syntaxTree().filePath(), semanticModel, );
+                    classDefinitionNode.syntaxTree().filePath(), semanticModel);
             syntaxTreeJson = mapGenerator.transform(classDefinitionNode);
         } catch (NullPointerException e) {
             syntaxTreeJson = new JsonObject();
@@ -71,8 +71,8 @@ public class DiagramUtil {
                                                           SemanticModel semanticModel) {
         JsonElement syntaxTreeJson;
         try {
-            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(
-                    typeDefinitionNode.syntaxTree().filePath(), semanticModel, );
+            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(typeDefinitionNode.syntaxTree().filePath(),
+                                                                             semanticModel);
             syntaxTreeJson = mapGenerator.transform(typeDefinitionNode);
         } catch (NullPointerException e) {
             syntaxTreeJson = new JsonObject();

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/DiagramUtil.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/DiagramUtil.java
@@ -24,9 +24,7 @@ import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import io.ballerina.projects.Document;
 
 /**
  * This is the DiagramUtil class for Diagram related Utils which include the JSON conversion of the Syntax Tree.
@@ -36,17 +34,16 @@ public class DiagramUtil {
     /**
      * Get the Modified JSON ST with type info.
      *
-     * @param syntaxTree    SyntaxTree to be modified and in need to convert to JSON.
+     * @param srcFile       The source file associated with the syntax tree
      * @param semanticModel Semantic model for the syntax tree.
      * @return {@link JsonObject}   ST as a Json Object
      */
-    public static JsonElement getSyntaxTreeJSON(SyntaxTree syntaxTree, SemanticModel semanticModel) {
+    public static JsonElement getSyntaxTreeJSON(Document srcFile, SemanticModel semanticModel) {
         JsonElement syntaxTreeJson;
         try {
             // Map each type data by looking at the line ranges and prepare the SyntaxTree JSON.
-            Path filePath = Paths.get(syntaxTree.filePath());
-            String fileName = filePath.getFileName() != null ? filePath.getFileName().toString() : "";
-            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(fileName, semanticModel);
+            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(srcFile, semanticModel);
+            SyntaxTree syntaxTree = srcFile.syntaxTree();
             ModulePartNode modulePartNode = syntaxTree.rootNode();
             syntaxTreeJson = mapGenerator.transform(modulePartNode);
         } catch (NullPointerException e) {
@@ -61,7 +58,7 @@ public class DiagramUtil {
         JsonElement syntaxTreeJson;
         try {
             SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(
-                    classDefinitionNode.syntaxTree().filePath(), semanticModel);
+                    classDefinitionNode.syntaxTree().filePath(), semanticModel, );
             syntaxTreeJson = mapGenerator.transform(classDefinitionNode);
         } catch (NullPointerException e) {
             syntaxTreeJson = new JsonObject();
@@ -75,7 +72,7 @@ public class DiagramUtil {
         JsonElement syntaxTreeJson;
         try {
             SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(
-                    typeDefinitionNode.syntaxTree().filePath(), semanticModel);
+                    typeDefinitionNode.syntaxTree().filePath(), semanticModel, );
             syntaxTreeJson = mapGenerator.transform(typeDefinitionNode);
         } catch (NullPointerException e) {
             syntaxTreeJson = new JsonObject();

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/DiagramUtil.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/DiagramUtil.java
@@ -42,7 +42,7 @@ public class DiagramUtil {
         JsonElement syntaxTreeJson;
         try {
             // Map each type data by looking at the line ranges and prepare the SyntaxTree JSON.
-            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(srcFile, semanticModel);
+            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(semanticModel);
             SyntaxTree syntaxTree = srcFile.syntaxTree();
             ModulePartNode modulePartNode = syntaxTree.rootNode();
             syntaxTreeJson = mapGenerator.transform(modulePartNode);
@@ -57,8 +57,7 @@ public class DiagramUtil {
                                                            SemanticModel semanticModel) {
         JsonElement syntaxTreeJson;
         try {
-            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(
-                    classDefinitionNode.syntaxTree().filePath(), semanticModel);
+            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(semanticModel);
             syntaxTreeJson = mapGenerator.transform(classDefinitionNode);
         } catch (NullPointerException e) {
             syntaxTreeJson = new JsonObject();
@@ -71,8 +70,7 @@ public class DiagramUtil {
                                                           SemanticModel semanticModel) {
         JsonElement syntaxTreeJson;
         try {
-            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(typeDefinitionNode.syntaxTree().filePath(),
-                                                                             semanticModel);
+            SyntaxTreeMapGenerator mapGenerator = new SyntaxTreeMapGenerator(semanticModel);
             syntaxTreeJson = mapGenerator.transform(typeDefinitionNode);
         } catch (NullPointerException e) {
             syntaxTreeJson = new JsonObject();

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -68,7 +68,7 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
     private Document srcFile;
     private List<JsonObject> visibleEpsForEachBlock;
 
-    public SyntaxTreeMapGenerator(String fileName, SemanticModel semanticModel, Document srcFile) {
+    public SyntaxTreeMapGenerator(String fileName, SemanticModel semanticModel) {
         this.semanticModel = semanticModel;
         this.fileName = fileName;
         this.visibleEpsForEachBlock = new ArrayList<>();

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -495,7 +495,7 @@ public class BallerinaDocGenerator {
             // Loop through bal files
             for (Map.Entry<String, SyntaxTree> syntaxTreeMapEntry : moduleDoc.getValue().syntaxTreeMap.entrySet()) {
                 boolean hasPublicConstructsTemp = Generator.setModuleFromSyntaxTree(module,
-                        syntaxTreeMapEntry.getValue(), model, syntaxTreeMapEntry.getKey());
+                        syntaxTreeMapEntry.getValue(), model);
                 if (hasPublicConstructsTemp) {
                     hasPublicConstructs = true;
                 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -126,9 +126,7 @@ public class Type {
             type.category = "reference";
             Optional<Symbol> symbol = null;
             try {
-                symbol = semanticModel.symbol(fileName,
-                        LinePosition.from(node.lineRange().startLine().line(),
-                                node.lineRange().startLine().offset()));
+                symbol = semanticModel.symbol(node);
             } catch (NullPointerException nullException) {
                 if (BallerinaDocUtils.isDebugEnabled()) {
                     log.error("Symbol find threw null pointer in " + fileName + " : Line range:" + node.lineRange());
@@ -144,10 +142,7 @@ public class Type {
             type.name = qualifiedNameReferenceNode.identifier().text();
             Optional<Symbol> symbol = null;
             try {
-                    symbol = semanticModel.symbol(fileName,
-                            LinePosition.from(qualifiedNameReferenceNode.identifier().lineRange().startLine().line(),
-                                    qualifiedNameReferenceNode.identifier().lineRange().startLine().offset()));
-
+                symbol = semanticModel.symbol(node);
             } catch (NullPointerException nullException) {
                 System.out.print(Arrays.toString(nullException.getStackTrace()));
             }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -117,7 +117,7 @@ public class Type {
     private Type() {
     }
 
-    public static Type fromNode(Node node, SemanticModel semanticModel, String fileName) {
+    public static Type fromNode(Node node, SemanticModel semanticModel) {
         Type type = new Type();
         if (node instanceof SimpleNameReferenceNode) {
             SimpleNameReferenceNode simpleNameReferenceNode = (SimpleNameReferenceNode) node;
@@ -128,7 +128,7 @@ public class Type {
                 symbol = semanticModel.symbol(node);
             } catch (NullPointerException nullException) {
                 if (BallerinaDocUtils.isDebugEnabled()) {
-                    log.error("Symbol find threw null pointer in " + fileName + " : Line range:" + node.lineRange());
+                    log.error("Symbol find threw null pointer in : Line range:" + node.lineRange());
                 }
             }
             if (symbol != null && symbol.isPresent()) {
@@ -163,25 +163,25 @@ public class Type {
             ArrayTypeDescriptorNode arrayTypeDescriptorNode = (ArrayTypeDescriptorNode) node;
             type.isArrayType = true;
             type.arrayDimensions = 1;
-            type.elementType = fromNode(arrayTypeDescriptorNode.memberTypeDesc(), semanticModel, fileName);
+            type.elementType = fromNode(arrayTypeDescriptorNode.memberTypeDesc(), semanticModel);
         } else if (node instanceof OptionalTypeDescriptorNode) {
             OptionalTypeDescriptorNode optionalTypeDescriptorNode = (OptionalTypeDescriptorNode) node;
-            type = fromNode(optionalTypeDescriptorNode.typeDescriptor(), semanticModel, fileName);
+            type = fromNode(optionalTypeDescriptorNode.typeDescriptor(), semanticModel);
             type.isNullable = true;
         } else if (node instanceof UnionTypeDescriptorNode) {
             type.isAnonymousUnionType = true;
             Node unionTypeNode = node;
             while (unionTypeNode instanceof UnionTypeDescriptorNode) {
                 UnionTypeDescriptorNode unionType = (UnionTypeDescriptorNode) unionTypeNode;
-                type.memberTypes.add(fromNode(unionType.leftTypeDesc(), semanticModel, fileName));
+                type.memberTypes.add(fromNode(unionType.leftTypeDesc(), semanticModel));
                 unionTypeNode = unionType.rightTypeDesc();
             }
-            type.memberTypes.add(fromNode(unionTypeNode, semanticModel, fileName));
+            type.memberTypes.add(fromNode(unionTypeNode, semanticModel));
         } else if (node instanceof IntersectionTypeDescriptorNode) {
             type.isIntersectionType = true;
             IntersectionTypeDescriptorNode intersectionType = (IntersectionTypeDescriptorNode) node;
-            type.memberTypes.add(fromNode(intersectionType.leftTypeDesc(), semanticModel, fileName));
-            type.memberTypes.add(fromNode(intersectionType.rightTypeDesc(), semanticModel, fileName));
+            type.memberTypes.add(fromNode(intersectionType.leftTypeDesc(), semanticModel));
+            type.memberTypes.add(fromNode(intersectionType.rightTypeDesc(), semanticModel));
         } else if (node instanceof RecordTypeDescriptorNode) {
             type.name = node.toString();
             type.generateUserDefinedTypeLink = false;
@@ -192,9 +192,9 @@ public class Type {
             type.name = streamNode.streamKeywordToken().text();
             type.category = "stream";
             if (streamParams != null) {
-                type.memberTypes.add(fromNode(streamParams.leftTypeDescNode(), semanticModel, fileName));
+                type.memberTypes.add(fromNode(streamParams.leftTypeDescNode(), semanticModel));
                 if (streamParams.rightTypeDescNode().isPresent()) {
-                    type.memberTypes.add(fromNode(streamParams.rightTypeDescNode().get(), semanticModel, fileName));
+                    type.memberTypes.add(fromNode(streamParams.rightTypeDescNode().get(), semanticModel));
                 }
             }
         } else if (node instanceof FunctionTypeDescriptorNode) {
@@ -203,19 +203,19 @@ public class Type {
             FunctionSignatureNode functionSignature = functionDescNode.functionSignature();
             List<DefaultableVariable> variables =
                     Generator.getDefaultableVariableList(functionSignature.parameters(), Optional.empty(),
-                            semanticModel, fileName);
+                            semanticModel);
             type.paramTypes.addAll(variables.stream().map((defaultableVariable) -> defaultableVariable.type)
                     .collect(Collectors.toList()));
             if (functionSignature.returnTypeDesc().isPresent()) {
                 ReturnTypeDescriptorNode returnType = functionSignature.returnTypeDesc().get();
-                type.returnType = Type.fromNode(returnType.type(), semanticModel, fileName);
+                type.returnType = Type.fromNode(returnType.type(), semanticModel);
             }
         } else if (node instanceof ParameterizedTypeDescriptorNode) {
             ParameterizedTypeDescriptorNode parameterizedNode = (ParameterizedTypeDescriptorNode) node;
             if (parameterizedNode.parameterizedType().kind().equals(SyntaxKind.MAP_KEYWORD)) {
                 type.name = "map";
                 type.category = "map";
-                type.constraint = fromNode(parameterizedNode.typeParameter().typeNode(), semanticModel, fileName);
+                type.constraint = fromNode(parameterizedNode.typeParameter().typeNode(), semanticModel);
             }
         } else if (node instanceof ErrorTypeDescriptorNode) {
             ErrorTypeDescriptorNode errorType = (ErrorTypeDescriptorNode) node;
@@ -231,12 +231,12 @@ public class Type {
             type.category = "builtin";
         } else if (node instanceof ParenthesisedTypeDescriptorNode) {
             ParenthesisedTypeDescriptorNode parenthesisedNode = (ParenthesisedTypeDescriptorNode) node;
-            type.elementType = fromNode(parenthesisedNode.typedesc(), semanticModel, fileName);
+            type.elementType = fromNode(parenthesisedNode.typedesc(), semanticModel);
             type.isParenthesisedType = true;
         } else if (node instanceof TupleTypeDescriptorNode) {
             TupleTypeDescriptorNode typeDescriptor = (TupleTypeDescriptorNode) node;
             type.memberTypes.addAll(typeDescriptor.memberTypeDesc().stream().map(memberType ->
-                    Type.fromNode(memberType, semanticModel, fileName)).collect(Collectors.toList()));
+                    Type.fromNode(memberType, semanticModel)).collect(Collectors.toList()));
             type.isTuple = true;
         } else {
             type.category = "UNKNOWN";

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -50,7 +50,6 @@ import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.TupleTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.UnionTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.XmlTypeDescriptorNode;
-import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.docgen.Generator;
 import org.ballerinalang.docgen.docs.BallerinaDocGenerator;
 import org.ballerinalang.docgen.docs.utils.BallerinaDocUtils;

--- a/misc/observability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
+++ b/misc/observability-symbol-collector/src/main/java/org/ballerinalang/observability/anaylze/DefaultObservabilitySymbolCollector.java
@@ -94,7 +94,7 @@ public class DefaultObservabilitySymbolCollector implements ObservabilitySymbolC
             Module module = currentPackage.module(moduleId);
             for (DocumentId documentId : module.documentIds()) {
                 Document document = module.document(documentId);
-                JsonElement syntaxTreeJSON = DiagramUtil.getSyntaxTreeJSON(document.syntaxTree(), semanticModel);
+                JsonElement syntaxTreeJSON = DiagramUtil.getSyntaxTreeJSON(document, semanticModel);
                 packageHolder.addSyntaxTree(module.descriptor(), document.name(), syntaxTreeJSON);
             }
         }

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -100,19 +100,19 @@ public class TestProcessor {
      * Get the syntax tree for tests.
      *
      * @param module Module
-     * @return Map<String, SyntaxTree>
+     * @return Map<Document, SyntaxTree>
      */
-    private Map<String, SyntaxTree> getTestSyntaxTreeMap(Module module) {
-        Map<String, SyntaxTree> syntaxTreeMap = new HashMap<>();
+    private Map<Document, SyntaxTree> getTestSyntaxTreeMap(Module module) {
+        Map<Document, SyntaxTree> syntaxTreeMap = new HashMap<>();
         if (isSingleFileProject(module.project())) {
             module.documentIds().forEach(documentId -> {
                 Document document = module.document(documentId);
-                syntaxTreeMap.put(document.name(), document.syntaxTree());
+                syntaxTreeMap.put(document, document.syntaxTree());
             });
         } else {
             module.testDocumentIds().forEach(documentId -> {
                 Document document = module.document(documentId);
-                syntaxTreeMap.put(document.name(), document.syntaxTree());
+                syntaxTreeMap.put(document, document.syntaxTree());
             });
         }
         return syntaxTreeMap;
@@ -144,7 +144,7 @@ public class TestProcessor {
      * @param suite        TestSuite
      */
     private void processAnnotations(Module module, TestSuite suite) {
-        Map<String, SyntaxTree> syntaxTreeMap = getTestSyntaxTreeMap(module);
+        Map<Document, SyntaxTree> syntaxTreeMap = getTestSyntaxTreeMap(module);
         List<FunctionSymbol> functionSymbolList = getFunctionSymbolList(syntaxTreeMap, module);
         for (FunctionSymbol functionSymbol : functionSymbolList) {
             String functionName = functionSymbol.name();
@@ -180,13 +180,13 @@ public class TestProcessor {
      * Returns the relevant AnnotationNode from Syntax Tree for a AnnotationSymbol.
      *
      * @param annotationSymbol AnnotationSymbol
-     * @param syntaxTreeMap Map<String, SyntaxTree>
-     * @param function String
+     * @param syntaxTreeMap    Map<String, SyntaxTree>
+     * @param function         String
      * @return AnnotationNode
      */
-    private AnnotationNode getAnnotationNode(AnnotationSymbol annotationSymbol, Map<String, SyntaxTree> syntaxTreeMap,
+    private AnnotationNode getAnnotationNode(AnnotationSymbol annotationSymbol, Map<Document, SyntaxTree> syntaxTreeMap,
                                              String function) {
-        for (Map.Entry<String, SyntaxTree> syntaxTreeEntry : syntaxTreeMap.entrySet()) {
+        for (Map.Entry<Document, SyntaxTree> syntaxTreeEntry : syntaxTreeMap.entrySet()) {
             if (syntaxTreeEntry.getValue().containsModulePart()) {
                 ModulePartNode modulePartNode = syntaxTreeMap.get(syntaxTreeEntry.getKey()).rootNode();
                 for (Node node : modulePartNode.members()) {
@@ -216,18 +216,18 @@ public class TestProcessor {
     /**
      * Get function symbols list using syntax tree and semantic API.
      *
-     * @param syntaxTreeMap Map<String, SyntaxTree>
+     * @param syntaxTreeMap Map<Document, SyntaxTree>
      * @param module        Module
      * @return List<FunctionSymbol>
      */
-    private List<FunctionSymbol> getFunctionSymbolList(Map<String, SyntaxTree> syntaxTreeMap, Module module) {
+    private List<FunctionSymbol> getFunctionSymbolList(Map<Document, SyntaxTree> syntaxTreeMap, Module module) {
         List<FunctionSymbol> functionSymbolList = new ArrayList<>();
         List<String> functionNamesList = new ArrayList<>();
-        for (Map.Entry<String, SyntaxTree> syntaxTreeEntry : syntaxTreeMap.entrySet()) {
+        for (Map.Entry<Document, SyntaxTree> syntaxTreeEntry : syntaxTreeMap.entrySet()) {
             List<Symbol> symbols = module.getCompilation().getSemanticModel().visibleSymbols(
                     syntaxTreeEntry.getKey(),
                     LinePosition.from(syntaxTreeEntry.getValue().rootNode().location().lineRange().endLine().line(),
-                            syntaxTreeEntry.getValue().rootNode().location().lineRange().endLine().offset()));
+                                      syntaxTreeEntry.getValue().rootNode().location().lineRange().endLine().offset()));
             for (Symbol symbol : symbols) {
                 if (symbol.kind() == SymbolKind.FUNCTION && symbol instanceof FunctionSymbol &&
                         !functionNamesList.contains(symbol.name())) {
@@ -260,15 +260,15 @@ public class TestProcessor {
      * @param testSuite     TestSuite
      */
     private void addUtilityFunctions(Module module, TestSuite testSuite) {
-        Map<String, SyntaxTree> syntaxTreeMap = new HashMap<>();
+        Map<Document, SyntaxTree> syntaxTreeMap = new HashMap<>();
         module.documentIds().forEach(documentId -> {
             Document document = module.document(documentId);
-            syntaxTreeMap.put(document.name(), document.syntaxTree());
+            syntaxTreeMap.put(document, document.syntaxTree());
         });
         if (!isSingleFileProject(module.project())) {
             module.testDocumentIds().forEach(documentId -> {
                 Document document = module.document(documentId);
-                syntaxTreeMap.put(document.name(), document.syntaxTree());
+                syntaxTreeMap.put(document, document.syntaxTree());
             });
         }
         List<FunctionSymbol> functionSymbolList = getFunctionSymbolList(syntaxTreeMap, module);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -739,12 +739,25 @@ public class TestBuildProject {
         // 6) Get semantic model
         SemanticModel semanticModel = compilation.getSemanticModel();
 
+        // 7) Get the document
+        Document srcFile = null;
+        for (Document doc : defaultModule.documents()) {
+            if (doc.name().equals("main.bal")) {
+                srcFile = doc;
+                break;
+            }
+        }
+
+        if (srcFile == null) {
+            Assert.fail("Source file 'main.bal' not found");
+        }
+
         // Test module level symbols
         List<Symbol> symbols = semanticModel.moduleLevelSymbols();
         Assert.assertEquals(symbols.size(), 5);
 
         // Test symbol
-        Optional<Symbol> symbol = semanticModel.symbol("main.bal", LinePosition.from(5, 10));
+        Optional<Symbol> symbol = semanticModel.symbol(srcFile, LinePosition.from(5, 10));
         symbol.ifPresent(value -> assertEquals(value.name(), "runServices"));
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -23,7 +23,9 @@ import io.ballerina.compiler.api.symbols.Annotatable;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -38,6 +40,8 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static java.util.List.of;
 import static org.testng.Assert.assertEquals;
@@ -50,16 +54,18 @@ import static org.testng.Assert.assertEquals;
 public class AnnotationsTest {
 
     private SemanticModel model;
-    private final String fileName = "annotations_test.bal";
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/annotations_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/annotations_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test(dataProvider = "PosProvider")
     public void test(int line, int col, SymbolKind kind, List<String> annots) {
-        Optional<Symbol> symbol = model.symbol(fileName, from(line, col));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(line, col));
         assertEquals(symbol.get().kind(), kind);
 
         List<AnnotationSymbol> annotSymbols = ((Annotatable) symbol.get()).annotations();

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -24,8 +24,10 @@ import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -38,6 +40,8 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertList;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -49,17 +53,19 @@ import static org.testng.Assert.assertTrue;
 public class ClassSymbolTest {
 
     private SemanticModel model;
-    private final String fileName = "class_symbols_test.bal";
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/class_symbols_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/class_symbols_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test
     public void testSymbolAtCursor() {
         final List<String> fieldNames = List.of("fname", "lname");
-        ClassSymbol symbol = (ClassSymbol) model.symbol(fileName, LinePosition.from(16, 6)).get();
+        ClassSymbol symbol = (ClassSymbol) model.symbol(srcFile, LinePosition.from(16, 6)).get();
 
         assertList(symbol.fieldDescriptors(), fieldNames);
         assertList(symbol.methods(), List.of("getFullName"));
@@ -73,7 +79,7 @@ public class ClassSymbolTest {
 
     @Test
     public void testTypeReference() {
-        Symbol symbol = model.symbol(fileName, LinePosition.from(40, 6)).get();
+        Symbol symbol = model.symbol(srcFile, LinePosition.from(40, 6)).get();
         assertEquals(symbol.name(), "Person1");
         assertEquals(symbol.kind(), TYPE);
 
@@ -89,7 +95,7 @@ public class ClassSymbolTest {
 
     @Test
     public void testClassWithoutInit() {
-        Symbol symbol = model.symbol(fileName, LinePosition.from(41, 4)).get();
+        Symbol symbol = model.symbol(srcFile, LinePosition.from(41, 4)).get();
         assertEquals(symbol.name(), "Person2");
         assertEquals(symbol.kind(), TYPE);
 
@@ -105,7 +111,7 @@ public class ClassSymbolTest {
 
     @Test(dataProvider = "TypeInitPosProvider")
     public void testTypeInit(int line, int col, String name) {
-        Symbol symbol = model.symbol(fileName, LinePosition.from(line, col)).get();
+        Symbol symbol = model.symbol(srcFile, LinePosition.from(line, col)).get();
         ClassSymbol clazz = (ClassSymbol) ((TypeReferenceTypeSymbol) symbol).typeDescriptor();
         assertEquals(clazz.name(), name);
     }
@@ -125,7 +131,7 @@ public class ClassSymbolTest {
 
     @Test
     public void testDistinctClasses() {
-        Symbol symbol = model.symbol(fileName, LinePosition.from(45, 15)).get();
+        Symbol symbol = model.symbol(srcFile, LinePosition.from(45, 15)).get();
         ClassSymbol clazz = (ClassSymbol) symbol;
         assertEquals(clazz.typeKind(), OBJECT);
         assertEquals(clazz.kind(), CLASS);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
@@ -27,7 +27,9 @@ import io.ballerina.compiler.api.symbols.EnumSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -36,6 +38,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -48,24 +52,26 @@ import static org.testng.Assert.assertTrue;
 public class DocumentationTest {
 
     private SemanticModel model;
-    private final String fileName = "documentation_test.bal";
+    private Document srcFile;
     private final Map<String, String> emptyMap = new HashMap<>();
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/documentation_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/documentation_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test
     public void testAnnotationDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(27, 30));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(27, 30));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDescriptionOnly(documentation.get(), "This is an annotation");
     }
 
     @Test
     public void testClassDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(30, 6));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(30, 6));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDescriptionOnly(documentation.get(), "This is a class");
 
@@ -81,14 +87,14 @@ public class DocumentationTest {
 
     @Test
     public void testConstantDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(47, 13));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(47, 13));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDescriptionOnly(documentation.get(), "This is a constant");
     }
 
     @Test
     public void testEnumDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(50, 12));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(50, 12));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDescriptionOnly(documentation.get(), "This is an enum");
 
@@ -100,7 +106,7 @@ public class DocumentationTest {
 
     @Test
     public void testTypeDefDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(19, 5));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(19, 5));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDocumentation(documentation.get(), "This is a record", Map.of("foo", "Field foo", "bar", "Field bar"),
                             null);
@@ -112,7 +118,7 @@ public class DocumentationTest {
 
     @Test
     public void testFunctionDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(63, 9));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(63, 9));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDocumentation(documentation.get(), "This is a function", Map.of("x", "Param x", "y", "Param y"),
                             "The sum");
@@ -120,7 +126,7 @@ public class DocumentationTest {
 
     @Test
     public void testModuleVarDocs() {
-        Optional<Symbol> symbol = model.symbol(fileName, from(66, 7));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(66, 7));
         Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
         assertDescriptionOnly(documentation.get(), "This is a variable");
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -329,6 +329,6 @@ public class ExpressionTypeTest {
     private TypeSymbol getExprType(int sLine, int sCol, int eLine, int eCol) {
         LinePosition start = LinePosition.from(sLine, sCol);
         LinePosition end = LinePosition.from(eLine, eCol);
-        return model.type("expressions_test.bal", LineRange.from("expressions_test.bal", start, end)).get();
+        return model.type(LineRange.from("expressions_test.bal", start, end)).get();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -26,7 +26,9 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -54,6 +56,8 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -70,10 +74,13 @@ public class LangLibFunctionTest {
                                                        "fromJsonString", "fromJsonFloatString", "fromJsonDecimalString",
                                                        "fromJsonWithType", "fromJsonStringWithType", "mergeJson");
     private SemanticModel model;
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/langlib_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/langlib_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test
@@ -320,7 +327,7 @@ public class LangLibFunctionTest {
     }
 
     private Symbol getSymbol(int line, int column) {
-        return model.symbol("langlib_test.bal", from(line, column)).get();
+        return model.symbol(srcFile, from(line, column)).get();
     }
 
     private void assertLangLibList(List<FunctionSymbol> langLib, List<String> expFunctions) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -26,7 +26,9 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -45,6 +47,8 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertList;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -57,16 +61,17 @@ import static org.testng.Assert.assertTrue;
 public class ServiceSemanticAPITest {
 
     private SemanticModel model;
-    private final String fileName = "service_symbol_test.bal";
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/service_symbol_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/service_symbol_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
-
     @Test
     public void testServiceClass() {
-        ClassSymbol symbol = (ClassSymbol) model.symbol(fileName, from(22, 14)).get();
+        ClassSymbol symbol = (ClassSymbol) model.symbol(srcFile, from(22, 14)).get();
 
         List<String> expMethods = List.of("foo", "$get$barPath", "$get$foo$path", "$get$.", "$get$foo$baz",
                                           "$get$foo$*", "$get$foo$*$**");
@@ -83,7 +88,7 @@ public class ServiceSemanticAPITest {
 
     @Test
     public void testServiceDeclTypedesc() {
-        TypeSymbol symbol = (TypeSymbol) model.symbol(fileName, from(66, 8)).get();
+        TypeSymbol symbol = (TypeSymbol) model.symbol(srcFile, from(66, 8)).get();
         assertEquals(symbol.typeKind(), TYPE_REFERENCE);
         assertEquals(symbol.name(), "ProcessingService");
         assertEquals(((TypeReferenceTypeSymbol) symbol).typeDescriptor().typeKind(), OBJECT);
@@ -91,7 +96,7 @@ public class ServiceSemanticAPITest {
 
     @Test
     public void testServiceDeclListener() {
-        VariableSymbol symbol = (VariableSymbol) model.symbol(fileName, from(66, 31)).get();
+        VariableSymbol symbol = (VariableSymbol) model.symbol(srcFile, from(66, 31)).get();
         assertEquals(symbol.name(), "lsn");
         assertEquals(symbol.typeDescriptor().typeKind(), TYPE_REFERENCE);
         assertEquals(symbol.typeDescriptor().name(), "Listener");
@@ -102,7 +107,7 @@ public class ServiceSemanticAPITest {
 
     @Test
     public void testServiceDeclField() {
-        VariableSymbol symbol = (VariableSymbol) model.symbol(fileName, from(68, 18)).get();
+        VariableSymbol symbol = (VariableSymbol) model.symbol(srcFile, from(68, 18)).get();
         assertEquals(symbol.name(), "magic");
         assertEquals(symbol.typeDescriptor().typeKind(), STRING);
         assertEquals(symbol.qualifiers().size(), 1);
@@ -111,7 +116,7 @@ public class ServiceSemanticAPITest {
 
     @Test(dataProvider = "ServiceDeclMethodPos")
     public void testServiceDeclMethods(int line, int col, String name, List<Qualifier> quals) {
-        MethodSymbol symbol = (MethodSymbol) model.symbol(fileName, from(line, col)).get();
+        MethodSymbol symbol = (MethodSymbol) model.symbol(srcFile, from(line, col)).get();
         assertEquals(symbol.name(), name);
         assertEquals(symbol.qualifiers().size(), quals.size());
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -135,7 +135,7 @@ public class ServiceSemanticAPITest {
 
     @Test(dataProvider = "LookupPosProvider")
     public void testInScopeSymbolLookup(int line, int col, List<String> expSymNames) {
-        List<Symbol> inscopeSymbols = model.visibleSymbols("service_symbol_test.bal", from(line, col));
+        List<Symbol> inscopeSymbols = model.visibleSymbols(srcFile, from(line, col));
         List<Symbol> sourceFileSymbols = getFilteredSymbolNames(inscopeSymbols);
 
         assertEquals(sourceFileSymbols.size(), expSymNames.size());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -19,13 +19,17 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -39,13 +43,14 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "BasicsPosProvider")
     public void testBasics(int line, int column, String expSymbolName) {
-        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
-                "test-src/symbol_at_cursor_basic_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_at_cursor_basic_test.bal");
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        Document srcFile = getDocumentForSingleSource(project);
 
-        Optional<Symbol> symbol = model.symbol("symbol_at_cursor_basic_test.bal", LinePosition.from(line, column));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
 
-        if (!symbol.isPresent()) {
+        if (symbol.isEmpty()) {
             assertNull(expSymbolName);
         }
     }
@@ -95,13 +100,14 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "EnumPosProvider")
     public void testEnum(int line, int column, String expSymbolName) {
-        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
-                "test-src/symbol_at_cursor_enum_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_at_cursor_enum_test.bal");
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        Document srcFile = getDocumentForSingleSource(project);
 
-        Optional<Symbol> symbol = model.symbol("symbol_at_cursor_enum_test.bal", LinePosition.from(line, column));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
 
-        if (!symbol.isPresent()) {
+        if (symbol.isEmpty()) {
             assertNull(expSymbolName);
         }
     }
@@ -121,13 +127,14 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "WorkerSymbolPosProvider")
     public void testWorkers(int line, int column, String expSymbolName) {
-        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
-                "test-src/symbol_lookup_with_workers_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_workers_test.bal");
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        Document srcFile = getDocumentForSingleSource(project);
 
-        Optional<Symbol> symbol = model.symbol("symbol_lookup_with_workers_test.bal", LinePosition.from(line, column));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
 
-        if (!symbol.isPresent()) {
+        if (symbol.isEmpty()) {
             assertNull(expSymbolName);
         }
     }
@@ -147,11 +154,11 @@ public class SymbolAtCursorTest {
 
     @Test(dataProvider = "MissingConstructPosProvider")
     public void testMissingConstructs(int line, int column) {
-        SemanticModel model = SemanticAPITestUtils
-                .getDefaultModulesSemanticModel("test-src/symbol_at_cursor_undefined_constructs_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_at_cursor_undefined_constructs_test.bal");
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        Document srcFile = getDocumentForSingleSource(project);
 
-        Optional<Symbol> symbol = model.symbol("symbol_at_cursor_undefined_constructs_test.bal",
-                                               LinePosition.from(line, column));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
         symbol.ifPresent(value -> assertTrue(true, "Unexpected symbol: " + value.name()));
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.BallerinaModule;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.projects.Document;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
@@ -49,6 +50,8 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.MODULE;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getSymbolNames;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
@@ -110,10 +113,11 @@ public class SymbolBIRTest {
 
     @Test(dataProvider = "ImportSymbolPosProvider")
     public void testImportSymbols(int line, int column, String expSymbolName) {
-        SemanticModel model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
-                "test-src/symbol_at_cursor_import_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_at_cursor_import_test.bal");
+        SemanticModel model = getDefaultModulesSemanticModel(project);
+        Document srcFile = getDocumentForSingleSource(project);
 
-        Optional<Symbol> symbol = model.symbol("symbol_at_cursor_import_test.bal", LinePosition.from(line, column));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
         symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
 
         if (symbol.isEmpty()) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -78,6 +78,7 @@ public class SymbolBIRTest {
         Project project = BCompileUtil.loadProject("test-src/symbol_lookup_with_imports_test.bal");
         Package currentPackage = project.currentPackage();
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        Document srcFile = getDocumentForSingleSource(project);
 
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
@@ -89,8 +90,7 @@ public class SymbolBIRTest {
         List<SymbolInfo> moduleSymbols = getModuleSymbolInfo();
         List<SymbolInfo> expSymbolNames = getSymbolNames(annotationModuleSymbols, moduleLevelSymbols, moduleSymbols);
 
-        List<Symbol> symbolsInScope =
-                model.visibleSymbols("symbol_lookup_with_imports_test.bal", LinePosition.from(18, 0));
+        List<Symbol> symbolsInScope = model.visibleSymbols(srcFile, LinePosition.from(18, 0));
         assertList(symbolsInScope, expSymbolNames);
 
         BallerinaModule fooModule = (BallerinaModule) symbolsInScope.stream()

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -22,8 +22,11 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,6 +34,8 @@ import org.testng.annotations.Test;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -46,19 +51,25 @@ public class SymbolEquivalenceTest {
 
     private SemanticModel model;
     private SemanticModel typesModel;
-    private final String fileName = "symbol_at_cursor_basic_test.bal";
+    private Document srcFile;
+    private Document typesSrcFile;
     private final String typesFileName = "typedesc_test.bal";
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/symbol_at_cursor_basic_test.bal");
-        typesModel = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/typedesc_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_at_cursor_basic_test.bal");
+        srcFile = getDocumentForSingleSource(project);
+        model = getDefaultModulesSemanticModel(project);
+
+        project = BCompileUtil.loadProject("test-src/typedesc_test.bal");
+        typesSrcFile = getDocumentForSingleSource(project);
+        typesModel = getDefaultModulesSemanticModel(project);
     }
 
     @Test(dataProvider = "SymbolPosProvider")
     public void testSymbols(List<LinePosition> positions) {
         List<Symbol> symbols = positions.stream()
-                .map(pos -> model.symbol(fileName, pos).get())
+                .map(pos -> model.symbol(srcFile, pos).get())
                 .collect(Collectors.toList());
         assertSymbols(symbols);
     }
@@ -79,7 +90,7 @@ public class SymbolEquivalenceTest {
         List<LinePosition> positions = List.of(from(16, 7), from(17, 4), from(19, 9),
                                                from(20, 11), from(49, 5), from(40, 4));
         List<Symbol> symbols = positions.stream()
-                .map(pos -> model.symbol(fileName, pos).get())
+                .map(pos -> model.symbol(srcFile, pos).get())
                 .collect(Collectors.toList());
 
         for (int i = 0; i < symbols.size(); i++) {
@@ -99,7 +110,7 @@ public class SymbolEquivalenceTest {
                                                from(114, 5));
         SemanticModel typeRefModel = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/typedesc_test.bal");
         List<Symbol> symbols = positions.stream()
-                .map(pos -> typeRefModel.symbol("typedesc_test.bal", pos).get())
+                .map(pos -> typeRefModel.symbol(typesSrcFile, pos).get())
                 .collect(Collectors.toList());
 
         assertSymbols(symbols);
@@ -108,7 +119,7 @@ public class SymbolEquivalenceTest {
     @Test(dataProvider = "TypeSymbolPosProvider")
     public void testTypedescriptors(List<LinePosition> positions) {
         List<TypeSymbol> types = positions.stream()
-                .map(pos -> typesModel.symbol(typesFileName, pos).get())
+                .map(pos -> typesModel.symbol(typesSrcFile, pos).get())
                 .map(s -> ((VariableSymbol) s).typeDescriptor())
                 .collect(Collectors.toList());
         assertTypeSymbols(types);
@@ -127,7 +138,7 @@ public class SymbolEquivalenceTest {
     public void testTypedescriptorsNegative() {
         List<LinePosition> positions = List.of(from(24, 17), from(19, 11), from(24, 26));
         List<TypeSymbol> types = positions.stream()
-                .map(pos -> typesModel.symbol(typesFileName, pos).get())
+                .map(pos -> typesModel.symbol(typesSrcFile, pos).get())
                 .map(s -> ((VariableSymbol) s).typeDescriptor())
                 .collect(Collectors.toList());
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
@@ -22,8 +22,10 @@ import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -41,6 +43,8 @@ import static io.ballerina.compiler.api.symbols.Qualifier.PUBLIC;
 import static io.ballerina.compiler.api.symbols.Qualifier.READONLY;
 import static io.ballerina.compiler.api.symbols.Qualifier.REMOTE;
 import static io.ballerina.compiler.api.symbols.Qualifier.RESOURCE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -52,18 +56,19 @@ import static org.testng.Assert.assertTrue;
  */
 public class SymbolFlagToQualifierMappingTest {
 
-    SemanticModel model;
+    private SemanticModel model;
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel(
-                "test-src/symbol_flag_to_qualifier_mapping_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_flag_to_qualifier_mapping_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test(dataProvider = "QualifierProvider")
     public void testFlagToQualifierMapping(int line, int column, Set<Qualifier> expQuals) {
-        Optional<Symbol> optionalSymbol = model.symbol("symbol_flag_to_qualifier_mapping_test.bal",
-                                                       LinePosition.from(line, column));
+        Optional<Symbol> optionalSymbol = model.symbol(srcFile, LinePosition.from(line, column));
         Qualifiable symbol = (Qualifiable) optionalSymbol.get();
         assertTrue(symbol.qualifiers().containsAll(expQuals) && symbol.qualifiers().size() == expQuals.size());
     }
@@ -88,8 +93,7 @@ public class SymbolFlagToQualifierMappingTest {
 
     @Test(dataProvider = "SymbolKindProvider")
     public void testFlagToSymbolKindMapping(int line, int column, SymbolKind kind) {
-        Optional<Symbol> optionalSymbol = model.symbol("symbol_flag_to_qualifier_mapping_test.bal",
-                                                       LinePosition.from(line, column));
+        Optional<Symbol> optionalSymbol = model.symbol(srcFile, LinePosition.from(line, column));
         Symbol symbol = optionalSymbol.get();
         assertEquals(symbol.kind(), kind);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolLookupTest.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.Document;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.Package;
 import io.ballerina.projects.PackageCompilation;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertList;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getSymbolNames;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getSymbolsInFile;
 import static java.util.Arrays.asList;
@@ -55,12 +57,12 @@ public class SymbolLookupTest {
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
 
         BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "var_symbol_lookup_test.bal", line, column,
-                moduleID);
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, line, column, moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbols);
         for (String symName : expSymbolNames) {
@@ -90,12 +92,12 @@ public class SymbolLookupTest {
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
 
         BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_with_workers_test.bal", line, column,
-                moduleID);
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, line, column, moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbols);
         for (String symName : expSymbolNames) {
@@ -125,12 +127,12 @@ public class SymbolLookupTest {
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
 
         BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_with_typedefs_test.bal", line,
-                column, moduleID);
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, line, column, moduleID);
 
         assertEquals(symbolsInFile.size(), expSymbols);
         for (String symName : expSymbolNames) {
@@ -167,12 +169,12 @@ public class SymbolLookupTest {
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
 
         BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_with_exprs_test.bal", line, column,
-                moduleID);
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, line, column, moduleID);
         assertList(symbolsInFile, expSymbolNames);
     }
 
@@ -197,12 +199,12 @@ public class SymbolLookupTest {
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
 
         BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "symbol_lookup_in_assignment.bal", 18, 9,
-                moduleID);
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, 18, 9, moduleID);
         assertList(symbolsInFile, Arrays.asList("test", "v1"));
     }
 
@@ -213,12 +215,12 @@ public class SymbolLookupTest {
         ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
         PackageCompilation packageCompilation = currentPackage.getCompilation();
         SemanticModel model = packageCompilation.getSemanticModel(defaultModuleId);
+        Document srcFile = getDocumentForSingleSource(project);
 
         BLangPackage pkg = packageCompilation.defaultModuleBLangPackage();
         ModuleID moduleID = new BallerinaModuleID(pkg.packageID);
 
-        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, "missing_node_filtering_test.bal", 19, 4,
-                moduleID);
+        Map<String, Symbol> symbolsInFile = getSymbolsInFile(model, srcFile, 19, 4, moduleID);
         assertList(symbolsInFile, Arrays.asList("test", "x"));
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -19,15 +19,19 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 
@@ -39,15 +43,18 @@ import static org.testng.Assert.assertNull;
 public class SymbolPositionTest {
 
     private SemanticModel model;
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/symbol_position_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/symbol_position_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test(dataProvider = "PositionProvider")
     public void testSymbolPositions(int sLine, int sCol, int eLine, int eCol, String expSymbolName) {
-        Optional<Symbol> symbol = model.symbol("symbol_position_test.bal", LinePosition.from(sLine, sCol));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(sLine, sCol));
 
         if (!symbol.isPresent()) {
             assertNull(expSymbolName);
@@ -84,7 +91,7 @@ public class SymbolPositionTest {
 
     @Test(dataProvider = "PositionProvider2")
     public void testTypeNarrowedSymbolPositions(int line, int col) {
-        Optional<Symbol> symbol = model.symbol("symbol_position_test.bal", LinePosition.from(line, col));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
 
         assertEquals(symbol.get().name(), "val");
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LineRange;
@@ -58,7 +59,8 @@ public class TestSourcesTest {
         Project project = BCompileUtil.loadProject("test-src/test-project");
         Module baz = getModule(project, "baz");
         model = baz.getCompilation().getSemanticModel();
-        srcFile = baz.testDocuments().iterator().next();
+        DocumentId id = baz.testDocumentIds().iterator().next();
+        srcFile = baz.document(id);
     }
 
     @Test(dataProvider = "SymbolPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -85,7 +85,7 @@ public class TestSourcesTest {
 
     @Test(dataProvider = "VisibleSymbolPosProvider")
     public void testVisibleSymbols(int line, int col, List<String> expSymbols) {
-        List<Symbol> symbols = model.visibleSymbols("tests/test1.bal", from(line, col)).stream()
+        List<Symbol> symbols = model.visibleSymbols(srcFile, from(line, col)).stream()
                 .filter(sym -> sym.moduleID().moduleName().equals("semapi.baz") ||
                         !sym.moduleID().moduleName().startsWith("lang."))
                 .collect(Collectors.toList());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeAssignabilityTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeAssignabilityTest.java
@@ -22,11 +22,15 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -39,17 +43,19 @@ import static org.testng.Assert.assertTrue;
 public class TypeAssignabilityTest {
 
     private SemanticModel model;
-    private final String fileName = "type_assignability_test.bal";
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/type_assignability_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/type_assignability_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test(dataProvider = "ClassPosProvider")
     public void testAssignabilityForClasses(int sourceLine, int sourceCol, int targetLine, int targetCol) {
-        ClassSymbol srcSymbol = (ClassSymbol) model.symbol(fileName, from(sourceLine, sourceCol)).get();
-        ClassSymbol targetSymbol = (ClassSymbol) model.symbol(fileName, from(targetLine, targetCol)).get();
+        ClassSymbol srcSymbol = (ClassSymbol) model.symbol(srcFile, from(sourceLine, sourceCol)).get();
+        ClassSymbol targetSymbol = (ClassSymbol) model.symbol(srcFile, from(targetLine, targetCol)).get();
 
         assertTrue(srcSymbol.assignableTo(targetSymbol));
     }
@@ -64,8 +70,8 @@ public class TypeAssignabilityTest {
 
     @Test
     public void testAssignabilityForClassesAndObjects() {
-        ClassSymbol srcSymbol = (ClassSymbol) model.symbol(fileName, from(30, 6)).get();
-        TypeDefinitionSymbol targetSymbol = (TypeDefinitionSymbol) model.symbol(fileName, from(39, 5)).get();
+        ClassSymbol srcSymbol = (ClassSymbol) model.symbol(srcFile, from(30, 6)).get();
+        TypeDefinitionSymbol targetSymbol = (TypeDefinitionSymbol) model.symbol(srcFile, from(39, 5)).get();
 
         assertTrue(srcSymbol.assignableTo(targetSymbol.typeDescriptor()));
     }
@@ -74,9 +80,9 @@ public class TypeAssignabilityTest {
     public void testAssignabilityForTypeDefs(int sourceLine, int sourceCol, int targetLine, int targetCol,
                                              boolean assignable) {
         TypeDefinitionSymbol srcSymbol =
-                (TypeDefinitionSymbol) model.symbol(fileName, from(sourceLine, sourceCol)).get();
+                (TypeDefinitionSymbol) model.symbol(srcFile, from(sourceLine, sourceCol)).get();
         TypeDefinitionSymbol targetSymbol =
-                (TypeDefinitionSymbol) model.symbol(fileName, from(targetLine, targetCol)).get();
+                (TypeDefinitionSymbol) model.symbol(srcFile, from(targetLine, targetCol)).get();
 
         assertEquals(srcSymbol.typeDescriptor().assignableTo(targetSymbol.typeDescriptor()), assignable);
     }
@@ -93,8 +99,8 @@ public class TypeAssignabilityTest {
     @Test(dataProvider = "VarPosProvider")
     public void testAssignabilityForVars(int sourceLine, int sourceCol, int targetLine, int targetCol,
                                          boolean assignable) {
-        VariableSymbol srcSymbol = (VariableSymbol) model.symbol(fileName, from(sourceLine, sourceCol)).get();
-        VariableSymbol targetSymbol = (VariableSymbol) model.symbol(fileName, from(targetLine, targetCol)).get();
+        VariableSymbol srcSymbol = (VariableSymbol) model.symbol(srcFile, from(sourceLine, sourceCol)).get();
+        VariableSymbol targetSymbol = (VariableSymbol) model.symbol(srcFile, from(targetLine, targetCol)).get();
 
         assertEquals(srcSymbol.typeDescriptor().assignableTo(targetSymbol.typeDescriptor()), assignable);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -47,8 +47,10 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LineRange;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -99,6 +101,8 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_COMMENT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_ELEMENT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_PROCESSING_INSTRUCTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_TEXT;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -113,10 +117,13 @@ import static org.testng.Assert.assertTrue;
 public class TypedescriptorTest {
 
     private SemanticModel model;
+    private Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/typedesc_test.bal");
+        Project project = BCompileUtil.loadProject("test-src/typedesc_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test
@@ -459,8 +466,8 @@ public class TypedescriptorTest {
 
     @Test
     public void testEnumsAsTypes() {
-        Optional<TypeSymbol> type = model.type("typedesc_test.bal",
-                                               LineRange.from("typedesc_test.bal", from(160, 37), from(160, 38)));
+        Optional<TypeSymbol> type =
+                model.type(LineRange.from("typedesc_test.bal", from(160, 37), from(160, 38)));
         assertEquals(type.get().typeKind(), TYPE_REFERENCE);
         assertEquals(type.get().name(), "Colour");
 
@@ -526,7 +533,7 @@ public class TypedescriptorTest {
     @Test
     public void testCompileErrorType1() {
         LineRange range = LineRange.from("typedesc_test.bal", from(181, 12), from(181, 17));
-        Optional<TypeSymbol> type = model.type("typedesc_test.bal", range);
+        Optional<TypeSymbol> type = model.type(range);
         assertEquals(type.get().typeKind(), COMPILATION_ERROR);
     }
 
@@ -557,7 +564,7 @@ public class TypedescriptorTest {
     }
 
     private Symbol getSymbol(int line, int column) {
-        return model.symbol("typedesc_test.bal", from(line, column)).get();
+        return model.symbol(srcFile, from(line, column)).get();
     }
 
     private void validateParam(ParameterSymbol param, String name, ParameterKind kind, TypeDescKind typeKind) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/AnnotationRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/AnnotationRefsTest.java
@@ -59,11 +59,6 @@ public class AnnotationRefsTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "find_ref_annotation_context.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_ref_annotation_context.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
@@ -22,7 +22,6 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.test.BCompileUtil;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
@@ -20,9 +20,12 @@ package io.ballerina.semantic.api.test.allreferences;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
 import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -33,6 +36,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -45,21 +50,24 @@ public abstract class FindAllReferencesTest {
 
     public static final List<Location> EMPTY_LIST = Collections.unmodifiableList(new ArrayList<>());
     protected SemanticModel model;
+    protected Document srcFile;
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getDefaultModulesSemanticModel(getTestSourcePath());
+        Project project = BCompileUtil.loadProject(getTestSourcePath());
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
     }
 
     @Test(dataProvider = "PositionProvider")
     public void testFindAllReferencesUsingLocation(int line, int col, List<Location> expLocations) {
-        List<Location> locations = model.references(getFileName(), LinePosition.from(line, col));
+        List<Location> locations = model.references(srcFile.name(), LinePosition.from(line, col));
         assertLocations(locations, expLocations);
     }
 
     @Test(dataProvider = "PositionProvider")
     public void testFindAllReferencesUsingSymbol(int line, int col, List<Location> expLocations) {
-        Optional<Symbol> symbol = model.symbol(getFileName(), LinePosition.from(line, col));
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
 
         if (expLocations.isEmpty()) {
             assertTrue(symbol.isEmpty());
@@ -73,9 +81,11 @@ public abstract class FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public abstract Object[][] getLookupPositions();
 
-    public abstract String getFileName();
-
     public abstract String getTestSourcePath();
+
+    public String getFileName() {
+        return this.srcFile.name();
+    }
 
     // Util methods
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
@@ -60,7 +60,7 @@ public abstract class FindAllReferencesTest {
 
     @Test(dataProvider = "PositionProvider")
     public void testFindAllReferencesUsingLocation(int line, int col, List<Location> expLocations) {
-        List<Location> locations = model.references(srcFile.name(), LinePosition.from(line, col));
+        List<Location> locations = model.references(srcFile, LinePosition.from(line, col));
         assertLocations(locations, expLocations);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
@@ -61,11 +61,6 @@ public class FindModulePrefixRefsTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "find_var_ref_in_module_prefix.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_var_ref_in_module_prefix.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsAcrossFilesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsAcrossFilesTest.java
@@ -54,11 +54,6 @@ public class FindRefsAcrossFilesTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "functions.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/test-project";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsAcrossFilesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsAcrossFilesTest.java
@@ -18,12 +18,18 @@
 
 package io.ballerina.semantic.api.test.allreferences;
 
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getModule;
 
 /**
  * Test cases for the finding all references of a symbol across multiple files in the module.
@@ -35,7 +41,10 @@ public class FindRefsAcrossFilesTest extends FindAllReferencesTest {
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getSemanticModelOf("test-src/test-project", "baz");
+        Project project = BCompileUtil.loadProject(getTestSourcePath());
+        Module baz = getModule(project, "baz");
+        model = baz.getCompilation().getSemanticModel();
+        srcFile = getDocument(baz);
     }
 
     @DataProvider(name = "PositionProvider")
@@ -56,5 +65,16 @@ public class FindRefsAcrossFilesTest extends FindAllReferencesTest {
     @Override
     public String getTestSourcePath() {
         return "test-src/test-project";
+    }
+
+    private Document getDocument(Module module) {
+        for (DocumentId id : module.documentIds()) {
+            Document doc = module.document(id);
+            if ("functions.bal".equals(doc.name())) {
+                return doc;
+            }
+        }
+
+        throw new IllegalStateException("Source file 'functions.bal' not found");
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
@@ -105,11 +105,6 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "find_var_ref_in_exprs.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_var_ref_in_exprs.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInLambdasTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInLambdasTest.java
@@ -67,11 +67,6 @@ public class FindRefsInLambdasTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "find_var_ref_within_lambdas.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_var_ref_within_lambdas.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInServiceDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInServiceDeclTest.java
@@ -56,11 +56,6 @@ public class FindRefsInServiceDeclTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "service_symbol_test.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/service_symbol_test.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
@@ -18,12 +18,17 @@
 
 package io.ballerina.semantic.api.test.allreferences;
 
-import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.Module;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getModule;
 
 /**
  * Test cases for the finding all references of a symbol across a module, in tests.
@@ -35,7 +40,11 @@ public class FindRefsInTestsTest extends FindAllReferencesTest {
 
     @BeforeClass
     public void setup() {
-        model = SemanticAPITestUtils.getSemanticModelOf("test-src/test-project", "baz");
+        Project project = BCompileUtil.loadProject(getTestSourcePath());
+        Module baz = getModule(project, "baz");
+        model = baz.getCompilation().getSemanticModel();
+        DocumentId id = baz.testDocumentIds().iterator().next();
+        srcFile = baz.document(id);
     }
 
     @DataProvider(name = "PositionProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
@@ -51,11 +51,6 @@ public class FindRefsInTestsTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "tests/test1.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/test-project";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInWorkersTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInWorkersTest.java
@@ -63,11 +63,6 @@ public class FindRefsInWorkersTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "find_var_ref_within_workers.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_var_ref_within_workers.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/XMLRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/XMLRefsTest.java
@@ -49,11 +49,6 @@ public class XMLRefsTest extends FindAllReferencesTest {
     }
 
     @Override
-    public String getFileName() {
-        return "find_ref_xml_context.bal";
-    }
-
-    @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_ref_xml_context.bal";
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -20,6 +20,8 @@ package io.ballerina.semantic.api.test.util;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.ModuleName;
 import io.ballerina.projects.Package;
@@ -51,6 +53,23 @@ import static org.testng.Assert.assertTrue;
  * @since 2.0.0
  */
 public class SemanticAPITestUtils {
+
+    public static Document getDocumentForSingleSource(Project project) {
+        Package currentPackage = project.currentPackage();
+        return currentPackage.getDefaultModule().documents().iterator().next();
+    }
+
+    public static Module getModule(Project project, String moduleName) {
+        Package currentPackage = project.currentPackage();
+        ModuleName modName = ModuleName.from(currentPackage.packageName(), moduleName);
+        return currentPackage.module(modName);
+    }
+
+    public static SemanticModel getDefaultModulesSemanticModel(Project project) {
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        return currentPackage.getCompilation().getSemanticModel(defaultModuleId);
+    }
 
     public static SemanticModel getDefaultModulesSemanticModel(String sourceFilePath) {
         Project project = BCompileUtil.loadProject(sourceFilePath);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -112,7 +112,7 @@ public class SemanticAPITestUtils {
         }
     }
 
-    public static Map<String, Symbol> getSymbolsInFile(SemanticModel model, String srcFile, int line,
+    public static Map<String, Symbol> getSymbolsInFile(SemanticModel model, Document srcFile, int line,
                                                        int column, ModuleID moduleID) {
         List<Symbol> allInScopeSymbols = model.visibleSymbols(srcFile, LinePosition.from(line, column));
         return allInScopeSymbols.stream()

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.DocumentId;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
 import io.ballerina.projects.ModuleName;
@@ -56,7 +57,14 @@ public class SemanticAPITestUtils {
 
     public static Document getDocumentForSingleSource(Project project) {
         Package currentPackage = project.currentPackage();
-        return currentPackage.getDefaultModule().documents().iterator().next();
+        DocumentId id = currentPackage.getDefaultModule().documentIds().iterator().next();
+        return currentPackage.getDefaultModule().document(id);
+    }
+
+    public static Document getDocumentForSingleTestSource(Project project) {
+        Package currentPackage = project.currentPackage();
+        DocumentId id = currentPackage.getDefaultModule().testDocumentIds().iterator().next();
+        return currentPackage.getDefaultModule().document(id);
     }
 
     public static Module getModule(Project project, String moduleName) {
@@ -80,6 +88,12 @@ public class SemanticAPITestUtils {
 
     public static SemanticModel getSemanticModelOf(String projectPath, String moduleName) {
         Project project = BCompileUtil.loadProject(projectPath);
+        Package currentPackage = project.currentPackage();
+        ModuleName modName = ModuleName.from(currentPackage.packageName(), moduleName);
+        return currentPackage.module(modName).getCompilation().getSemanticModel();
+    }
+
+    public static SemanticModel getSemanticModelOf(Project project, String moduleName) {
         Package currentPackage = project.currentPackage();
         ModuleName modName = ModuleName.from(currentPackage.packageName(), moduleName);
         return currentPackage.module(modName).getCompilation().getSemanticModel();


### PR DESCRIPTION
## Purpose
This PR modifies the signature of the methods in the semantic API to accept a `Document` instance instead of the file name as a `String`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
