### PR TITLE
Refactor API for retrieving documentation from a symbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -18,7 +18,6 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.LangLibrary;
-import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -31,7 +30,6 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * Represents a Ballerina Type Descriptor.
@@ -46,14 +44,12 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     private final TypeDescKind typeDescKind;
     private final ModuleID moduleID;
     private final BType bType;
-    private final Documentation docAttachment;
 
     public AbstractTypeSymbol(CompilerContext context, TypeDescKind typeDescKind, ModuleID moduleID, BType bType) {
         this.context = context;
         this.typeDescKind = typeDescKind;
         this.moduleID = moduleID;
         this.bType = bType;
-        this.docAttachment = getDocAttachment(bType);
     }
 
     @Override
@@ -77,11 +73,6 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     @Override
     public SymbolKind kind() {
         return SymbolKind.TYPE;
-    }
-
-    @Override
-    public Optional<Documentation> docAttachment() {
-        return Optional.ofNullable(this.docAttachment);
     }
 
     @Override
@@ -158,10 +149,5 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         }
 
         return ((BallerinaClassSymbol) typeSymbol).getBType();
-    }
-
-    private Documentation getDocAttachment(BType bType) {
-        return (bType == null || bType.tsymbol == null) ? null
-                : new BallerinaDocumentation(bType.tsymbol.markdownDocumentation);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -19,6 +19,7 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.AnnotationAttachPoint;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -45,6 +46,7 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
     private final TypeSymbol typeDescriptor;
     private final List<AnnotationAttachPoint> attachPoints;
     private final List<AnnotationSymbol> annots;
+    private final Documentation docAttachment;
     private final boolean deprecated;
 
     private BallerinaAnnotationSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
@@ -55,6 +57,7 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
         this.typeDescriptor = typeDescriptor;
         this.attachPoints = Collections.unmodifiableList(attachPoints);
         this.annots = Collections.unmodifiableList(annots);
+        this.docAttachment = getDocAttachment(bSymbol);
         this.deprecated = Symbols.isFlagOn(bSymbol.flags, Flags.DEPRECATED);
     }
 
@@ -91,6 +94,11 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
     @Override
     public List<AnnotationSymbol> annotations() {
         return this.annots;
+    }
+
+    @Override
+    public Optional<Documentation> documentation() {
+        return Optional.ofNullable(this.docAttachment);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.api.impl.symbols;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
@@ -55,6 +56,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     private final boolean deprecated;
     private final BClassSymbol internalSymbol;
     private final CompilerContext context;
+    private final Documentation docAttachment;
     private MethodSymbol initMethod;
 
     protected BallerinaClassSymbol(CompilerContext context, String name, PackageID moduleID, List<Qualifier> qualifiers,
@@ -63,6 +65,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         super(name, moduleID, SymbolKind.CLASS, classSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
+        this.docAttachment = getDocAttachment(classSymbol);
         this.typeDescriptor = typeDescriptor;
         this.deprecated = Symbols.isFlagOn(classSymbol.flags, Flags.DEPRECATED);
         this.internalSymbol = classSymbol;
@@ -99,6 +102,11 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     @Override
     public List<AnnotationSymbol> annotations() {
         return this.annots;
+    }
+
+    @Override
+    public Optional<Documentation> documentation() {
+        return Optional.ofNullable(this.docAttachment);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -30,6 +31,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represent Function Symbol.
@@ -41,6 +43,7 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     private final FunctionTypeSymbol typeDescriptor;
     private final List<Qualifier> qualifiers;
     private final List<AnnotationSymbol> annots;
+    private final Documentation docAttachment;
     private final boolean isExternal;
     private final boolean deprecated;
 
@@ -53,6 +56,7 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
         super(name, moduleID, SymbolKind.FUNCTION, invokableSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
+        this.docAttachment = getDocAttachment(invokableSymbol);
         this.typeDescriptor = typeDescriptor;
         this.isExternal = Symbols.isFlagOn(invokableSymbol.flags, Flags.NATIVE);
         this.deprecated = Symbols.isFlagOn(invokableSymbol.flags, Flags.DEPRECATED);
@@ -86,6 +90,11 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     @Override
     public List<AnnotationSymbol> annotations() {
         return this.annots;
+    }
+
+    @Override
+    public Optional<Documentation> documentation() {
+        return Optional.ofNullable(this.docAttachment);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -66,8 +66,8 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     }
 
     @Override
-    public Optional<Documentation> docAttachment() {
-        return this.functionSymbol.docAttachment();
+    public Optional<Documentation> documentation() {
+        return this.functionSymbol.documentation();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -40,7 +40,6 @@ public class BallerinaSymbol implements Symbol {
     private final String name;
     private final PackageID moduleID;
     private final SymbolKind symbolKind;
-    private final Documentation docAttachment;
     private final Location position;
     private final BSymbol internalSymbol;
 
@@ -48,7 +47,6 @@ public class BallerinaSymbol implements Symbol {
         this.name = name;
         this.moduleID = moduleID;
         this.symbolKind = symbolKind;
-        this.docAttachment = getDocAttachment(symbol);
 
         if (symbol == null) {
             throw new IllegalArgumentException("'symbol' cannot be null");
@@ -91,7 +89,7 @@ public class BallerinaSymbol implements Symbol {
      */
     @Override
     public Optional<Documentation> docAttachment() {
-        return Optional.ofNullable(this.docAttachment);
+        return Optional.empty();
     }
 
     @Override
@@ -126,7 +124,7 @@ public class BallerinaSymbol implements Symbol {
         return this.internalSymbol;
     }
 
-    private Documentation getDocAttachment(BSymbol symbol) {
+    Documentation getDocAttachment(BSymbol symbol) {
         return symbol == null ? null : new BallerinaDocumentation(symbol.markdownDocumentation);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -28,7 +28,6 @@ import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
 import java.util.Objects;
-import java.util.Optional;
 
 /**
  * Represents the implementation of a Compiled Ballerina Symbol.
@@ -82,14 +81,6 @@ public class BallerinaSymbol implements Symbol {
     @Override
     public SymbolKind kind() {
         return this.symbolKind;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public Optional<Documentation> docAttachment() {
-        return Optional.empty();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
@@ -30,6 +31,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a ballerina type definition implementation.
@@ -40,6 +42,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
 
     private final List<Qualifier> qualifiers;
     private final TypeSymbol typeDescriptor;
+    private final Documentation docAttachment;
     private final boolean deprecated;
     private final boolean readonly;
 
@@ -51,6 +54,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
         super(name, moduleID, SymbolKind.TYPE_DEFINITION, bSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.typeDescriptor = typeDescriptor;
+        this.docAttachment = getDocAttachment(bSymbol);
         this.deprecated = Symbols.isFlagOn(bSymbol.flags, Flags.DEPRECATED);
         this.readonly = Symbols.isFlagOn(bSymbol.flags, Flags.READONLY);
     }
@@ -83,6 +87,11 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
     @Override
     public List<AnnotationSymbol> annotations() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public Optional<Documentation> documentation() {
+        return Optional.ofNullable(this.docAttachment);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -18,6 +18,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -30,6 +31,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a ballerina variable.
@@ -40,6 +42,7 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
 
     private final List<Qualifier> qualifiers;
     private final List<AnnotationSymbol> annots;
+    private final Documentation docAttachment;
     private final TypeSymbol typeDescriptorImpl;
     private final boolean deprecated;
 
@@ -53,6 +56,7 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
         super(name, moduleID, ballerinaSymbolKind, bSymbol);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
+        this.docAttachment = getDocAttachment(bSymbol);
         this.typeDescriptorImpl = typeDescriptorImpl;
         this.deprecated = Symbols.isFlagOn(bSymbol.flags, Flags.DEPRECATED);
     }
@@ -85,6 +89,11 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     @Override
     public List<AnnotationSymbol> annotations() {
         return this.annots;
+    }
+
+    @Override
+    public Optional<Documentation> documentation() {
+        return Optional.ofNullable(this.docAttachment);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnnotationSymbol.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface AnnotationSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
+public interface AnnotationSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the type descriptor.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ClassSymbol.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface ClassSymbol extends ObjectTypeSymbol, Qualifiable, Deprecatable, Annotatable {
+public interface ClassSymbol extends ObjectTypeSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the init method.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ConstantSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol, Annotatable, Deprecatable {
+public interface ConstantSymbol extends VariableSymbol, SingletonTypeSymbol, Annotatable, Deprecatable, Documentable {
 
     /**
      * Get the constant value.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Documentable.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Documentable.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.compiler.api.symbols;
+
+import java.util.Optional;
+
+/**
+ * Represents a symbol which may have documentation attached to it.
+ *
+ * @since 2.0.0
+ */
+public interface Documentable {
+
+    /**
+     * Fetches the documentation info attached to the symbol, if there are any.
+     *
+     * @return A {@link Documentation} instance if available
+     */
+    Optional<Documentation> documentation();
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/EnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/EnumSymbol.java
@@ -24,7 +24,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public interface EnumSymbol extends TypeDefinitionSymbol, Qualifiable, Deprecatable, Annotatable {
+public interface EnumSymbol extends TypeDefinitionSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Retrieves a list of the members of this enum.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FieldSymbol.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface FieldSymbol extends Symbol, Annotatable, Deprecatable {
+public interface FieldSymbol extends Symbol, Annotatable, Deprecatable, Documentable {
 
     /**
      * Whether optional field or not.
@@ -46,13 +46,6 @@ public interface FieldSymbol extends Symbol, Annotatable, Deprecatable {
      * @return {@link TypeSymbol} of the field
      */
     TypeSymbol typeDescriptor();
-
-    /**
-     * Get the documentation attachment.
-     *
-     * @return {@link Optional} doc attachment of the field
-     */
-    Optional<Documentation> documentation();
 
     /**
      * Get the accessibility modifier if available.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface FunctionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
+public interface FunctionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the type descriptor of the function.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -64,6 +64,4 @@ public interface Symbol {
      * @return The position information of the symbol
      */
     Location location();
-
-    // TODO: Add the annotation attachment API
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -20,8 +20,6 @@ package io.ballerina.compiler.api.symbols;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.tools.diagnostics.Location;
 
-import java.util.Optional;
-
 /**
  * Represents a compiled language symbol.
  *
@@ -49,13 +47,6 @@ public interface Symbol {
      * @return {@link SymbolKind} of the symbol
      */
     SymbolKind kind();
-
-    /**
-     * Get the Documentation attachment bound to the symbol.
-     *
-     * @return {@link Optional} doc attachment
-     */
-    Optional<Documentation> docAttachment();
 
     /**
      * This retrieves position information of the symbol in the source code. The position given here is the location of

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDefinitionSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface TypeDefinitionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
+public interface TypeDefinitionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the module qualified name.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable {
+public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the Type of the variable.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/UpdateDocumentationExecutor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/executors/UpdateDocumentationExecutor.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.command.executors;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
@@ -97,7 +98,7 @@ public class UpdateDocumentationExecutor implements LSCommandExecutor {
             Range range = getDocsRange(node).orElseThrow();
             LanguageClient languageClient = ctx.getLanguageClient();
 
-            docs = docs.mergeDocAttachment(documentableSymbol.get().docAttachment().orElseThrow());
+            docs = docs.mergeDocAttachment(((Documentable) documentableSymbol.get()).documentation().orElseThrow());
             return applySingleTextEdit(docs.getDocumentationString().trim(), range, textDocumentIdentifier,
                                        languageClient);
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ConstantCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ConstantCompletionItemBuilder.java
@@ -55,7 +55,7 @@ public class ConstantCompletionItemBuilder {
 
     private static MarkupContent getDocumentation(ConstantSymbol constantSymbol) {
         MarkupContent docMarkupContent = new MarkupContent();
-        Optional<Documentation> docAttachment = constantSymbol.docAttachment();
+        Optional<Documentation> docAttachment = constantSymbol.documentation();
         String description = docAttachment.isEmpty() || docAttachment.get().description().isEmpty() ? ""
                 : docAttachment.get().description().get();
         docMarkupContent.setValue(description);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -143,7 +143,7 @@ public final class FunctionCompletionItemBuilder {
                 item.setCommand(cmd);
             }
             boolean skipFirstParam = skipFirstParam(ctx, bSymbol);
-            if (bSymbol.docAttachment().isPresent()) {
+            if (bSymbol.documentation().isPresent()) {
                 item.setDocumentation(getDocumentation(bSymbol, skipFirstParam, ctx));
             }
         }
@@ -155,7 +155,7 @@ public final class FunctionCompletionItemBuilder {
         String pkgID = functionSymbol.moduleID().toString();
         FunctionTypeSymbol functionTypeDesc = functionSymbol.typeDescriptor();
 
-        Optional<Documentation> docAttachment = functionSymbol.docAttachment();
+        Optional<Documentation> docAttachment = functionSymbol.documentation();
         String description = docAttachment.isEmpty() || docAttachment.get().description().isEmpty()
                 ? "" : docAttachment.get().description().get();
         Map<String, String> docParamsMap = new HashMap<>();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeCompletionItemBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.ballerinalang.langserver.completions.builder;
 
+import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -120,9 +121,13 @@ public class TypeCompletionItemBuilder {
             default:
                 item.setKind(CompletionItemKind.Unit);
         }
-        if (bSymbol.docAttachment().isPresent() && bSymbol.docAttachment().get().description().isPresent()) {
-            item.setDocumentation(bSymbol.docAttachment().get().description().get());
+
+        Documentable documentableSymbol = bSymbol instanceof Documentable ? (Documentable) bSymbol : null;
+        if (documentableSymbol != null && documentableSymbol.documentation().isPresent()
+                && documentableSymbol.documentation().get().description().isPresent()) {
+            item.setDocumentation(documentableSymbol.documentation().get().description().get());
         }
+
         // set sub bType
         String name = typeDescriptor.get().kind() == SymbolKind.CLASS
                 ? typeDescriptor.get().kind().name()

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/VariableCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/VariableCompletionItemBuilder.java
@@ -54,8 +54,8 @@ public final class VariableCompletionItemBuilder {
         if (varSymbol == null) {
             return;
         }
-        if (varSymbol.docAttachment().isPresent() && varSymbol.docAttachment().get().description().isPresent()) {
-            item.setDocumentation(varSymbol.docAttachment().get().description().get());
+        if (varSymbol.documentation().isPresent() && varSymbol.documentation().get().description().isPresent()) {
+            item.setDocumentation(varSymbol.documentation().get().description().get());
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/WorkerCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/WorkerCompletionItemBuilder.java
@@ -43,14 +43,7 @@ public final class WorkerCompletionItemBuilder {
         item.setLabel(name);
         item.setInsertText(name);
         item.setDetail(ItemResolverConstants.WORKER);
-        setMeta(item, workerSymbol);
-        return item;
-    }
-
-    private static void setMeta(CompletionItem item, WorkerSymbol workerSymbol) {
         item.setKind(CompletionItemKind.Variable);
-        if (workerSymbol.docAttachment().isPresent() && workerSymbol.docAttachment().get().description().isPresent()) {
-            item.setDocumentation(workerSymbol.docAttachment().get().description().get());
-        }
+        return item;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/XMLNSCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/XMLNSCompletionItemBuilder.java
@@ -17,14 +17,9 @@
  */
 package org.ballerinalang.langserver.completions.builder;
 
-import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.XMLNamespaceSymbol;
-import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
-import org.eclipse.lsp4j.MarkupContent;
-
-import java.util.Optional;
 
 /**
  * Completion item builder for the {@link XMLNamespaceSymbol}.
@@ -46,20 +41,8 @@ public class XMLNSCompletionItemBuilder {
         completionItem.setLabel(namespaceSymbol.name());
         completionItem.setInsertText(namespaceSymbol.name());
         completionItem.setDetail(namespaceSymbol.namespaceUri());
-        completionItem.setDocumentation(getDocumentation(namespaceSymbol));
         completionItem.setKind(CompletionItemKind.Unit);
 
         return completionItem;
-    }
-
-    private static MarkupContent getDocumentation(XMLNamespaceSymbol namespaceSymbol) {
-        MarkupContent docMarkupContent = new MarkupContent();
-        Optional<Documentation> docAttachment = namespaceSymbol.docAttachment();
-        String description = docAttachment.isEmpty() || docAttachment.get().description().isEmpty() ? ""
-                : docAttachment.get().description().get();
-        docMarkupContent.setValue(description);
-        docMarkupContent.setKind(CommonUtil.MARKDOWN_MARKUP_KIND);
-
-        return docMarkupContent;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.hover;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Documentable;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
@@ -73,11 +74,9 @@ public class HoverUtil {
             case METHOD:
                 return getFunctionHoverMarkupContent((MethodSymbol) symbolAtCursor.get());
             case TYPE_DEFINITION:
-                return getTypeDefHoverMarkupContent(((TypeDefinitionSymbol) symbolAtCursor.get()).typeDescriptor());
-            case TYPE:
-                return getTypeDefHoverMarkupContent(CommonUtil.getRawType((TypeSymbol) symbolAtCursor.get()));
+                return getTypeDefHoverMarkupContent(((TypeDefinitionSymbol) symbolAtCursor.get()));
             case CLASS:
-                return getObjectHoverMarkupContent((ClassSymbol) symbolAtCursor.get());
+                return getClassHoverMarkupContent((ClassSymbol) symbolAtCursor.get());
             case CONSTANT:
             case ANNOTATION:
             case ENUM:
@@ -88,18 +87,13 @@ public class HoverUtil {
         }
     }
 
-    private static Hover getObjectHoverMarkupContent(ObjectTypeSymbol classSymbol) {
-        Optional<Documentation> documentation = classSymbol.docAttachment();
-        if (documentation.isEmpty()) {
-            return getDefaultHoverObject();
-        }
-
+    private static Hover getObjectHoverMarkupContent(Documentation documentation, ObjectTypeSymbol classSymbol) {
         List<String> hoverContent = new ArrayList<>();
-        if (documentation.get().description().isPresent()) {
-            hoverContent.add(documentation.get().description().get());
+        if (documentation.description().isPresent()) {
+            hoverContent.add(documentation.description().get());
         }
 
-        Map<String, String> paramsMap = documentation.get().parameterMap();
+        Map<String, String> paramsMap = documentation.parameterMap();
         if (!paramsMap.isEmpty()) {
             List<String> params = new ArrayList<>();
             params.add(header(3, ContextConstants.FIELD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
@@ -118,7 +112,7 @@ public class HoverUtil {
         List<String> methods = new ArrayList<>();
         classSymbol.methods().forEach(method -> {
             StringBuilder methodInfo = new StringBuilder();
-            Optional<Documentation> methodDoc = method.docAttachment();
+            Optional<Documentation> methodDoc = method.documentation();
             methodInfo.append(quotedString(method.typeDescriptor().signature()));
             if (methodDoc.isPresent() && methodDoc.get().description().isPresent()) {
                 methodInfo.append(CommonUtil.MD_LINE_SEPARATOR).append(methodDoc.get().description().get());
@@ -140,30 +134,41 @@ public class HoverUtil {
         return hover;
     }
 
-    private static Hover getTypeDefHoverMarkupContent(TypeSymbol symbol) {
-        TypeSymbol rawType = CommonUtil.getRawType(symbol);
+    private static Hover getTypeDefHoverMarkupContent(TypeDefinitionSymbol symbol) {
+        TypeSymbol rawType = CommonUtil.getRawType(symbol.typeDescriptor());
+        Optional<Documentation> documentation = symbol.documentation();
 
-        if (rawType.typeKind() == TypeDescKind.RECORD) {
-            return getRecordTypeHoverContent((RecordTypeSymbol) rawType);
-        }
-        if (rawType.typeKind() == TypeDescKind.OBJECT) {
-            return getObjectHoverMarkupContent((ObjectTypeSymbol) rawType);
-        }
-        return getDescriptionOnlyHoverObject(symbol);
-    }
-
-    private static Hover getRecordTypeHoverContent(RecordTypeSymbol recordType) {
-        Optional<Documentation> documentation = recordType.docAttachment();
         if (documentation.isEmpty()) {
             return getDefaultHoverObject();
         }
 
-        List<String> hoverContent = new ArrayList<>();
-        if (documentation.get().description().isPresent()) {
-            hoverContent.add(documentation.get().description().get());
+        if (rawType.typeKind() == TypeDescKind.RECORD) {
+            return getRecordTypeHoverContent(documentation.get(), (RecordTypeSymbol) rawType);
+        }
+        if (rawType.typeKind() == TypeDescKind.OBJECT) {
+            return getObjectHoverMarkupContent(documentation.get(), (ObjectTypeSymbol) rawType);
         }
 
-        Map<String, String> paramsMap = documentation.get().parameterMap();
+        return getDescriptionOnlyHoverObject(documentation.get());
+    }
+
+    private static Hover getClassHoverMarkupContent(ClassSymbol symbol) {
+        Optional<Documentation> documentation = symbol.documentation();
+
+        if (documentation.isEmpty()) {
+            return getDefaultHoverObject();
+        }
+
+        return getObjectHoverMarkupContent(documentation.get(), symbol);
+    }
+
+    private static Hover getRecordTypeHoverContent(Documentation documentation, RecordTypeSymbol recordType) {
+        List<String> hoverContent = new ArrayList<>();
+        if (documentation.description().isPresent()) {
+            hoverContent.add(documentation.description().get());
+        }
+
+        Map<String, String> paramsMap = documentation.parameterMap();
         if (!paramsMap.isEmpty()) {
             List<String> params = new ArrayList<>();
             params.add(header(3, ContextConstants.FIELD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
@@ -210,10 +215,11 @@ public class HoverUtil {
      *
      * @return {@link Hover}
      */
-    public static Hover getDescriptionOnlyHoverObject(Symbol symbol) {
-        Optional<Documentation> documentation = symbol.docAttachment();
-        String description = documentation.isEmpty() || documentation.get().description().isEmpty()
-                ? "" : documentation.get().description().get();
+    private static Hover getDescriptionOnlyHoverObject(Documentation documentation) {
+        String description = "";
+        if (documentation.description().isPresent()) {
+            description = documentation.description().get();
+        }
         Hover hover = new Hover();
         MarkupContent hoverMarkupContent = new MarkupContent();
         hoverMarkupContent.setKind(CommonUtil.MARKDOWN_MARKUP_KIND);
@@ -221,6 +227,19 @@ public class HoverUtil {
         hover.setContents(hoverMarkupContent);
 
         return hover;
+    }
+
+    /**
+     * Get the description only hover object.
+     *
+     * @return {@link Hover}
+     */
+    public static Hover getDescriptionOnlyHoverObject(Symbol symbol) {
+        if (!(symbol instanceof Documentable) || ((Documentable) symbol).documentation().isEmpty()) {
+            return getDefaultHoverObject();
+        }
+
+        return getDescriptionOnlyHoverObject(((Documentable) symbol).documentation().get());
     }
 
 //    private static boolean skipFirstParam(LSContext context, BInvokableSymbol invokableSymbol) {
@@ -231,7 +250,7 @@ public class HoverUtil {
 //    }
 
     private static Hover getFunctionHoverMarkupContent(FunctionSymbol symbol) {
-        Optional<Documentation> documentation = symbol.docAttachment();
+        Optional<Documentation> documentation = symbol.documentation();
         if (documentation.isEmpty()) {
             return getDefaultHoverObject();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -135,7 +135,7 @@ public class SignatureHelpUtil {
         Map<String, String> paramToDesc = new HashMap<>();
         SignatureInfoModel signatureInfoModel = new SignatureInfoModel();
         List<ParameterInfoModel> paramModels = new ArrayList<>();
-        Optional<Documentation> documentation = functionSymbol.docAttachment();
+        Optional<Documentation> documentation = functionSymbol.documentation();
         List<Parameter> parameters = new ArrayList<>();
         // TODO: Handle the error constructor in the next phase
         // Handle error constructors

--- a/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_typedef2.json
+++ b/language-server/modules/langserver-core/src/test/resources/hover/configs/hover_typedef2.json
@@ -7,7 +7,7 @@
     "result": {
       "contents": {
         "kind": "markdown",
-        "value": ""
+        "value": "Test Type definition2"
       }
     },
     "id": {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.Documentable;
+import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
+import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for documentation() API.
+ *
+ * @since 2.0.0
+ */
+public class DocumentationTest {
+
+    private SemanticModel model;
+    private final String fileName = "documentation_test.bal";
+    private final Map<String, String> emptyMap = new HashMap<>();
+
+    @BeforeClass
+    public void setup() {
+        model = SemanticAPITestUtils.getDefaultModulesSemanticModel("test-src/documentation_test.bal");
+    }
+
+    @Test
+    public void testAnnotationDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(27, 30));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDescriptionOnly(documentation.get(), "This is an annotation");
+    }
+
+    @Test
+    public void testClassDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(30, 6));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDescriptionOnly(documentation.get(), "This is a class");
+
+        ClassSymbol classSymbol = (ClassSymbol) symbol.get();
+        classSymbol.fieldDescriptors().forEach(
+                field -> assertDescriptionOnly(field.documentation().get(), "Field name"));
+        classSymbol.methods().forEach(
+                method -> assertDocumentation(method.documentation().get(), "Method getName", emptyMap, "string"));
+
+        assertDocumentation(classSymbol.initMethod().get().documentation().get(), "Method init",
+                            Map.of("name", "Param name"), "error or nil");
+    }
+
+    @Test
+    public void testConstantDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(47, 13));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDescriptionOnly(documentation.get(), "This is a constant");
+    }
+
+    @Test
+    public void testEnumDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(50, 12));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDescriptionOnly(documentation.get(), "This is an enum");
+
+        List<ConstantSymbol> members = ((EnumSymbol) symbol.get()).members();
+        for (ConstantSymbol member : members) {
+            assertDescriptionOnly(member.documentation().get(), "Enum member " + member.name());
+        }
+    }
+
+    @Test
+    public void testTypeDefDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(19, 5));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDocumentation(documentation.get(), "This is a record", Map.of("foo", "Field foo", "bar", "Field bar"),
+                            null);
+
+        RecordTypeSymbol recordType = (RecordTypeSymbol) ((TypeDefinitionSymbol) symbol.get()).typeDescriptor();
+        recordType.fieldDescriptors().forEach(
+                field -> assertDescriptionOnly(field.documentation().get(), "Field " + field.name()));
+    }
+
+    @Test
+    public void testFunctionDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(63, 9));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDocumentation(documentation.get(), "This is a function", Map.of("x", "Param x", "y", "Param y"),
+                            "The sum");
+    }
+
+    @Test
+    public void testModuleVarDocs() {
+        Optional<Symbol> symbol = model.symbol(fileName, from(66, 7));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        assertDescriptionOnly(documentation.get(), "This is a variable");
+    }
+
+    // util methods
+
+    private void assertDescriptionOnly(Documentation documentation, String description) {
+        assertEquals(documentation.description().get(), description);
+        assertEquals(documentation.parameterMap(), emptyMap);
+        assertTrue(documentation.returnDescription().isEmpty());
+    }
+
+    private void assertDocumentation(Documentation documentation, String description, Map<String, String> params,
+                                     String returnDesc) {
+        assertEquals(documentation.description().get(), description);
+        assertEquals(documentation.parameterMap().size(), params.size());
+        params.forEach((param, doc) -> assertEquals(documentation.parameterMap().get(param), doc));
+
+        if (returnDesc == null) {
+            assertTrue(documentation.returnDescription().isEmpty());
+        } else {
+            assertEquals(documentation.returnDescription().get(), returnDesc);
+        }
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/documentation_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/documentation_test.bal
@@ -1,0 +1,67 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# This is a record
+# + foo - Field foo
+# + bar - Field bar
+type Annot record {
+    # Field foo
+    string foo;
+    # Field bar
+    int bar?;
+};
+
+# This is an annotation
+public const annotation Annot v1 on source type, class, service, annotation, var, const, worker;
+
+# This is a class
+class Person {
+    # Field name
+    string name;
+
+    # Method init
+    # + name - Param name
+    # + return - error or nil
+    function init(string name) returns error? {
+        self.name = name;
+    }
+
+    # Method getName
+    # + return - string
+    function getName() returns string => self.name;
+}
+
+# This is a constant
+public const PI = 3.14;
+
+# This is an enum
+public enum Colour {
+    # Enum member RED
+    RED,
+    # Enum member GREEN
+    GREEN,
+    # Enum member BLUE
+    BLUE
+}
+
+# This is a function
+# + x - Param x
+# + y - Param y
+# + return - The sum
+function sum(int x, int y) returns int => x + y;
+
+# This is a variable
+string greet = "Hello";

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -24,6 +24,7 @@
             <class name="io.ballerina.semantic.api.test.AnnotationsTest" />
             <class name="io.ballerina.semantic.api.test.ClassSymbolTest" />
             <class name="io.ballerina.semantic.api.test.DiagnosticsTest" />
+            <class name="io.ballerina.semantic.api.test.DocumentationTest" />
             <class name="io.ballerina.semantic.api.test.ExpressionTypeTest" />
             <class name="io.ballerina.semantic.api.test.LangLibFunctionTest" />
             <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest" />


### PR DESCRIPTION
## Purpose
This PR refactors the API provided for retrieving documentation from a symbol. Previously, a method named `docAttachment()` was provided in `Symbol` to get the documentation. With this PR, this method has been removed and replaced by an interface named `Documentable`, which provides the method `documentation()` to retrieve the documentation from symbols implementing `Documentable`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
