### PR TITLE
Fix isOptional() in FieldSymbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -70,7 +70,7 @@ public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol
      */
     @Override
     public boolean isOptional() {
-        return (this.bField.type.flags & Flags.OPTIONAL) == Flags.OPTIONAL;
+        return (this.bField.symbol.flags & Flags.OPTIONAL) == Flags.OPTIONAL;
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
@@ -18,10 +18,13 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
@@ -46,6 +49,7 @@ import static io.ballerina.compiler.api.symbols.Qualifier.RESOURCE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 /**
@@ -104,5 +108,15 @@ public class SymbolFlagToQualifierMappingTest {
                 {19, 20, SymbolKind.METHOD},
                 {75, 7, SymbolKind.CONSTANT},
         };
+    }
+
+    @Test
+    public void testRecordField() {
+        Optional<Symbol> optionalSymbol = model.symbol(srcFile, LinePosition.from(51, 5));
+        TypeDefinitionSymbol person = (TypeDefinitionSymbol) optionalSymbol.get();
+        RecordTypeSymbol type = (RecordTypeSymbol) person.typeDescriptor();
+        FieldSymbol field = type.fieldDescriptors().get(1);
+        assertTrue(field.isOptional());
+        assertFalse(field.hasDefaultValue());
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_flag_to_qualifier_mapping_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_flag_to_qualifier_mapping_test.bal
@@ -51,7 +51,7 @@ isolated function add(int x, int y) returns int => x + y;
 
 type Person record {|
     readonly string name;
-    int age;
+    int age?;
 |};
 
 client class TestEP {


### PR DESCRIPTION
## Purpose
Fixes a bug in the `isOptional()` implementation in `FieldSymbol`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
