### PR TITLE
Remove trace logging API and change to events

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObservabilityConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObservabilityConstants.java
@@ -67,10 +67,9 @@ public class ObservabilityConstants {
     public static final String PROPERTY_HTTP_HOST = "host";
     public static final String PROPERTY_HTTP_PORT = "port";
 
-    public static final String PROPERTY_TRACE_PROPERTIES = "trace_properties";
-    public static final String PROPERTY_KEY_HTTP_STATUS_CODE = "http.status_code";
-    public static final String PROPERTY_ERROR_MESSAGE = "error_message";
-    public static final String PROPERTY_BSTRUCT_ERROR = "bstruct_error";
+    public static final String PROPERTY_TRACE_PROPERTIES = "_trace_properties_";
+    public static final String PROPERTY_KEY_HTTP_STATUS_CODE = "_http_status_code_";
+    public static final String PROPERTY_ERROR_VALUE = "_ballerina_error_value_";
 
     public static final String TAG_TRUE_VALUE = "true";
     public static final String STATUS_CODE_GROUP_SUFFIX = "xx";

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -327,25 +327,7 @@ public class ObserveUtils {
     @Deprecated     // Discussion: https://groups.google.com/g/ballerina-dev/c/VMEk3t8boH0
     public static void logMessageToActiveSpan(String logLevel, Supplier<String> logMessage,
                                               boolean isError) {
-        if (!tracingEnabled) {
-            return;
-        }
-        Environment balEnv = new Environment(Scheduler.getStrand());
-        ObserverContext observerContext = (ObserverContext) balEnv.getStrandLocal(KEY_OBSERVER_CONTEXT);
-        if (observerContext == null) {
-            return;
-        }
-        BSpan span = (BSpan) observerContext.getProperty(KEY_SPAN);
-        if (span == null) {
-            return;
-        }
-        HashMap<String, Object> logs = new HashMap<>(1);
-        logs.put(logLevel, logMessage.get());
-        if (!isError) {
-            span.log(logs);
-        } else {
-            span.logError(logs);
-        }
+        // Do Nothing
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -227,10 +227,8 @@ public class ObserveUtils {
         if (observerContext == null) {
             return;
         }
-        observers.forEach(observer -> {
-            observerContext.addTag(ObservabilityConstants.TAG_KEY_ERROR, TAG_TRUE_VALUE);
-            observerContext.addProperty(ObservabilityConstants.PROPERTY_BSTRUCT_ERROR, errorValue);
-        });
+        observerContext.addTag(ObservabilityConstants.TAG_KEY_ERROR, TAG_TRUE_VALUE);
+        observerContext.addProperty(ObservabilityConstants.PROPERTY_ERROR_VALUE, errorValue);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -23,7 +23,6 @@ import io.ballerina.runtime.api.Module;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
-import io.ballerina.runtime.internal.scheduling.Scheduler;
 import io.ballerina.runtime.internal.values.ErrorValue;
 import io.ballerina.runtime.observability.tracer.BSpan;
 import org.ballerinalang.config.ConfigRegistry;
@@ -185,9 +184,9 @@ public class ObserveUtils {
         eventAttributes.put(TAG_KEY_SRC_MODULE, pkg.getValue());
         eventAttributes.put(TAG_KEY_SRC_POSITION, position.getValue());
 
-        HashMap<String, Object> events = new HashMap<>(1);
-        events.put(CHECKPOINT_EVENT_NAME, eventAttributes);
-        span.log(events);
+        HashMap<String, Object> event = new HashMap<>(1);
+        event.put(CHECKPOINT_EVENT_NAME, eventAttributes);
+        span.addEvent(event);
     }
 
     /**

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/BSpan.java
@@ -21,15 +21,12 @@ package io.ballerina.runtime.observability.tracer;
 import io.ballerina.runtime.observability.ObserverContext;
 import io.opentracing.Span;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import static io.ballerina.runtime.observability.tracer.TraceConstants.DEFAULT_OPERATION_NAME;
 import static io.ballerina.runtime.observability.tracer.TraceConstants.DEFAULT_SERVICE_NAME;
 import static io.ballerina.runtime.observability.tracer.TraceConstants.KEY_SPAN;
-import static io.ballerina.runtime.observability.tracer.TraceConstants.TAG_KEY_STR_ERROR;
-import static io.ballerina.runtime.observability.tracer.TraceConstants.TAG_STR_TRUE;
 
 /**
  * {@code BSpan} holds the trace of the current context.
@@ -83,14 +80,8 @@ public class BSpan {
         manager.finishSpan(this);
     }
 
-    public void log(Map<String, Object> fields) {
-        manager.log(this, fields);
-    }
-
-    public void logError(Map<String, Object> fields) {
-        addTags(Collections.singletonMap(TAG_KEY_STR_ERROR, TAG_STR_TRUE));
-        manager.log(this, fields);
-
+    public void addEvent(Map<String, Object> fields) {
+        manager.addEvent(this, fields);
     }
 
     public void addTags(Map<String, String> tags) {

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/TraceConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/TraceConstants.java
@@ -35,15 +35,10 @@ public class TraceConstants {
     public static final String TAG_KEY_SPAN_KIND = "span.kind";
 
     public static final String TAG_KEY_STR_ERROR = "error";
+    public static final String TAG_KEY_STR_ERROR_MESSAGE = "error.message";
     public static final String TAG_KEY_HTTP_STATUS_CODE = "http.status_code";
     public static final String TAG_STR_TRUE = "true";
 
     public static final String TAG_SPAN_KIND_SERVER = "server";
     public static final String TAG_SPAN_KIND_CLIENT = "client";
-
-    public static final String LOG_KEY_MESSAGE = "message";
-    public static final String LOG_KEY_ERROR_KIND = "error.kind";
-    public static final String LOG_KEY_EVENT_TYPE = "event";
-    public static final String LOG_ERROR_KIND_EXCEPTION = "Exception";
-    public static final String LOG_EVENT_TYPE_ERROR = "error";
 }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/TraceManager.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/tracer/TraceManager.java
@@ -67,7 +67,7 @@ public class TraceManager {
         bSpan.getSpan().finish();
     }
 
-    public void log(BSpan bSpan, Map<String, Object> fields) {
+    public void addEvent(BSpan bSpan, Map<String, Object> fields) {
         bSpan.getSpan().log(fields);
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -177,7 +177,11 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
                     new AbstractMap.SimpleEntry<>("src.function.name", "callWithPanic"),
-                    new AbstractMap.SimpleEntry<>("error", "true")
+                    new AbstractMap.SimpleEntry<>("error", "true"),
+                    new AbstractMap.SimpleEntry<>("error.message", "Test Error\n" +
+                            "\tat intg_tests.tracing_tests.utils.0_0_1.MockClient:callWithPanic(" +
+                            "mock_client_endpoint.bal:58)\n" +
+                            "\t   intg_tests.tracing_tests.0_0_1:main(01_main_function.bal:32)")
             ));
         });
 
@@ -198,7 +202,11 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
                     new AbstractMap.SimpleEntry<>("src.function.name", "callWithErrorReturn"),
-                    new AbstractMap.SimpleEntry<>("error", "true")
+                    new AbstractMap.SimpleEntry<>("error", "true"),
+                    new AbstractMap.SimpleEntry<>("error.message", "Test Error\n" +
+                            "\tat intg_tests.tracing_tests.utils.0_0_1.MockClient:callWithErrorReturn(" +
+                            "mock_client_endpoint.bal:46)\n" +
+                            "\t   intg_tests.tracing_tests.0_0_1:main(01_main_function.bal:38)")
             ));
         });
     }


### PR DESCRIPTION
## Purpose
> With OpenTelemetry, the logging support will be removed and changed to Events. As a preparation for this change, the API had been updated to event (Refer discussion https://groups.google.com/g/ballerina-dev/c/VMEk3t8boH0). Moreover, the errors returned from a function were added as logs to the span. This is not required as this is an error of the function itself and it can be added as a tag to the Span.

## Approach
> Remove adding logs to traces. Refactor adding error messages which were added to logs as well into trace tags.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
