### PR TITLE
Override langlibMethods() for intersection type symbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
@@ -17,6 +17,8 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.LangLibrary;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -71,6 +73,17 @@ public class BallerinaIntersectionTypeSymbol extends AbstractTypeSymbol implemen
         TypesFactory typesFactory = TypesFactory.getInstance(this.context);
         this.effectiveType = typesFactory.getTypeDescriptor(((BIntersectionType) this.getBType()).effectiveType);
         return this.effectiveType;
+    }
+
+    @Override
+    public List<FunctionSymbol> langLibMethods() {
+        if (this.langLibFunctions == null) {
+            LangLibrary langLibrary = LangLibrary.getInstance(this.context);
+            List<FunctionSymbol> functions = langLibrary.getMethods(this.effectiveTypeDescriptor().typeKind());
+            this.langLibFunctions = filterLangLibMethods(functions, this.getBType());
+        }
+
+        return this.langLibFunctions;
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -42,6 +42,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INTERSECTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
@@ -317,6 +318,22 @@ public class LangLibFunctionTest {
                 {64, 22, expFunctions},
                 {65, 32, Stream.concat(expFunctions.stream(), additionalFuncs.stream()).collect(Collectors.toList())}
         };
+    }
+
+    @Test
+    public void testIntersectionType() {
+        Symbol symbol = getSymbol(70, 21);
+        TypeSymbol type = ((VariableSymbol) symbol).typeDescriptor();
+        assertEquals(type.typeKind(), INTERSECTION);
+
+        List<String> expFunctions = List.of("reduce", "forEach", "shift", "length", "sort", "reverse", "toStream",
+                                            "remove", "push", "filter", "pop", "lastIndexOf", "iterator", "removeAll",
+                                            "setLength", "slice", "enumerate", "unshift", "map", "indexOf",
+                                            "cloneWithType", "cloneReadOnly", "toBalString", "toJson", "isReadOnly",
+                                            "fromJsonWithType", "mergeJson", "clone", "ensureType", "toString",
+                                            "toJsonString");
+
+        assertLangLibList(type.langLibMethods(), expFunctions);
     }
 
     private Symbol getSymbol(int line, int column) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/langlib_test.bal
@@ -67,4 +67,6 @@ function test() {
 
     xml xm = xml `<Greeting>Hello</Greeting>`;
     'xml:Element xm2 = xml `<Greeting>Hola</Greeting>`;
+
+    int[] & readonly iarr = [1, 2];
 }


### PR DESCRIPTION
## Purpose
This PR provides an implementation for `langlibMethods()` for intersection type symbol to be able to provide a more accurate list of lang lib methods associated with an intersection type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
