### PR TITLE
Fix OutOfMemoryError: Java heap space Issue

### DIFF
--- a/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/CompilerPluginTest.java
+++ b/tests/ballerina-compiler-plugin-test/src/test/java/io/ballerina/test/compiler/plugins/CompilerPluginTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -109,5 +110,10 @@ public class CompilerPluginTest {
                 Assert.assertEquals(actualEventSet.contains(expectedEvent), true,
                         "The " + kind.name + " '" + expectedEvent.nodeName + "' is not processed")
         );
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/annotation/AnnotationTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/annotation/AnnotationTests.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -78,5 +79,10 @@ public class AnnotationTests {
         Assert.assertEquals(returns.length, 1);
         Assert.assertNotNull(returns[0]);
         Assert.assertTrue(returns[0].stringValue().contains("/bar"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInBaloTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -32,7 +33,7 @@ import org.testng.annotations.Test;
  */
 public class MapConstantEqualityInBaloTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -1142,5 +1143,10 @@ public class MapConstantEqualityInBaloTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testSimpleNilMapReferenceEqualityInDifferentMap");
         Assert.assertNotNull(returns[0]);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInDifferentBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantEqualityInDifferentBaloTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -32,7 +33,7 @@ import org.testng.annotations.Test;
  */
 public class MapConstantEqualityInDifferentBaloTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -1144,5 +1145,10 @@ public class MapConstantEqualityInDifferentBaloTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testSimpleNilMapReferenceEqualityInDifferentMap");
         Assert.assertNotNull(returns[0]);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantInBaloTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -264,5 +265,10 @@ public class MapConstantInBaloTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testConstInAnnotations");
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "{s:\"Ballerina\", i:100, m:{\"mKey\":\"mValue\"}}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantPanicInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/MapConstantPanicInBaloTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -289,5 +290,10 @@ public class MapConstantPanicInBaloTest {
             expectedExceptionsMessageRegExp = ".*modification not allowed on readonly value.*")
     public void updateConstantNilMapValueInArrayWithNewKey() {
         BRunUtil.invoke(compileResult, "updateConstantNilMapValueInArrayWithNewKey");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantAccessInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/constant/SimpleConstantAccessInBaloTest.java
@@ -160,5 +160,6 @@ public class SimpleConstantAccessInBaloTest {
     @AfterClass
     public void tearDown() {
         BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -594,7 +594,6 @@ public class ObjectInBaloTest {
 
     @AfterClass
     public void tearDown() {
-        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
         result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -26,8 +26,10 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.ballerinalang.test.balo.BaloCreator;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -589,4 +591,10 @@ public class ObjectInBaloTest {
 //                                          "non-public fields or methods",
 //                                  42, 6);
 //    }
+
+    @AfterClass
+    public void tearDown() {
+        BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ObjectInBaloTest.java
@@ -26,7 +26,6 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
-import org.ballerinalang.test.balo.BaloCreator;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ReadOnlyObjectBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/object/ReadOnlyObjectBaloTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.balo.object;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -56,5 +57,10 @@ public class ReadOnlyObjectBaloTest {
         validateError(result, index++, "cannot initialize abstract object '(testorg/readonly_objects:" +
                 "1.0.0:CustomController & readonly)'", 20, 54);
         assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/readonly/SelectivelyImmutableTypeBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/readonly/SelectivelyImmutableTypeBaloTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.balo.readonly;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -84,5 +85,10 @@ public class SelectivelyImmutableTypeBaloTest {
                 ".0:MyConfig'", 88, 5);
 
         assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/ClosedRecordTypeReferenceTest.java
@@ -172,5 +172,6 @@ public class ClosedRecordTypeReferenceTest {
     @AfterClass
     public void tearDown() {
         BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project", "testorg", "foo");
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/OpenRecordTypeReferenceTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -170,5 +171,10 @@ public class OpenRecordTypeReferenceTest {
     @Test()
     public void testCreatingRecordWithOverriddenFields() {
         BRunUtil.invoke(compileResult, "testCreatingRecordWithOverriddenFields");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/RecordInBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/record/RecordInBaloTest.java
@@ -62,5 +62,6 @@ public class RecordInBaloTest {
     @AfterClass
     public void tearDown() {
         BaloCreator.clearPackageFromRepository("test-src/balo/test_projects/test_project/", "testorg", "records");
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/ErrorTypeTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -119,5 +120,11 @@ public class ErrorTypeTest {
                 "incompatible types: expected 'testorg/errors:1.0.0:NewPostDefinedError', " +
                         "found 'testorg/errors:1.0.0:PostDefinedError'", 28, 32);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/FiniteTypeTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -305,6 +306,11 @@ public class FiniteTypeTest {
                 {"testFiniteTypesAsUnionsAsBroaderTypes_1"},
                 {"testFiniteTypesAsUnionsAsBroaderTypes_2"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/NeverTypeBaloTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/balo/types/NeverTypeBaloTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -67,5 +68,10 @@ public class NeverTypeBaloTest {
     @Test
     public void testNeverWithKeyLessTable() {
         BRunUtil.invoke(result, "testNeverWithKeyLessTable");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/enums/EnumTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/enums/EnumTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.enums;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -89,5 +90,13 @@ public class EnumTest {
         validateError(accessTestNegative, i++, "attempt to refer to non-accessible symbol 'PF'", 23, 4);
         validateError(accessTestNegative, i++, "unknown type 'PF'", 23, 4);
         assertEquals(accessTestNegative.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeTest = null;
+        accessTest = null;
+        accessTestNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/TemplateExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/TemplateExpressionTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -117,5 +118,10 @@ public class TemplateExpressionTest {
         String expected = "{\"intStrIndex0\":\"0\", \"intStrIndex1\":\"1\", "
                 + "\"boolStrIndex0\":\"true\", \"boolStrIndex1\":\"false\"}";
         Assert.assertEquals(returns[0].stringValue(), expected);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/FunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/FunctionTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,5 +58,10 @@ public class FunctionTest {
         BRunUtil.invoke(result, "test1", args);
         BRunUtil.invoke(result, "test2", args);
         BRunUtil.invoke(result, "test3", args);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/PackageInitInvocationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/PackageInitInvocationTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -54,5 +55,10 @@ public class PackageInitInvocationTest {
         Assert.assertEquals(values.length, 1);
         Assert.assertTrue(values[0] instanceof BInteger);
         Assert.assertEquals(((BInteger) values[0]).intValue(), 899);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/StringFunctionInvocationExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/invocations/StringFunctionInvocationExprTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -66,5 +67,11 @@ public class StringFunctionInvocationExprTest {
         Assert.assertEquals(compileResultNegative.getErrorCount(), 1);
         BAssertUtil.validateError(compileResultNegative, 0, "undefined function 'randomFunction' in type 'string'", 2
                 , 27);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        compileResultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/ArrowExprTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -275,4 +276,11 @@ public class ArrowExprTest {
         BRunUtil.invoke(basic, "testTypeNarrowingInArrowExpression");
     }
 
+    @AfterClass
+    public void tearDown() {
+        basic = null;
+        resultNegative = null;
+        resultTypeNarrowNegative = null;
+        resultSemanticsNegative = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -323,5 +324,14 @@ public class FunctionPointersTest {
     @Test(description = "Test function pointers defaultable params")
     public void testDefaultParams() {
         BRunUtil.invoke(fpProgram, "testDefaultParams");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        fpProgram = null;
+        closureFPProgram = null;
+        privateFPProgram = null;
+        globalProgram = null;
+        structProgram = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithOptionalArgsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithOptionalArgsTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -63,5 +64,10 @@ public class FunctionPointersWithOptionalArgsTest {
 
         Assert.assertNotNull(returns[2]);
         Assert.assertEquals(returns[2].stringValue(), "Alex");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithRestArgsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithRestArgsNegativeTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,5 +45,10 @@ public class FunctionPointersWithRestArgsNegativeTest {
         int index = 0;
         BAssertUtil.validateError(fpProgram, index, "incompatible types: expected 'function (string,int[]) returns " +
                 "(string)', found 'function (string, int...) returns (string)'", 2, 54);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        fpProgram = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithRestArgsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/FunctionPointersWithRestArgsTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -107,5 +108,10 @@ public class FunctionPointersWithRestArgsTest {
         Assert.assertEquals(returns.length, 1);
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "Irshad");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        fpProgram = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableArrowExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableArrowExprTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -138,5 +139,11 @@ public class IterableArrowExprTest {
                 "incompatible types: expected 'string[]', found 'map<string>'", 34, 24);
         BAssertUtil.validateError(resultNegative, i++,
                 "incompatible types: expected 'string[]', found 'int'", 35, 20);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        basic = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsTests.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -291,5 +292,11 @@ public class IterableOperationsTests {
         Assert.assertEquals(returns[0].getType().toString(), "function (int) returns (boolean)");
         Assert.assertEquals(returns[1].getType().toString(), "function (int) returns (boolean)");
         Assert.assertEquals(returns[2].getType().toString(), "function (int) returns (boolean)");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        basic = null;
+        negative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsWithVarMutabilityTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/lambda/IterableOperationsWithVarMutabilityTests.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -185,5 +186,10 @@ public class IterableOperationsWithVarMutabilityTests {
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "[\"USD\", \"USD\", \"EUR\", \"GBP\", \"USD\", \"EUR\", " +
                 "\"GBP\", \"USD\"]");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -102,5 +103,12 @@ public class LetExpressionTest {
 //                {"testLetExpressionErrorBindingVar"},
 //                {"testLetExpressionRecordConstrainedErrorBinding"},
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeResult = null;
+        notSupportedResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -116,5 +116,4 @@ public class ListConstructorExprTest {
         resultInferType = null;
         resultNegative = null;
     }
-
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/listconstructor/ListConstructorExprTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -108,4 +109,12 @@ public class ListConstructorExprTest {
         BRunUtil.invoke(resultInferType, "testInferringForReadOnly");
         BRunUtil.invoke(resultInferType, "testInferringForReadOnlyInUnion");
     }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultInferType = null;
+        resultNegative = null;
+    }
+
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralPackageTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralPackageTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -70,5 +71,10 @@ public class IdentifierLiteralPackageTest {
         Assert.assertEquals(returns[0].stringValue(), "Harry");
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 25);
 
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/IdentifierLiteralTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -271,4 +272,8 @@ public class IdentifierLiteralTest {
         BRunUtil.invoke(result, "testILInTableType");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/NullLiteralUsageTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/NullLiteralUsageTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -161,5 +162,10 @@ public class NullLiteralUsageTest {
     public void testNullInNestedTernaryExpr() {
         BValue[] returns = BRunUtil.invoke(result, "testNullInNestedTernaryExpr");
         assertNull(returns[0]);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/NumericLiteralAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/literals/NumericLiteralAssignmentTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -146,5 +147,10 @@ public class NumericLiteralAssignmentTest {
     public void testFloatLiteralAsIntWithBuiltinUnion() {
         BValue[] returns = BRunUtil.invoke(result, "testFloatLiteralAsFloatWithBuiltinUnion");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/mappingconstructor/MappingConstructorExprTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -386,5 +387,14 @@ public class MappingConstructorExprTest {
                 "expected a string literal or an expression", 39, 9);
 
         Assert.assertEquals(compileResult.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        varNameFieldResult = null;
+        inferRecordResult = null;
+        spreadOpFieldResult = null;
+        readOnlyFieldResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ObjectConstructorTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -126,5 +127,10 @@ public class ObjectConstructorTest {
         validateError(negativeResult, index++, "incompatible types: expected '()', found 'stream<string>'",
                       117, 22);
         Assert.assertEquals(negativeResult.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compiledConstructedObjects = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ServiceConstructorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/object/ServiceConstructorTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.expressions.object;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,5 +41,10 @@ public class ServiceConstructorTest {
     @Test
     public void testObjectCreationViaObjectConstructor() {
         BRunUtil.invoke(compiledConstructedObjects, "testServiceCtor");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compiledConstructedObjects = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/rawtemplate/RawTemplateLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/rawtemplate/RawTemplateLiteralTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.expressions.rawtemplate;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -145,5 +146,10 @@ public class RawTemplateLiteralTest {
                 {"testIndirectAssignmentToConcreteType"},
                 {"testModifyStringsField"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/AnydataStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/AnydataStampInbuiltFunctionTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -228,5 +229,10 @@ public class AnydataStampInbuiltFunctionTest {
 
         Assert.assertEquals(mapValue.get("status").stringValue(), "single");
         Assert.assertEquals(mapValue.get("status").getType().getClass(), BStringType.class);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/ArrayStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/ArrayStampInbuiltFunctionTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -382,5 +383,10 @@ public class ArrayStampInbuiltFunctionTest {
         Assert.assertEquals(jsonValue2.get("name").stringValue(), "Heshitha");
         Assert.assertEquals(((BInteger) jsonValue1.get("age")).intValue(), 10);
         Assert.assertEquals(((BInteger) jsonValue2.get("age")).intValue(), 15);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/JSONStampInbuiltFunctionTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -288,5 +289,10 @@ public class JSONStampInbuiltFunctionTest {
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "cannot convert '()' to type 'StringArray'");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/MapStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/MapStampInbuiltFunctionTest.java
@@ -32,6 +32,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -559,5 +560,10 @@ public class MapStampInbuiltFunctionTest {
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "'Person' value has cyclic reference");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/RecordStampInbuiltFunctionTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -586,5 +587,10 @@ public class RecordStampInbuiltFunctionTest {
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "'Employee' value cannot be converted to 'Teacher'");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/StampInbuiltFunctionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/StampInbuiltFunctionNegativeTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -421,5 +422,18 @@ public class StampInbuiltFunctionNegativeTest {
         Assert.assertEquals(error.getType().getClass(), BErrorType.class);
         Assert.assertEquals(((BMap<String, BString>) ((BError) results[0]).getDetails()).get("message").stringValue(),
                             "'int' value cannot be converted to 'float|decimal|[string,int]': ambiguous target type");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        recordNegativeTestCompileResult = null;
+        jsonNegativeTestCompileResult = null;
+        xmlNegativeTestCompileResult = null;
+        mapNegativeTestCompileResult = null;
+        objectNegativeTestCompileResult = null;
+        arrayNegativeTestCompileResult = null;
+        tupleNegativeTestCompileResult = null;
+        unionNegativeTestCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/TupleTypeStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/TupleTypeStampInbuiltFunctionTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -197,5 +198,10 @@ public class TupleTypeStampInbuiltFunctionTest {
         BValue[] results = BRunUtil.invoke(compileResult, "stampAnydataTupleToBasicTypeTuple");
         Assert.assertEquals(((BInteger) results[0]).value().intValue(), 1);
         Assert.assertEquals(((BInteger) results[1]).value().intValue(), 2);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/UnionTypeStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/UnionTypeStampInbuiltFunctionTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -200,6 +201,11 @@ public class UnionTypeStampInbuiltFunctionTest {
                 BStringType.class);
         Assert.assertEquals(((BValue) ((BMap) employee0.getMap().get("b")).getMap().get("batch")).getType().getClass(),
                 BStringType.class);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/XMLStampInbuiltFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/stamp/XMLStampInbuiltFunctionTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,6 +63,11 @@ public class XMLStampInbuiltFunctionTest {
         Assert.assertEquals(results.length, 1);
         Assert.assertEquals(anydataValue.stringValue(), "<book>The Lost World</book>");
         Assert.assertEquals(anydataValue.getType().getClass(), BXMLType.class);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/ternary/TernaryExpressionTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -344,5 +345,10 @@ public class TernaryExpressionTest {
     public void testErrorInTernary() {
         BValue[] results = BRunUtil.invoke(compileResult, "testErrorInTernary");
         Assert.assertEquals(((BInteger) results[0]).intValue(), 7);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/NumericConversionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/NumericConversionTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -716,5 +717,11 @@ public class NumericConversionTest {
                 {256},
                 {3055},
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/SimpleTypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/SimpleTypeCastExprTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -88,5 +89,10 @@ public class SimpleTypeCastExprTest {
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].getClass(), BInteger.class);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), expected);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -708,6 +708,6 @@ public class TypeCastExprTest {
 
     @AfterClass
     public void tearDown() {
-        compileResult = null;
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExprTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -703,5 +704,10 @@ public class TypeCastExprTest {
     public void testAnonRecordInCast() {
         BValue[] returns = BRunUtil.invoke(result, "testAnonRecordInCast");
         Assert.assertEquals(returns[0].stringValue(), "{name:\"Pubudu\"}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/TypeCastExpressionsTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -352,4 +353,9 @@ public class TypeCastExpressionsTest {
         Assert.assertEquals(((BMap) returns[0]).get("id").stringValue(), "1100");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/ValueTypeCastExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typecast/ValueTypeCastExprTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -171,5 +172,10 @@ public class ValueTypeCastExprTest {
         Assert.assertTrue(returns[0] instanceof BBoolean);
         final boolean expected = false;
         Assert.assertEquals(((BBoolean) returns[0]).booleanValue(), expected);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/typeof/TypeofOverLiteralExpressionTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -83,5 +84,10 @@ public class TypeofOverLiteralExpressionTest {
         Assert.assertEquals(res[0].stringValue(), "int");
         Assert.assertEquals(res[1].stringValue(), "int");
         Assert.assertEquals(res[2].stringValue(), "float");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/LengthOfOperatorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/LengthOfOperatorTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -268,5 +269,11 @@ public class LengthOfOperatorTest {
     public void lengthOfJSONObject() {
         BValue[] returns = BRunUtil.invoke(result, "lengthOfJSONObject");
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 2);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/unaryoperations/UnaryExprTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -184,5 +185,11 @@ public class UnaryExprTest {
         BAssertUtil.validateError(resultNegative, 0, "operator '+' not defined for 'json'", 5, 10);
         BAssertUtil.validateError(resultNegative, 1, "operator '-' not defined for 'json'", 14, 10);
         BAssertUtil.validateError(resultNegative, 2, "operator '!' not defined for 'json'", 23, 10);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/ExprBodiedFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/ExprBodiedFunctionTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -116,5 +117,10 @@ public class ExprBodiedFunctionTest {
                 {"testReturningServiceConstructors"},
                 {"testLetExprAsExprBody"},
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionNilReturnTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionNilReturnTest.java
@@ -207,4 +207,9 @@ public class FunctionNilReturnTest {
         Assert.assertNull(BRunUtil.invoke(compileResult, "testNilableTupleArray")[0]);
         Assert.assertNull(BRunUtil.invoke(compileResult, "testNilableTypedescArray")[0]);
     }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionSignatureTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -457,5 +458,11 @@ public class FunctionSignatureTest {
     @Test(description = "Test2: function signature which has a function typed param with only rest param")
     public void testFunctionWithFunctionTypedParamWithOnlyRestParam2() {
         BRunUtil.invoke(result, "testFunctionOfFunctionTypedParamWithRest2");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        pkgResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionWithIncludedRecordParam.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionWithIncludedRecordParam.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -189,5 +190,10 @@ public class FunctionWithIncludedRecordParam {
     @Test
     public void testFuctionWithIncludedRecordParameters23() {
         BRunUtil.invoke(result, "testFuctionWithIncludedRecordParameters23");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionsAndNilTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionsAndNilTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -90,5 +91,10 @@ public class FunctionsAndNilTest {
     public void testNilReturnAssignment() {
         BValue[] returns = BRunUtil.invoke(result, "testNilReturnAssignment");
         Assert.assertNull(returns[0]);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionsWithDefaultableArguments.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/FunctionsWithDefaultableArguments.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -229,5 +230,10 @@ public class FunctionsWithDefaultableArguments {
         Assert.assertTrue(returns[0] instanceof BString);
 
         Assert.assertEquals(returns[0].stringValue(), "hellohelloasyncworldworldasyncsamplevalue");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/UndefinedFunctionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/functions/UndefinedFunctionsTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -47,5 +48,10 @@ public class UndefinedFunctionsTest {
         BAssertUtil.validateError(result, i++, "undefined function 'add' in type 'string'", 4, 16);
         BAssertUtil.validateError(result, i++, "undefined function 'length' in type 'string?'", 17, 30);
         BAssertUtil.validateError(result, i++, "undefined function 'delete' in type 'map<string>'", 26, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -225,5 +226,10 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_NON_ISOLATED_FUNCTION_CALL_IN_OBJECT_FIELD_DEFAULT, 68, 14);
         validateError(result, i++, INVALID_NON_ISOLATED_INIT_EXPRESSION_IN_OBJECT_FIELD_DEFAULT, 74, 12);
         Assert.assertEquals(result.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeTests.java
@@ -44,6 +44,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -413,5 +414,10 @@ public class RefTypeTests {
     public static io.ballerina.runtime.api.values.BString useHandle(HandleValue h) {
         Map<String, String> m = (Map<String, String>) h.getValue();
         return StringUtils.fromString(m.get("name"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/RefTypeWithBValueAPITests.java
@@ -48,6 +48,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -503,5 +504,10 @@ public class RefTypeWithBValueAPITests {
 
     public static io.ballerina.runtime.api.values.BFuture getFuture(Object a) {
         return (FutureValue) a;
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/VariableReturnTypeTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -147,5 +148,10 @@ public class VariableReturnTypeTest {
                 {"testDependentlyTypedMethodsWithObjectTypeInclusion"},
                 {"testSubtypingWithDependentlyTypedMethods"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/AsyncTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/AsyncTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -49,4 +50,8 @@ public class AsyncTest {
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 42);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/ConstructorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/ConstructorTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -75,5 +76,10 @@ public class ConstructorTest {
         ClassWithTwoParamConstructor createdClass =
                 (ClassWithTwoParamConstructor) ((BHandleValue) returns[0]).getValue();
         Assert.assertEquals(createdClass.getValue(), "Bye Ballerina");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/FieldAccessMutateTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/FieldAccessMutateTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -119,5 +120,10 @@ public class FieldAccessMutateTest {
         args[1] = new BFloat(123.0f);
         BRunUtil.invoke(result, "testInstancePrimitiveFieldMutate", args);
         Assert.assertEquals(receiver.lkr, 123.0f);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/HandleRefersNullTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/HandleRefersNullTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -55,5 +56,10 @@ public class HandleRefersNullTest {
         BValue[] returns = BRunUtil.invoke(result, "testIsNull", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/InstanceMethodTest.java
@@ -31,6 +31,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -263,5 +264,10 @@ public class InstanceMethodTest {
         BValue[] args = new BValue[1];
         args[0] = new BHandleValue(testIns);
         BRunUtil.invoke(result, "testGetCurrentModule", args);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/JavaCastTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -100,5 +101,10 @@ public class JavaCastTest {
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(returns[0].stringValue().contains("{ballerina/java} Error while retrieving details of " +
                 "the `@java:Binding` annotation from `Object2` object: java.lang.NullPointerException"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/ObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/ObjectTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.javainterop.basic;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,5 +41,10 @@ public class ObjectTest {
     @Test (enabled = false)
     public void testInteropsInsideObject() {
         BRunUtil.invoke(result, "testInteropsInsideObject");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -185,5 +186,10 @@ public class StaticMethodTest {
         return new String[]{"testBalEnvSlowAsyncVoidSig", "testBalEnvFastAsyncVoidSig", "testBalEnvSlowAsync",
                 "testBalEnvFastAsync", "testReturnNullString", "testReturnNotNullString", "testStaticResolve",
                 "testStringCast", "testGetCurrentModule", "testCreateStudentUsingType", "testCreateStudent"};
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/overloading/OverloadedMethodTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/overloading/OverloadedMethodTests.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -79,5 +80,10 @@ public class OverloadedMethodTests {
         BValue[] args = new BValue[1];
         args[0] = new BString("BALLERINA");
         BRunUtil.invoke(result, "testOverloadedMethodsWithDifferentParametersTwo", args);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/overloading/OverriddenMethodTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/overloading/OverriddenMethodTests.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,5 +45,10 @@ public class OverriddenMethodTests {
         Assert.assertEquals(returns.length, 2);
         Assert.assertEquals(returns[0].stringValue(), "Motor Car : Honda");
         Assert.assertEquals(returns[1].stringValue(), "GrazeHonda");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/FunctionsReturningPrimitivesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/FunctionsReturningPrimitivesTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -83,5 +84,10 @@ public class FunctionsReturningPrimitivesTest {
         BValue[] returns = BRunUtil.invoke(result, "testReturningBFloatJDouble", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BFloat) returns[0]).floatValue(), receiver);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/PrimitiveConversionInFunctionReturnsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/PrimitiveConversionInFunctionReturnsTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -92,5 +93,10 @@ public class PrimitiveConversionInFunctionReturnsTest {
         returns = BRunUtil.invoke(result, "testReturningBFloatJChar", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals((char) (((BFloat) returns[0]).floatValue()), charValue.charValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/PrimitiveConversionsInFunctionParamsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/PrimitiveConversionsInFunctionParamsTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -134,5 +135,10 @@ public class PrimitiveConversionsInFunctionParamsTest {
         returns = BRunUtil.invoke(result, "testCreateJFloatFromBFloat", args);
         Float floatValue = (Float) ((BHandleValue) returns[0]).getValue();
         Assert.assertEquals(floatValue.doubleValue(), value);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/PrimitiveTypeFunctionParamTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/PrimitiveTypeFunctionParamTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -78,5 +79,10 @@ public class PrimitiveTypeFunctionParamTest {
         BValue[] returns = BRunUtil.invoke(result, "testCreateBoxedDoubleFromBFloat", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(((BHandleValue) returns[0]).getValue(), 30000000.00d);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/UnionsWithPrimitiveTypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/primitivetypes/UnionsWithPrimitiveTypesTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -107,5 +108,10 @@ public class UnionsWithPrimitiveTypesTest {
         dataOS.writeDouble(aDouble);
         ByteArrayInputStream byteAIS = new ByteArrayInputStream(byteAOS.toByteArray());
         return new DataInputStream(byteAIS);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/AnonymousFunctionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/AnonymousFunctionsTest.java
@@ -22,6 +22,7 @@
  import org.ballerinalang.test.BRunUtil;
  import org.ballerinalang.test.CompileResult;
  import org.testng.Assert;
+ import org.testng.annotations.AfterClass;
  import org.testng.annotations.BeforeClass;
  import org.testng.annotations.Test;
 
@@ -68,5 +69,10 @@
      public void testWorkerBasic() {
          BValue[] result = BRunUtil.invoke(compileResult, "basicWorkerTest");
          Assert.assertEquals(result[0].stringValue(), "120");
+     }
+
+     @AfterClass
+     public void tearDown() {
+         compileResult = null;
      }
  }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/BuiltinMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/BuiltinMethodTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -54,5 +55,10 @@ public class BuiltinMethodTest {
         Assert.assertTrue(result[0] instanceof BMap);
         BMap bMap = (BMap) result[0];
         Assert.assertEquals(bMap.get("test").stringValue(), "sample");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ErrorTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -124,5 +125,10 @@ public class ErrorTest {
             return;
         }
         Assert.fail("runtime out of memory errors are not handled");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/FiniteTypeTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -298,5 +299,10 @@ public class FiniteTypeTest {
                 {"testFiniteTypesAsUnionsAsBroaderTypes_1"},
                 {"testFiniteTypesAsUnionsAsBroaderTypes_2"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachArrayTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachArrayTests.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -222,5 +223,10 @@ public class ForeachArrayTests {
     @Test
     public void testEmptyArray() {
         BRunUtil.invoke(program, "testEmptyArray");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        program = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachMapTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ForeachMapTests.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -76,4 +77,8 @@ public class ForeachMapTests {
         Assert.assertEquals(returns[0].stringValue(), result);
     }
 
+    @AfterClass
+    public void tearDown() {
+        program = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ModuleTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ModuleTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -46,5 +47,10 @@ public class ModuleTest {
         Assert.assertTrue(result[0] instanceof BInteger);
         BInteger calculatedValue = (BInteger) result[0];
         Assert.assertEquals(calculatedValue.intValue(), 12);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ObjectSubtypingTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ObjectSubtypingTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -121,5 +122,10 @@ public class ObjectSubtypingTest {
         validateError(result, i++, "uninitialized field 'intField1'", 27, 5);
         validateError(result, i++, "uninitialized field 'intField2'", 28, 5);
         assertEquals(result.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ParallelismTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/ParallelismTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -59,4 +60,8 @@ public class ParallelismTest {
         Assert.assertEquals(result[0].stringValue(), "[1, 2, 3, 4, 5, 6, 7, 8, 9, 10]");
     }
 
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypeTestExprTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -135,5 +136,10 @@ public class TypeTestExprTest {
     @Test
     public void testIsLikeForTupleWithOutRestDescriptor() {
         BRunUtil.invoke(compileResult, "testIsLikeForTupleWithOutRestDescriptor");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/TypesTest.java
@@ -35,6 +35,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -780,5 +781,11 @@ public class TypesTest {
     @Test
     public void testTypeDescValuePrint() {
         BRunUtil.invoke(compileResult, "testTypeDescValuePrint");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        objectsResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/XMLTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/jvm/XMLTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.ballerinalang.test.util.BFileUtil;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -201,5 +202,11 @@ public class XMLTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testGetGlobalXML");
         Assert.assertTrue(returns[0] instanceof BXML);
         Assert.assertEquals(returns[0].stringValue(), "<test><name>ballerina</name></test>");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        literalWithNamespacesResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/klass/ClassTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/klass/ClassTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -115,5 +116,11 @@ public class ClassTest {
         BAssertUtil.validateError(negative, i++, String.format(uninitializedMessage, "q"), 17, 13);
         BAssertUtil.validateError(negative, i++, String.format(uninitializedMessage, "q"), 18, 13);
         Assert.assertEquals(negative.getErrorCount(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        distinctCompUnit = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/loc/LineOfCodeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/loc/LineOfCodeTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -47,5 +48,10 @@ public class LineOfCodeTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "largeFunction");
         Assert.assertTrue(returns[0] instanceof BInteger);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 37000);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/lock/LocksInMainTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -296,5 +297,10 @@ public class LocksInMainTest {
     @Test(description = "Test for global reference updated inside conditional statment")
     public void testForGlobalRefUpdateInsideConditional() {
         BRunUtil.invoke(parallelCompileResult, "testForGlobalRefUpdateInsideConditional");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        parallelCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/ArgumentParserPositiveTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -289,5 +290,10 @@ public class ArgumentParserPositiveTest {
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/MainFunctionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/main/function/MainFunctionsTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.model.values.BValueArray;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
@@ -131,5 +132,10 @@ public class MainFunctionsTest {
         } catch (Throwable e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/nativeimpl/functions/RuntimeTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -101,5 +102,11 @@ public class RuntimeTest {
         Assert.assertEquals(returns[2].stringValue(),
                 "{callableName:\"testErrorStackFrame\", moduleName:\".\", fileName:\"runtime-error.bal\", " +
                         "lineNumber:16}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        errorResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AbstractObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AbstractObjectTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -117,5 +118,11 @@ public class AbstractObjectTest {
     public void testAbstractObjectInObject() {
         BValue[] result = BRunUtil.invoke(abstractObjects, "testAbstractObjectInObject");
         Assert.assertEquals(result[0].stringValue(), "{city:\"Colombo\", address:{city:\"Colombo\"}}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        anonAbstractObjects = null;
+        abstractObjects = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AnonymousObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/AnonymousObjectTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -167,5 +168,10 @@ public class AnonymousObjectTest {
     @Test(description = "Test Code analyzer execution on Anonymous objects")
     public void testCodeAnalyzerRunningOnAnonymousObjectsForDeprecatedFunctionAnnotation() {
         BAssertUtil.validateWarning(compileResult, 0, "usage of construct 'Test()' is deprecated", 218, 17);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectAttachedFunctionPointerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectAttachedFunctionPointerTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -91,5 +92,10 @@ public class ObjectAttachedFunctionPointerTest {
     public void testInvokeAttachedFunctionAsFunctionPointer4() {
         BValue[] returns = BRunUtil.invoke(compileResult, "test9");
         Assert.assertEquals(returns[0].stringValue(), "finally");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectEquivalencyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectEquivalencyTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -149,5 +150,10 @@ public class ObjectEquivalencyTest {
     @Test
     public void testSubtypingBetweenNonClientAndClientObject() {
         BRunUtil.invoke(compileResult, "testSubtypingBetweenNonClientAndClientObject");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectFunctionsWithDefaultableArguments.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectFunctionsWithDefaultableArguments.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -265,5 +266,10 @@ public class ObjectFunctionsWithDefaultableArguments {
         bValueArray = (BValueArray) returns[3];
         Assert.assertEquals(((BInteger) bValueArray.getRefValue(0)).intValue(), 400);
         Assert.assertEquals(((BFloat) bValueArray.getRefValue(1)).floatValue(), 44.4);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/object/ObjectInitializerTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
@@ -297,5 +298,10 @@ public class ObjectInitializerTest {
     @Test(description = "Test invoking 'init' function with lambda function args")
     public void testFunctionPointerAsDefaultableParam2() {
         BRunUtil.invoke(compileResult, "testFunctionPointerAsDefaultableParam2");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/InnerQueryTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/InnerQueryTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -89,4 +90,9 @@ public class InnerQueryTest {
         validateError(negativeResult, i, "undefined symbol 'emp'", 88, 30);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/JoinClauseTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -151,5 +152,11 @@ public class JoinClauseTest {
         validateError(negativeResult, i++, "undefined symbol 'dept'", 329, 24);
         validateError(negativeResult, i++, "missing equals keyword", 330, 1);
         validateError(negativeResult, i, "missing identifier", 330, 1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/LimitClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/LimitClauseTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -161,5 +162,11 @@ public class LimitClauseTest {
         validateError(negativeResult, i++, "incompatible types: expected 'int', found 'boolean'", 38, 19);
         validateError(negativeResult, i++, "incompatible types: expected 'int', found 'boolean'", 78, 19);
         validateError(negativeResult, i, "more clauses after select clause", 123, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleFromClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleFromClauseTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -374,5 +375,10 @@ public class MultipleFromClauseTest {
                 "deptAccess:\"HR\", address:{city:\"NY\", country:\"America\"}}");
         Assert.assertEquals(person4.stringValue(), "{firstName:\"Ranjan\", lastName:\"Fonseka\", " +
                 "deptAccess:\"Operations\", address:{city:\"NY\", country:\"America\"}}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleFromClauseWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleFromClauseWithVarTypeTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -156,5 +157,10 @@ public class MultipleFromClauseWithVarTypeTest {
         Assert.assertEquals(person6.get("firstName").stringValue(), "John");
         Assert.assertEquals(person6.get("lastName").stringValue(), "David");
         Assert.assertEquals(person6.get("deptAccess").stringValue(), "Operations");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleLetClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleLetClauseTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -100,5 +101,10 @@ public class MultipleLetClauseTest {
         Assert.assertEquals(teacher2.get("firstName").stringValue(), "Ranjan");
         Assert.assertEquals(teacher2.get("lastName").stringValue(), "Fonseka");
         Assert.assertEquals(teacher2.get("age").stringValue(), "30");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleWhereClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleWhereClauseTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -86,5 +87,10 @@ public class MultipleWhereClauseTest {
         Assert.assertEquals(person1.get("firstName").stringValue(), "Ranjan");
         Assert.assertEquals(person1.get("lastName").stringValue(), "Fonseka");
         Assert.assertEquals(((BFloat) person1.get("score")).floatValue(), 90.6);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleWhereClauseWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/MultipleWhereClauseWithVarTypeTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -72,5 +73,10 @@ public class MultipleWhereClauseWithVarTypeTest {
         Assert.assertEquals(person1.get("firstName").stringValue(), "Alex");
         Assert.assertEquals(person1.get("lastName").stringValue(), "George");
         Assert.assertEquals(person1.get("deptAccess").stringValue(), "Operations");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/ObjectQueryTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/ObjectQueryTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.query;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,4 +44,8 @@ public class ObjectQueryTest {
         BRunUtil.invoke(result, "testObjectBasedQueryExpr");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/OrderByClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/OrderByClauseTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -251,5 +252,11 @@ public class OrderByClauseTest {
         validateError(negativeResult, index, "order by not supported for complex type fields, " +
                         "order key should belong to a basic type",
                 47, 18);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -125,5 +126,10 @@ public class QueryActionTest {
 
         Assert.assertEquals(employee.get("firstName").stringValue(), "Alex");
         Assert.assertEquals(employee.get("deptAccess").stringValue(), "Human Resource");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExprWithQueryConstructTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExprWithQueryConstructTypeTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -190,5 +191,12 @@ public class QueryExprWithQueryConstructTypeTest {
         validateError(semanticsNegativeResult, 0, "on conflict can only be used with queries which produce tables " +
                         "with key specifiers",
                 39, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
+        semanticsNegativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -115,5 +116,10 @@ public class QueryExpressionIterableObjectTest {
         Assert.assertEquals(array.getInt(i++), 3);
         Assert.assertEquals(array.getInt(i++), 4);
         Assert.assertEquals(array.getInt(i), 5);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        program = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionWithVarTypeTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -266,4 +267,8 @@ public class QueryExpressionWithVarTypeTest {
         Assert.assertTrue(((BBoolean) returnValues[0]).booleanValue());
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/RecordQueryTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/RecordQueryTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.query;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,4 +44,8 @@ public class RecordQueryTest {
         BRunUtil.invoke(result, "testRecordBasedQueryExpr");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/SimpleQueryExpressionWithDefinedTypeTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -360,5 +361,10 @@ public class SimpleQueryExpressionWithDefinedTypeTest {
                 "deptAccess:\"XYZ\", address:{city:\"Colombo\", country:\"SL\"}}");
         Assert.assertEquals(person2.stringValue(), "{firstName:\"John\", lastName:\"David\", " +
                 "deptAccess:\"XYZ\", address:{city:\"Colombo\", country:\"SL\"}}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/StringQueryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/StringQueryExpressionTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -170,5 +171,10 @@ public class StringQueryExpressionTest {
         Assert.assertNotNull(returnValues);
 
         Assert.assertEquals(returnValues[0].stringValue(), "Ranjan John ");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -197,5 +198,10 @@ public class XMLQueryExpressionTest {
         BValue[] returnValues = BRunUtil.invoke(result, "testSimpleQueryExprWithNestedXMLElements");
         Assert.assertNotNull(returnValues);
         Assert.assertEquals(returnValues[0].stringValue(), "<doc> <entry>Value</entry> </doc>");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousClosedRecordTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -69,5 +70,10 @@ public class AnonymousClosedRecordTest {
 
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(), "JAN:12 Gemba St APT 134:CA:sam");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousOpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/AnonymousOpenRecordTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -93,5 +94,11 @@ public class AnonymousOpenRecordTest {
     @Test(description = "Test Code analyzer execution on Anonymous records")
     public void testCodeAnalyzerRunningOnAnonymousRecordsForDeprecatedFunctionAnnotation() {
         BAssertUtil.validateWarning(result, 0, "usage of construct 'Test()' is deprecated", 3, 17);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyRulesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyRulesTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -112,5 +113,10 @@ public class ClosedRecordEquivalencyRulesTest {
                       25);
         validateError(openRecToClosedRec, index, "incompatible types: expected 'AnotherPerson4', found 'Person2'", 74,
                       25);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        closedRecToClosedRec = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordEquivalencyTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -131,5 +132,10 @@ public class ClosedRecordEquivalencyTest {
         Assert.assertEquals(((BInteger) foo.get("d")).intValue(), 10);
         Assert.assertEquals(((BFloat) foo.get("e")).floatValue(), 0.0D);
         Assert.assertNull(foo.get("p"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordIterationTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -332,5 +333,11 @@ public class ClosedRecordIterationTest {
         Assert.assertEquals(((BInteger) grades.get("maths")).intValue(), 80);
         Assert.assertEquals(((BInteger) grades.get("physics")).intValue(), 75);
         Assert.assertEquals(((BInteger) grades.get("chemistry")).intValue(), 65);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        closedRecNegatives = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordOptionalFieldsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordOptionalFieldsTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -144,5 +145,10 @@ public class ClosedRecordOptionalFieldsTest {
         Assert.assertNull(person.get("lname"));
         Assert.assertNull(person.get("age"));
         Assert.assertNull(person.get("adrs"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -308,5 +309,10 @@ public class ClosedRecordTest {
     @Test
     public void removeIfHasKeyRest() {
         BRunUtil.invoke(compileResult, "removeIfHasKeyRest");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/MapToRecordAssignabilityTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/MapToRecordAssignabilityTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -106,5 +107,10 @@ public class MapToRecordAssignabilityTest {
                 {"testInclusiveRecordTypes"},
                 {"testRecordsWithOptionalFields"},
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyRulesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyRulesTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -193,5 +194,11 @@ public class OpenRecordEquivalencyRulesTest {
         BValue[] returns = BRunUtil.invoke(openRecToOpenRec, "testHeterogeneousTypedescEq4");
         assertEquals(returns[0].stringValue(),
                      "{name:\"John Doe\", age:25, address:\"Colombo, Sri Lanka\"}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        closedRecToOpenRec = null;
+        openRecToOpenRec = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordEquivalencyTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -133,5 +134,10 @@ public class OpenRecordEquivalencyTest {
         Assert.assertEquals(((BFloat) foo.get("e")).floatValue(), 0.0D);
         Assert.assertEquals(foo.get("f").stringValue(), "rest field");
         Assert.assertNull(foo.get("p"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordIterationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordIterationTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -368,5 +369,11 @@ public class OpenRecordIterationTest {
         Assert.assertEquals(((BInteger) grades.get("physics")).intValue(), 75);
         Assert.assertEquals(((BInteger) grades.get("chemistry")).intValue(), 65);
         Assert.assertEquals(((BInteger) grades.get("english")).intValue(), 78);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        openRecNegatives = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordOptionalFieldsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordOptionalFieldsTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -145,5 +146,10 @@ public class OpenRecordOptionalFieldsTest {
         Assert.assertNull(person.get("lname"));
         Assert.assertNull(person.get("age"));
         Assert.assertNull(person.get("adrs"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -512,5 +513,10 @@ public class OpenRecordTest {
     @Test
     public void testScopingRules() {
         BRunUtil.invoke(compileResult, "testScopingRules");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordAccessWithIndexTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordAccessWithIndexTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -249,5 +250,11 @@ public class RecordAccessWithIndexTest {
     @Test(description = "Test setting the field of a noninitialized root record")
     public void testSetNonInitLastField() {
         BRunUtil.invoke(compileResult, "testSetFieldOfNonInitStruct");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordRemoveNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordRemoveNegativeTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,5 +45,10 @@ public class RecordRemoveNegativeTest {
     @Test
     public void testClosedRecordRequiredFieldRemove() {
         BValue[] returns = BRunUtil.invoke(result, "testRemoveRequiredClosed");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordValueTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -167,5 +168,10 @@ public class RecordValueTest {
         Assert.assertTrue(result instanceof MapValue);
         MapValue<String, Object> person = (MapValue<String, Object>) result;
         person.clear();
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordWithClosureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/RecordWithClosureTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,4 +44,8 @@ public class RecordWithClosureTest {
         Assert.assertEquals(returns.length, 1);
     }
 
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/ComplexObjectSerializationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/serializer/json/ComplexObjectSerializationTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -190,5 +191,10 @@ public class ComplexObjectSerializationTest {
             resolved = true;
             return this;
         }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayAccessExprTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -150,5 +151,10 @@ public class ArrayAccessExprTest {
     public void testAccessPrimitiveAsArray() {
         CompileResult compileResult = BCompileUtil.compile("test-src/statements/arrays/access-primitive-as-array.bal");
         BAssertUtil.validateError(compileResult, 0, "invalid operation: type 'int' does not support indexing", 3, 5);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTest.java
@@ -36,6 +36,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -623,5 +624,11 @@ public class ArrayFillTest {
                 .filter(entry -> !Flags.isFlagOn(entry.getValue().flags, Flags.OPTIONAL))
                 .forEach(entry -> record.put(entry.getKey(), entry.getValue().fieldType.getZeroValue()));
         return record;
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayFillTestRuntime.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.statements.arrays;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -41,5 +42,10 @@ public class ArrayFillTestRuntime {
     @Test
     public void runtimeArrayFillTest() {
         BRunUtil.runMain(compileResult, new String[]{});
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayIndexTooLargeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayIndexTooLargeTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -70,5 +71,10 @@ public class ArrayIndexTooLargeTest {
     public void accessMinusIndex() {
         BValue[] args = {new BInteger(-4)};
         BValue[] returns =  BRunUtil.invoke(compileResult, "accessMinusIndex", args);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayInitializerExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayInitializerExprTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -159,5 +160,10 @@ public class ArrayInitializerExprTest {
         Assert.assertEquals(arrayValue.getFloat(0), 2.0);
         Assert.assertEquals(arrayValue.getFloat(1), 4.0);
         Assert.assertEquals(arrayValue.getFloat(2), 5.0);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayLValueFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayLValueFillTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -171,5 +172,10 @@ public class ArrayLValueFillTest {
     @Test
     public void testMapArrayAsAnLValue() {
         BRunUtil.invoke(compileResult, "testMapArrayAsAnLValue");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayLengthAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayLengthAccessExprTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -193,4 +194,8 @@ public class ArrayLengthAccessExprTest {
         Assert.assertEquals(actual, expected);
     }
 
+    @AfterClass
+    public void tearDown() {
+        compilerResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayMutabilityTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayMutabilityTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -190,5 +191,11 @@ public class ArrayMutabilityTest {
                 "incompatible types: expected 'Animal[]', found 'Cat[]'", 80, 28);
         BAssertUtil.validateError(resultNegative, i,
                 "incompatible types: expected '(int[]|boolean[])', found '(int|boolean)?[]'", 90, 10);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/ArrayTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.util.BArrayState;
@@ -241,5 +242,10 @@ public class ArrayTest {
     @Test
     public void testUpdatingJsonTupleViaArrayTypedVar() {
         BRunUtil.invokeFunction(compileResult, "testUpdatingJsonTupleViaArrayTypedVar");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/BArrayValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/BArrayValueTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -131,5 +132,10 @@ public class BArrayValueTest {
 
         BInteger value = (BInteger) returns[0];
         Assert.assertEquals(value.intValue(), 2390725);
+    }
+
+    @AfterClass
+    public void tearDown() {
+         compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/arrays/SealedArrayTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -422,5 +423,13 @@ public class SealedArrayTest {
     @Test
     public void createConstLiteralAutoFilledSealedArray() {
         BRunUtil.invoke(compileResult, "createConstLiteralAutoFilledSealedArray");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        resultNegative = null;
+        semanticsNegative = null;
+        listExprNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/AssignStmtTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -282,5 +283,11 @@ public class AssignStmtTest {
     @Test()
     public void assignAnyToUnionWithErrorAndAny() {
         BRunUtil.invoke(result, "assignAnyToUnionWithErrorAndAny");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/assign/LValueTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -216,5 +217,12 @@ public class LValueTest {
                     " 'l'\"\\}\n.*")
     public void testFillingReadOnRecordNegativeMemberAccessLvExpr() {
         BRunUtil.invoke(result, "testFillingReadOnRecordNegativeMemberAccessLvExpr");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
+        semanticsNegativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/block/BlockStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/block/BlockStmtTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -114,5 +115,12 @@ public class BlockStmtTest {
         //testUninitializedVariableAssignInBlock
         BAssertUtil.validateError(resultNegative, 12, "variable 'a' is not initialized", 136, 17);
         BAssertUtil.validateError(resultNegative, 13, "variable 'a' is not initialized", 143, 9);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+        resultSemanticsNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/breakstatement/BreakStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/breakstatement/BreakStmtTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -109,5 +110,11 @@ public class BreakStmtTest {
         Assert.assertEquals(negativeCompileResult.getErrorCount(), 2);
         BAssertUtil.validateError(negativeCompileResult, 0, "break cannot be used outside of a loop", 15, 5);
         BAssertUtil.validateError(negativeCompileResult, 1, "unreachable code", 31, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        positiveCompileResult = null;
+        negativeCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/comment/CommentStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/comment/CommentStmtTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.statements.comment;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.wso2.ballerinalang.compiler.tree.BLangBlockFunctionBody;
@@ -55,5 +56,11 @@ public class CommentStmtTest {
         statements = ((BLangBlockFunctionBody) compiledPackage.functions.get(1).body).getStatements();
         Assert.assertNotNull(statements, "statements not found");
         Assert.assertEquals(statements.size(), 3, "statement count mismatched");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        compiledPackage = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/compoundassignment/CompoundAssignmentTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -445,5 +446,10 @@ public class CompoundAssignmentTest {
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int?'", 140, 5);
         BAssertUtil.validateError(compileResult, i++, "operator '+' not defined for 'int?' and 'int'", 150, 11);
         BAssertUtil.validateError(compileResult, i, "invalid expr in compound assignment lhs", 156, 18);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/continuestatement/ContinueStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/continuestatement/ContinueStmtTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -100,5 +101,11 @@ public class ContinueStmtTest {
         Assert.assertEquals(negativeCompileResult.getErrorCount(), 2);
         BAssertUtil.validateError(negativeCompileResult, 0, "continue cannot be used outside of a loop", 15, 5);
         BAssertUtil.validateError(negativeCompileResult, 1, "unreachable code", 31, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        positiveCompileResult = null;
+        negativeCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/dostatement/DoStmtsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/dostatement/DoStmtsTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -65,5 +66,12 @@ public class DoStmtsTest {
         BAssertUtil.validateError(negativeFile2, 1, "incompatible types: expected 'string', " +
                 "found 'error'", 8, 12);
         BAssertUtil.validateError(negativeFile2, 2, "undefined symbol 'd'", 26, 12);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        programFile = null;
+        negativeFile1 = null;
+        negativeFile2 = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/fail/FailStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/fail/FailStmtTest.java
@@ -24,10 +24,12 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
+import static org.ballerinalang.test.BAssertUtil.validateWarning;
 
 /**
  * This contains methods to test fail statement.
@@ -62,5 +64,10 @@ public class FailStmtTest {
         validateError(negativeResult, index++,
                 "type 'err' not allowed here; expected an 'error' or a subtype of 'error'.",
                 5, 10);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/fail/FailStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/fail/FailStmtTest.java
@@ -29,7 +29,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.ballerinalang.test.BAssertUtil.validateError;
-import static org.ballerinalang.test.BAssertUtil.validateWarning;
 
 /**
  * This contains methods to test fail statement.

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/IfElseStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/IfElseStmtTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -265,5 +266,12 @@ public class IfElseStmtTest {
                 "incompatible types: expected 'boolean', found 'int'", 37, 15);
         BAssertUtil.validateError(semanticsNegativeResult, 5,
                 "incompatible types: expected 'boolean', found '[int,string]'", 41, 8);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
+        semanticsNegativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -624,5 +625,10 @@ public class TypeGuardTest {
     public void testTypetestForTypedefs2() {
         BValue[] returns = BRunUtil.invoke(result, "testTypeDescTypeTest2");
         Assert.assertEquals(BBoolean.TRUE, returns[0]);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementOnFailTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementOnFailTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -131,5 +132,11 @@ public class MatchStatementOnFailTest {
         BAssertUtil.validateError(resultNegative, ++i, "unreachable code", 90, 9);
         BAssertUtil.validateError(resultNegative, ++i, "incompatible error definition type: " +
                 "'ErrorTypeA' will not be matched to 'ErrorTypeB'", 124, 7);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementStaticPatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementStaticPatternsTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -468,5 +469,13 @@ public class MatchStatementStaticPatternsTest {
         BAssertUtil.validateError(resultNegative2, ++i, unreachablePattern, 158, 13);
         BAssertUtil.validateError(resultNegative2, ++i, unreachablePattern, 159, 13);
         BAssertUtil.validateError(resultNegative2, ++i, unreachablePattern, 160, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+        resultNegative2 = null;
+        resultSemanticsNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementSyntaxErrorsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStatementSyntaxErrorsTest.java
@@ -20,6 +20,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -55,5 +56,10 @@ public class MatchStatementSyntaxErrorsTest {
         BAssertUtil.validateError(result, ++i, "missing identifier", 17, 1);
         BAssertUtil.validateError(result, ++i, "missing open brace token", 17, 1);
         BAssertUtil.validateError(result, ++i, "missing close brace token", 18, 1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtConstPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtConstPatternTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -168,5 +169,12 @@ public class MatchStmtConstPatternTest {
     public void testConstPatternNegativeSemantics() {
         Assert.assertEquals(resultNegativeSemantics.getErrorCount(), 1);
         BAssertUtil.validateError(resultNegativeSemantics, 0, "variable 'a' should be declared as constant", 22, 9);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+        resultNegativeSemantics = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtListMatchPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStmtListMatchPatternTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -213,5 +214,13 @@ public class MatchStmtListMatchPatternTest {
                 17);
         BAssertUtil.validateError(resultSemanticsNegative, ++i, "same variable cannot repeat in a match pattern", 21,
                 17);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+        resultSemanticsNegative = null;
+        restMatchPatternResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredErrorPatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredErrorPatternsTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -225,5 +226,11 @@ public class MatchStructuredErrorPatternsTest {
     public void testErrorMatchWihtoutReason() {
         BValue[] returns = BRunUtil.invoke(result, "testErrorMatchWihtoutReason");
         Assert.assertEquals(returns[0].stringValue(), "error detail message");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredPatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredPatternsTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -163,5 +164,13 @@ public class MatchStructuredPatternsTest {
                 "match statement has a static value default pattern and a binding value default pattern", 155, 5);
         BAssertUtil.validateError(resultNegative2, ++i, unreachablePattern, 166, 9);
         BAssertUtil.validateError(resultNegative2, ++i, unreachablePattern, 167, 13);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+        resultSemanticsNegative = null;
+        resultNegative2 = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredRecordPatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredRecordPatternsTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -228,4 +229,8 @@ public class MatchStructuredRecordPatternsTest {
         Assert.assertEquals(results.getString(++i), msg + "a: 1, b: 2, c: 3");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredTuplePatternsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/MatchStructuredTuplePatternsTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -271,4 +272,8 @@ public class MatchStructuredTuplePatternsTest {
         Assert.assertEquals(results.getString(++i), msg + "default");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/CaptureBindingPatternTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/matchstmt/varbindingpatternmatchpattern/CaptureBindingPatternTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -67,5 +68,11 @@ public class CaptureBindingPatternTest {
 
         int i = -1;
         BAssertUtil.validateError(resultNegative, ++i, "unreachable pattern", 22, 9);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/onfail/OnFailClauseTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,5 +63,10 @@ public class OnFailClauseTest {
         //TODO Fix required https://github.com/ballerina-platform/ballerina-lang/issues/26201
         Assert.assertEquals(negativeResult.getErrorCount(), 2);
         BAssertUtil.validateError(negativeResult, 0, "unreachable code", 21, 9);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/NestedRetryStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/NestedRetryStmtTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,5 +41,10 @@ public class NestedRetryStmtTest {
     public void testRetryStatement() {
         BValue[] params = {};
         BRunUtil.invoke(programFile, "testRetryStatement", params);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        programFile = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/RetryStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/RetryStmtTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -61,5 +62,12 @@ public class RetryStmtTest {
         BAssertUtil.validateError(retryStmtNegative, index++, "no implementation found for the function " +
                 "'shouldRetry' of non-abstract object 'CustomRetryManager'", 14, 10);
         BAssertUtil.validateError(retryStmtNegative, index++, "unreachable code", 25, 5);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        programFile = null;
+        managerNegative = null;
+        retryStmtNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/RetryStmtWithOnFailTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/retrystmt/RetryStmtWithOnFailTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -54,5 +55,11 @@ public class RetryStmtWithOnFailTest {
         BAssertUtil.validateError(negativeFile, 2, "unreachable code", 62, 7);
         BAssertUtil.validateError(negativeFile, 3, "incompatible error definition type: " +
                 "'ErrorTypeB' will not be matched to 'ErrorTypeA'", 100, 4);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        programFile = null;
+        negativeFile = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/NamedReturnParameterTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/NamedReturnParameterTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -85,5 +86,10 @@ public class NamedReturnParameterTest {
 
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 12);
         Assert.assertEquals(returns[1].stringValue(), "test, john");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtInBranchTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtInBranchTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,5 +63,10 @@ public class ReturnStmtInBranchTest {
         Assert.assertSame(returns[0].getClass(), BInteger.class);
 
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 819);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/returnstmt/ReturnStmtTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -205,4 +206,8 @@ public class ReturnStmtTest {
         Assert.assertEquals(result.getErrorCount(), 0);
     }
 
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/ErrorVariableDefinitionTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -258,5 +259,10 @@ public class ErrorVariableDefinitionTest {
                 "incompatible types: expected 'string', found '(anydata|readonly)'", 64, 16);
         BAssertUtil.validateError(resultNegative, ++i,
                 "incompatible types: expected 'string', found '(anydata|readonly)'", 70, 16);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/RecordVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/RecordVariableDefinitionTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -321,5 +322,11 @@ public class RecordVariableDefinitionTest {
         BAssertUtil.validateError(resultNegative, ++i,
                 "no new variables on left side", 158, 19);
         Assert.assertEquals(resultNegative.getErrorCount(), i + 1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/TupleVariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/TupleVariableDefinitionTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -410,5 +411,11 @@ public class TupleVariableDefinitionTest {
                                   110, 16);
 
         Assert.assertEquals(resultNegative.getErrorCount(), i + 1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/VariableDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/VariableDefinitionTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -189,5 +190,11 @@ public class VariableDefinitionTest {
                 .compile("test-src/statements/variabledef/variable-def-array-constants-negative.bal");
         Assert.assertEquals(resultNegative.getErrorCount(), 1);
         BAssertUtil.validateError(resultNegative, 0, "incompatible types: expected 'int[]', found 'int'", 1, 17);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/VariableScopeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/variabledef/VariableScopeTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -77,5 +78,11 @@ public class VariableScopeTest {
         //testVariableResourceScope
         BAssertUtil.validateError(resultNegative, 3, "undefined symbol 'a'", 42, 17);
         BAssertUtil.validateError(resultNegative, 4, "undefined symbol 'b'", 47, 17);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/strand/worker/StrandMetadataTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/strand/worker/StrandMetadataTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -41,5 +42,10 @@ public class StrandMetadataTest {
     @Test
     public void testStrandMetadataAsyncCalls() {
         BRunUtil.invoke(compileResult, "testStrandMetadataAsyncCalls", new BValue[0]);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/AnonymousStructTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/AnonymousStructTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -71,5 +72,10 @@ public class AnonymousStructTest {
 
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(), "JAN:12 Gemba St APT 134:CA:sam");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/ObjectWithPrivateFieldsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/ObjectWithPrivateFieldsTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -106,5 +107,10 @@ public class ObjectWithPrivateFieldsTest {
 
         Assert.assertEquals(returns[0].stringValue(), "mal");
         Assert.assertEquals(((BInteger) returns[1]).intValue(), 56);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructAccessWithIndexTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructAccessWithIndexTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -170,5 +171,11 @@ public class StructAccessWithIndexTest {
     @Test(description = "Test setting the field of a noninitialized root struct")
     public void testSetNonInitLastField() {
         BRunUtil.invoke(compileResult, "testSetFieldOfNonInitStruct");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructEquivalencyNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructEquivalencyNegativeTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -70,5 +71,10 @@ public class StructEquivalencyNegativeTest {
                     "value cannot be converted to 'equivalencynegative.foo:userFoo'.*")
     public void testEquivalenceOfStructsInSamePackageFromDifferentPackage() {
         BValue[] result = BRunUtil.invoke(compileResult, "testStructEqViewFromThirdPackage");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructNegativeTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -151,4 +152,8 @@ public class StructNegativeTest {
         BRunUtil.invoke(compileResult, "testSetFieldOfNonInitStruct");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/structs/StructTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -183,5 +184,10 @@ public class StructTest {
         Assert.assertEquals(returns[0].stringValue(),
                 "{name:\"default first name\", fname:\"\", lname:\"Doe\", adrs:{}, age:999, " +
                         "family:{spouse:\"Jane\", noOfChildren:0, children:[\"Alex\", \"Bob\"]}}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/FunctionCallTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/FunctionCallTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -97,4 +98,8 @@ public class FunctionCallTest {
         Assert.assertEquals(i, negativeResult.getDiagnostics().length);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/UntaintAndTaintAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/taintchecking/UntaintAndTaintAnnotationTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -98,5 +99,10 @@ public class UntaintAndTaintAnnotationTest {
     public void untaintWithLengthOf() {
         BValue[] returns = BRunUtil.invoke(compileResult, "untaintWithLengthOf");
         Assert.assertEquals(returns[0].stringValue(), "24");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/testerina/TopLevelNodesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/testerina/TopLevelNodesTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -45,5 +46,10 @@ public class TopLevelNodesTest {
         BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'Person'", 4, 13);
         BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'testString'", 9, 8);
         BAssertUtil.validateError(compileResult, index++, "redeclared symbol 'Company'", 11, 1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/DistinctTypeDefTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/DistinctTypeDefTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.typedefs;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -30,7 +31,7 @@ import org.testng.annotations.Test;
 @Test(groups = "disableOnOldParser")
 public class DistinctTypeDefTest {
 
-    private static CompileResult negative;
+    private CompileResult negative;
 
     @BeforeClass
     public void setup() {
@@ -46,5 +47,10 @@ public class DistinctTypeDefTest {
         BAssertUtil.validateError(negative, 2,
                 "distinct typing is only supported for object type and error type", 7, 1);
 
+    }
+
+    @AfterClass
+    public void tearDown() {
+        negative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/TypeDefinitionsTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -33,7 +34,7 @@ import org.testng.annotations.Test;
  */
 public class TypeDefinitionsTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -146,5 +147,10 @@ public class TypeDefinitionsTest {
     @Test
     public void testTupleTypeDef() {
         BRunUtil.invoke(compileResult, "testTupleTypeDef");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/TypeUnificationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/TypeUnificationTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -115,5 +116,10 @@ public class TypeUnificationTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testSetValueToJsonInStruct");
         Assert.assertTrue(returns[0] instanceof BMap);
         Assert.assertEquals(returns[0].stringValue(), "{\"status\":\"widowed\", \"retired\":true}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/any/BAnyTypeNativeSuccessScenariosTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/any/BAnyTypeNativeSuccessScenariosTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -107,5 +108,10 @@ public class BAnyTypeNativeSuccessScenariosTest {
             outContent.close();
             System.setOut(original);
         }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/any/BAnyTypeSuccessScenariosTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/any/BAnyTypeSuccessScenariosTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -143,5 +144,10 @@ public class BAnyTypeSuccessScenariosTest {
         BValue[] returns = BRunUtil.invokeFunction(result, "anyArrayWithMapArray", args);
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].getClass(), BValueArray.class);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTernaryConvTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/anydata/AnydataTernaryConvTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.core.model.values.BValueArray;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -158,5 +159,10 @@ public class AnydataTernaryConvTest {
         assertEquals(rets.getRefValue(5).stringValue(), "<book>The Lost World</book>");
         assertEquals(rets.getRefValue(6).stringValue(), "{a:15}");
         assertEquals(rets.getRefValue(7).stringValue(), "{ca:15}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteOperationsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteOperationsTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -363,5 +364,10 @@ public class BByteOperationsTest {
         Assert.assertSame(returns[0].getClass(), BInteger.class);
         BInteger value = (BInteger) returns[0];
         Assert.assertEquals(value.intValue(), -192, "Invalid int value returned.");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueNegativeTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -122,5 +123,10 @@ public class BByteValueNegativeTest {
         Assert.assertTrue(returnValue[0] instanceof BError);
         Assert.assertEquals(returnValue[0].stringValue(), "{ballerina}NumberConversionError {\"message\":" +
                 "\"'int' value '12,345' cannot be converted to 'byte'\"}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/BByteValueTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -798,5 +799,10 @@ public class BByteValueTest {
         BRunUtil.invoke(result, "testByteReturnAsIntInLambda1");
         BRunUtil.invoke(result, "testByteReturnAsIntInLambda2");
         BRunUtil.invoke(result, "testByteReturnAsIntInLambda3");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/ByteAsIntTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/ByteAsIntTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -78,5 +79,10 @@ public class ByteAsIntTest {
         BRunUtil.invoke(result, "testByteArrayCastToIntArray");
         BRunUtil.invoke(result, "testDowncastOfByteArrayCastToIntArray");
         BRunUtil.invoke(result, "testInherentTypeViolationOfByteArrayCastToIntArray");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/ByteAsJsonTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/bytetype/ByteAsJsonTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -72,5 +73,10 @@ public class ByteAsJsonTest {
                 {"testBytesInJsonMap"},
                 {"testByteStructuredTypeAsJsonStructuredType"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantAccessTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -103,5 +104,10 @@ public class ConstantAccessTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testTypeAssignment");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "A");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantAssignmentTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantAssignmentTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -36,8 +37,8 @@ import java.util.Map;
  */
 public class ConstantAssignmentTest {
 
-    private static CompileResult positiveCompileResult;
-    private static CompileResult negativeCompileResult;
+    private CompileResult positiveCompileResult;
+    private CompileResult negativeCompileResult;
 
     @BeforeClass
     public void setup() {
@@ -109,5 +110,11 @@ public class ConstantAssignmentTest {
                 31);
         BAssertUtil.validateError(negativeCompileResult, 2, "incompatible types: expected 'int', found 'string'", 5,
                 27);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        positiveCompileResult = null;
+        negativeCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantExpressionTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -33,7 +34,7 @@ import org.testng.annotations.Test;
  */
 public class ConstantExpressionTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -130,4 +131,8 @@ public class ConstantExpressionTest {
         Assert.assertEquals(returns[0].stringValue(), "{\"v1\":3.0, \"v2\":5.0}");
     }
 
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantInTypeDefinitionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/ConstantInTypeDefinitionTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -36,7 +37,7 @@ import org.testng.annotations.Test;
  */
 public class ConstantInTypeDefinitionTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -146,5 +147,10 @@ public class ConstantInTypeDefinitionTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testStringTypeWithoutType");
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "Ballerina rocks");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/MapConstantEqualityTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/MapConstantEqualityTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -32,7 +33,7 @@ import org.testng.annotations.Test;
  */
 public class MapConstantEqualityTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -1141,5 +1142,10 @@ public class MapConstantEqualityTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testSimpleNilMapReferenceEqualityInDifferentMap");
         Assert.assertNotNull(returns[0]);
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/MapConstantPanicTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/MapConstantPanicTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -30,7 +31,7 @@ import org.testng.annotations.Test;
  */
 public class MapConstantPanicTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -301,5 +302,10 @@ public class MapConstantPanicTest {
             expectedExceptionsMessageRegExp = ".*modification not allowed on readonly value.*")
     public void updateConstantNilMapValueInArrayWithNewKey() {
         BRunUtil.invoke(compileResult, "updateConstantNilMapValueInArrayWithNewKey");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/MapConstantTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/MapConstantTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,7 +40,7 @@ import java.math.MathContext;
  */
 public class MapConstantTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -268,5 +269,10 @@ public class MapConstantTest {
     public void testNestedConstMapAccess() {
         BValue[] returns = BRunUtil.invoke(compileResult, "testNestedConstMapAccess");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/constant/SimpleConstantTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,7 +40,7 @@ import java.math.MathContext;
  */
 public class SimpleConstantTest {
 
-    private static CompileResult compileResult;
+    private CompileResult compileResult;
 
     @BeforeClass
     public void setup() {
@@ -455,5 +456,10 @@ public class SimpleConstantTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testDecimalConcat");
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "25.5 rocks");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalBFloatComparisonTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalBFloatComparisonTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -80,5 +81,10 @@ public class BDecimalBFloatComparisonTest {
         BBoolean result2 = (BBoolean) returns[1];
         // Expected: true
         Assert.assertTrue(result2.booleanValue(), "Invalid result returned.");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalTypeConversionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalTypeConversionTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -106,5 +107,10 @@ public class BDecimalTypeConversionTest {
                 compareTo(DELTA) < 0, "Invalid decimal value returned.");
         Assert.assertEquals(val3.decimalValue().compareTo(new BigDecimal("23.456", MathContext.DECIMAL128)), 0,
                             "Invalid decimal value returned.");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalUsageTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalUsageTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -137,5 +138,10 @@ public class BDecimalUsageTest {
                 "Invalid decimal value returned.");
         Assert.assertEquals(height.decimalValue(), new BigDecimal("168.67", MathContext.DECIMAL128),
                 "Invalid decimal value returned.");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/decimaltype/BDecimalValueTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -265,5 +266,10 @@ public class BDecimalValueTest {
     public void testDecimalArrayValueLoading() {
         BValue[] returns = BRunUtil.invoke(result, "decimalArrayLoad");
         Assert.assertEquals(returns[0], new BDecimal("2.0", DecimalValueKind.OTHER));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/errors/TestErrorReturn.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/errors/TestErrorReturn.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -98,4 +99,8 @@ public class TestErrorReturn {
         BRunUtil.invoke(compileResult, "test5", args);
     }
 
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalAccessTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -167,5 +168,11 @@ public class FinalAccessTest {
                 {"testSubsequentInitializationOfFinalVar"},
                 {"testSubsequentInitializationOfFinalVarInBranches"}
         };
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        finalLocalNoInitVarResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalTypedBindingPatternsNegative.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finaltypes/FinalTypedBindingPatternsNegative.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -58,5 +59,10 @@ public class FinalTypedBindingPatternsNegative {
         BAssertUtil.validateError(compileResult, index++, "cannot assign a value to final 'i'", 83, 5);
         BAssertUtil.validateError(compileResult, index++, "cannot assign a value to final 'j'", 84, 5);
         BAssertUtil.validateError(compileResult, index, "cannot assign a value to final 'k'", 85, 5);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -376,5 +377,10 @@ public class FiniteTypeTest {
     @Test(description = "Test finite type where float literals with positive sign as members")
     public void testFiniteTypesWithPositiveFloats() {
         BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/floattype/BFloatValueTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -173,5 +174,12 @@ public class BFloatValueTest {
         Assert.assertEquals(negativeDiscrimination.getErrorCount(), 1);
         BAssertUtil.validateError(negativeDiscrimination, 0, "incompatible types: expected 'float', found 'decimal'",
                 18, 15);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
+        negativeDiscrimination = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/future/FutureTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/future/FutureTests.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.types.future;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -87,5 +88,10 @@ public class FutureTests {
     @Test
     public void testCustomErrorFutureWithoutConstraint() {
         BRunUtil.invoke(result, "testCustomErrorFutureWithoutConstraint");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarFunctionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarFunctionTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -107,5 +108,10 @@ public class GlobalVarFunctionTest {
 
         Assert.assertEquals(returns[0].stringValue(), "{\"name\":\"James\", \"age\":30}");
         Assert.assertEquals(((BFloat) returns[1]).floatValue(), 3432.3423);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarFunctionWithPkgTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/globalvar/GlobalVarFunctionWithPkgTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -107,5 +108,10 @@ public class GlobalVarFunctionWithPkgTest {
         Assert.assertSame(returns[0].getClass(), BString.class);
 
         Assert.assertEquals(((BString) returns[0]).stringValue(), "sample value");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/handle/OpaqueHandleTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/handle/OpaqueHandleTypeTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -225,5 +226,10 @@ public class OpaqueHandleTypeTest {
         BValue[] returns = BRunUtil.invoke(result, "testCreateObjectWithHandleValues", args);
         Assert.assertEquals(((BHandleValue) returns[0]).getValue(),
                 ((BHandleValue) args[1]).getValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/integer/BIntegerValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/integer/BIntegerValueTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -170,5 +171,10 @@ public class BIntegerValueTest {
         Assert.assertSame(returns[0].getClass(), BInteger.class);
         BInteger intValue = (BInteger) returns[0];
         Assert.assertEquals(intValue.intValue(), 1, "Invalid int value returned.");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.types.intersection;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -105,5 +106,11 @@ public class IntersectionTypeTest {
                       38);
 
         assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        readOnlyIntersectionResults = null;
+        errorIntersectionResults = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/BJSONValueTest.java
@@ -34,6 +34,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -544,5 +545,11 @@ public class BJSONValueTest {
         Assert.assertEquals(returns[0].stringValue(), "[true, true, false, true]");
         Assert.assertTrue(returns[1] instanceof BBoolean);
         Assert.assertTrue(((BBoolean) returns[1]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/JSONTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -199,5 +200,10 @@ public class JSONTest {
     public void testStreamingJsonType() {
         StreamingJsonValue jsonValue = new StreamingJsonValue(Mockito.mock(JsonDataSource.class));
         Assert.assertEquals(jsonValue.getType().toString(), "map<json>[]");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/json/RecordToJSONTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -81,5 +82,10 @@ public class RecordToJSONTest {
     @Test
     public void testRecursiveCheckAgainstJson() {
         BRunUtil.invoke(compileResult, "testRecursiveCheckAgainstJson");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/BMapValueTest.java
@@ -30,6 +30,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -246,5 +247,10 @@ public class BMapValueTest {
         Assert.assertEquals(map.get(keys[1]).stringValue(), "bar");
         Assert.assertEquals(map.get(keys[2]).stringValue(), "foobar");
 
+    }
+
+    @AfterClass
+    public void tearDown() {
+        programFile = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapNegativeTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -47,5 +48,10 @@ public class ConstrainedMapNegativeTest {
     public void testMapAnyDataClosedRecordAssignmentNegative() {
 
         BRunUtil.invoke(negativeRunTimeResult, "testMapAnyDataClosedRecordAssignmentNegative");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        negativeRunTimeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/ConstrainedMapTest.java
@@ -33,6 +33,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -559,5 +560,11 @@ public class ConstrainedMapTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testMapAnyDataClosedRecordAssignment");
         Assert.assertNotNull(returns[0]);
         Assert.assertEquals(returns[0].stringValue(), "Jack");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapAccessExprTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -227,5 +228,12 @@ public class MapAccessExprTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testMapToString");
         BString value = (BString) returns[0];
         Assert.assertEquals(value.stringValue(), "typedesc map<map<json>>");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        resultNegative = null;
+        resultSemanticsNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprNegativeTest.java
@@ -20,6 +20,7 @@ package org.ballerinalang.test.types.map;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -51,5 +52,10 @@ public class MapInitializerExprNegativeTest {
     @Test(description = "Test map initializer expression with duplicated keys when both keys are string literals")
     public void mapInitWithDuplicatedKeysBothStringKeysTest() {
         BAssertUtil.validateError(compileResult, 2, "invalid usage of map literal: duplicate key 'key'", 12, 42);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/map/MapInitializerExprTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -176,5 +177,10 @@ public class MapInitializerExprTest {
 
         returns = BRunUtil.invoke(compileResult, "testExpressionAsKeysWithSameKeysDefinedAsLiteralsOrFieldNames");
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/never/NeverTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/never/NeverTypeTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -142,5 +143,11 @@ public class NeverTypeTest {
                 "table key specifier '[name]' does not match with key constraint type '[never]'", 129, 34);
         BAssertUtil.validateError(negativeCompileResult, i++,
                 "table key specifier mismatch with key constraint. expected: '1' fields but found '0'", 138, 37);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        neverTypeTestResult = null;
+        negativeCompileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/nullable/NullableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/nullable/NullableTypeTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -75,5 +76,10 @@ public class NullableTypeTest {
         CompileResult result = BCompileUtil.compile("test-src/types/nullable/nilable_types_negative.bal");
         Assert.assertEquals(result.getErrorCount(), 1);
         validateError(result, 0, "incompatible types: expected '(()|any)', found '(()|any)?'", 33, 19);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/nullvalue/BNullValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/nullvalue/BNullValueTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -52,5 +53,11 @@ public class BNullValueTest {
     void testNullValueNegative() {
         Assert.assertEquals(resultNegative.getErrorCount(), 1);
         BAssertUtil.validateError(resultNegative, 0, "'null' literal is only supported for 'json'", 20, 12);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        resultNegative = null;
+        resultSemanticsNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/InherentlyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/InherentlyImmutableTypeTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.types.readonly;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -41,5 +42,10 @@ public class InherentlyImmutableTypeTest {
     @Test
     public void testReadonlyType() {
         BRunUtil.invoke(result, "testReadonlyType");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/readonly/SelectivelyImmutableTypeTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.types.readonly;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -200,5 +201,10 @@ public class SelectivelyImmutableTypeTest {
                 "(xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text) & readonly)> & readonly'", 87, 9);
 
         assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/stream/BStreamValueTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -225,6 +226,12 @@ public class BStreamValueTest {
         BAssertUtil.validateError(negativeResult, i, "invalid stream constructor. expected a subtype of 'object { " +
                 "public isolated function next() returns (record {| int value; |}|error)?; public isolated function " +
                 "close() returns error?; }', but found 'IteratorWithIsolatedNextAndNonIsolatedClose'", 352, 42);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringAnnotationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringAnnotationTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -35,5 +36,10 @@ public class BStringAnnotationTest extends BStringTestCommons {
     @Test
     public void testAnnotation() {
         testAndAssert("testAnnotation", 8);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringJsonTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringJsonTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,5 +41,10 @@ public class BStringJsonTest extends BStringTestCommons {
     @Test
     public void testJsonOptionalAccess() {
         testAndAssert("testJsonOptionalAccess", 9);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringMainTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringMainTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,5 +41,10 @@ public class BStringMainTest extends BStringTestCommons {
     @Test
     public void testJsonOptionalAccess() {
         testAndAssert("testJsonOptionalAccess", 9);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringObjectTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -45,5 +46,10 @@ public class BStringObjectTest extends BStringTestCommons {
     @Test
     public void testObjectSet() {
         testAndAssert("testObjectSet", 8);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringTableValueTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringTableValueTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -41,5 +42,10 @@ public class BStringTableValueTest extends BStringTestCommons {
     @Test
     public void testTableWithArrayGeneration() {
         testAndAssert("testTableWithArrayGeneration", 55);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringToStringTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/BStringToStringTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -75,5 +76,10 @@ public class BStringToStringTest extends BStringTestCommons {
     @Test
     public void testArrayValueToString() {
         testAndAssert("testArrayValueToString", 30);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralNegativeTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 /**
@@ -61,5 +62,10 @@ public class StringTemplateLiteralNegativeTest {
         BAssertUtil.validateError(resultNegative, index++, "missing semicolon token", 10, 38);
         BAssertUtil.validateError(resultNegative, index++, "invalid token ';\n    return s;\n}\n'", 13, 1);
         BAssertUtil.validateError(resultNegative, index++, "invalid token '`'", 13, 1);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -302,5 +303,10 @@ public class StringTemplateLiteralTest {
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(),
                 "Hello \\n$\\\\$$\\{Dummy\\tText\\`\\\\test Ballerina endText\\\\{{{{{innerStartText 7 }}!!!");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
@@ -34,6 +34,7 @@ import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.ballerinalang.test.utils.ByteArrayUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -237,5 +238,10 @@ public class StringTest {
         validateError(multilineLiterals, indx++, "missing double quote", 19, 11);
         validateError(multilineLiterals, indx++, "missing semicolon token", 20, 1);
         Assert.assertEquals(multilineLiterals.getErrorCount(), indx);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringUtilsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringUtilsTest.java
@@ -22,6 +22,7 @@ import io.ballerina.runtime.api.values.BString;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -51,4 +52,8 @@ public class StringUtilsTest {
         return StringUtils.fromString(content.toString());
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueBasicsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueBasicsTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -79,5 +80,10 @@ public class StringValueBasicsTest extends BStringTestCommons {
     public void testCastToString() {
         testAndAssert("anyToStringCasting", 6);
         testAndAssert("anydataToStringCast", 6);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueRecordTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -62,5 +63,10 @@ public class StringValueRecordTest {
         BValue[] returns = BRunUtil.invoke(result, funcName);
         Assert.assertEquals(returns[0].getClass(), BInteger.class);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), i);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueXmlTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringValueXmlTest.java
@@ -19,6 +19,7 @@
 package org.ballerinalang.test.types.string;
 
 import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -70,5 +71,10 @@ public class StringValueXmlTest extends BStringTestCommons {
     @Test
     public void testXmlInterpolation() {
         testAndAssert("testXmlInterpolation", 249);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.types.string;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -39,5 +40,10 @@ public class UnicodeTest {
     @Test(description = "Test the unicode code patterns.")
     public void testUnicode() {
         BRunUtil.invoke(result, "testUnicode");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/MapConstraintTableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/MapConstraintTableTest.java
@@ -19,6 +19,7 @@ package org.ballerinalang.test.types.table;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -41,4 +42,8 @@ public class MapConstraintTableTest {
         BRunUtil.invoke(result, "testTableConstructExprs");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/RecordConstraintTableTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/RecordConstraintTableTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -122,5 +123,11 @@ public class RecordConstraintTableTest {
     @Test(description = "Test table equality")
     public void testTableEquality() {
         BRunUtil.invoke(result, "testTableEquality", new BValue[]{});
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableCastTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableCastTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -77,5 +78,11 @@ public class TableCastTest {
         BAssertUtil.validateError(negativeResult, 3, "invalid key constraint provided for member access. " +
                 "key constraint expected with type 'string'", 60, 12);
         BAssertUtil.validateError(negativeResult, 4, "incompatible types: expected 'string', found 'int'", 60, 16);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableCyclicKeyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableCyclicKeyTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -40,5 +41,10 @@ public class TableCyclicKeyTest {
                     "\\{\"message\":\"'Address' value has cyclic reference.*")
     public void testCyclesInRecords() {
         BRunUtil.invoke(result, "testCyclesInRecords");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableWithRecordKeySpecifierTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableWithRecordKeySpecifierTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -72,6 +73,11 @@ public class TableWithRecordKeySpecifierTest {
     @Test(description = "Test Table with var type")
     public void testTableWithVarType() {
         BRunUtil.invoke(result, "runTableTestcasesWithVarType");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableWithXMLKeySpecifierTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TableWithXMLKeySpecifierTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -67,6 +68,11 @@ public class TableWithXMLKeySpecifierTest {
     @Test(description = "Test Table with var type")
     public void testTableWithVarType() {
         BRunUtil.invoke(result, "runTableTestcasesWithVarType");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TablesAsFuncArgs.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/table/TablesAsFuncArgs.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -112,5 +113,11 @@ public class TablesAsFuncArgs {
                 "incompatible types: expected 'table<Person> key(name)', found 'table<Person> key(age)'",
                 98, 13);
 
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/BasicTupleTest.java
@@ -25,6 +25,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -240,5 +241,11 @@ public class BasicTupleTest {
         BAssertUtil.validateError(resultNegative, i++,
                                   "invalid list index expression: value space '(3|4|5|6)' out of range", 158, 19);
         BAssertUtil.validateError(resultNegative, i, "list index out of range: index: '-1'", 165, 19);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleAccessExprTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -201,5 +202,10 @@ public class TupleAccessExprTest {
                     "out of range: index: 6, size: 4.*")
     public void testTupleAccessUsingUnionWithFiniteTypesNegative() {
         BRunUtil.invoke(compileResult, "testTupleAccessUsingUnionWithFiniteTypesNegative");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleDestructureTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleDestructureTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -101,4 +102,9 @@ public class TupleDestructureTest {
                 "int]'", 46, 14);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleFillMemberTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleFillMemberTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.types.tuples;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -44,5 +45,10 @@ public class TupleFillMemberTest {
         BRunUtil.invoke(compileResult, "testTupleFillMemberSimpleTypesWithRest");
         BRunUtil.invoke(compileResult, "testTupleFillMemberStructuredTypes");
         BRunUtil.invoke(compileResult, "testTupleFillMemberStructuredTypesWithRest");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleLValueFillTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleLValueFillTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -63,5 +64,10 @@ public class TupleLValueFillTest {
                   "length 1 cannot be expanded into tuple of length 3 without filler values.*")
     public void testRecordsWithoutFillerValues2() {
         BRunUtil.invoke(compileResult, "testRecordsWithoutFillerValues2");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleMutabilityTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleMutabilityTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -131,5 +132,11 @@ public class TupleMutabilityTest {
         Assert.assertTrue(((BBoolean) returnValues[2]).booleanValue());
         Assert.assertEquals(returnValues[3].stringValue(), "json");
         Assert.assertEquals(((BFloat) returnValues[4]).floatValue(), 12.0);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleRestDescriptorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/tuples/TupleRestDescriptorTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -129,4 +130,9 @@ public class TupleRestDescriptorTest {
         Assert.assertEquals(resultNegative.getErrorCount(), i);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        resultNegative = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -190,4 +191,9 @@ public class TypedescTests {
    public void testCustomErrorTypeDescWithoutConstraint() {
        BRunUtil.invoke(result, "testCustomErrorTypeDescWithoutConstraint");
    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/uniontypes/UnionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/uniontypes/UnionTypeTest.java
@@ -29,6 +29,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -143,5 +144,11 @@ public class UnionTypeTest {
     @Test(description = "Test union type with a function pointer accessing")
     public void testUnionTypeWithFunctionPointerAccess() {
         BRunUtil.invoke(result, "testUnionTypeWithFunctionPointerAccess");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
+        negativeResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/TopLevelVarDeclarationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/TopLevelVarDeclarationTest.java
@@ -28,6 +28,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -99,5 +100,10 @@ public class TopLevelVarDeclarationTest {
         BValue[] returns = BRunUtil.invoke(result, "testVarAssign");
         Assert.assertEquals(returns.length, 1);
         Assert.assertEquals(returns[0].stringValue(), "{\"x\":\"y\"}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarDeclaredAssignmentStmtTest.java
@@ -27,6 +27,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -342,4 +343,8 @@ public class VarDeclaredAssignmentStmtTest {
                             "incompatible types: 'string' cannot be cast to 'map'");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarIgnoreTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/var/VarIgnoreTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -51,5 +52,10 @@ public class VarIgnoreTest {
         Assert.assertEquals(res.getErrorCount(), 2);
         BAssertUtil.validateError(res, 0, "no new variables on left side", 2, 5);
         BAssertUtil.validateError(res, 1, "no new variables on left side", 3, 5);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/variable/shadowing/ShadowingTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/variable/shadowing/ShadowingTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.core.model.values.BValue;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -139,5 +140,10 @@ public class ShadowingTest {
     @Test(description = "test shadowing with ballerina generated names")
     public void testGeneratedNames() {
         BRunUtil.invoke(result, "testGeneratedNames");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/vm/DynamicControlStackTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/vm/DynamicControlStackTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -52,4 +53,8 @@ public class DynamicControlStackTest {
         Assert.assertEquals(((BInteger) vals[0]).intValue(), 50125000);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkNegativeTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -54,5 +55,10 @@ public class BasicForkNegativeTest {
         BAssertUtil.validateError(result, index++, "worker interactions are only allowed between peers", 52, 5);
         BAssertUtil.validateError(result, index++, "worker interactions are only allowed between peers", 53, 16);
         Assert.assertEquals(result.getErrorCount(), index);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicForkTest.java
@@ -21,6 +21,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -80,5 +81,10 @@ public class BasicForkTest {
 
     private int lastNum(String multiLineStr) {
         return Integer.parseInt(lastLine(multiLineStr));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerActionsNegativeTest.java
@@ -20,6 +20,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -82,5 +83,11 @@ public class BasicWorkerActionsNegativeTest {
 
         Assert.assertEquals(resultNegative.getErrorCount(), index, "Worker actions negative test error count");
 
+    }
+
+    @AfterClass
+    public void tearDown() {
+        resultNegative = null;
+        resultSemanticsNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/BasicWorkerTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -88,5 +89,10 @@ public class BasicWorkerTest {
         BMap result = (BMap) vals[0];
         Assert.assertEquals(result.get("w"), result.get("w1"));
         Assert.assertEquals(result.get("w"), result.get("w2"));
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/ForkReturnAnyTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/ForkReturnAnyTest.java
@@ -24,6 +24,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -46,4 +47,8 @@ public class ForkReturnAnyTest {
         Assert.assertTrue(returns[1] instanceof BString);
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/NotSoBasicWorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/NotSoBasicWorkerTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -163,5 +164,10 @@ public class NotSoBasicWorkerTest {
         BValue[] vals = BRunUtil.invoke(result, "testVoidFunction", new BValue[0]);
         Assert.assertEquals(vals.length, 1);
         Assert.assertTrue((((BInteger) vals[0]).intValue() == 10) || ((BInteger) vals[0]).intValue() == 5);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/StackOverflowTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/StackOverflowTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -55,5 +56,10 @@ public class StackOverflowTest {
     @Test
     public void stackOverflowInWorker() {
         BRunUtil.invoke(result, "stackOverflowInWorker");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/VarMutabilityWithWorkersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/VarMutabilityWithWorkersTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -102,5 +103,10 @@ public class VarMutabilityWithWorkersTest {
         BValue[] returns = BRunUtil.invoke(compileResult, "testWithObjects");
         Assert.assertEquals(((BMap) returns[0]).size(), 3);
         Assert.assertEquals(((BMap) returns[0]).getMap().toString(), "{age=40, name=Adam, fullName=Adam Adam Page}");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        compileResult = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitActionsNegativeTest.java
@@ -20,6 +20,7 @@ import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -87,5 +88,10 @@ public class WaitActionsNegativeTest {
                 "incompatible types: expected 'future<int>', found 'future<string>'", 89, 55);
         BAssertUtil.validateError(resultNegative, index,
                 "incompatible types: expected 'future<string>', found 'future<int>'", 90, 54);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        resultNegative = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllActionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllActionsTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -410,5 +411,10 @@ public class WaitForAllActionsTest {
             }
         }
         return true;
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllWorkersTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAllWorkersTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -59,4 +60,8 @@ public class WaitForAllWorkersTest {
         }
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAnyActionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForAnyActionsTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -216,5 +217,10 @@ public class WaitForAnyActionsTest {
         Assert.assertEquals(vals.length, 1);
         Assert.assertTrue(vals[0] instanceof BError);
         Assert.assertEquals(((BError) vals[0]).getReason(), "A hazardous error occurred!!! Abort immediately!!");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForOneActionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WaitForOneActionsTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -105,5 +106,10 @@ public class WaitForOneActionsTest {
     @Test
     public void asyncObjectCreationTest() {
         BRunUtil.invoke(result, "asyncObjectCreationTest", new BValue[0]);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerCallingFunction.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerCallingFunction.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -43,5 +44,10 @@ public class WorkerCallingFunction {
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(returns[0] instanceof BInteger);
         Assert.assertEquals(((BInteger) returns[0]).intValue(), 20);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerCancelledTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerCancelledTest.java
@@ -20,6 +20,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -54,5 +55,10 @@ public class WorkerCancelledTest {
         } finally {
             System.setOut(defaultOut);
         }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFlushTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerFlushTest.java
@@ -23,6 +23,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -99,5 +100,10 @@ public class WorkerFlushTest {
 
         BValue[] returns = BRunUtil.invoke(result, "flushInDefault");
         Assert.assertEquals(returns[0].stringValue(), "25");
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerInActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerInActionTest.java
@@ -22,6 +22,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -57,4 +58,8 @@ public class WorkerInActionTest {
         Assert.assertEquals(returns[0].stringValue(), "REACHED");
     }
 
+    @AfterClass
+    public void tearDown() {
+        result = null;
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerSyncSendTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -206,5 +207,10 @@ public class WorkerSyncSendTest {
         BValue[] returns = BRunUtil.invoke(result, "testFailureForReceiveWithError");
         Assert.assertEquals(returns.length, 1);
         Assert.assertTrue(((BBoolean) returns[0]).booleanValue());
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/worker/WorkerTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -386,5 +387,10 @@ public class WorkerTest {
         CompileResult result = BCompileUtil.compile("test-src/workers/multiple-receive-action.bal");
         Assert.assertEquals(result.getErrorCount(), 1);
         BAssertUtil.validateError(result, 0, "multiple receive action not yet supported", 23, 25);
+    }
+
+    @AfterClass
+    public void tearDown() {
+        result = null;
     }
 }


### PR DESCRIPTION
## Purpose
The test suite is keeping `CompileResult` objects live during the run using a large portion of the memory.

<img width="948" alt="Screenshot 2021-01-14 at 12 46 44 AM" src="https://user-images.githubusercontent.com/2173530/104498656-017fad00-5602-11eb-8503-2385a9b822d2.png">


eg: 

```Java
@AfterClass
public void tearDown() {
    compileResult = null;
    negativeResult = null;
}
```
partially fix https://github.com/ballerina-platform/ballerina-lang/issues/27856

## Before
<img width="1312" alt="Screenshot 2021-01-13 at 11 49 33 PM" src="https://user-images.githubusercontent.com/2173530/104497645-ad27fd80-5600-11eb-9e9a-d1510058b050.png">

## After
<img width="1131" alt="Screenshot 2021-01-14 at 12 44 36 AM" src="https://user-images.githubusercontent.com/2173530/104498461-b8c7f400-5601-11eb-8677-91eb03e0a35f.png">


## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
