### PR TITLE
Fix bad sad error when assigning a constant value to an enum member

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3488,33 +3488,37 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
         bLangConstant.setName((BLangIdentifier) transform(member.identifier()));
 
-        BLangLiteral literal;
-        BLangLiteral deepLiteral;
+        BLangExpression deepLiteral;
         if (member.constExprNode().isPresent()) {
-            literal = createSimpleLiteral(member.constExprNode().orElse(null));
-            deepLiteral = createSimpleLiteral(member.constExprNode().orElse(null));
+            BLangExpression expression = createExpression(member.constExprNode().orElse(null));
+            bLangConstant.setInitialExpression(expression);
+            deepLiteral = createExpression(member.constExprNode().orElse(null));
         } else {
-            literal = createSimpleLiteral(member.identifier());
-            deepLiteral = createSimpleLiteral(member.identifier());
-        }
-        if (literal.originalValue != "" || member.identifier().isMissing()) {
+            BLangLiteral literal = createSimpleLiteral(member.identifier());
             bLangConstant.setInitialExpression(literal);
-        } else {
-            bLangConstant.setInitialExpression(createExpression(member.constExprNode().orElse(null)));
+            deepLiteral = createSimpleLiteral(member.identifier());
         }
 
         BLangValueType typeNode = (BLangValueType) TreeBuilder.createValueTypeNode();
         typeNode.typeKind = TypeKind.STRING;
         bLangConstant.setTypeNode(typeNode);
 
-        if (deepLiteral.originalValue != "") {
-            BLangFiniteTypeNode typeNodeAssosiated = (BLangFiniteTypeNode) TreeBuilder.createFiniteTypeNode();
-            deepLiteral.originalValue = null;
-            typeNodeAssosiated.addValue(deepLiteral);
-            bLangConstant.associatedTypeDefinition = createTypeDefinitionWithTypeNode(typeNodeAssosiated);
+        if (deepLiteral instanceof BLangLiteral) {
+            BLangLiteral literal = (BLangLiteral) deepLiteral;
+            if (literal.originalValue != "") {
+                BLangFiniteTypeNode typeNodeAssociated = (BLangFiniteTypeNode) TreeBuilder.createFiniteTypeNode();
+                literal.originalValue = null;
+                typeNodeAssociated.addValue(deepLiteral);
+                bLangConstant.associatedTypeDefinition = createTypeDefinitionWithTypeNode(typeNodeAssociated);
+            } else {
+                bLangConstant.associatedTypeDefinition = null;
+            }
         } else {
-            bLangConstant.associatedTypeDefinition = null;
+            BLangFiniteTypeNode typeNodeAssociated = (BLangFiniteTypeNode) TreeBuilder.createFiniteTypeNode();
+            typeNodeAssociated.addValue(deepLiteral);
+            bLangConstant.associatedTypeDefinition = createTypeDefinitionWithTypeNode(typeNodeAssociated);
         }
+
         return bLangConstant;
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/enums/enums.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/enums/enums.bal
@@ -26,9 +26,12 @@ public enum Language {
     SI = "Sinhala"
 }
 
+const string beatles = "The " + "Beatles";
+
 public enum Bands {
     QUEEN,
-    PF = "Pink " + "Floyd"
+    PF = "Pink " + "Floyd",
+    BEATLES = beatles
 }
 
 string colorOfSky = BLUE;
@@ -48,6 +51,9 @@ function testBasicEnumSupport() {
 
     string q = QUEEN;
     assert(q, "QUEEN");
+
+    string b = BEATLES;
+    assert(b, "The Beatles");
 }
 
 function testEnumAsType() {
@@ -59,6 +65,9 @@ function testEnumAsType() {
 
     PF pf = "Pink Floyd";
     assert(pf, "Pink Floyd");
+    
+    BEATLES btl = "The Beatles";
+    assert(btl, "The Beatles");
 }
 
 function testEnumAsGlobalRef() {


### PR DESCRIPTION
## Purpose
When a constant is assigned as the value of an enum member, a bad sad error is printed while internal log complaining of an `IllegalStateException` inside `Desugar`. This PR addresses that issue reported in #27421.

Fixes #27421 

## Approach
### Cause
When `BLangNodeTransformer` handles enum members, it currently treats a constant expression as a simple literal. According to the spec, the constant expression (if available) can be an expression. This cause `Desugar.visit(BLangConstant)` to throw an `IllegalStateException` due to the `BLangConstant#symbol#value#value` being `null`. 

### Fix
- Updated `BLangNodeTransformer` to treat the constant expression (if available) as an expression instead as a simple literal.
- Updated the existing `EnumTest` unit test to cover this scenario as well.

Earlier:
```
    BLangLiteral literal;
    if (member.constExprNode().isPresent()) {
        literal = createSimpleLiteral(member.constExprNode().orElse(null));
```

Now:
```
    if (member.constExprNode().isPresent()) {
        BLangExpression expression = createExpression(member.constExprNode().orElse(null));
```

## Remarks
I have removed the below logic which appeared after obtaining the `BLangLiteral` from either the constant expression or from the member's identifier.
```
        if (literal.originalValue != "" || member.identifier().isMissing()) {
            bLangConstant.setInitialExpression(literal);
        } else {
            bLangConstant.setInitialExpression(createExpression(member.constExprNode().orElse(null)));
        }
```
Since we handle the constant expression (if available) as an expression and handle the identifier as a simple literal (if constant expression is not present), I think we don't need to do an additional check like above. Please check and confirm.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
