### PR TITLE
Fix configurable toml parsing errrors

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 
 import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.CONFIGURATION_NOT_SUPPORTED;
-import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.CONFIG_FILE_NAME;
 import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.DEFAULT_MODULE;
 import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.INVALID_TOML_FILE;
 import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.INVALID_VARIABLE_TYPE;
@@ -59,8 +58,7 @@ public class ConfigTomlParser {
     private ConfigTomlParser() {
     }
 
-    private static TomlTableNode getConfigurationData(Path filePath) throws TomlException {
-        Path configFilePath = filePath.resolve(CONFIG_FILE_NAME);
+    private static TomlTableNode getConfigurationData(Path configFilePath) throws TomlException {
         if (!Files.exists(configFilePath)) {
             return null;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/configurable/ConfigTomlParser.java
@@ -78,6 +78,10 @@ public class ConfigTomlParser {
         }
         for (Map.Entry<Module, VariableKey[]> moduleEntry : configurationData.entrySet()) {
             TomlTableNode moduleNode = retrieveModuleNode(tomlNode, moduleEntry.getKey());
+            if (moduleNode == null) {
+                //Module could contain optional configurable variable
+                continue;
+            }
             for (VariableKey key : moduleEntry.getValue()) {
                 if (!moduleNode.entries().containsKey(key.variable)) {
                     //It is an optional configurable variable
@@ -97,10 +101,6 @@ public class ConfigTomlParser {
         }
         TomlTableNode moduleNode = moduleName.equals(DEFAULT_MODULE) ? tomlNode : extractModuleNode(tomlNode,
                 moduleName);
-        if (moduleNode == null) {
-            throw new TomlException(INVALID_TOML_FILE + "Module '" + moduleName + "' from organization '" + orgName
-                    + "' not found.");
-        }
         return moduleNode;
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/launch/LaunchUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/launch/LaunchUtils.java
@@ -50,6 +50,7 @@ import static io.ballerina.runtime.api.constants.RuntimeConstants.UTIL_LOGGING_C
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UTIL_LOGGING_CONFIG_CLASS_VALUE;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UTIL_LOGGING_MANAGER_CLASS_PROPERTY;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.UTIL_LOGGING_MANAGER_CLASS_VALUE;
+import static io.ballerina.runtime.internal.configurable.ConfigurableConstants.CONFIG_FILE_NAME;
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_METRICS_ENABLED;
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_OBSERVABILITY_ENABLED;
 import static io.ballerina.runtime.observability.ObservabilityConstants.CONFIG_OBSERVABILITY_METRICS_REPORTER;
@@ -172,6 +173,7 @@ public class LaunchUtils {
 
     public static Path getConfigPath() {
         Map<String, String> envVariables = System.getenv();
-        return Paths.get(envVariables.getOrDefault(ConfigurableConstants.CONFIG_ENV_VARIABLE, RuntimeUtils.USER_DIR));
+        return Paths.get(envVariables.getOrDefault(ConfigurableConstants.CONFIG_ENV_VARIABLE,
+                Paths.get(RuntimeUtils.USER_DIR, CONFIG_FILE_NAME).toString()));
     }
 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/BTestRunner.java
@@ -38,6 +38,7 @@ import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.scheduling.Scheduler;
 import io.ballerina.runtime.internal.scheduling.Strand;
+import io.ballerina.runtime.internal.util.RuntimeUtils;
 import io.ballerina.runtime.internal.values.ArrayValue;
 import io.ballerina.runtime.internal.values.DecimalValue;
 import io.ballerina.runtime.internal.values.MapValue;
@@ -59,6 +60,7 @@ import java.io.OutputStreamWriter;
 import java.io.PrintStream;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
@@ -82,6 +84,7 @@ public class BTestRunner {
     private static final String TEST_START_FUNCTION_NAME = ".<teststart>";
     private static final String TEST_STOP_FUNCTION_NAME = ".<teststop>";
     private static final String CONFIGURATION_CLASS_NAME = "$ConfigurationMapper";
+    private static final String CONFIG_FILE_NAME = "Config.toml";
 
     private PrintStream errStream;
     private PrintStream outStream;
@@ -575,7 +578,11 @@ public class BTestRunner {
         if (!moduleName.equals("")) {
             configFilePath = configFilePath.resolve(ProjectConstants.MODULES_ROOT).resolve(moduleName);
         }
-        return configFilePath.resolve(ProjectConstants.TEST_DIR_NAME);
+        configFilePath = configFilePath.resolve(ProjectConstants.TEST_DIR_NAME).resolve(CONFIG_FILE_NAME);
+        if (!Files.exists(configFilePath)) {
+            configFilePath = Paths.get(RuntimeUtils.USER_DIR).resolve(CONFIG_FILE_NAME);
+        }
+        return configFilePath;
     }
 
     private void stopSuite(TestSuite suite, Scheduler scheduler, Class<?> initClazz, Class<?> testInitClazz,

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -139,7 +139,7 @@ public class ConfigurableTest extends BaseTest {
     public void testInvalidOrganizationName() throws BallerinaTestException {
         Path projectPath = Paths.get(negativeTestFileLocation, "InvalidOrgName").toAbsolutePath();
         LogLeecher errorLeecher =
-                new LogLeecher(errorMsg + "Module 'main' from organization 'testOrg' not found.", ERROR);
+                new LogLeecher("Value not provided for required configurable variable 'booleanVar'", ERROR);
         bMainInstance.runMain("run", new String[]{"main"}, null, new String[]{},
                 new LogLeecher[]{errorLeecher}, projectPath.toString());
         errorLeecher.waitForText(5000);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -78,8 +78,17 @@ public class ConfigurableTest extends BaseTest {
     }
 
     @Test
+    public void testAPIConfigFilePathOverRiding() throws BallerinaTestException {
+        Path projectPath = Paths.get(testFileLocation, "testPathProject").toAbsolutePath();
+        LogLeecher runLeecher = new LogLeecher("4 passing");
+        bMainInstance.runMain("test", new String[]{"configPkg"}, null, new String[]{},
+                new LogLeecher[]{runLeecher}, projectPath.toString());
+        runLeecher.waitForText(5000);
+    }
+
+    @Test
     public void testEnvironmentVariableBasedConfigFile() throws BallerinaTestException {
-        String configFilePath = Paths.get(testFileLocation, "ConfigFiles").toString();
+        String configFilePath = Paths.get(testFileLocation, "ConfigFiles", "Config.toml").toString();
         Path projectPath = Paths.get(testFileLocation).toAbsolutePath();
         LogLeecher runLeecher = new LogLeecher("Tests passed");
         bMainInstance.runMain("run", new String[]{"envVarPkg"}, addEnvVariables(configFilePath),

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/Config.toml
@@ -1,0 +1,21 @@
+[configPkg]
+intVar = 45
+floatVar = 3.5
+stringVar = "abc"
+booleanVar = false
+testInt = 24
+testFloat = 77.2
+testString = "configurable variable test"
+testBoolean = true
+
+
+[configPkg.util.foo]
+intVar = 41
+floatVar = 3.6
+stringVar = "test string"
+booleanVar = true
+testInt = 22
+testFloat = 12.4
+testString = "configurable variable inside test source"
+testBoolean = true
+

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/Ballerina.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/Ballerina.toml
@@ -1,0 +1,9 @@
+[package]
+org= "testOrg"
+name= "configPkg"
+version= "0.1.0"
+
+[build-options]
+observability-included=true
+
+[dependencies]

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/main.bal
@@ -1,0 +1,37 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+configurable int intVar = 3;
+configurable float floatVar = 12.8;
+configurable string stringVar = ?;
+configurable boolean booleanVar = ?;
+
+public function main() {
+	 //Do nothing
+}
+
+function getAverage() returns float {
+    return <float>(intVar + floatVar) / 2;
+}
+
+function getString() returns string {
+    return stringVar;
+}
+
+function getBoolean() returns boolean {
+    return booleanVar;
+}
+

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/modules/util.foo/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/modules/util.foo/main.bal
@@ -1,0 +1,32 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+configurable int intVar = ?;
+configurable float floatVar = 9.5;
+configurable string stringVar = "hello";
+configurable boolean booleanVar = ?;
+
+public function getAverage() returns float {
+    return <float>(intVar + floatVar) / 2;
+}
+
+public function getString() returns string {
+    return stringVar;
+}
+
+public function getBoolean() returns boolean {
+    return booleanVar;
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/modules/util.foo/tests/module_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/modules/util.foo/tests/module_test.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+
+configurable int testInt = ?;
+configurable float testFloat = 9.5;
+configurable string testString = "hello";
+configurable boolean testBoolean = ?;
+
+@test:Config {}
+function testAverage() {
+    float res = getAverage();
+    test:assertEquals(res, 22.3);
+}
+
+@test:Config {}
+function testStringValue() {
+    string res = getString();
+    test:assertEquals(res, "test string");
+}
+
+@test:Config {}
+function testBooleanValue() {
+    boolean res = getBoolean();
+    test:assertEquals(res, true);
+}
+
+@test:Config {}
+function testInternalVariables() {
+    test:assertEquals(testInt, 22);
+    test:assertEquals(testFloat, 12.4);
+    test:assertEquals(testString, "configurable variable inside test source");
+    test:assertEquals(testBoolean, true);
+}

--- a/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/tests/main_test.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/testPathProject/configPkg/tests/main_test.bal
@@ -1,0 +1,48 @@
+ // Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/test;
+ 
+configurable int testInt = ?;
+configurable float testFloat = 66.8;
+configurable string testString = "test";
+configurable boolean testBoolean = ?;
+
+@test:Config {}
+ function testAverage() {
+    float res = getAverage();
+    test:assertEquals(res, 24.25);
+ }
+ 
+@test:Config {}
+ function testStringValue() {
+    string res = getString();
+    test:assertEquals(res, "abc");
+ }
+
+@test:Config {}
+ function testBooleanValue() {
+    boolean res = getBoolean();
+    test:assertEquals(res, false);
+ }
+
+@test:Config {}
+ function testInternalVariables() {
+    test:assertEquals(testInt, 24);
+    test:assertEquals(testFloat, 77.2);
+    test:assertEquals(testString, "configurable variable test");
+    test:assertEquals(testBoolean, true);
+ }


### PR DESCRIPTION
## Purpose
This PR fixes the following bugs
- Configuration file path not overridden to CWD, if not found in test directory
- Config TOML Parser checks for module information to be mandatory (It can be optional, if configurable variables are optional)
- Include TOML file name in the path given by env variable

## Approach
N/A

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
