### PR TITLE
Change value.cloneReadonly argument and return type

### DIFF
--- a/langlib/lang.value/src/main/ballerina/value.bal
+++ b/langlib/lang.value/src/main/ballerina/value.bal
@@ -50,7 +50,7 @@ public isolated function clone(CloneableType v) returns CloneableType = @java:Me
 #
 # + v - source value
 # + return - immutable clone of `v`
-public isolated function cloneReadOnly(AnydataType v) returns AnydataType = @java:Method {
+public isolated function cloneReadOnly(CloneableType  v) returns CloneableType = @java:Method {
     'class: "org.ballerinalang.langlib.value.CloneReadOnly",
     name: "cloneReadOnly"
 } external;

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config10.json
@@ -23,13 +23,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config11.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
@@ -255,13 +255,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config4.json
@@ -53,17 +53,17 @@
       }
     },
     {
-        "label": "iterator()(object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;})",
-        "kind": "Function",
-        "detail": "Function",
-        "documentation": {
-            "right": {
-                "kind": "markdown",
-                "value": "**Package:** _ballerina/lang.xml:0.8.0_  \\n  \\nReturns an iterator over the xml items of `x`\\n  \\n  \\n  \\n**Returns** `object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;}`   \\n- iterator object  \\nEach item is represented by an xml singleton.  \\n  \\n"
-            }
-        },
-        "insertText": "iterator()",
-        "insertTextFormat": "Snippet"
+      "label": "iterator()(object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;})",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| ballerina/lang.xml:0.8.0:Element|ballerina/lang.xml:0.8.0:Comment|ballerina/lang.xml:0.8.0:ProcessingInstruction|ballerina/lang.xml:0.8.0:Text value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
+        }
+      },
+      "insertText": "iterator()",
+      "insertTextFormat": "Snippet"
     },
     {
       "label": "strip()(xml<>)",
@@ -194,13 +194,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config8.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config9.json
@@ -249,13 +249,13 @@
       }
     },
     {
-      "label": "cloneReadOnly()(anydata)",
+      "label": "cloneReadOnly()(CloneableType)",
       "kind": "Function",
       "detail": "Function",
       "documentation": {
         "right": {
           "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `anydata`   \n- immutable clone of `v`  \n  \n"
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `CloneableType`   \n- immutable clone of `v`  \n  \n"
         }
       },
       "insertText": "cloneReadOnly()",


### PR DESCRIPTION
## Purpose
Changing argument type to CloneableType

partially fix #23691

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
