### PR TITLE
Fix record implicit readonly-ness with inclusion and fix cyclic union comparison

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/PredefinedTypes.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/PredefinedTypes.java
@@ -201,9 +201,7 @@ public class PredefinedTypes {
         MapType internalAnydataMap = new BMapType(TypeConstants.MAP_TNAME, anydataType, EMPTY_MODULE);
         ArrayType internalAnydataArray = new BArrayType(anydataType);
         BTableType internalAnydataMapTable = new BTableType(internalAnydataMap, false);
-        members.add(internalAnydataArray);
-        members.add(internalAnydataMap);
-        members.add(internalAnydataMapTable);
+        anydataType.addMembers(internalAnydataArray, internalAnydataMap, internalAnydataMapTable);
         TYPE_ANYDATA = anydataType;
         TYPE_READONLY_ANYDATA = new BAnydataType(anydataType, TypeConstants.READONLY_ANYDATA_TNAME, true);
     }
@@ -222,8 +220,7 @@ public class PredefinedTypes {
         jsonType.isCyclic = true;
         MapType internalJsonMap = new BMapType(TypeConstants.MAP_TNAME, jsonType, EMPTY_MODULE);
         ArrayType internalJsonArray = new BArrayType(jsonType);
-        members.add(internalJsonArray);
-        members.add(internalJsonMap);
+        jsonType.addMembers(internalJsonArray, internalJsonMap);
         TYPE_JSON = jsonType;
         TYPE_JSON_ARRAY = new BArrayType(TYPE_JSON);
         TYPE_READONLY_JSON = new BJsonType(jsonType, TypeConstants.READONLY_JSON_TNAME, true);
@@ -240,9 +237,7 @@ public class PredefinedTypes {
         MapType internalCloneableMap = new BMapType(TypeConstants.MAP_TNAME, cloneable, valueModule);
         ArrayType internalCloneableArray = new BArrayType(cloneable);
         BTableType internalCloneableMapTable = new BTableType(internalCloneableMap, false);
-        members.add(internalCloneableMap);
-        members.add(internalCloneableArray);
-        members.add(internalCloneableMapTable);
+        cloneable.addMembers(internalCloneableMap, internalCloneableArray, internalCloneableMapTable);
         TYPE_CLONEABLE = cloneable;
         TYPE_DETAIL = new BMapType(TypeConstants.MAP_TNAME, TYPE_CLONEABLE, EMPTY_MODULE);
         TYPE_ERROR_DETAIL = ReadOnlyUtils.setImmutableTypeAndGetEffectiveType(TYPE_DETAIL);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -630,10 +630,13 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
 
             BRecordType recordType = (BRecordType) type;
             fields = recordType.fields;
-            allReadOnlyFields = recordType.sealed;
+            allReadOnlyFields = recordType.sealed || recordType.restFieldType.tag == TypeTags.NEVER;
         }
 
-        for (BLangSimpleVariable field : recordTypeNode.fields) {
+        List<BLangSimpleVariable> recordFields = new ArrayList<>(recordTypeNode.fields);
+        recordFields.addAll(recordTypeNode.referencedFields);
+
+        for (BLangSimpleVariable field : recordFields) {
             if (field.flagSet.contains(Flag.READONLY)) {
                 handleReadOnlyField(isRecordType, fields, field);
             } else {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2607,7 +2607,12 @@ public class SymbolEnter extends BLangNodeVisitor {
                 continue;
             }
 
-            if (nodeKind != NodeKind.RECORD_TYPE || !(((BRecordType) structureType).sealed)) {
+            if (nodeKind != NodeKind.RECORD_TYPE) {
+                continue;
+            }
+
+            BRecordType recordType = (BRecordType) structureType;
+            if (!recordType.sealed && recordType.restFieldType.tag != TypeTags.NEVER) {
                 continue;
             }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ReadonlyRecordFieldTest.java
@@ -57,7 +57,9 @@ public class ReadonlyRecordFieldTest {
                 {"testSubTypingWithReadOnlyFieldsPositiveComposite"},
                 {"testSubTypingWithReadOnlyFieldsNegativeComposite"},
                 {"testSubTypingMapAsRecordWithReadOnlyFields"},
-                {"testReadOnlyFieldsOfClassTypes"}
+                {"testReadOnlyFieldsOfClassTypes"},
+                {"testTypeReadOnlynessNegativeWithNonReadOnlyFieldsViaInclusion"},
+                {"testTypeReadOnlynessWithReadOnlyFieldsViaInclusion"}
         };
     }
 
@@ -107,6 +109,10 @@ public class ReadonlyRecordFieldTest {
                 "'OpenRecordWithFieldDescriptors'", 248, 20);
         validateError(result, index++, "incompatible types: expected 'readonly', found 'record {| readonly int x; int" +
                 "...; |}'", 249, 20);
+        validateError(result, index++, "incompatible types: expected 'readonly', found '(Unauthorized|Forbidden)?'",
+                      269, 19);
+        validateError(result, index++, "incompatible types: expected 'readonly', found 'Unauthorized?'", 272, 19);
+        validateError(result, index++, "incompatible types: expected 'readonly', found 'Unauthorized?'", 273, 18);
         assertEquals(result.getErrorCount(), index);
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/typedefs/CyclicTypeDefinitionsTest.java
@@ -57,6 +57,7 @@ public class CyclicTypeDefinitionsTest {
                 {"testCyclicTypeDefInTuple"},
                 {"testComplexCyclicUnion"},
                 {"testCyclicUserDefinedType"},
+                {"testCyclicUnionAgainstSubSetNegative"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/readonly_record_fields_negative.bal
@@ -248,3 +248,31 @@ function testNonReadOnlynessOfOpenRecordWithAllReadOnlyFields() {
     readonly rd6 = r6;
     readonly rd7 = localRecord;
 }
+
+type CommonResponse record {|
+    string mediaType?;
+    map<string|string[]> headers?;
+    anydata body?;
+|};
+public type Forbidden record {|
+    *CommonResponse;
+|};
+
+public type Unauthorized record {|
+    *CommonResponse;
+    readonly byte[] body;
+    readonly boolean valid;
+|};
+
+function testTypeReadOnlynessNegativeWithNonReadOnlyFieldsViaInclusion() {
+    Unauthorized|Forbidden? x = ();
+    readonly r1 = x;
+
+    Unauthorized? y = tryAuthenticate();
+    readonly r2 = y;
+    readonly z = tryAuthenticate();
+}
+
+function tryAuthenticate() returns Unauthorized? {
+    return {headers: {"h1": "v1"}, body: [1, 2, 3], valid: false};
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions-cyclic.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/typedefs/type-definitions-cyclic.bal
@@ -161,6 +161,11 @@ function testCyclicUserDefinedType() {
     assert(<int> i, 1);
 }
 
+function testCyclicUnionAgainstSubSetNegative() {
+    record {} x = {};
+    assert(false, x is record {| int|boolean|decimal|float|string|xml?...; |});
+}
+
 function assert(anydata expected, anydata actual) {
     if (expected != actual) {
         typedesc<anydata> expT = typeof expected;


### PR DESCRIPTION
## Purpose
This PR fixes
- considering included fields when setting the `readonly` flag for record types with all `readonly` fields
- `readonly` flag not being set for some unions with implicitly `readonly` members
- certain cyclic unions not having all members at runtime
- `equals` check for cyclic unions with the fix for the previous issue

Fixes #27981 - Invalid `readonly` flag for record that has non-`readonly` fields via inclusions
Fixes #28003 - Cyclic union types are incomplete at times

## Remarks
Not convinced that the approach to add the read-only flag to unions at compile-time is the best approach (even though this only happens at times). Will create an issue to revisit this.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
