### PR TITLE
Refactor symbols to include name() only for symbols with names

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -66,11 +66,6 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     public abstract String signature();
 
     @Override
-    public String name() {
-        return "";
-    }
-
-    @Override
     public SymbolKind kind() {
         return SymbolKind.TYPE;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaAnnotationSymbol extends BallerinaSymbol implements AnnotationSymbol {
+public class BallerinaAnnotationSymbol extends BallerinaNamedSymbol implements AnnotationSymbol {
 
     private final List<Qualifier> qualifiers;
     private final TypeSymbol typeDescriptor;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
@@ -35,11 +35,6 @@ public class BallerinaByteTypeSymbol extends AbstractTypeSymbol implements ByteT
     }
 
     @Override
-    public String name() {
-        return "byte";
-    }
-
-    @Override
     public String signature() {
         return "byte";
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -48,7 +48,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol {
+public class BallerinaClassSymbol extends BallerinaNamedSymbol implements ClassSymbol {
 
     private final ObjectTypeSymbol typeDescriptor;
     private final List<Qualifier> qualifiers;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFieldSymbol.java
@@ -40,7 +40,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaFieldSymbol extends BallerinaSymbol implements FieldSymbol {
+public class BallerinaFieldSymbol extends BallerinaNamedSymbol implements FieldSymbol {
 
     private final Documentation docAttachment;
     private final BField bField;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaFunctionSymbol extends BallerinaSymbol implements FunctionSymbol {
+public class BallerinaFunctionSymbol extends BallerinaNamedSymbol implements FunctionSymbol {
 
     private final FunctionTypeSymbol typeDescriptor;
     private final List<Qualifier> qualifiers;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -51,7 +51,7 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.is
  *
  * @since 2.0.0
  */
-public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
+public class BallerinaModule extends BallerinaNamedSymbol implements ModuleSymbol {
 
     private final CompilerContext context;
     private BPackageSymbol packageSymbol;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNamedSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNamedSymbol.java
@@ -15,30 +15,29 @@
  * limitations under the License.
  */
 
-package io.ballerina.compiler.api.symbols;
+package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.tools.diagnostics.Location;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import org.ballerinalang.model.elements.PackageID;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
 /**
- * Represents a symbol which is associated with a name and can be located in a source file.
+ * Implementation of NamedSymbol.
  *
  * @since 2.0.0
  */
-public interface NamedSymbol extends Symbol, Identifiable {
+public class BallerinaNamedSymbol extends BallerinaSymbol implements NamedSymbol {
 
-    /**
-     * Get the moduleID of the symbol.
-     *
-     * @return {@link ModuleID} of the symbol
-     */
-    ModuleID moduleID();
+    private final String name;
 
-    /**
-     * This retrieves position information of the symbol in the source code. The position given here is the location of
-     * the definition of the symbol.
-     *
-     * @return The position information of the symbol
-     */
-    Location location();
+    protected BallerinaNamedSymbol(String name, PackageID moduleID, SymbolKind symbolKind, BSymbol symbol) {
+        super(name, moduleID, symbolKind, symbol);
+        this.name = name;
+    }
+
+    @Override
+    public String name() {
+        return this.name;
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -36,14 +36,12 @@ import java.util.Objects;
  */
 public class BallerinaSymbol implements Symbol {
 
-    private final String name;
     private final PackageID moduleID;
     private final SymbolKind symbolKind;
     private final Location position;
     private final BSymbol internalSymbol;
 
     protected BallerinaSymbol(String name, PackageID moduleID, SymbolKind symbolKind, BSymbol symbol) {
-        this.name = name;
         this.moduleID = moduleID;
         this.symbolKind = symbolKind;
 
@@ -57,14 +55,6 @@ public class BallerinaSymbol implements Symbol {
                                                     symbol.pos.lineRange().endLine().line(),
                                                     symbol.pos.lineRange().startLine().offset(),
                                                     symbol.pos.lineRange().endLine().offset());
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String name() {
-        return this.name;
     }
 
     /**
@@ -100,15 +90,14 @@ public class BallerinaSymbol implements Symbol {
 
         Symbol symbol = (Symbol) obj;
 
-        return this.name().equals(symbol.name())
-                && this.moduleID().equals(symbol.moduleID())
+        return this.moduleID().equals(symbol.moduleID())
                 && this.kind().equals(symbol.kind())
                 && this.location().lineRange().equals(symbol.location().lineRange());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.name(), this.moduleID(), this.kind(), this.location().lineRange());
+        return Objects.hash(this.moduleID(), this.kind(), this.location().lineRange());
     }
 
     public BSymbol getInternalSymbol() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements TypeDefinitionSymbol {
+public class BallerinaTypeDefinitionSymbol extends BallerinaNamedSymbol implements TypeDefinitionSymbol {
 
     private final List<Qualifier> qualifiers;
     private final TypeSymbol typeDescriptor;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
@@ -17,6 +17,7 @@
 package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
@@ -25,7 +26,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
  *
  * @since 2.0.0
  */
-public class BallerinaTypeSymbol extends AbstractTypeSymbol {
+public class BallerinaTypeSymbol extends AbstractTypeSymbol implements Identifiable {
 
     private final String typeName;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -38,7 +38,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class BallerinaVariableSymbol extends BallerinaSymbol implements VariableSymbol {
+public class BallerinaVariableSymbol extends BallerinaNamedSymbol implements VariableSymbol {
 
     private final List<Qualifier> qualifiers;
     private final List<AnnotationSymbol> annots;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -32,7 +32,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymbol {
+public class BallerinaWorkerSymbol extends BallerinaNamedSymbol implements WorkerSymbol {
 
     private TypeSymbol returnType;
     private List<AnnotationSymbol> annots;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
@@ -28,7 +28,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
  *
  * @since 2.0.0
  */
-public class BallerinaXMLNSSymbol extends BallerinaSymbol implements XMLNamespaceSymbol {
+public class BallerinaXMLNSSymbol extends BallerinaNamedSymbol implements XMLNamespaceSymbol {
 
     private final String namespaceUri;
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -52,7 +52,7 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
     }
 
     @Override
-    public String name() {
+    public String signature() {
         if (this.typeName == null) {
             BXMLType xmlType = (BXMLType) this.getBType();
             SymbolTable symbolTable = SymbolTable.getInstance(this.context);
@@ -60,15 +60,10 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
             if (xmlType == symbolTable.xmlType || this.typeParameter().isEmpty()) {
                 this.typeName = "xml";
             } else {
-                this.typeName = "xml<" + this.typeParameter().get().name() + ">";
+                this.typeName = "xml<" + this.typeParameter().get().signature() + ">";
             }
         }
 
         return this.typeName;
-    }
-
-    @Override
-    public String signature() {
-        return name();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/AnnotationSymbol.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface AnnotationSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
+public interface AnnotationSymbol extends NamedSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the type descriptor.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ClassSymbol.java
@@ -24,7 +24,8 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface ClassSymbol extends ObjectTypeSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
+public interface ClassSymbol
+        extends NamedSymbol, ObjectTypeSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the init method.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FieldSymbol.java
@@ -24,7 +24,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface FieldSymbol extends Symbol, Annotatable, Deprecatable, Documentable {
+public interface FieldSymbol extends NamedSymbol, Annotatable, Deprecatable, Documentable {
 
     /**
      * Whether optional field or not.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface FunctionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
+public interface FunctionSymbol extends NamedSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the type descriptor of the function.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Identifiable.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Identifiable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -18,9 +18,16 @@
 package io.ballerina.compiler.api.symbols;
 
 /**
- * Represents the string:Char type descriptor.
+ * Marks a symbol as identifiable by a given name.
  *
  * @since 2.0.0
  */
-public interface StringCharTypeSymbol extends StringTypeSymbol, NamedSymbol {
+public interface Identifiable {
+
+    /**
+     * Get the symbol name.
+     *
+     * @return {@link String} name of the symbol
+     */
+    String name();
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntSigned16TypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface IntSigned16TypeSymbol extends IntTypeSymbol {
+public interface IntSigned16TypeSymbol extends IntTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntSigned32TypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface IntSigned32TypeSymbol extends IntTypeSymbol {
+public interface IntSigned32TypeSymbol extends IntTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntSigned8TypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface IntSigned8TypeSymbol extends IntTypeSymbol {
+public interface IntSigned8TypeSymbol extends IntTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntUnsigned16TypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface IntUnsigned16TypeSymbol extends IntTypeSymbol {
+public interface IntUnsigned16TypeSymbol extends IntTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntUnsigned32TypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface IntUnsigned32TypeSymbol extends IntTypeSymbol {
+public interface IntUnsigned32TypeSymbol extends IntTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/IntUnsigned8TypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface IntUnsigned8TypeSymbol extends IntTypeSymbol {
+public interface IntUnsigned8TypeSymbol extends IntTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ModuleSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ModuleSymbol.java
@@ -24,7 +24,7 @@ import java.util.List;
  *
  * @since 2.0.0
  */
-public interface ModuleSymbol extends Symbol {
+public interface ModuleSymbol extends NamedSymbol {
 
     /**
      * Get the public functions defined within the module.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/NamedSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/NamedSymbol.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.ballerina.compiler.api.symbols;
+
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.tools.diagnostics.Location;
+
+/**
+ * Represents a symbol which is associated with a name and can be located in a source file.
+ *
+ * @since 2.0.0
+ */
+public interface NamedSymbol extends Symbol {
+
+    /**
+     * Get the symbol name.
+     *
+     * @return {@link String} name of the symbol
+     */
+    String name();
+
+    /**
+     * Get the moduleID of the symbol.
+     *
+     * @return {@link ModuleID} of the symbol
+     */
+    ModuleID moduleID();
+
+    /**
+     * This retrieves position information of the symbol in the source code. The position given here is the location of
+     * the definition of the symbol.
+     *
+     * @return The position information of the symbol
+     */
+    Location location();
+}

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -28,13 +28,6 @@ import io.ballerina.tools.diagnostics.Location;
 public interface Symbol {
 
     /**
-     * Get the symbol name.
-     * 
-     * @return {@link String} name of the symbol
-     */
-    String name();
-
-    /**
      * Get the moduleID of the symbol.
      * 
      * @return {@link ModuleID} of the symbol

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeDefinitionSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface TypeDefinitionSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
+public interface TypeDefinitionSymbol extends NamedSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the module qualified name.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeReferenceTypeSymbol.java
@@ -21,7 +21,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface TypeReferenceTypeSymbol extends TypeSymbol {
+public interface TypeReferenceTypeSymbol extends NamedSymbol, TypeSymbol {
 
     /**
      * Get the associated type descriptor.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/VariableSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface VariableSymbol extends Symbol, Qualifiable, Deprecatable, Annotatable, Documentable {
+public interface VariableSymbol extends NamedSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
 
     /**
      * Get the Type of the variable.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/WorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/WorkerSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface WorkerSymbol extends Symbol, Annotatable {
+public interface WorkerSymbol extends NamedSymbol, Annotatable {
 
     /**
      * Get the return type.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLCommentTypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface XMLCommentTypeSymbol extends XMLTypeSymbol {
+public interface XMLCommentTypeSymbol extends XMLTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLElementTypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface XMLElementTypeSymbol extends XMLTypeSymbol {
+public interface XMLElementTypeSymbol extends XMLTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLNamespaceSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLNamespaceSymbol.java
@@ -22,7 +22,7 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface XMLNamespaceSymbol extends Symbol {
+public interface XMLNamespaceSymbol extends NamedSymbol {
 
     /**
      * Get the namespace URI.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLProcessingInstructionTypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface XMLProcessingInstructionTypeSymbol extends XMLTypeSymbol {
+public interface XMLProcessingInstructionTypeSymbol extends XMLTypeSymbol, NamedSymbol {
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/XMLTextTypeSymbol.java
@@ -22,5 +22,5 @@ package io.ballerina.compiler.api.symbols;
  *
  * @since 2.0.0
  */
-public interface XMLTextTypeSymbol extends XMLTypeSymbol {
+public interface XMLTextTypeSymbol extends XMLTypeSymbol, NamedSymbol {
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -194,7 +195,7 @@ public class CodeActionUtil {
      */
     public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, List<TextEdit> edits,
                                                 DocumentServiceContext context) {
-        if (typeDescriptor.name().startsWith("$")) {
+        if (typeDescriptor instanceof Identifiable && ((Identifiable) typeDescriptor).name().startsWith("$")) {
             typeDescriptor = CommonUtil.getRawType(typeDescriptor);
         }
         ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.codeaction.providers.createvar;
 
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Diagnostic;
@@ -91,7 +92,9 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
 
         Position position = CommonUtil.toPosition(context.positionDetails().matchedNode().lineRange().startLine());
         Set<String> allNameEntries = context.visibleSymbols(position).stream()
-                .map(Symbol::name)
+                .filter(s -> s instanceof Identifiable)
+                .map(s -> (Identifiable) s)
+                .map(Identifiable::name)
                 .collect(Collectors.toSet());
 
         String name = CommonUtil.generateVariableName(matchedSymbol, typeDescriptor, allNameEntries);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.codeaction.providers.createvar;
 
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -60,7 +61,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         Symbol matchedSymbol = context.positionDetails().matchedSymbol();
         TypeSymbol typeDescriptor = context.positionDetails().matchedExprType();
         String uri = context.fileUri();
-        if (typeDescriptor == null || typeDescriptor.typeKind() != TypeDescKind.UNION) {
+        if (!(matchedSymbol instanceof Identifiable) || typeDescriptor == null
+                || typeDescriptor.typeKind() != TypeDescKind.UNION) {
             return Collections.emptyList();
         }
         UnionTypeSymbol unionType = (UnionTypeSymbol) typeDescriptor;
@@ -74,7 +76,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         CreateVariableOut createVarTextEdits = getCreateVariableTextEdits(range, context);
 
         // Add type guard code action
-        String commandTitle = String.format(CommandConstants.CREATE_VAR_TYPE_GUARD_TITLE, matchedSymbol.name());
+        String commandTitle = String.format(CommandConstants.CREATE_VAR_TYPE_GUARD_TITLE,
+                                            ((Identifiable) matchedSymbol).name());
         List<TextEdit> edits = CodeActionUtil.getTypeGuardCodeActionEdits(createVarTextEdits.name, range, unionType,
                                                                           context);
         if (edits.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -15,6 +15,8 @@
  */
 package org.ballerinalang.langserver.codeaction.providers.createvar;
 
+import io.ballerina.compiler.api.symbols.Identifiable;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
@@ -60,8 +62,11 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         if (!(diagnostic.message().contains(CommandConstants.VAR_ASSIGNMENT_REQUIRED))) {
             return Collections.emptyList();
         }
+
+        Symbol matchedSymbol = context.positionDetails().matchedSymbol();
         TypeSymbol typeSymbol = context.positionDetails().matchedExprType();
-        if (typeSymbol == null || typeSymbol.typeKind() != TypeDescKind.UNION) {
+        if (!(matchedSymbol instanceof Identifiable) || typeSymbol == null
+                || typeSymbol.typeKind() != TypeDescKind.UNION) {
             return Collections.emptyList();
         }
         UnionTypeSymbol unionTypeDesc = (UnionTypeSymbol) typeSymbol;
@@ -77,7 +82,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         edits.addAll(getAddCheckTextEdits(CommonUtil.toRange(diagnostic.location().lineRange()).getStart(), context));
 
         String commandTitle = String.format(CommandConstants.CREATE_VAR_ADD_CHECK_TITLE,
-                                            context.positionDetails().matchedSymbol().name());
+                                            ((Identifiable) matchedSymbol).name());
         return Collections.singletonList(AbstractCodeActionProvider.createQuickFixCodeAction(commandTitle, edits, uri));
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
@@ -201,7 +202,7 @@ public class SymbolUtil {
         }
         List<String> attachedMethods = ((ClassSymbol) CommonUtil.getRawType(symbolTypeDesc.get())).methods()
                 .stream()
-                .map(Symbol::name)
+                .map(MethodSymbol::name)
                 .collect(Collectors.toList());
         return attachedMethods.contains("start") && attachedMethods.contains("immediateStop")
                 && attachedMethods.contains("immediateStop") && attachedMethods.contains("attach");

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
@@ -86,8 +86,8 @@ public class BLangRecordLiteralUtil {
         if (canSpread && symbol.kind() == SymbolKind.FUNCTION) {
             cItem = FunctionCompletionItemBuilder.build((FunctionSymbol) symbol, context);
         } else if (canSpread) {
-            cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbol.name(),
-                    typeDescriptor.get().signature());
+            cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, ((VariableSymbol) symbol).name(),
+                                                        typeDescriptor.get().signature());
         } else {
             return Optional.empty();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -160,11 +161,12 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                 VariableSymbol varSymbol = (VariableSymbol) symbol;
                 TypeSymbol typeDesc = (varSymbol).typeDescriptor();
                 String typeName = typeDesc == null ? "" : typeDesc.signature();
-                CompletionItem variableCItem = VariableCompletionItemBuilder.build(varSymbol, symbol.name(), typeName);
+                CompletionItem variableCItem =
+                        VariableCompletionItemBuilder.build(varSymbol, varSymbol.name(), typeName);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
             } else if (symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS) {
                 // Here skip all the package symbols since the package is added separately
-                CompletionItem typeCItem = TypeCompletionItemBuilder.build(symbol, symbol.name());
+                CompletionItem typeCItem = TypeCompletionItemBuilder.build(symbol, ((Identifiable) symbol).name());
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, typeCItem));
             } else if (symbol.kind() == SymbolKind.WORKER) {
                 CompletionItem workerItem = WorkerCompletionItemBuilder.build((WorkerSymbol) symbol);
@@ -191,7 +193,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
         visibleSymbols.forEach(bSymbol -> {
             if (bSymbol.kind() == SymbolKind.TYPE_DEFINITION || bSymbol.kind() == SymbolKind.CLASS
                     || bSymbol.kind() == ENUM) {
-                CompletionItem cItem = TypeCompletionItemBuilder.build(bSymbol, bSymbol.name());
+                CompletionItem cItem = TypeCompletionItemBuilder.build(bSymbol, ((Identifiable) bSymbol).name());
                 completionItems.add(new SymbolCompletionItem(context, bSymbol, cItem));
             }
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -165,7 +166,7 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
             case SIMPLE_NAME_REFERENCE:
                 String nameRef = ((SimpleNameReferenceNode) expressionNode).name().text();
                 for (Symbol symbol : visibleSymbols) {
-                    if (symbol.name().equals(nameRef)) {
+                    if (symbol instanceof Identifiable && ((Identifiable) symbol).name().equals(nameRef)) {
                         return Optional.of(symbol);
                     }
                 }
@@ -188,7 +189,7 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
                 } else if (refName.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                     String funcName = ((SimpleNameReferenceNode) refName).name().text();
                     for (Symbol symbol : visibleSymbols) {
-                        if (symbol.kind() == FUNCTION && symbol.name().equals(funcName)) {
+                        if (symbol.kind() == FUNCTION && ((FunctionSymbol) symbol).name().equals(funcName)) {
                             return Optional.of(symbol);
                         }
                     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AssignmentStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AssignmentStatementNodeContext.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
@@ -98,7 +99,7 @@ public class AssignmentStatementNodeContext extends AbstractCompletionProvider<A
         if (varRef.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) varRef).name().text();
             objectType = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((Identifiable) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AssignmentStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AssignmentStatementNodeContext.java
@@ -98,7 +98,7 @@ public class AssignmentStatementNodeContext extends AbstractCompletionProvider<A
         if (varRef.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) varRef).name().text();
             objectType = visibleSymbols.stream()
-                    .filter(symbol -> symbol.name().equals(identifier) && SymbolUtil.isClass(symbol))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -235,16 +235,17 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                     if (symbol.kind() != SymbolKind.VARIABLE) {
                         return false;
                     }
-                    TypeSymbol typeDesc = ((VariableSymbol) symbol).typeDescriptor();
-                    return typeDesc.typeKind() == TypeDescKind.UNION && !capturedSymbols.contains(symbol.name());
+                    VariableSymbol varSymbol = (VariableSymbol) symbol;
+                    TypeSymbol typeDesc = varSymbol.typeDescriptor();
+                    return typeDesc.typeKind() == TypeDescKind.UNION && !capturedSymbols.contains(varSymbol.name());
                 })
                 .map(symbol -> {
-                    capturedSymbols.add(symbol.name());
+                    VariableSymbol varSymbol = (VariableSymbol) symbol;
+                    capturedSymbols.add(varSymbol.name());
                     List<TypeSymbol> errorTypes = new ArrayList<>();
                     List<TypeSymbol> resultTypes = new ArrayList<>();
                     List<TypeSymbol> members
-                            = new ArrayList<>(((UnionTypeSymbol) ((VariableSymbol) symbol).typeDescriptor())
-                            .memberTypeDescriptors());
+                            = new ArrayList<>(((UnionTypeSymbol) varSymbol.typeDescriptor()).memberTypeDescriptors());
                     members.forEach(bType -> {
                         if (bType.typeKind() == TypeDescKind.ERROR) {
                             errorTypes.add(bType);
@@ -255,7 +256,7 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                     if (errorTypes.size() == 1) {
                         resultTypes.addAll(errorTypes);
                     }
-                    String symbolName = symbol.name();
+                    String symbolName = varSymbol.name();
                     String label = symbolName + " - typeguard " + symbolName;
                     String detail = "Destructure the variable " + symbolName + " with typeguard";
                     StringBuilder snippet = new StringBuilder();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -162,7 +163,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         String name = ((SimpleNameReferenceNode) referenceNode).name().text();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         Optional<Symbol> symbolRef = visibleSymbols.stream()
-                .filter(symbol -> symbol.name().equals(name))
+                .filter(symbol -> symbol instanceof Identifiable && ((Identifiable) symbol).name().equals(name))
                 .findFirst();
         if (symbolRef.isEmpty()) {
             return Optional.empty();
@@ -176,7 +177,8 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         String fName = ((SimpleNameReferenceNode) expr.functionName()).name().text();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         Optional<FunctionSymbol> symbolRef = visibleSymbols.stream()
-                .filter(symbol -> symbol.name().equals(fName) && symbol.kind() == SymbolKind.FUNCTION)
+                .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION &&
+                        ((FunctionSymbol) symbol).name().equals(fName))
                 .map(symbol -> (FunctionSymbol) symbol)
                 .findFirst();
         if (symbolRef.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
@@ -18,6 +18,7 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
@@ -97,12 +98,14 @@ public class ImplicitNewExpressionNodeContext extends AbstractCompletionProvider
                 return Optional.empty();
             }
             nameReferenceSymbol = pkgSymbol.get().allSymbols().stream()
-                    .filter(symbol -> symbol.name().equals(nameReferenceNode.identifier().text()))
+                    .filter(symbol -> symbol instanceof Identifiable &&
+                            ((Identifiable) symbol).name().equals(nameReferenceNode.identifier().text()))
                     .findFirst();
         } else if (typeDescriptor.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             SimpleNameReferenceNode nameReferenceNode = (SimpleNameReferenceNode) typeDescriptor;
             nameReferenceSymbol = visibleSymbols.stream()
-                    .filter(symbol -> symbol.name().equals(nameReferenceNode.name().text()))
+                    .filter(symbol -> symbol instanceof Identifiable &&
+                            ((Identifiable) symbol).name().equals(nameReferenceNode.name().text()))
                     .findFirst();
         }
 
@@ -120,7 +123,8 @@ public class ImplicitNewExpressionNodeContext extends AbstractCompletionProvider
         }
         String varName = ((SimpleNameReferenceNode) varRefNode).name().text();
         Optional<Symbol> varEntry = visibleSymbols.stream()
-                .filter(symbol -> symbol.name().equals(varName))
+                .filter(symbol -> symbol instanceof Identifiable &&
+                        ((Identifiable) symbol).name().equals(varName))
                 .findFirst();
 
         if (varEntry.isEmpty() || !SymbolUtil.isObject(varEntry.get())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
@@ -16,7 +16,9 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ListenerDeclarationNode;
@@ -165,7 +167,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         Optional<ModuleSymbol> moduleSymbol = visibleSymbols.stream()
-                .filter(symbol -> symbol.kind() == MODULE && symbol.name().equals(modulePrefix))
+                .filter(symbol -> symbol.kind() == MODULE && ((ModuleSymbol) symbol).name().equals(modulePrefix))
                 .map(symbol -> (ModuleSymbol) symbol)
                 .findAny();
 
@@ -267,7 +269,8 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
                 return Optional.empty();
             }
             ModuleSymbol module = moduleSymbol.get();
-            Stream<Symbol> objsAndClasses = Stream.concat(module.classes().stream(), module.typeDefinitions().stream());
+            Stream<NamedSymbol> objsAndClasses = Stream.concat(module.classes().stream(),
+                                                               module.typeDefinitions().stream());
             typeSymbol = objsAndClasses
                     .filter(type -> SymbolUtil.isListener(type)
                             && type.name().equals(nameReferenceNode.identifier().text()))
@@ -278,7 +281,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
             SimpleNameReferenceNode nameReferenceNode = (SimpleNameReferenceNode) typeDescriptor;
             typeSymbol = visibleSymbols.stream()
                     .filter(visibleSymbol -> SymbolUtil.isListener(visibleSymbol)
-                            && visibleSymbol.name().equals(nameReferenceNode.name().text()))
+                            && ((Identifiable) visibleSymbol).name().equals(nameReferenceNode.name().text()))
                     .map(symbol -> (ClassSymbol) symbol)
                     .findAny();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -18,6 +18,7 @@ package org.ballerinalang.langserver.completions.providers.context;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.FieldSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -160,7 +161,7 @@ public class MappingConstructorExpressionNodeContext extends
             if (typeDesc.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                 String varName = ((SimpleNameReferenceNode) typeDesc).name().text();
                 return visibleSymbols.stream()
-                        .filter(symbol -> SymbolUtil.isRecord(symbol) && symbol.name().equals(varName))
+                        .filter(symbol -> SymbolUtil.isRecord(symbol) && ((NamedSymbol) symbol).name().equals(varName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst();
             }
@@ -187,7 +188,8 @@ public class MappingConstructorExpressionNodeContext extends
             if (bPattern.kind() == SyntaxKind.CAPTURE_BINDING_PATTERN) {
                 String variableName = ((CaptureBindingPatternNode) bPattern).variableName().text();
                 return visibleSymbols.stream()
-                        .filter(symbol -> SymbolUtil.isRecord(symbol) && symbol.name().equals(variableName))
+                        .filter(symbol -> SymbolUtil.isRecord(symbol) &&
+                                ((NamedSymbol) symbol).name().equals(variableName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst();
             }
@@ -196,7 +198,7 @@ public class MappingConstructorExpressionNodeContext extends
             if (varRef.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                 String varName = ((SimpleNameReferenceNode) varRef).name().text();
                 return visibleSymbols.stream()
-                        .filter(symbol -> SymbolUtil.isRecord(symbol) && symbol.name().equals(varName))
+                        .filter(symbol -> SymbolUtil.isRecord(symbol) && ((NamedSymbol) symbol).name().equals(varName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst();
             }
@@ -219,14 +221,14 @@ public class MappingConstructorExpressionNodeContext extends
             if (!(symbol instanceof VariableSymbol)) {
                 return;
             }
-            TypeSymbol typeDescriptor = ((VariableSymbol) symbol).typeDescriptor();
-            String symbolName = symbol.name();
+            VariableSymbol varSymbol = (VariableSymbol) symbol;
+            TypeSymbol typeDescriptor = varSymbol.typeDescriptor();
+            String symbolName = varSymbol.name();
             if (fieldTypeMap.containsKey(symbolName)
                     && fieldTypeMap.get(symbolName).typeKind() == typeDescriptor.typeKind()) {
                 String bTypeName = typeDescriptor.signature();
-                CompletionItem cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbolName,
-                        bTypeName);
-                completionItems.add(new SymbolCompletionItem(ctx, symbol, cItem));
+                CompletionItem cItem = VariableCompletionItemBuilder.build(varSymbol, symbolName, bTypeName);
+                completionItems.add(new SymbolCompletionItem(ctx, varSymbol, cItem));
             }
         });
 
@@ -300,7 +302,8 @@ public class MappingConstructorExpressionNodeContext extends
         }
 
         Optional<TypeSymbol> bTypeSymbol = searchableEntries.stream()
-                .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION && symbol.name().equals(annotationName))
+                .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION &&
+                        ((AnnotationSymbol) symbol).name().equals(annotationName))
                 .map(entry -> ((AnnotationSymbol) entry).typeDescriptor().orElse(null))
                 .findAny();
         if (bTypeSymbol.isEmpty() || CommonUtil.getRawType(bTypeSymbol.get()).typeKind() != TypeDescKind.RECORD) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
@@ -99,13 +100,13 @@ public class RecordFieldWithDefaultValueNodeContext extends
             Stream<Symbol> classesAndTypes = Stream.concat(moduleSymbol.classes().stream(),
                     moduleSymbol.typeDefinitions().stream());
             objectType = classesAndTypes
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((Identifiable) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else if (typeNameNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) typeNameNode).name().text();
             objectType = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((Identifiable) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
@@ -99,13 +99,13 @@ public class RecordFieldWithDefaultValueNodeContext extends
             Stream<Symbol> classesAndTypes = Stream.concat(moduleSymbol.classes().stream(),
                     moduleSymbol.typeDefinitions().stream());
             objectType = classesAndTypes
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && symbol.name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else if (typeNameNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) typeNameNode).name().text();
             objectType = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && symbol.name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.completions.providers.context;
 
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -58,12 +59,15 @@ public abstract class RightArrowActionNodeContext<T extends Node> extends Abstra
         switch (node.kind()) {
             case SIMPLE_NAME_REFERENCE:
                 predicate = symbol -> symbol.kind() != SymbolKind.FUNCTION
-                        && symbol.name().equals(((SimpleNameReferenceNode) node).name().text());
+                        && symbol instanceof Identifiable &&
+                        ((Identifiable) symbol).name().equals(((SimpleNameReferenceNode) node).name().text());
                 break;
             case FUNCTION_CALL:
                 predicate = symbol -> symbol.kind() == SymbolKind.FUNCTION
-                        && symbol.name().equals(((SimpleNameReferenceNode) ((FunctionCallExpressionNode) node)
-                        .functionName()).name().text());
+                        && symbol instanceof Identifiable &&
+                        ((Identifiable) symbol).name().equals(
+                                ((SimpleNameReferenceNode) ((FunctionCallExpressionNode) node).functionName()).name()
+                                        .text());
                 break;
             default:
                 return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -106,7 +107,7 @@ public abstract class VariableDeclarationProvider<T extends Node> extends Abstra
         } else if (typeDescriptorNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) typeDescriptorNode).name().text();
             classSymbol = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((Identifiable) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
@@ -17,6 +17,7 @@ package org.ballerinalang.langserver.completions.providers.context;
 
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
@@ -96,8 +97,8 @@ public abstract class VariableDeclarationProvider<T extends Node> extends Abstra
             }
             String identifier = ((QualifiedNameReferenceNode) typeDescriptorNode).identifier().text();
             ModuleSymbol moduleSymbol = module.get();
-            Stream<Symbol> classesAndTypes = Stream.concat(moduleSymbol.classes().stream(),
-                    moduleSymbol.typeDefinitions().stream());
+            Stream<NamedSymbol> classesAndTypes = Stream.concat(moduleSymbol.classes().stream(),
+                                                                moduleSymbol.typeDefinitions().stream());
             classSymbol = classesAndTypes
                     .filter(typeSymbol -> SymbolUtil.isClass(typeSymbol) && typeSymbol.name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
@@ -105,7 +106,7 @@ public abstract class VariableDeclarationProvider<T extends Node> extends Abstra
         } else if (typeDescriptorNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) typeDescriptorNode).name().text();
             classSymbol = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && symbol.name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol) && ((ClassSymbol) symbol).name().equals(identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
@@ -240,7 +240,8 @@ public class SortingUtil {
         if (typeDesc.get().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String nameRef = ((SimpleNameReferenceNode) typeDesc.get()).name().text();
             for (Symbol symbol : visibleSymbols) {
-                if (symbol.kind() == SymbolKind.TYPE_DEFINITION && symbol.name().equals(nameRef)) {
+                if (symbol.kind() == SymbolKind.TYPE_DEFINITION
+                        && ((TypeDefinitionSymbol) symbol).name().equals(nameRef)) {
                     TypeDefinitionSymbol typeDefinitionSymbol = (TypeDefinitionSymbol) symbol;
                     return Optional.of(typeDefinitionSymbol.typeDescriptor());
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
@@ -91,8 +91,9 @@ public class ConnectorNodeVisitor extends NodeVisitor {
         Optional<Symbol> typeSymbol = this.semanticModel.symbol(typeDefinitionNode);
 
         if (typeSymbol.isPresent() && typeSymbol.get() instanceof TypeDefinitionSymbol) {
-            TypeSymbol rawType = getRawType(((TypeDefinitionSymbol) typeSymbol.get()).typeDescriptor());
-            String typeName = String.format("%s:%s", typeSymbol.get().moduleID().toString(), typeSymbol.get().name());
+            TypeDefinitionSymbol typeDef = (TypeDefinitionSymbol) typeSymbol.get();
+            TypeSymbol rawType = getRawType(typeDef.typeDescriptor());
+            String typeName = String.format("%s:%s", typeDef.moduleID().toString(), typeDef.name());
             if (rawType.typeKind() == TypeDescKind.RECORD || rawType.typeKind() == TypeDescKind.UNION) {
                 this.records.put(typeName, typeDefinitionNode);
             }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BallerinaTypeResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BallerinaTypeResolver.java
@@ -21,7 +21,6 @@ import com.sun.jdi.ReferenceType;
 import com.sun.jdi.Value;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Identifiable;
-import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.Node;

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BallerinaTypeResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BallerinaTypeResolver.java
@@ -20,6 +20,8 @@ import com.sun.jdi.Field;
 import com.sun.jdi.ReferenceType;
 import com.sun.jdi.Value;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -122,8 +124,8 @@ public class BallerinaTypeResolver {
         return semanticContext.moduleLevelSymbols()
                 .stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS)
-                .filter(symbol -> encodeIdentifier(symbol.name(), IdentifierModifier.IdentifierType.OTHER)
-                        .equals(typeName))
+                .filter(symbol -> encodeIdentifier(((Identifiable) symbol).name(),
+                                                   IdentifierModifier.IdentifierType.OTHER).equals(typeName))
                 .findAny();
     }
 }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
@@ -91,7 +91,7 @@ public class FunctionInvocationExpressionEvaluator extends Evaluator {
         List<Symbol> functionMatches = semanticContext.moduleLevelSymbols()
                 .stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION
-                        && modifyName(symbol.name()).equals(functionName))
+                        && modifyName(((FunctionSymbol) symbol).name()).equals(functionName))
                 .collect(Collectors.toList());
         if (functionMatches.isEmpty()) {
             return Optional.empty();

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
@@ -191,7 +191,8 @@ public class MethodCallExpressionEvaluator extends Evaluator {
         SemanticModel semanticContext = context.getDebugCompiler().getSemanticInfo();
         return semanticContext.moduleLevelSymbols()
                 .stream()
-                .filter(symbol -> symbol.kind() == SymbolKind.CLASS && modifyName(symbol.name()).equals(className))
+                .filter(symbol -> symbol.kind() == SymbolKind.CLASS && modifyName(((ClassSymbol) symbol).name())
+                        .equals(className))
                 .findFirst()
                 .map(symbol -> (ClassSymbol) symbol);
     }

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -23,6 +23,7 @@ import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -195,8 +196,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             RequiredParameterNode requiredParameterNode = (RequiredParameterNode) node;
             Optional<Token> paramName = requiredParameterNode.paramName();
             symbolMetaInfo.addProperty("name", paramName.isPresent() ? paramName.get().text() : "");
-            symbolMetaInfo.addProperty("isCaller", typeSymbol.name().equals("Caller"));
-            symbolMetaInfo.addProperty("typeName", typeSymbol.name());
+            symbolMetaInfo.addProperty("isCaller", getTypeName(typeSymbol).equals("Caller"));
+            symbolMetaInfo.addProperty("typeName", getTypeName(typeSymbol));
             symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
             symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
         } else if (node.kind() == SyntaxKind.LOCAL_VAR_DECL) {
@@ -204,8 +205,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             CaptureBindingPatternNode captureBindingPatternNode =
                     (CaptureBindingPatternNode) variableDeclarationNode.typedBindingPattern().bindingPattern();
             symbolMetaInfo.addProperty("name", captureBindingPatternNode.variableName().text());
-            symbolMetaInfo.addProperty("isCaller", typeSymbol.name().equals("Caller"));
-            symbolMetaInfo.addProperty("typeName", typeSymbol.name());
+            symbolMetaInfo.addProperty("isCaller", getTypeName(typeSymbol).equals("Caller"));
+            symbolMetaInfo.addProperty("typeName", getTypeName(typeSymbol));
             symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
             symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
         } else if (node.kind() == SyntaxKind.ASSIGNMENT_STATEMENT) {
@@ -214,8 +215,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 SimpleNameReferenceNode simpleNameReferenceNode =
                         (SimpleNameReferenceNode) assignmentStatementNode.varRef();
                 symbolMetaInfo.addProperty("name", simpleNameReferenceNode.name().text());
-                symbolMetaInfo.addProperty("isCaller", typeSymbol.name().equals("Caller"));
-                symbolMetaInfo.addProperty("typeName", typeSymbol.name());
+                symbolMetaInfo.addProperty("isCaller", getTypeName(typeSymbol).equals("Caller"));
+                symbolMetaInfo.addProperty("typeName", getTypeName(typeSymbol));
                 symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
                 symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
             }
@@ -331,5 +332,13 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 .map(String::toLowerCase)
                 .map(StringUtils::capitalize)
                 .collect(Collectors.joining());
+    }
+
+    private String getTypeName(TypeSymbol type) {
+        if (type instanceof Identifiable) {
+            return ((Identifiable) type).name();
+        }
+
+        return "";
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.AnnotationAttachPointNode;
@@ -598,8 +599,8 @@ public class Generator {
                         Type type = new Type(field.name());
                         Type elemType;
                         String name;
-                        if (field.typeDescriptor() instanceof TypeReferenceTypeSymbol) {
-                            name = field.typeDescriptor().name();
+                        if (field.typeDescriptor().typeKind() == TypeDescKind.TYPE_REFERENCE) {
+                            name = ((TypeReferenceTypeSymbol) field.typeDescriptor()).name();
                         } else {
                             name = field.typeDescriptor().signature();
                         }
@@ -614,8 +615,8 @@ public class Generator {
                         Type type = new Type(field.name());
                         Type elemType;
                         String name;
-                        if (field.typeDescriptor() instanceof TypeReferenceTypeSymbol) {
-                            name = field.typeDescriptor().name();
+                        if (field.typeDescriptor().typeKind() == TypeDescKind.TYPE_REFERENCE) {
+                            name = ((TypeReferenceTypeSymbol) field.typeDescriptor()).name();
                         } else {
                             name = field.typeDescriptor().signature();
                         }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -19,7 +19,6 @@ import com.google.gson.annotations.Expose;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
-import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -17,6 +17,7 @@ package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Qualifiable;
 import io.ballerina.compiler.api.symbols.Qualifier;
@@ -281,12 +282,11 @@ public class Type {
             } else if (typeDescriptor.typeKind().equals(TypeDescKind.TYPE_REFERENCE)) {
                 return getTypeCategory(((TypeReferenceTypeSymbol) typeDescriptor).typeDescriptor());
             }
-        } else if (typeDescriptor.kind().equals(SymbolKind.CLASS)) {
-            Qualifiable classSymbol = (Qualifiable) typeDescriptor;
+        } else if (typeDescriptor.kind() == SymbolKind.CLASS) {
+            ClassSymbol classSymbol = (ClassSymbol) typeDescriptor;
             if (classSymbol.qualifiers().contains(Qualifier.CLIENT)) {
                 return "clients";
-            } else if (classSymbol.qualifiers().contains(Qualifier.LISTENER) ||
-                    typeDescriptor.name().equals("Listener")) {
+            } else if (classSymbol.qualifiers().contains(Qualifier.LISTENER) || classSymbol.name().equals("Listener")) {
                 return "listeners";
             } else {
                 return "classes";

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -229,10 +229,14 @@ public class TestProcessor {
                     LinePosition.from(syntaxTreeEntry.getValue().rootNode().location().lineRange().endLine().line(),
                                       syntaxTreeEntry.getValue().rootNode().location().lineRange().endLine().offset()));
             for (Symbol symbol : symbols) {
-                if (symbol.kind() == SymbolKind.FUNCTION && symbol instanceof FunctionSymbol &&
-                        !functionNamesList.contains(symbol.name())) {
-                    functionSymbolList.add((FunctionSymbol) symbol);
-                    functionNamesList.add(symbol.name());
+                if (symbol.kind() != SymbolKind.FUNCTION) {
+                    continue;
+                }
+
+                FunctionSymbol fnSymbol = (FunctionSymbol) symbol;
+                if (!functionNamesList.contains(fnSymbol.name())) {
+                    functionSymbolList.add(fnSymbol);
+                    functionNamesList.add(fnSymbol.name());
                 }
             }
         }

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -18,6 +18,7 @@
 package io.ballerina.projects.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.BallerinaToml;
 import io.ballerina.projects.BuildOptions;
@@ -758,7 +759,7 @@ public class TestBuildProject {
 
         // Test symbol
         Optional<Symbol> symbol = semanticModel.symbol(srcFile, LinePosition.from(5, 10));
-        symbol.ifPresent(value -> assertEquals(value.name(), "runServices"));
+        symbol.ifPresent(value -> assertEquals(((Identifiable) value).name(), "runServices"));
     }
 
     @AfterClass (alwaysRun = true)

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -80,10 +80,10 @@ public class ClassSymbolTest {
     @Test
     public void testTypeReference() {
         Symbol symbol = model.symbol(srcFile, LinePosition.from(40, 6)).get();
-        assertEquals(symbol.name(), "Person1");
         assertEquals(symbol.kind(), TYPE);
 
         TypeReferenceTypeSymbol tSymbol = (TypeReferenceTypeSymbol) symbol;
+        assertEquals(tSymbol.name(), "Person1");
         assertEquals(tSymbol.typeKind(), TYPE_REFERENCE);
 
         ClassSymbol clazz = (ClassSymbol) tSymbol.typeDescriptor();
@@ -96,10 +96,10 @@ public class ClassSymbolTest {
     @Test
     public void testClassWithoutInit() {
         Symbol symbol = model.symbol(srcFile, LinePosition.from(41, 4)).get();
-        assertEquals(symbol.name(), "Person2");
         assertEquals(symbol.kind(), TYPE);
 
         TypeReferenceTypeSymbol tSymbol = (TypeReferenceTypeSymbol) symbol;
+        assertEquals(tSymbol.name(), "Person2");
         assertEquals(tSymbol.typeKind(), TYPE_REFERENCE);
 
         ClassSymbol clazz = (ClassSymbol) tSymbol.typeDescriptor();

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -90,7 +90,7 @@ public class ServiceSemanticAPITest {
     public void testServiceDeclTypedesc() {
         TypeSymbol symbol = (TypeSymbol) model.symbol(srcFile, from(66, 8)).get();
         assertEquals(symbol.typeKind(), TYPE_REFERENCE);
-        assertEquals(symbol.name(), "ProcessingService");
+        assertEquals(((TypeReferenceTypeSymbol) symbol).name(), "ProcessingService");
         assertEquals(((TypeReferenceTypeSymbol) symbol).typeDescriptor().typeKind(), OBJECT);
     }
 
@@ -99,7 +99,7 @@ public class ServiceSemanticAPITest {
         VariableSymbol symbol = (VariableSymbol) model.symbol(srcFile, from(66, 31)).get();
         assertEquals(symbol.name(), "lsn");
         assertEquals(symbol.typeDescriptor().typeKind(), TYPE_REFERENCE);
-        assertEquals(symbol.typeDescriptor().name(), "Listener");
+        assertEquals(((TypeReferenceTypeSymbol) symbol.typeDescriptor()).name(), "Listener");
         assertEquals(symbol.qualifiers().size(), 2);
         assertTrue(symbol.qualifiers().contains(LISTENER));
         assertTrue(symbol.qualifiers().contains(FINAL));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
@@ -48,7 +49,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(((Identifiable) value).name(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -105,7 +106,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(((Identifiable) value).name(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -132,7 +133,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(((Identifiable) value).name(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -159,7 +160,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertTrue(true, "Unexpected symbol: " + value.name()));
+        symbol.ifPresent(value -> assertTrue(true, "Unexpected symbol: " + ((Identifiable) value).name()));
     }
 
     @DataProvider(name = "MissingConstructPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -19,6 +19,7 @@ package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.symbols.BallerinaModule;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.projects.Document;
@@ -94,7 +95,7 @@ public class SymbolBIRTest {
         assertList(symbolsInScope, expSymbolNames);
 
         BallerinaModule fooModule = (BallerinaModule) symbolsInScope.stream()
-                .filter(sym -> sym.name().equals("testproject")).findAny().get();
+                .filter(sym -> ((Identifiable) sym).name().equals("testproject")).findAny().get();
         List<String> fooFunctions = getSymbolNames(fooPkgSymbol, SymTag.FUNCTION);
         SemanticAPITestUtils.assertList(fooModule.functions(), fooFunctions);
 
@@ -118,7 +119,7 @@ public class SymbolBIRTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(((Identifiable) value).name(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -146,9 +147,9 @@ public class SymbolBIRTest {
         assertEquals(actualValues.size(), expectedValues.size());
 
         for (SymbolInfo val : expectedValues) {
-            assertTrue(actualValues.stream().anyMatch(sym -> val.equals(new SymbolInfo(sym.name(), sym.kind()))),
+            assertTrue(actualValues.stream()
+                               .anyMatch(sym -> val.equals(new SymbolInfo(((Identifiable) sym).name(), sym.kind()))),
                        "Symbol not found: " + val);
-
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -19,6 +19,7 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
@@ -98,7 +99,8 @@ public class SymbolEquivalenceTest {
 
             for (int j = i + 1; j < symbols.size(); j++) {
                 assertFalse(symbol.equals(symbols.get(j)),
-                            "'" + symbol.name() + "' is equal to '" + symbols.get(j).name() + "'");
+                            "'" + ((Identifiable) symbol).name() + "' is equal to '" +
+                                    ((Identifiable) symbols.get(j)).name() + "'");
                 assertNotEquals(symbol.hashCode(), symbols.get(j).hashCode());
             }
         }
@@ -160,7 +162,8 @@ public class SymbolEquivalenceTest {
 
             for (int j = i + 1; j < symbols.size(); j++) {
                 assertTrue(symbol.equals(symbols.get(j)),
-                           "'" + symbol.name() + "' not equal to '" + symbols.get(j).name() + "'");
+                           "'" + ((Identifiable) symbol).name() + "' not equal to '" +
+                                   ((Identifiable) symbols.get(j)).name() + "'");
                 assertEquals(symbol.hashCode(), symbols.get(j).hashCode());
             }
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
@@ -60,7 +61,7 @@ public class SymbolPositionTest {
             assertNull(expSymbolName);
         }
 
-        assertEquals(symbol.get().name(), expSymbolName);
+        assertEquals(((Identifiable) symbol.get()).name(), expSymbolName);
 
         Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
@@ -93,7 +94,7 @@ public class SymbolPositionTest {
     public void testTypeNarrowedSymbolPositions(int line, int col) {
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
 
-        assertEquals(symbol.get().name(), "val");
+        assertEquals(((Identifiable) symbol.get()).name(), "val");
 
         Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -71,7 +72,7 @@ public class TestSourcesTest {
             assertNull(expSymbolName);
         }
 
-        assertEquals(symbol.get().name(), expSymbolName);
+        assertEquals(((Identifiable) symbol.get()).name(), expSymbolName);
     }
 
     @DataProvider(name = "SymbolPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -30,6 +30,7 @@ import io.ballerina.compiler.api.symbols.FutureTypeSymbol;
 import io.ballerina.compiler.api.symbols.IntersectionTypeSymbol;
 import io.ballerina.compiler.api.symbols.MapTypeSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
@@ -330,7 +331,7 @@ public class TypedescriptorTest {
         TypeSymbol type = symbol.typeDescriptor();
         assertEquals(type.typeKind(), XML);
         assertEquals(((XMLTypeSymbol) type).typeParameter().get().typeKind(), kind);
-        assertEquals(type.name(), name);
+        assertEquals(type.signature(), name);
     }
 
     @DataProvider(name = "XMLPosProvider")
@@ -350,7 +351,7 @@ public class TypedescriptorTest {
 
         TableTypeSymbol tableType = (TableTypeSymbol) type;
         assertEquals(tableType.rowTypeParameter().typeKind(), rowTypeKind);
-        assertEquals(tableType.rowTypeParameter().name(), rowTypeName);
+        assertEquals(tableType.rowTypeParameter().signature(), rowTypeName);
         assertEquals(tableType.keySpecifiers(), keySpecifiers);
         tableType.keyConstraintTypeParameter().ifPresent(t -> assertEquals(t.typeKind(), keyConstraintTypeKind));
         assertEquals(type.signature(), signature);
@@ -373,7 +374,7 @@ public class TypedescriptorTest {
 
         TypeSymbol type = ((TypeReferenceTypeSymbol) typeRef).typeDescriptor();
         assertEquals(type.typeKind(), kind);
-        assertEquals(type.name(), name);
+        assertEquals(((NamedSymbol) type).name(), name);
     }
 
     @DataProvider(name = "BuiltinTypePosProvider")
@@ -425,8 +426,9 @@ public class TypedescriptorTest {
         List<TypeSymbol> typeInclusions = type.typeInclusions();
 
         for (TypeSymbol inclusion : typeInclusions) {
-            assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), typeKind);
-            assertTrue(expTypes.contains(inclusion.name()));
+            TypeReferenceTypeSymbol typeRef = (TypeReferenceTypeSymbol) inclusion;
+            assertEquals(typeRef.typeDescriptor().typeKind(), typeKind);
+            assertTrue(expTypes.contains(typeRef.name()));
         }
     }
 
@@ -446,8 +448,9 @@ public class TypedescriptorTest {
         List<TypeSymbol> typeInclusions = type.typeInclusions();
 
         for (TypeSymbol inclusion : typeInclusions) {
-            assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), OBJECT);
-            assertTrue(expTypes.contains(inclusion.name()));
+            TypeReferenceTypeSymbol typeRef = (TypeReferenceTypeSymbol) inclusion;
+            assertEquals(typeRef.typeDescriptor().typeKind(), OBJECT);
+            assertTrue(expTypes.contains(typeRef.name()));
         }
     }
 
@@ -459,8 +462,9 @@ public class TypedescriptorTest {
         List<TypeSymbol> typeInclusions = clazz.typeInclusions();
 
         for (TypeSymbol inclusion : typeInclusions) {
-            assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), OBJECT);
-            assertTrue(expTypes.contains(inclusion.name()));
+            TypeReferenceTypeSymbol typeRef = (TypeReferenceTypeSymbol) inclusion;
+            assertEquals(typeRef.typeDescriptor().typeKind(), OBJECT);
+            assertTrue(expTypes.contains(typeRef.name()));
         }
     }
 
@@ -469,7 +473,7 @@ public class TypedescriptorTest {
         Optional<TypeSymbol> type =
                 model.type(LineRange.from("typedesc_test.bal", from(160, 37), from(160, 38)));
         assertEquals(type.get().typeKind(), TYPE_REFERENCE);
-        assertEquals(type.get().name(), "Colour");
+        assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "Colour");
 
         TypeSymbol enumType = ((TypeReferenceTypeSymbol) type.get()).typeDescriptor();
         assertEquals(enumType.typeKind(), UNION);
@@ -494,9 +498,9 @@ public class TypedescriptorTest {
 
         List<TypeSymbol> members = ((IntersectionTypeSymbol) type).memberTypeDescriptors();
 
-        TypeSymbol mem1 = members.get(0);
+        TypeReferenceTypeSymbol mem1 = (TypeReferenceTypeSymbol) members.get(0);
         assertEquals(mem1.name(), "Foo");
-        assertEquals(((TypeReferenceTypeSymbol) mem1).typeDescriptor().typeKind(), RECORD);
+        assertEquals(mem1.typeDescriptor().typeKind(), RECORD);
 
         assertEquals(members.get(1).typeKind(), READONLY);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.AnnotationDeclarationNode;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
@@ -69,7 +70,7 @@ public class SymbolByAnnotationTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), ANNOTATION);
-        assertEquals(symbol.get().name(), "v1");
+        assertEquals(((Identifiable) symbol.get()).name(), "v1");
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
@@ -102,7 +103,7 @@ public class SymbolByClassTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -68,7 +69,7 @@ public class SymbolByConstantTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), CONSTANT);
-        assertEquals(symbol.get().name(), "PI");
+        assertEquals(((Identifiable) symbol.get()).name(), "PI");
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
@@ -79,7 +80,7 @@ public class SymbolByEnumTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
@@ -103,7 +104,7 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
@@ -86,7 +87,7 @@ public class SymbolByImportTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.MethodDeclarationNode;
@@ -81,7 +82,7 @@ public class SymbolByObjectTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -81,7 +82,7 @@ public class SymbolByRecordTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
@@ -82,7 +83,7 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
             @Override
             public void visit(TypedBindingPatternNode typedBindingPatternNode) {
                 Optional<Symbol> symbol = model.symbol(typedBindingPatternNode);
-                Object[] expVals = expVarDetails.get(symbol.get().name());
+                Object[] expVals = expVarDetails.get(((Identifiable) symbol.get()).name());
                 assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
 
                 typedBindingPatternNode.bindingPattern().accept(this);
@@ -91,7 +92,7 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
             @Override
             public void visit(CaptureBindingPatternNode captureBindingPatternNode) {
                 Optional<Symbol> symbol = model.symbol(captureBindingPatternNode);
-                Object[] expVals = expVarDetails.get(symbol.get().name());
+                Object[] expVals = expVarDetails.get(((Identifiable) symbol.get()).name());
                 assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
             }
         };
@@ -104,7 +105,7 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
 
     private void assertSymbol(Symbol symbol, String name, TypeDescKind typeKind) {
         assertEquals(symbol.kind(), VARIABLE);
-        assertEquals(symbol.name(), name);
+        assertEquals(((Identifiable) symbol).name(), name);
         assertEquals(((VariableSymbol) symbol).typeDescriptor().typeKind(), typeKind);
         incrementAssertCount();
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.NamedWorkerDeclarationNode;
@@ -71,7 +72,7 @@ public class SymbolByWorkerTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), SymbolKind.WORKER);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Identifiable;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.ModuleXMLNamespaceDeclarationNode;
@@ -76,7 +77,7 @@ public class SymbolByXMLNSTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), SymbolKind.XMLNS);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(((Identifiable) symbol.get()).name(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -19,6 +19,7 @@ package io.ballerina.semantic.api.test.util;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.NamedSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentId;
@@ -100,7 +101,9 @@ public class SemanticAPITestUtils {
     }
 
     public static void assertList(List<? extends Symbol> actualValues, List<String> expectedValues) {
-        Map<String, Symbol> symbols = actualValues.stream().collect(Collectors.toMap(Symbol::name, s -> s));
+        Map<String, Symbol> symbols = actualValues.stream()
+                .map(s -> (NamedSymbol) s)
+                .collect(Collectors.toMap(NamedSymbol::name, s -> s));
         assertList(symbols, expectedValues);
     }
 
@@ -117,7 +120,8 @@ public class SemanticAPITestUtils {
         List<Symbol> allInScopeSymbols = model.visibleSymbols(srcFile, LinePosition.from(line, column));
         return allInScopeSymbols.stream()
                 .filter(s -> s.moduleID().equals(moduleID))
-                .collect(Collectors.toMap(Symbol::name, s -> s));
+                .map(s -> (NamedSymbol) s)
+                .collect(Collectors.toMap(NamedSymbol::name, s -> s));
     }
 
     public static List<String> getSymbolNames(List<String> mainList, String... args) {


### PR DESCRIPTION
## Purpose
Previously, `name()` was defined in `Symbol`. With this PR, we are clearly marking the distinction between named symbols and ones without a name (e.g., type symbols in general). This forces the user to be mindful of when `name()` is used and ensures that you rely on `name()` really for symbols associated with a name.

## Approach
- `name()` moved to a separate interface called `Identifiable`
- `moduleId()` and `location()` moved to a new interface called `NamedSymbol` which extends from both `Symbol` and `Identifiable`.

The following shows how the new design looks like, using a few of the symbols.

![named-symbol](https://user-images.githubusercontent.com/6260009/104813306-628bc880-582e-11eb-932a-70567d41a302.jpg)


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
