### PR TITLE
Extract resource name for http filters

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
@@ -53,6 +53,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangFunctionBody;
 import org.wso2.ballerinalang.compiler.tree.BLangIdentifier;
 import org.wso2.ballerinalang.compiler.tree.BLangImportPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
+import org.wso2.ballerinalang.compiler.tree.BLangResourceFunction;
 import org.wso2.ballerinalang.compiler.tree.BLangSimpleVariable;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangBinaryExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
@@ -201,7 +202,7 @@ public class HttpFiltersDesugar {
         serviceRef.pos = resourceNode.pos;
 
         BLangLiteral resourceName = new BLangLiteral();
-        resourceName.value = resourceNode.name.value;
+        resourceName.value = extractResourceName(resourceNode);
         resourceName.type = symTable.stringType;
         resourceName.pos = resourceNode.pos;
 
@@ -231,6 +232,11 @@ public class HttpFiltersDesugar {
         addStatementToResourceBody(resourceNode.body,
                                    ASTBuilderUtil.createVariableDef(resourceNode.pos, filterContextVar), 0);
         return filterContextVar;
+    }
+
+    private String extractResourceName(BLangFunction resourceNode) {
+        String resourceName = resourceNode.name.value;
+        return resourceName.replace("$" + ((BLangResourceFunction) resourceNode).accessorName.value + "$", "");
     }
 
     private void addStatementToResourceBody(BLangFunctionBody body, BLangStatement stmt, int index) {


### PR DESCRIPTION
## Purpose
The `resourceNode.name.value` is evaluated as the resource name concatenated with the `accessor` and `$` symbols. In order to engage HTTP filters, the exact resource name should be desugard in to the HTTP filter context.

Example 1:
`resource function get sayHello` is evaluated as `"$get$sayHello"` and converted by the PR as `"sayHello"`

Example 2:
`resource function myAccessor sayHello` is evaluated as `"$myAccessor$sayHello"` and converted by the PR as `"sayHello"`

Example 3:
`resource function my\$Accessor say\$Hello` is evaluated as `"$my\$Accessor$say\$Hello"` and converted by the PR as `"sayHello"`

Related to https://github.com/ballerina-platform/ballerina-lang/pull/27820
Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/584

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
