### PR TITLE
Modify return type of fieldDescriptors() and methods() to Map<String, *FieldSymbol> and Map<String, MethodSymbol>

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -19,11 +19,11 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
-import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -34,13 +34,17 @@ import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -58,6 +62,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     private final CompilerContext context;
     private final Documentation docAttachment;
     private MethodSymbol initMethod;
+    private Map<String, ClassFieldSymbol> classFields;
 
     protected BallerinaClassSymbol(CompilerContext context, String name, PackageID moduleID, List<Qualifier> qualifiers,
                                    List<AnnotationSymbol> annots, ObjectTypeSymbol typeDescriptor,
@@ -73,8 +78,20 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     }
 
     @Override
-    public List<ObjectFieldSymbol> fieldDescriptors() {
-        return this.typeDescriptor.fieldDescriptors();
+    public Map<String, ClassFieldSymbol> fieldDescriptors() {
+        if (this.classFields != null) {
+            return classFields;
+        }
+
+        Map<String, ClassFieldSymbol> fields = new LinkedHashMap<>();
+        BObjectType type = (BObjectType) this.getBType();
+
+        for (BField field : type.fields.values()) {
+            fields.put(field.name.value, new BallerinaClassFieldSymbol(this.context, field));
+        }
+
+        this.classFields = Collections.unmodifiableMap(fields);
+        return classFields;
     }
 
     @Override
@@ -88,7 +105,6 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
             SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
             this.initMethod = symbolFactory.createMethodSymbol(internalSymbol.initializerFunc.symbol,
                                                                internalSymbol.initializerFunc.funcName.value);
-
         }
 
         return Optional.ofNullable(this.initMethod);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -95,7 +95,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     }
 
     @Override
-    public List<MethodSymbol> methods() {
+    public Map<String, MethodSymbol> methods() {
         return this.typeDescriptor.methods();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -28,7 +28,9 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.StringJoiner;
 
@@ -39,7 +41,7 @@ import java.util.StringJoiner;
  */
 public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements RecordTypeSymbol {
 
-    private List<RecordFieldSymbol> fieldSymbols;
+    private Map<String, RecordFieldSymbol> fieldSymbols;
     private final boolean isInclusive;
     private TypeSymbol restTypeDesc;
     private List<TypeSymbol> typeInclusions;
@@ -49,20 +51,20 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
         this.isInclusive = !recordType.sealed;
     }
 
-    /**
-     * Get the list of field descriptors.
-     *
-     * @return {@link List} of ballerina field
-     */
     @Override
-    public List<RecordFieldSymbol> fieldDescriptors() {
-        if (this.fieldSymbols == null) {
-            this.fieldSymbols = new ArrayList<>();
-            for (BField field : ((BRecordType) this.getBType()).fields.values()) {
-                this.fieldSymbols.add(new BallerinaRecordFieldSymbol(this.context, field));
-            }
+    public Map<String, RecordFieldSymbol> fieldDescriptors() {
+        if (this.fieldSymbols != null) {
+            return this.fieldSymbols;
         }
 
+        Map<String, RecordFieldSymbol> fields = new LinkedHashMap<>();
+        BRecordType type = (BRecordType) this.getBType();
+
+        for (BField field : type.fields.values()) {
+            fields.put(field.name.value, new BallerinaRecordFieldSymbol(this.context, field));
+        }
+
+        this.fieldSymbols = Collections.unmodifiableMap(fields);
         return this.fieldSymbols;
     }
 
@@ -107,7 +109,7 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
         } else {
             joiner = new StringJoiner(" ", "{| ", " |}");
         }
-        for (RecordFieldSymbol fieldSymbol : this.fieldDescriptors()) {
+        for (RecordFieldSymbol fieldSymbol : this.fieldDescriptors().values()) {
             String ballerinaFieldSignature = fieldSymbol.signature() + ";";
             joiner.add(ballerinaFieldSignature);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ClassSymbol.java
@@ -17,6 +17,7 @@
  */
 package io.ballerina.compiler.api.symbols;
 
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -25,6 +26,15 @@ import java.util.Optional;
  * @since 2.0.0
  */
 public interface ClassSymbol extends ObjectTypeSymbol, Qualifiable, Deprecatable, Annotatable, Documentable {
+
+    /**
+     * Get the symbols of the fields of the class. The mapping is a set of field name and field symbol pairs. The
+     * returned map is ordered. The order in which the fields were specified in the source code is preserved when
+     * iterating the entries of the map.
+     *
+     * @return An ordered map containing the symbols of the fields
+     */
+    Map<String, ClassFieldSymbol> fieldDescriptors();
 
     /**
      * Get the init method.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
@@ -36,11 +36,13 @@ public interface ObjectTypeSymbol extends TypeSymbol, Qualifiable {
     Map<String, ? extends ObjectFieldSymbol> fieldDescriptors();
 
     /**
-     * Get the list of methods.
+     * Get the symbols of the methods of the object type. The mapping is a set of method name and method symbol pairs.
+     * The returned map is ordered. The order in which the fields were specified in the source code is preserved when
+     * iterating the entries of the map.
      *
-     * @return {@link List} of object methods
+     * @return An ordered map containing the symbols of the methods
      */
-    List<MethodSymbol> methods();
+    Map<String, MethodSymbol> methods();
 
     /**
      * Gets a list of included types. An included type is always a subtype of object.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ObjectTypeSymbol.java
@@ -17,6 +17,7 @@
 package io.ballerina.compiler.api.symbols;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents an object type descriptor.
@@ -26,11 +27,13 @@ import java.util.List;
 public interface ObjectTypeSymbol extends TypeSymbol, Qualifiable {
 
     /**
-     * Get the object fields.
+     * Get the symbols of the fields of the object type. The mapping is a set of field name and field symbol pairs. The
+     * returned map is ordered. The order in which the fields were specified in the source code is preserved when
+     * iterating the entries of the map.
      *
-     * @return {@link List} of object fields
+     * @return An ordered map containing the symbols of the fields
      */
-    List<ObjectFieldSymbol> fieldDescriptors();
+    Map<String, ? extends ObjectFieldSymbol> fieldDescriptors();
 
     /**
      * Get the list of methods.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/RecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/RecordTypeSymbol.java
@@ -17,6 +17,7 @@
 package io.ballerina.compiler.api.symbols;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 /**
@@ -27,11 +28,13 @@ import java.util.Optional;
 public interface RecordTypeSymbol extends TypeSymbol {
 
     /**
-     * Get the list of field descriptors.
+     * Get the symbols of the fields of the record type. The mapping is a set of field name and field symbol pairs. The
+     * returned map is ordered. The order in which the fields were specified in the source code is preserved when
+     * iterating the entries of the map.
      *
-     * @return {@link List} of ballerina field
+     * @return An ordered map containing the symbols of the fields
      */
-    List<RecordFieldSymbol> fieldDescriptors();
+    Map<String, RecordFieldSymbol> fieldDescriptors();
 
     /**
      * Get the rest type descriptor.

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -222,7 +222,7 @@ public class CodeActionUtil {
             // Map
             TypeSymbol prevType = null;
             boolean isConstrainedMap = true;
-            for (RecordFieldSymbol recordField : recordLiteral.fieldDescriptors()) {
+            for (RecordFieldSymbol recordField : recordLiteral.fieldDescriptors().values()) {
                 TypeDescKind typeDescKind = recordField.typeDescriptor().typeKind();
                 if (prevType != null && typeDescKind != prevType.typeKind()) {
                     isConstrainedMap = false;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ImplementFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ImplementFunctionCodeAction.java
@@ -40,7 +40,6 @@ import org.eclipse.lsp4j.TextEdit;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.stream.Collectors;
 
@@ -79,14 +78,11 @@ public class ImplementFunctionCodeAction extends AbstractCodeActionProvider {
         ClassDefinitionNode classDefNode = (ClassDefinitionNode) matchedNode;
         ClassSymbol classSymbol = (ClassSymbol) matchedSymbol;
 
-        Optional<MethodSymbol> unimplMethod = classSymbol.methods().stream()
-                .filter(m -> m.name().equals(methodName))
-                .findFirst();
-
-        if (unimplMethod.isEmpty()) {
+        if (!classSymbol.methods().containsKey(methodName)) {
             return Collections.emptyList();
         }
 
+        MethodSymbol unimplMethod = classSymbol.methods().get(methodName);
         List<FunctionDefinitionNode> concreteMethods = classDefNode.members().stream()
                 .filter(member -> member.kind() == SyntaxKind.FUNCTION_DEFINITION)
                 .map(member -> (FunctionDefinitionNode) member)
@@ -103,13 +99,12 @@ public class ImplementFunctionCodeAction extends AbstractCodeActionProvider {
         }
 
         ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);
-        String typeName = FunctionGenerator.processModuleIDsInText(importsAcceptor, unimplMethod.get().signature(),
-                                                                   context);
+        String typeName = FunctionGenerator.processModuleIDsInText(importsAcceptor, unimplMethod.signature(), context);
         List<TextEdit> edits = new ArrayList<>(importsAcceptor.getNewImportTextEdits());
         String editText = offsetStr + typeName + " {" + LINE_SEPARATOR + offsetStr + "}" + LINE_SEPARATOR;
         Position editPos = CommonUtil.toPosition(classDefNode.closeBrace().lineRange().startLine());
         edits.add(new TextEdit(new Range(editPos, editPos), editText));
-        String commandTitle = String.format(CommandConstants.IMPLEMENT_FUNCS_TITLE, unimplMethod.get().name());
+        String commandTitle = String.format(CommandConstants.IMPLEMENT_FUNCS_TITLE, unimplMethod.name());
         CodeAction quickFixCodeAction = createQuickFixCodeAction(commandTitle, edits, context.fileUri());
         quickFixCodeAction.setDiagnostics(CodeActionUtil.toDiagnostics(Collections.singletonList((diagnostic))));
         return Collections.singletonList(quickFixCodeAction);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -280,18 +280,18 @@ public class CommonUtil {
      * Get completion items list for struct fields.
      *
      * @param context Language server operation context
-     * @param fields  List of field descriptors
+     * @param fields  Map of field descriptors
      * @return {@link List}     List of completion items for the struct fields
      */
     public static List<LSCompletionItem> getRecordFieldCompletionItems(BallerinaCompletionContext context,
-                                                                       List<RecordFieldSymbol> fields) {
+                                                                       Map<String, RecordFieldSymbol> fields) {
         List<LSCompletionItem> completionItems = new ArrayList<>();
-        fields.forEach(field -> {
+        fields.forEach((name, field) -> {
             String insertText = getRecordFieldCompletionInsertText(field, 0);
             CompletionItem fieldItem = new CompletionItem();
             fieldItem.setInsertText(insertText);
             fieldItem.setInsertTextFormat(InsertTextFormat.Snippet);
-            fieldItem.setLabel(field.name());
+            fieldItem.setLabel(name);
             fieldItem.setDetail(ItemResolverConstants.FIELD_TYPE);
             fieldItem.setKind(CompletionItemKind.Field);
             fieldItem.setSortText(Priority.PRIORITY120.toString());
@@ -305,16 +305,17 @@ public class CommonUtil {
      * Get the completion item to fill all the struct fields.
      *
      * @param context Language Server Operation Context
-     * @param fields  List of fields
+     * @param fields  Map of fields
      * @return {@link LSCompletionItem}   Completion Item to fill all the options
      */
     public static LSCompletionItem getFillAllStructFieldsItem(BallerinaCompletionContext context,
-                                                              List<RecordFieldSymbol> fields) {
+                                                              Map<String, RecordFieldSymbol> fields) {
         List<String> fieldEntries = new ArrayList<>();
 
-        for (RecordFieldSymbol fieldSymbol : fields) {
-            String defaultFieldEntry = fieldSymbol.name()
-                    + PKG_DELIMITER_KEYWORD + " " + getDefaultValueForType(fieldSymbol.typeDescriptor());
+        for (Map.Entry<String, RecordFieldSymbol> fieldSymbolEntry : fields.entrySet()) {
+            String defaultFieldEntry = fieldSymbolEntry.getKey()
+                    + PKG_DELIMITER_KEYWORD + " "
+                    + getDefaultValueForType(fieldSymbolEntry.getValue().typeDescriptor());
             fieldEntries.add(defaultFieldEntry);
         }
 
@@ -503,7 +504,7 @@ public class CommonUtil {
      * @return {@link List} of required fields captured
      */
     public static List<RecordFieldSymbol> getMandatoryRecordFields(RecordTypeSymbol recordType) {
-        return recordType.fieldDescriptors().stream()
+        return recordType.fieldDescriptors().values().stream()
                 .filter(field -> !field.hasDefaultValue() && !field.isOptional())
                 .collect(Collectors.toList());
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.RecordTypeSymbol;
@@ -29,9 +30,8 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 
-import java.util.List;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 /**
  * Carries a set of utilities to check the types of the symbols.
@@ -195,16 +195,15 @@ public class SymbolUtil {
      */
     public static boolean isListener(Symbol symbol) {
         Optional<? extends TypeSymbol> symbolTypeDesc = getTypeDescriptor(symbol);
-        
+
         if (symbolTypeDesc.isEmpty() || CommonUtil.getRawType(symbolTypeDesc.get()).kind() != SymbolKind.CLASS) {
             return false;
         }
-        List<String> attachedMethods = ((ClassSymbol) CommonUtil.getRawType(symbolTypeDesc.get())).methods()
-                .stream()
-                .map(Symbol::name)
-                .collect(Collectors.toList());
-        return attachedMethods.contains("start") && attachedMethods.contains("immediateStop")
-                && attachedMethods.contains("immediateStop") && attachedMethods.contains("attach");
+
+        Map<String, MethodSymbol> attachedMethods =
+                ((ClassSymbol) CommonUtil.getRawType(symbolTypeDesc.get())).methods();
+        return attachedMethods.containsKey("start") && attachedMethods.containsKey("immediateStop")
+                && attachedMethods.containsKey("immediateStop") && attachedMethods.containsKey("attach");
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
@@ -109,7 +109,7 @@ public class BLangRecordLiteralUtil {
             }
             return Collections.singletonList(memberType.get());
         } else if (typeDesc.typeKind() == TypeDescKind.RECORD) {
-            return ((RecordTypeSymbol) typeDesc).fieldDescriptors().stream()
+            return ((RecordTypeSymbol) typeDesc).fieldDescriptors().values().stream()
                     .map(RecordFieldSymbol::typeDescriptor)
                     .collect(Collectors.toList());
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -145,9 +145,11 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         TypeSymbol rawType = CommonUtil.getRawType(typeDescriptor.get());
         switch (rawType.typeKind()) {
             case OBJECT:
-                return lookupTypedescOfObjectField(((ObjectTypeSymbol) rawType).fieldDescriptors(), fieldName);
+                ObjectFieldSymbol objField = ((ObjectTypeSymbol) rawType).fieldDescriptors().get(fieldName);
+                return objField != null ? Optional.of(objField.typeDescriptor()) : Optional.empty();
             case RECORD:
-                return lookupTypedescOfRecordField(((RecordTypeSymbol) rawType).fieldDescriptors(), fieldName);
+                RecordFieldSymbol recField = ((RecordTypeSymbol) rawType).fieldDescriptors().get(fieldName);
+                return recField != null ? Optional.of(recField.typeDescriptor()) : Optional.empty();
             default:
                 return Optional.empty();
         }
@@ -227,20 +229,20 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         TypeSymbol rawType = CommonUtil.getRawType(typeDescriptor);
         switch (rawType.typeKind()) {
             case RECORD:
-                ((RecordTypeSymbol) rawType).fieldDescriptors().forEach(fieldDescriptor -> {
+                ((RecordTypeSymbol) rawType).fieldDescriptors().forEach((name, fieldDescriptor) -> {
                     CompletionItem completionItem = new CompletionItem();
-                    completionItem.setLabel(fieldDescriptor.name());
-                    completionItem.setInsertText(fieldDescriptor.name());
+                    completionItem.setLabel(name);
+                    completionItem.setInsertText(name);
                     completionItem.setDetail(fieldDescriptor.typeDescriptor().signature());
                     completionItems.add(new RecordFieldCompletionItem(context, fieldDescriptor, completionItem));
                 });
                 break;
             case OBJECT:
                 ObjectTypeSymbol objTypeDesc = (ObjectTypeSymbol) rawType;
-                objTypeDesc.fieldDescriptors().forEach(fieldDescriptor -> {
+                objTypeDesc.fieldDescriptors().forEach((name, fieldDescriptor) -> {
                     CompletionItem completionItem = new CompletionItem();
-                    completionItem.setLabel(fieldDescriptor.name());
-                    completionItem.setInsertText(fieldDescriptor.name());
+                    completionItem.setLabel(name);
+                    completionItem.setInsertText(name);
                     completionItem.setDetail(fieldDescriptor.typeDescriptor().signature());
                     completionItems.add(new ObjectFieldCompletionItem(context, fieldDescriptor, completionItem));
                 });
@@ -261,25 +263,5 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         completionItems.addAll(this.getCompletionItemList(typeDescriptor.langLibMethods(), context));
 
         return completionItems;
-    }
-
-    private Optional<TypeSymbol> lookupTypedescOfObjectField(List<ObjectFieldSymbol> fields, String fieldName) {
-        for (ObjectFieldSymbol fieldDescriptor : fields) {
-            if (fieldDescriptor.name().equals(fieldName)) {
-                TypeSymbol typeDescriptor = fieldDescriptor.typeDescriptor();
-                return Optional.of(typeDescriptor);
-            }
-        }
-        return Optional.empty();
-    }
-
-    private Optional<TypeSymbol> lookupTypedescOfRecordField(List<RecordFieldSymbol> fields, String fieldName) {
-        for (RecordFieldSymbol fieldDescriptor : fields) {
-            if (fieldDescriptor.name().equals(fieldName)) {
-                TypeSymbol typeDescriptor = fieldDescriptor.typeDescriptor();
-                return Optional.of(typeDescriptor);
-            }
-        }
-        return Optional.empty();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -199,7 +199,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         TypeSymbol rawType = CommonUtil.getRawType(fieldTypeDesc.get());
         List<FunctionSymbol> visibleMethods = rawType.langLibMethods();
         if (rawType.typeKind() == TypeDescKind.OBJECT) {
-            visibleMethods.addAll(((ObjectTypeSymbol) rawType).methods());
+            visibleMethods.addAll(((ObjectTypeSymbol) rawType).methods().values());
         }
         Optional<FunctionSymbol> filteredMethod = visibleMethods.stream()
                 .filter(methodSymbol -> methodSymbol.name().equals(methodName))
@@ -246,7 +246,8 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
                     completionItem.setDetail(fieldDescriptor.typeDescriptor().signature());
                     completionItems.add(new ObjectFieldCompletionItem(context, fieldDescriptor, completionItem));
                 });
-                completionItems.addAll(this.getCompletionItemList(objTypeDesc.methods(), context));
+                completionItems.addAll(
+                        this.getCompletionItemList(new ArrayList<>(objTypeDesc.methods().values()), context));
                 break;
             case UNION:
                 UnionTypeSymbol unionTypeSymbol = (UnionTypeSymbol) rawType;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -55,7 +55,7 @@ import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -104,7 +104,7 @@ public class MappingConstructorExpressionNodeContext extends
         }
         Optional<RecordTypeSymbol> recordTypeDesc = this.getRecordTypeDesc(context, node);
         if (recordTypeDesc.isPresent()) {
-            List<RecordFieldSymbol> fields = new ArrayList<>(recordTypeDesc.get().fieldDescriptors());
+            Map<String, RecordFieldSymbol> fields = new LinkedHashMap<>(recordTypeDesc.get().fieldDescriptors());
             // TODO: Revamp the implementation
 //            completionItems.addAll(BLangRecordLiteralUtil.getSpreadCompletionItems(context, recordType));
             completionItems.addAll(CommonUtil.getRecordFieldCompletionItems(context, fields));
@@ -210,10 +210,8 @@ public class MappingConstructorExpressionNodeContext extends
     }
 
     private List<LSCompletionItem> getVariableCompletionsForFields(BallerinaCompletionContext ctx,
-                                                                   List<RecordFieldSymbol> recFields) {
+                                                                   Map<String, RecordFieldSymbol> recFields) {
         List<Symbol> visibleSymbols = ctx.visibleSymbols(ctx.getCursorPosition());
-        Map<String, TypeSymbol> fieldTypeMap = new HashMap<>();
-        recFields.forEach(fieldDesc -> fieldTypeMap.put(fieldDesc.name(), fieldDesc.typeDescriptor()));
         List<LSCompletionItem> completionItems = new ArrayList<>();
         visibleSymbols.forEach(symbol -> {
             if (!(symbol instanceof VariableSymbol)) {
@@ -221,11 +219,11 @@ public class MappingConstructorExpressionNodeContext extends
             }
             TypeSymbol typeDescriptor = ((VariableSymbol) symbol).typeDescriptor();
             String symbolName = symbol.name();
-            if (fieldTypeMap.containsKey(symbolName)
-                    && fieldTypeMap.get(symbolName).typeKind() == typeDescriptor.typeKind()) {
+            if (recFields.containsKey(symbolName)
+                    && recFields.get(symbolName).typeDescriptor().typeKind() == typeDescriptor.typeKind()) {
                 String bTypeName = typeDescriptor.signature();
                 CompletionItem cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbolName,
-                        bTypeName);
+                                                                           bTypeName);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, cItem));
             }
         });
@@ -262,14 +260,16 @@ public class MappingConstructorExpressionNodeContext extends
         RecordTypeSymbol recordType = record.get();
         Collections.reverse(fieldNames);
         for (String fieldName : fieldNames) {
-            Optional<RecordFieldSymbol> fieldDesc = recordType.fieldDescriptors().stream()
-                    .filter(fieldDescriptor -> fieldDescriptor.name().equals(fieldName))
-                    .findAny();
-            if (fieldDesc.isEmpty()
-                    || CommonUtil.getRawType(fieldDesc.get().typeDescriptor()).typeKind() != TypeDescKind.RECORD) {
+            if (!recordType.fieldDescriptors().containsKey(fieldName)) {
                 return Optional.empty();
             }
-            recordType = (RecordTypeSymbol) CommonUtil.getRawType(fieldDesc.get().typeDescriptor());
+
+            RecordFieldSymbol fieldDesc = recordType.fieldDescriptors().get(fieldName);
+            if (CommonUtil.getRawType(fieldDesc.typeDescriptor()).typeKind() != TypeDescKind.RECORD) {
+                return Optional.empty();
+            }
+
+            recordType = (RecordTypeSymbol) CommonUtil.getRawType(fieldDesc.typeDescriptor());
         }
 
         return Optional.ofNullable(recordType);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
@@ -108,7 +108,7 @@ public abstract class RightArrowActionNodeContext<T extends Node> extends Abstra
             return new ArrayList<>();
         }
         TypeSymbol typeDescriptor = CommonUtil.getRawType(((VariableSymbol) symbol).typeDescriptor());
-        return ((ObjectTypeSymbol) typeDescriptor).methods().stream()
+        return ((ObjectTypeSymbol) typeDescriptor).methods().values().stream()
                 .filter(method -> method.qualifiers().contains(Qualifier.REMOTE))
                 .collect(Collectors.toList());
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -117,7 +117,7 @@ public class HoverUtil {
         }
 
         List<String> methods = new ArrayList<>();
-        classSymbol.methods().forEach(method -> {
+        classSymbol.methods().forEach((name, method) -> {
             StringBuilder methodInfo = new StringBuilder();
             Optional<Documentation> methodDoc = method.documentation();
             methodInfo.append(quotedString(method.typeDescriptor().signature()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -106,12 +106,11 @@ public class HoverUtil {
             List<String> params = new ArrayList<>();
             params.add(header(3, ContextConstants.FIELD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
 
-            params.addAll(classSymbol.fieldDescriptors().stream()
-                    .map(field -> {
-                        String paramName = field.name();
-                        String desc = paramsMap.get(paramName);
-                        return quotedString(field.typeDescriptor().signature()) + " "
-                                + italicString(boldString(paramName)) + " : " + desc;
+            params.addAll(classSymbol.fieldDescriptors().entrySet().stream()
+                    .map(fieldEntry -> {
+                        String desc = paramsMap.get(fieldEntry.getKey());
+                        return quotedString(fieldEntry.getValue().typeDescriptor().signature()) + " "
+                                + italicString(boldString(fieldEntry.getKey())) + " : " + desc;
                     }).collect(Collectors.toList()));
 
             hoverContent.add(String.join(CommonUtil.MD_LINE_SEPARATOR, params));
@@ -181,12 +180,11 @@ public class HoverUtil {
             List<String> params = new ArrayList<>();
             params.add(header(3, ContextConstants.FIELD_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
 
-            params.addAll(recordType.fieldDescriptors().stream()
-                    .map(field -> {
-                        String paramName = field.name();
-                        String desc = paramsMap.get(paramName);
-                        return quotedString(field.typeDescriptor().signature()) + " "
-                                + italicString(boldString(paramName)) + " : " + desc;
+            params.addAll(recordType.fieldDescriptors().entrySet().stream()
+                    .map(fieldEntry -> {
+                        String desc = paramsMap.get(fieldEntry.getKey());
+                        return quotedString(fieldEntry.getValue().typeDescriptor().signature()) + " "
+                                + italicString(boldString(fieldEntry.getKey())) + " : " + desc;
                     }).collect(Collectors.toList()));
             Optional<TypeSymbol> restTypeDesc = recordType.restTypeDescriptor();
             restTypeDesc.ifPresent(typeSymbol -> params.add(quotedString(typeSymbol.signature() + "...")));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -437,9 +437,11 @@ public class SignatureHelpUtil {
         TypeSymbol rawType = CommonUtil.getRawType(typeDescriptor.get());
         switch (rawType.typeKind()) {
             case OBJECT:
-                return lookupTypedescOfObjectField(((ObjectTypeSymbol) rawType).fieldDescriptors(), fieldName);
+                ObjectFieldSymbol objField = ((ObjectTypeSymbol) rawType).fieldDescriptors().get(fieldName);
+                return objField != null ? Optional.of(objField.typeDescriptor()) : Optional.empty();
             case RECORD:
-                return lookupTypedescOfRecordField(((RecordTypeSymbol) rawType).fieldDescriptors(), fieldName);
+                RecordFieldSymbol recField = ((RecordTypeSymbol) rawType).fieldDescriptors().get(fieldName);
+                return recField != null ? Optional.of(recField.typeDescriptor()) : Optional.empty();
             default:
                 return Optional.empty();
         }
@@ -511,25 +513,5 @@ public class SignatureHelpUtil {
         functionSymbols.addAll(typeDescriptor.langLibMethods());
 
         return functionSymbols;
-    }
-
-    private static Optional<TypeSymbol> lookupTypedescOfObjectField(List<ObjectFieldSymbol> fields, String fieldName) {
-        for (ObjectFieldSymbol fieldDescriptor : fields) {
-            if (fieldDescriptor.name().equals(fieldName)) {
-                TypeSymbol typeDescriptor = fieldDescriptor.typeDescriptor();
-                return Optional.of(typeDescriptor);
-            }
-        }
-        return Optional.empty();
-    }
-
-    private static Optional<TypeSymbol> lookupTypedescOfRecordField(List<RecordFieldSymbol> fields, String fieldName) {
-        for (RecordFieldSymbol fieldDescriptor : fields) {
-            if (fieldDescriptor.name().equals(fieldName)) {
-                TypeSymbol typeDescriptor = fieldDescriptor.typeDescriptor();
-                return Optional.of(typeDescriptor);
-            }
-        }
-        return Optional.empty();
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -491,7 +491,7 @@ public class SignatureHelpUtil {
 
         List<FunctionSymbol> visibleMethods = fieldTypeDesc.get().langLibMethods();
         if (CommonUtil.getRawType(fieldTypeDesc.get()).typeKind() == TypeDescKind.OBJECT) {
-            visibleMethods.addAll(((ObjectTypeSymbol) CommonUtil.getRawType(fieldTypeDesc.get())).methods());
+            visibleMethods.addAll(((ObjectTypeSymbol) CommonUtil.getRawType(fieldTypeDesc.get())).methods().values());
         }
         Optional<FunctionSymbol> filteredMethod = visibleMethods.stream()
                 .filter(methodSymbol -> methodSymbol.name().equals(methodName))
@@ -508,7 +508,7 @@ public class SignatureHelpUtil {
         List<FunctionSymbol> functionSymbols = new ArrayList<>();
         if (CommonUtil.getRawType(typeDescriptor).typeKind() == TypeDescKind.OBJECT) {
             ObjectTypeSymbol objTypeDesc = (ObjectTypeSymbol) CommonUtil.getRawType(typeDescriptor);
-            functionSymbols.addAll(objTypeDesc.methods());
+            functionSymbols.addAll(objTypeDesc.methods().values());
         }
         functionSymbols.addAll(typeDescriptor.langLibMethods());
 

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -51,6 +51,7 @@ import org.eclipse.lsp4j.TextEdit;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -251,10 +252,10 @@ class AIDataMapperCodeActionUtil {
 
         // Schema 1
         Symbol rightSymbol = findSymbol(foundTypeRight, fileContentSymbols);
-        List<RecordFieldSymbol> rightSchemaFields = SymbolUtil.getTypeDescForRecordSymbol(rightSymbol)
+        Map<String, RecordFieldSymbol> rightSchemaFields = SymbolUtil.getTypeDescForRecordSymbol(rightSymbol)
                 .fieldDescriptors();
 
-        JsonObject rightSchema = (JsonObject) recordToJSON(rightSchemaFields);
+        JsonObject rightSchema = (JsonObject) recordToJSON(rightSchemaFields.values());
 
         rightRecordJSON.addProperty(SCHEMA, foundTypeRight);
         rightRecordJSON.addProperty(ID, "dummy_id");
@@ -262,7 +263,7 @@ class AIDataMapperCodeActionUtil {
         rightRecordJSON.add(PROPERTIES, rightSchema);
 
         // Schema 2
-        List<RecordFieldSymbol> leftSchemaFields;
+        Map<String, RecordFieldSymbol> leftSchemaFields;
         if (positionDetails.matchedSymbol() == null) {
             Symbol leftSymbol = findSymbol(foundTypeLeft, fileContentSymbols);
             leftSchemaFields = SymbolUtil.getTypeDescForRecordSymbol(leftSymbol).fieldDescriptors();
@@ -271,7 +272,7 @@ class AIDataMapperCodeActionUtil {
                     fieldDescriptors();
         }
 
-        JsonObject leftSchema = (JsonObject) recordToJSON(leftSchemaFields);
+        JsonObject leftSchema = (JsonObject) recordToJSON(leftSchemaFields.values());
 
         leftRecordJSON.addProperty(SCHEMA, foundTypeLeft);
         leftRecordJSON.addProperty(ID, "dummy_id");
@@ -311,16 +312,16 @@ class AIDataMapperCodeActionUtil {
      * @param schemaFields {@link List<RecordFieldSymbol>}
      * @return Field symbol properties
      */
-    private static JsonElement recordToJSON(List<RecordFieldSymbol> schemaFields) {
+    private static JsonElement recordToJSON(Collection<RecordFieldSymbol> schemaFields) {
         JsonObject properties = new JsonObject();
         for (RecordFieldSymbol attribute : schemaFields) {
             JsonObject fieldDetails = new JsonObject();
             fieldDetails.addProperty(ID, "dummy_id");
             TypeSymbol attributeType = CommonUtil.getRawType(attribute.typeDescriptor());
             if (attributeType.typeKind() == TypeDescKind.RECORD) {
-                List<RecordFieldSymbol> recordFields = ((RecordTypeSymbol) attributeType).fieldDescriptors();
+                Map<String, RecordFieldSymbol> recordFields = ((RecordTypeSymbol) attributeType).fieldDescriptors();
                 fieldDetails.addProperty(TYPE, "ballerina_type");
-                fieldDetails.add(PROPERTIES, recordToJSON(recordFields));
+                fieldDetails.add(PROPERTIES, recordToJSON(recordFields.values()));
             } else {
                 fieldDetails.addProperty(TYPE, attributeType.typeKind().toString());
             }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
@@ -197,7 +197,7 @@ public class MethodCallExpressionEvaluator extends Evaluator {
     }
 
     private Optional<MethodSymbol> findObjectMethodInClass(ClassSymbol classDef, String methodName) {
-        return classDef.methods()
+        return classDef.methods().values()
                 .stream()
                 .filter(methodSymbol -> modifyName(methodSymbol.name()).equals(methodName))
                 .findFirst();

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -598,32 +598,32 @@ public class Generator {
                 }
                 if (typeSymbol instanceof RecordTypeSymbol) {
                     RecordTypeSymbol recordTypeSymbol = (RecordTypeSymbol) typeSymbol;
-                    recordTypeSymbol.fieldDescriptors().forEach(field -> {
-                        Type type = new Type(field.name());
+                    recordTypeSymbol.fieldDescriptors().forEach((name, field) -> {
+                        Type type = new Type(name);
                         Type elemType;
-                        String name;
+                        String typeName;
                         if (field.typeDescriptor() instanceof TypeReferenceTypeSymbol) {
-                            name = field.typeDescriptor().name();
+                            typeName = field.typeDescriptor().name();
                         } else {
-                            name = field.typeDescriptor().signature();
+                            typeName = field.typeDescriptor().signature();
                         }
-                        elemType = new Type(name);
+                        elemType = new Type(typeName);
                         Type.resolveSymbol(elemType, field.typeDescriptor());
                         type.elementType = elemType;
                         originType.memberTypes.add(type);
                     });
                 } else if (typeSymbol instanceof ObjectTypeSymbol) {
                     ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) typeSymbol;
-                    objectTypeSymbol.fieldDescriptors().forEach(field -> {
-                        Type type = new Type(field.name());
+                    objectTypeSymbol.fieldDescriptors().forEach((name, field) -> {
+                        Type type = new Type(name);
                         Type elemType;
-                        String name;
+                        String typeName;
                         if (field.typeDescriptor() instanceof TypeReferenceTypeSymbol) {
-                            name = field.typeDescriptor().name();
+                            typeName = field.typeDescriptor().name();
                         } else {
-                            name = field.typeDescriptor().signature();
+                            typeName = field.typeDescriptor().signature();
                         }
-                        elemType = new Type(name);
+                        elemType = new Type(typeName);
                         Type.resolveSymbol(elemType, field.typeDescriptor());
                         type.elementType = elemType;
                         originType.memberTypes.add(type);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -444,12 +444,13 @@ public class Generator {
         return new BAbstractObject(name, description, isDeprecated, fields, functions);
     }
 
+    // TODO: Revisit this. This probably can be written in a much simpler way.
     private static List<Function> getInclusionFunctions(TypeSymbol typeSymbol, Type originType,
                                                         NodeList<Node> members) {
         List<Function> functions = new ArrayList<>();
         if (typeSymbol instanceof ObjectTypeSymbol) {
             ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) typeSymbol;
-            objectTypeSymbol.methods().forEach(methodSymbol -> {
+            objectTypeSymbol.methods().values().forEach(methodSymbol -> {
                 String methodName = methodSymbol.name();
                 // Check if the inclusion function is overridden
                 if (members.stream().anyMatch(node -> {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
@@ -77,7 +77,7 @@ public class DocumentationTest {
 
         ClassSymbol classSymbol = (ClassSymbol) symbol.get();
         classSymbol.fieldDescriptors().forEach(
-                field -> assertDescriptionOnly(field.documentation().get(), "Field name"));
+                (name, field) -> assertDescriptionOnly(field.documentation().get(), "Field name"));
         classSymbol.methods().forEach(
                 method -> assertDocumentation(method.documentation().get(), "Method getName", emptyMap, "string"));
 
@@ -113,7 +113,7 @@ public class DocumentationTest {
 
         RecordTypeSymbol recordType = (RecordTypeSymbol) ((TypeDefinitionSymbol) symbol.get()).typeDescriptor();
         recordType.fieldDescriptors().forEach(
-                field -> assertDescriptionOnly(field.documentation().get(), "Field " + field.name()));
+                (name, field) -> assertDescriptionOnly(field.documentation().get(), "Field " + name));
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
@@ -79,7 +79,8 @@ public class DocumentationTest {
         classSymbol.fieldDescriptors().forEach(
                 (name, field) -> assertDescriptionOnly(field.documentation().get(), "Field name"));
         classSymbol.methods().forEach(
-                method -> assertDocumentation(method.documentation().get(), "Method getName", emptyMap, "string"));
+                (name, method) -> assertDocumentation(method.documentation().get(), "Method getName", emptyMap,
+                                                      "string"));
 
         assertDocumentation(classSymbol.initMethod().get().documentation().get(), "Method init",
                             Map.of("name", "Param name"), "error or nil");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -78,11 +78,11 @@ public class ServiceSemanticAPITest {
                                           "$get$foo$*", "$get$foo$*$**");
         assertList(symbol.methods(), expMethods);
 
-        MethodSymbol method = symbol.methods().get(0);
+        MethodSymbol method = symbol.methods().get("foo");
         assertEquals(method.qualifiers().size(), 1);
         assertTrue(method.qualifiers().contains(Qualifier.REMOTE));
 
-        method = symbol.methods().get(1);
+        method = symbol.methods().get("$get$barPath");
         assertEquals(method.qualifiers().size(), 1);
         assertTrue(method.qualifiers().contains(Qualifier.RESOURCE));
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolFlagToQualifierMappingTest.java
@@ -115,7 +115,7 @@ public class SymbolFlagToQualifierMappingTest {
         Optional<Symbol> optionalSymbol = model.symbol(srcFile, LinePosition.from(51, 5));
         TypeDefinitionSymbol person = (TypeDefinitionSymbol) optionalSymbol.get();
         RecordTypeSymbol type = (RecordTypeSymbol) person.typeDescriptor();
-        RecordFieldSymbol field = type.fieldDescriptors().get(1);
+        RecordFieldSymbol field = type.fieldDescriptors().get("age");
         assertTrue(field.isOptional());
         assertFalse(field.hasDefaultValue());
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeCacheTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypeCacheTest.java
@@ -34,7 +34,7 @@ import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.List;
+import java.util.Map;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
@@ -63,10 +63,8 @@ public class TypeCacheTest {
         TypeDefinitionSymbol personDefSymbol =
                 (TypeDefinitionSymbol) model.symbol(srcFile, LinePosition.from(30, 5)).get();
         TypeSymbol personTypedesc = personDefSymbol.typeDescriptor();
-        List<RecordFieldSymbol> personFields = ((RecordTypeSymbol) personTypedesc).fieldDescriptors();
-        RecordFieldSymbol parentField = personFields.stream()
-                .filter(field -> "parent".equals(field.name()))
-                .findAny().get();
+        Map<String, RecordFieldSymbol> personFields = ((RecordTypeSymbol) personTypedesc).fieldDescriptors();
+        RecordFieldSymbol parentField = personFields.get("parent");
         TypeSymbol type = ((UnionTypeSymbol) parentField.typeDescriptor()).memberTypeDescriptors().get(0);
 
         assertSame(personTypedesc, ((TypeReferenceTypeSymbol) type).typeDescriptor());
@@ -77,11 +75,10 @@ public class TypeCacheTest {
 
         assertSame(personTypedesc, ((TypeReferenceTypeSymbol) typeInclusion).typeDescriptor());
 
-        List<RecordFieldSymbol> empFields = ((RecordTypeSymbol) employeeDefSymbol.typeDescriptor()).fieldDescriptors();
-        RecordFieldSymbol designationType =
-                empFields.stream().filter(field -> "designation".equals(field.name())).findAny().get();
-        RecordFieldSymbol nameType =
-                personFields.stream().filter(field -> "name".equals(field.name())).findAny().get();
+        Map<String, RecordFieldSymbol> empFields =
+                ((RecordTypeSymbol) employeeDefSymbol.typeDescriptor()).fieldDescriptors();
+        RecordFieldSymbol designationType = empFields.get("designation");
+        RecordFieldSymbol nameType = personFields.get("name");
 
         assertSame(nameType.typeDescriptor(), designationType.typeDescriptor());
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -27,6 +27,7 @@ import io.ballerina.compiler.api.impl.symbols.BallerinaNilTypeSymbol;
 import io.ballerina.compiler.api.impl.symbols.BallerinaStringTypeSymbol;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -64,6 +65,7 @@ import org.testng.annotations.Test;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -208,8 +210,8 @@ public class TypedescriptorTest {
         ClassSymbol clazz = (ClassSymbol) symbol;
         assertEquals(clazz.typeKind(), OBJECT);
 
-        List<ObjectFieldSymbol> fields = clazz.fieldDescriptors();
-        ObjectFieldSymbol field = fields.get(0);
+        Map<String, ClassFieldSymbol> fields = clazz.fieldDescriptors();
+        ObjectFieldSymbol field = fields.get("name");
         assertEquals(fields.size(), 1);
         assertEquals(field.name(), "name");
         assertEquals(field.typeDescriptor().typeKind(), STRING);
@@ -229,9 +231,11 @@ public class TypedescriptorTest {
         assertEquals(type.typeKind(), RECORD);
         assertFalse(type.restTypeDescriptor().isPresent());
 
-        List<RecordFieldSymbol> fields = type.fieldDescriptors();
-        RecordFieldSymbol field = fields.get(0);
+        Map<String, RecordFieldSymbol> fields = type.fieldDescriptors();
         assertEquals(fields.size(), 1);
+        assertTrue(fields.containsKey("path"));
+
+        RecordFieldSymbol field = fields.get("path");
         assertEquals(field.name(), "path");
         assertEquals(field.typeDescriptor().typeKind(), STRING);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -216,8 +216,8 @@ public class TypedescriptorTest {
         assertEquals(field.name(), "name");
         assertEquals(field.typeDescriptor().typeKind(), STRING);
 
-        List<MethodSymbol> methods = clazz.methods();
-        MethodSymbol method = methods.get(0);
+        Map<String, MethodSymbol> methods = clazz.methods();
+        MethodSymbol method = methods.get("getName");
         assertEquals(fields.size(), 1);
         assertEquals(method.name(), "getName");
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -104,7 +104,7 @@ public class SemanticAPITestUtils {
         assertList(symbols, expectedValues);
     }
 
-    public static void assertList(Map<String, Symbol> actualValues, List<String> expectedValues) {
+    public static void assertList(Map<String, ? extends Symbol> actualValues, List<String> expectedValues) {
         assertEquals(actualValues.size(), expectedValues.size());
 
         for (String val : expectedValues) {


### PR DESCRIPTION
## Purpose
This PR modifies the return types of the `fieldDescriptors()` method in records, objects and classes to return `Map<String, *FieldSymbol>` instead of a `List<*FieldSymbol>`. This is because a common use case is to lookup fields in the aforementioned types by name and previously the user had to loop through the fields list and filter to get the relevant field symbol. The map used for this is a `LinkedHashMap` so that the original order is preserved when iterating.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
