### PR TITLE
Fix issue with cursor position checking logic

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
@@ -43,7 +43,7 @@ class PositionUtil {
 
         return (startLine < cursorLine && endLine > cursorLine)
                 || (startLine < cursorLine && endLine == cursorLine && endColumn > cursorColumn)
-                || (startLine == cursorLine && startColumn < cursorColumn && endLine > cursorLine)
+                || (startLine == cursorLine && endLine > cursorLine)
                 || (startLine == endLine && startLine == cursorLine
                 && startColumn <= cursorColumn && endColumn > cursorColumn);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -18,7 +18,13 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.impl.symbols.BallerinaBooleanTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaByteTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaDecimalTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaFloatTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaIntTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaNilTypeSymbol;
+import io.ballerina.compiler.api.impl.symbols.BallerinaStringTypeSymbol;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
@@ -63,9 +69,11 @@ import java.util.Set;
 import static io.ballerina.compiler.api.symbols.ParameterKind.DEFAULTABLE;
 import static io.ballerina.compiler.api.symbols.ParameterKind.REQUIRED;
 import static io.ballerina.compiler.api.symbols.ParameterKind.REST;
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANY;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.COMPILATION_ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
@@ -553,14 +561,22 @@ public class TypedescriptorTest {
     @DataProvider(name = "BasicTestPosProvider")
     public Object[][] getBasicTestPos() {
         return new Object[][]{
-//                {186, 8, INT, BallerinaIntTypeSymbol.class},
-//                {187, 10, FLOAT, BallerinaFloatTypeSymbol.class},
-//                {188, 12, DECIMAL, BallerinaDecimalTypeSymbol.class},
-//                {189, 12, BOOLEAN, BallerinaBooleanTypeSymbol.class},
-//                {190, 7, NIL, BallerinaNilTypeSymbol.class},
-//                {191, 11, STRING, BallerinaStringTypeSymbol.class},
+                {186, 8, INT, BallerinaIntTypeSymbol.class},
+                {187, 10, FLOAT, BallerinaFloatTypeSymbol.class},
+                {188, 12, DECIMAL, BallerinaDecimalTypeSymbol.class},
+                {189, 12, BOOLEAN, BallerinaBooleanTypeSymbol.class},
+                {190, 7, NIL, BallerinaNilTypeSymbol.class},
+                {191, 11, STRING, BallerinaStringTypeSymbol.class},
                 {192, 9, BYTE, BallerinaByteTypeSymbol.class},
         };
+    }
+
+    @Test
+    public void testMultilineTypedefs() {
+        Symbol symbol = getSymbol(198, 18);
+        assertEquals(symbol.kind(), TYPE);
+        assertEquals(((TypeSymbol) symbol).typeKind(), TYPE_REFERENCE);
+        assertEquals(((TypeReferenceTypeSymbol) symbol).name(), "CancelledError");
     }
 
     private Symbol getSymbol(int line, int column) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -192,3 +192,9 @@ function testBasicTypes() {
     string s = "foo";
     byte byt = 100;
 }
+
+public type CancelledError distinct error;
+public type UnKnownError distinct error;
+
+public type Error CancelledError |
+UnKnownError;


### PR DESCRIPTION
## Purpose
This PR fixes an issue with the logic for checking whether a given cursor position falls within a particular node. This bug led to an issue where looking up a symbol within a multi-line construct returned empty.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
