### PR TITLE
Fix issue in creating type ref symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -250,7 +250,10 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Optional.empty();
         }
 
-        if (isTypeSymbol(symbolAtCursor) && !PositionUtil.withinBlock(position, symbolAtCursor.pos)) {
+        if (isTypeSymbol(symbolAtCursor) &&
+                !(compilationUnit.getPackageID().equals(symbolAtCursor.pkgID)
+                        && compilationUnit.getName().equals(symbolAtCursor.pos.lineRange().filePath())
+                        && PositionUtil.withinBlock(position, symbolAtCursor.pos))) {
             ModuleID moduleID = new BallerinaModuleID(symbolAtCursor.pkgID);
             return Optional.of(new BallerinaTypeReferenceTypeSymbol(this.compilerContext, moduleID, symbolAtCursor.type,
                                                                     symbolAtCursor.getName().getValue()));


### PR DESCRIPTION
## Purpose
Fixes a position comparison issue in `symbol()` where when you refer to a symbol in another file, it would not get identified as a type reference since the although they are different files, the positions of them match. With this PR, the module, the file and the position are considered in comparing the positions when creating a type reff symbol.