### PR TITLE
Fix the new line separation after annotations in module variable declarations

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1292,7 +1292,12 @@ public class FormattingTreeModifier extends TreeModifier {
                 formatNode(moduleVariableDeclarationNode.typedBindingPattern(),
                         moduleVariableDeclarationNode.equalsToken().isPresent() ? 1 : 0, 0);
         Token equalsToken = formatToken(moduleVariableDeclarationNode.equalsToken().orElse(null), 1, 0);
+
+        boolean prevInLineAnnotation = env.inLineAnnotation;
+        setInLineAnnotation(true);
         ExpressionNode initializer = formatNode(moduleVariableDeclarationNode.initializer().orElse(null), 0, 0);
+        setInLineAnnotation(prevInLineAnnotation);
+
         Token semicolonToken = formatToken(moduleVariableDeclarationNode.semicolonToken(),
                 env.trailingWS, env.trailingNL);
 

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/start/assert/start_action_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/start/assert/start_action_2.bal
@@ -1,0 +1,1 @@
+future<int> f1 = @strand {thread: "any"} start multiply(1, 2);

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/start/source/start_action_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/start/source/start_action_2.bal
@@ -1,0 +1,7 @@
+future  < int  >
+f1   =
+@  strand
+  {  thread  : "any"
+}   start
+ multiply  (  1  ,   2  )
+ ;


### PR DESCRIPTION
## Purpose
Fixes #27601

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
