### PR TITLE
Throw compilation error for deprecated mock annotation

### DIFF
--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/MockAnnotationProcessor.java
@@ -22,6 +22,7 @@ import org.ballerinalang.compiler.plugins.AbstractCompilerPlugin;
 import org.ballerinalang.compiler.plugins.SupportedAnnotationPackages;
 import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.tree.AnnotationAttachmentNode;
+import org.ballerinalang.model.tree.FunctionNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.PackageNode;
 import org.ballerinalang.model.tree.SimpleVariableNode;
@@ -118,6 +119,21 @@ public class MockAnnotationProcessor extends AbstractCompilerPlugin {
                     diagnosticLog.logDiagnostic(DiagnosticSeverity.ERROR, attachmentNode.getPosition(),
                             "Annotation can only be attached to a test:MockFunction object");
                 }
+            }
+        }
+    }
+
+    @Override
+    public void process(FunctionNode functionNode, List<AnnotationAttachmentNode> annotations) {
+        // Remove the duplicated annotations.
+        annotations = annotations.stream().distinct().collect(Collectors.toList());
+        // Check for usage of mock annotation on a function which is deprecated.
+        for (AnnotationAttachmentNode attachmentNode : annotations) {
+            String annotationName = attachmentNode.getAnnotationName().getValue();
+            if (MOCK_ANNOTATION_NAME.equals(annotationName)) {
+                // Throw an error saying its not a MockFunction object
+                diagnosticLog.logDiagnostic(DiagnosticSeverity.ERROR, attachmentNode.getPosition(),
+                        "Annotation can only be attached to a test:MockFunction object");
             }
         }
     }

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/BaseTestCase.java
@@ -37,7 +37,7 @@ public class BaseTestCase {
     public static BalServer balServer;
     Path tempProjectDirectory;
     protected static Path singleFileTestsPath;
-    static Path projectBasedTestsPath;
+    protected static Path projectBasedTestsPath;
 
     @BeforeSuite(alwaysRun = true)
     public void initialize() throws BallerinaTestException, IOException {

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/DeprecatedAnnotationTestCase.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/negative/DeprecatedAnnotationTestCase.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.testerina.test.negative;
+
+import org.ballerinalang.test.context.BMainInstance;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.LogLeecher;
+import org.ballerinalang.testerina.test.BaseTestCase;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.context.LogLeecher.LeecherType.ERROR;
+
+/**
+ * Negative test cases for deprecated annotations.
+ */
+public class DeprecatedAnnotationTestCase extends BaseTestCase {
+    private BMainInstance balClient;
+    private String projectPath;
+
+    @BeforeClass
+    public void setup() throws BallerinaTestException {
+        balClient = new BMainInstance(balServer);
+        projectPath = projectBasedTestsPath.toString();
+    }
+
+    @Test
+    public void testDeprecatedMockAnnotation() throws BallerinaTestException {
+        String errMsg = "Annotation can only be attached to a test:MockFunction object";
+        LogLeecher clientLeecher = new LogLeecher(errMsg, ERROR);
+        balClient.runMain("test", new String[]{"deprecated-annotations"}, null, new String[]{},
+                new LogLeecher[]{clientLeecher}, projectPath);
+        clientLeecher.waitForText(20000);
+    }
+
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/deprecated-annotations/Ballerina.toml
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/deprecated-annotations/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "intg_tests"
+name = "deprecated_annotations"
+version = "0.0.0"

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/deprecated-annotations/main.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/deprecated-annotations/main.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+}
+
+public function stringAdd(string str) returns (string) {
+    return "test_" + str;
+}

--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/deprecated-annotations/tests/test-deprecated-mock-annotation.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/deprecated-annotations/tests/test-deprecated-mock-annotation.bal
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+@test:Mock {
+    functionName : "stringAdd"
+}
+public function mockStringAdd(string str1) returns (string) {
+    return "Hello " + str1;
+}
+
+@test:Config {}
+function testFunc() {
+        test:assertEquals(stringAdd("Test"), "Hello Test");
+}
+
+

--- a/tests/testerina-integration-test/src/test/resources/testng.xml
+++ b/tests/testerina-integration-test/src/test/resources/testng.xml
@@ -44,6 +44,7 @@ under the License.
             <class name="org.ballerinalang.testerina.test.FunctionNameValidationTest" />
             <class name="org.ballerinalang.testerina.test.ImportTest" />
             <class name="org.ballerinalang.testerina.test.ModuleExecutionTest" />
+            <class name="org.ballerinalang.testerina.test.negative.DeprecatedAnnotationTestCase" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
Throw compilation error if deprecated mock annotation(i.e. @test:Mock { } on a function instead of the mock object ) is used.

Fixes #27480

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
