### PR TITLE
Fix filter invocation only with HTTP caller and HTTP request temporarily

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
@@ -127,6 +127,8 @@ public class HttpFiltersDesugar {
 
     private static final String ORG_NAME = "ballerina";
     private static final String PACKAGE_NAME = "http";
+    private static final String CALLER_TYPE_NAME = "Caller";
+    private static final String REQUEST_TYPE_NAME = "Request";
 
     private static final int ENDPOINT_PARAM_NUM = 0;
     private static final int REQUEST_PARAM_NUM = 1;
@@ -149,6 +151,14 @@ public class HttpFiltersDesugar {
         this.symResolver = SymbolResolver.getInstance(context);
         this.names = Names.getInstance(context);
         this.types = Types.getInstance(context);
+    }
+
+    boolean isRequiredParamsAvailable(BLangFunction resourceNode) {
+        return resourceNode.requiredParams.size() >= 2 &&
+                resourceNode.requiredParams.stream().
+                        anyMatch(param -> param.type.tsymbol.name.value.equals(CALLER_TYPE_NAME)) &&
+                resourceNode.requiredParams.stream().
+                        anyMatch(param -> param.type.tsymbol.name.value.equals(REQUEST_TYPE_NAME));
     }
 
     boolean isHttpPackage(List<BType> expressionTypes) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/HttpFiltersDesugar.java
@@ -155,10 +155,8 @@ public class HttpFiltersDesugar {
 
     boolean isRequiredParamsAvailable(BLangFunction resourceNode) {
         return resourceNode.requiredParams.size() >= 2 &&
-                resourceNode.requiredParams.stream().
-                        anyMatch(param -> param.type.tsymbol.name.value.equals(CALLER_TYPE_NAME)) &&
-                resourceNode.requiredParams.stream().
-                        anyMatch(param -> param.type.tsymbol.name.value.equals(REQUEST_TYPE_NAME));
+                resourceNode.requiredParams.get(0).type.tsymbol.name.value.equals(CALLER_TYPE_NAME) &&
+                resourceNode.requiredParams.get(1).type.tsymbol.name.value.equals(REQUEST_TYPE_NAME);
     }
 
     boolean isHttpPackage(List<BType> expressionTypes) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ServiceDesugar.java
@@ -280,7 +280,8 @@ public class ServiceDesugar {
                     .createBeginParticipantInvocation(functionNode.pos));
             ((BLangBlockFunctionBody) functionNode.body).stmts.add(0, stmt);
         }
-        if (httpFiltersDesugar.isHttpPackage(expressionTypes)) {
+        if (httpFiltersDesugar.isHttpPackage(expressionTypes) &&
+                httpFiltersDesugar.isRequiredParamsAvailable(functionNode)) {
             httpFiltersDesugar.addFilterStatements(functionNode, env);
 //            httpFiltersDesugar.addOrderParamConfig(functionNode, env);
         }


### PR DESCRIPTION
## Purpose
The HTTP filter configurations are passed via `http:Caller` to the filter desugar. `http:Caller` and `http:Request` is passed to `filterRequest` function when desugared. This is no longer valid with the service design for Swan Lake. This PR mandate the `http:Caller` and `http:Request` in resource signature in order to filter engagement as a temporary fix. Additionally, this mandate the parameter order also. Created this to remove blocking situation of downstream modules.

Related to https://github.com/ballerina-platform/ballerina-lang/pull/27875

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
