### PR TITLE
Update type checker to use context information when deriving type of a let expression

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2821,7 +2821,7 @@ public class TypeChecker extends BLangNodeVisitor {
         for (BLangLetVariable letVariable : letExpression.letVarDeclarations) {
             semanticAnalyzer.analyzeDef((BLangNode) letVariable.definitionNode, letExpression.env);
         }
-        BType exprType = checkExpr(letExpression.expr, letExpression.env, letExpression.expectedType);
+        BType exprType = checkExpr(letExpression.expr, letExpression.env, this.expType);
         types.checkType(letExpression, exprType, this.expType);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2821,7 +2821,7 @@ public class TypeChecker extends BLangNodeVisitor {
         for (BLangLetVariable letVariable : letExpression.letVarDeclarations) {
             semanticAnalyzer.analyzeDef((BLangNode) letVariable.definitionNode, letExpression.env);
         }
-        BType exprType = checkExpr(letExpression.expr, letExpression.env);
+        BType exprType = checkExpr(letExpression.expr, letExpression.env, letExpression.expectedType);
         types.checkType(letExpression, exprType, this.expType);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
@@ -54,9 +54,9 @@ public class LetExpressionTest {
         BAssertUtil.validateError(negativeResult, i++, "redeclared symbol 'x'", 19, 21);
         BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'y'", 23, 27);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 27, 25);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 28, 13);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 28, 39);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 29, 28);
-        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'string', found 'int'", 30, 16);
+        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'string', found 'int'", 30, 42);
     }
 
     @Test(description = "Test cases for scenarios where let expression is not yet supported")
@@ -102,6 +102,7 @@ public class LetExpressionTest {
 //                {"testLetExpressionErrorBindingSimple"},
 //                {"testLetExpressionErrorBindingVar"},
 //                {"testLetExpressionRecordConstrainedErrorBinding"},
+                {"testAnonymousRecordWithLetExpression"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
@@ -58,7 +58,8 @@ public class LetExpressionTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 29, 28);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 30, 42);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'byte', found 'int'", 41, 37);
-        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'int', found 'string'", 48, 14);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 48, 14);
+        BAssertUtil.validateError(negativeResult, i, "too many arguments in call to 'new()'", 57, 37);
     }
 
     @Test(description = "Test cases for scenarios where let expression is not yet supported")
@@ -105,7 +106,8 @@ public class LetExpressionTest {
 //                {"testLetExpressionErrorBindingVar"},
 //                {"testLetExpressionRecordConstrainedErrorBinding"},
                 {"testAnonymousRecordWithLetExpression"},
-                {"testRecordWithLetExpression"}
+                {"testRecordWithLetExpression"},
+                {"testLetWithClass"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
@@ -56,7 +56,9 @@ public class LetExpressionTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 27, 25);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 28, 39);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 29, 28);
-        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'string', found 'int'", 30, 42);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 30, 42);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'byte', found 'int'", 41, 37);
+        BAssertUtil.validateError(negativeResult, i, "incompatible types: expected 'int', found 'string'", 48, 14);
     }
 
     @Test(description = "Test cases for scenarios where let expression is not yet supported")
@@ -102,7 +104,8 @@ public class LetExpressionTest {
 //                {"testLetExpressionErrorBindingSimple"},
 //                {"testLetExpressionErrorBindingVar"},
 //                {"testLetExpressionRecordConstrainedErrorBinding"},
-                {"testAnonymousRecordWithLetExpression"}
+                {"testAnonymousRecordWithLetExpression"},
+                {"testRecordWithLetExpression"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/let/LetExpressionTest.java
@@ -58,7 +58,8 @@ public class LetExpressionTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 29, 28);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'string', found 'int'", 30, 42);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'byte', found 'int'", 41, 37);
-        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 48, 14);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'string'", 46, 48);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'float'", 48, 14);
         BAssertUtil.validateError(negativeResult, i, "too many arguments in call to 'new()'", 57, 37);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-negative.bal
@@ -33,3 +33,17 @@ function wrongTypes() {
 function fun() returns int {
     return 1;
 }
+
+function invalidTypesWithAnonymousRecord() {
+    record {
+        byte i;
+        int j?;
+    } rec1 = let int v = 160 in {i: v};
+
+    record {
+        string i;
+        int j?;
+    } rec2 = let string v = "160" in {i: v};
+    
+    rec2.j = "invalid";
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-negative.bal
@@ -47,3 +47,12 @@ function invalidTypesWithAnonymousRecord() {
     
     rec2.j = "invalid";
 }
+
+class FooClass {
+    public function init(int m) {
+    }
+}
+
+function testLetWithClass() {
+    FooClass foo = let int m = 5 in new(m, m);
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-negative.bal
@@ -43,9 +43,9 @@ function invalidTypesWithAnonymousRecord() {
     record {
         string i;
         int j?;
-    } rec2 = let string v = "160" in {i: v};
+    } rec2 = let string v = "160" in {i: v, j: "invalid"};
     
-    rec2.j = "invalid";
+    rec2.j = 2.0;
 }
 
 class FooClass {
@@ -54,5 +54,5 @@ class FooClass {
 }
 
 function testLetWithClass() {
-    FooClass foo = let int m = 5 in new(m, m);
+    FooClass foo = let int m = 5 in new (m, m);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
@@ -316,6 +316,15 @@ function getRecordConstrainedError() returns FooError {
     return e;
 }
 
+public function testAnonymousRecordWithLetExpression() {
+    record {
+        int i;
+        int j?;
+    } rec = let int v = 1 in {i: v};
+    
+    assertTrue(rec.i == 1, "rec.i == 1");
+}
+
 //// Util functions
 
 function assert(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
@@ -322,10 +322,25 @@ public function testAnonymousRecordWithLetExpression() {
         int j?;
     } rec = let int v = 1 in {i: v};
     
-    assert(rec.i, 1);
+    assert(1, rec.i);
     
     rec.j = 5;
-    assert(rec?.j, 5);
+    assert(5, rec?.j);
+}
+
+type Rec record {|
+    int i;
+    int j = 100;
+|};
+    
+public function testRecordWithLetExpression() {
+    Rec rec1 = let int v = 160 in {i: v};
+    assert(160, rec1.i);
+    assert(100, rec1.j);
+    
+    Rec rec2 = let int v = 161 in {i: v, j: v};
+    assert(161, rec2.i);
+    assert(161, rec2.j);
 }
 
 //// Util functions

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
@@ -343,6 +343,24 @@ public function testRecordWithLetExpression() {
     assert(161, rec2.j);
 }
 
+class FooClass {
+    int m;
+    
+    public function init(int m) {
+        self.m = m;
+    }
+}
+
+function testLetWithClass() {
+    FooClass foo = let int m = 5 in new(m);
+    assert(5, foo.m);
+    
+    FooClass foo2 = new(let var arr = [1, 2, 3] in arr.reduce(function(int sum, int x) returns int {
+                                                                                return sum + x;
+                                                                            }, 0));
+    assert(6, foo2.m);
+}
+
 //// Util functions
 
 function assert(anydata expected, anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
@@ -352,10 +352,10 @@ class FooClass {
 }
 
 function testLetWithClass() {
-    FooClass foo = let int m = 5 in new(m);
+    FooClass foo = let int m = 5 in new (m);
     assert(5, foo.m);
     
-    FooClass foo2 = new(let var arr = [1, 2, 3] in arr.reduce(function(int sum, int x) returns int {
+    FooClass foo2 = new (let var arr = [1, 2, 3] in arr.reduce(function(int sum, int x) returns int {
                                                                                 return sum + x;
                                                                             }, 0));
     assert(6, foo2.m);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/let/let-expression-test.bal
@@ -322,7 +322,10 @@ public function testAnonymousRecordWithLetExpression() {
         int j?;
     } rec = let int v = 1 in {i: v};
     
-    assertTrue(rec.i == 1, "rec.i == 1");
+    assert(rec.i, 1);
+    
+    rec.j = 5;
+    assert(rec?.j, 5);
 }
 
 //// Util functions


### PR DESCRIPTION
## Purpose
This fixes #26906. 

## Approach
- `TypeCheker` was using `noType` as the expected type of the expression when an anonymous record is defined inline using a let expression. Updated the `TypeChecker.visit(BLangExpression)` method to use the expected type from let expression when checking the expression instead of `noType`.
- Added a test case to cover this scenario as described in #26906

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
