### PR TITLE
Add includes method to langlib string

### DIFF
--- a/langlib/lang.string/src/main/ballerina/string.bal
+++ b/langlib/lang.string/src/main/ballerina/string.bal
@@ -247,3 +247,15 @@ public isolated function fromCodePointInt(int codePoint) returns Char|error = @j
     'class: "org.ballerinalang.langlib.string.FromCodePointInt",
     name: "fromCodePointInt"
 } external;
+
+# Tests whether a string includes another string.
+#
+# + str - the string in which to search
+# + substr - the string to search for
+# + startIndex - index to start searching from
+# + return - `true` if there is an occurrence of `substr` in `str` at an index >= `startIndex`,
+#    or `false` otherwise
+public isolated function includes(string str, string substr, int startIndex = 0) returns boolean = @java:Method {
+    'class: "org.ballerinalang.langlib.string.Includes",
+    name: "includes"
+} external;

--- a/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/Includes.java
+++ b/langlib/lang.string/src/main/java/org/ballerinalang/langlib/string/Includes.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.langlib.string;
+
+import io.ballerina.runtime.api.values.BString;
+import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
+import io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons;
+import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
+
+/**
+ * Extern function lang.string:includes(string, string, int).
+ *
+ * @since 2.0.0
+ */
+
+public class Includes {
+    public static boolean includes(BString str, BString substr, long index) {
+        if (index  > Integer.MAX_VALUE) {
+            throw BLangExceptionHelper.getRuntimeException(BallerinaErrorReasons.STRING_OPERATION_ERROR,
+                    RuntimeErrors.INDEX_NUMBER_TOO_LARGE, index);
+        }
+        try {
+            return str.indexOf(substr, (int) index) >= 0;
+        } catch (NullPointerException e) {
+            return false;
+        }
+    }
+}

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibStringTest.java
@@ -268,4 +268,10 @@ public class LangLibStringTest {
         };
     }
 
+    @Test
+    public void testIncludes() {
+        BValue[] returns = BRunUtil.invoke(compileResult, "testIncludes");
+        assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
 }

--- a/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/stringlib_test.bal
@@ -133,3 +133,7 @@ function testEqualsIgnoreCaseAscii() {
         i = i + 1;
     }
 }
+
+function testIncludes() returns boolean {
+    return strings:includes(str1, str, 6);
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -137,7 +137,8 @@ public class LangLibFunctionTest {
                                             "toCodePointInts", "clone", "cloneReadOnly", "cloneWithType", "isReadOnly",
                                             "toString", "toBalString", "fromBalString", "toJson", "toJsonString",
                                             "fromJsonWithType", "mergeJson", "ensureType", "fromJsonString",
-                                            "fromJsonFloatString", "fromJsonDecimalString", "fromJsonStringWithType");
+                                            "fromJsonFloatString", "fromJsonDecimalString", "fromJsonStringWithType",
+                                            "includes");
 
         assertLangLibList(type.langLibMethods(), expFunctions);
     }


### PR DESCRIPTION
This PR introduces the `includes` method in the langlib string according to the spec issue https://github.com/ballerina-platform/ballerina-spec/issues/687