### PR TITLE
[Bindgen] Fix an issue when generating exception names of constructors

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/model/JConstructor.java
@@ -17,6 +17,8 @@
  */
 package org.ballerinalang.bindgen.model;
 
+import org.ballerinalang.bindgen.command.BindingsGenerator;
+
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Parameter;
 import java.util.ArrayList;
@@ -88,6 +90,10 @@ public class JConstructor implements Cloneable {
                     JError jError = new JError(exceptionType);
                     exceptionName = jError.getShortExceptionName();
                     exceptionConstName = jError.getExceptionConstName();
+                    if (BindingsGenerator.getModulesFlag()) {
+                        exceptionName = getPackageAlias(exceptionName, exceptionType);
+                        exceptionConstName = getPackageAlias(exceptionConstName, exceptionType);
+                    }
                     setExceptionList(jError);
                     hasException = true;
                     handleException = true;
@@ -96,6 +102,13 @@ public class JConstructor implements Cloneable {
             } catch (ClassNotFoundException ignore) {
             }
         }
+    }
+
+    private String getPackageAlias(String shortClassName, Class objectType) {
+        if (objectType.getPackage() != parentClass.getPackage()) {
+            return objectType.getPackageName().replace(".", "") + ":" + shortClassName;
+        }
+        return shortClassName;
     }
 
     void setConstructorName(String name) {


### PR DESCRIPTION
## Purpose
Fix the issue of not adding the alias when generating constructors returning exceptions.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
