### PR TITLE
Fix Config.toml pick-up issue in tests under windows

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -381,7 +381,7 @@ public class RunTestsTask implements Task {
         cmdArgs.add(target.path().toString());
         cmdArgs.add(orgName);
         cmdArgs.add(packageName);
-        cmdArgs.add(moduleName);
+        cmdArgs.add(moduleName.isEmpty() ? "''" : moduleName); // see JDK-7028124
         ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
         Process proc = processBuilder.start();
         return proc.waitFor();


### PR DESCRIPTION
## Purpose
wrong path is picked up for Config.toml when running tests under windows

issue discoed during https://github.com/ballerina-platform/module-ballerina-http/pull/174