### PR TITLE
Add an overloaded version of type() which takes syntax tree nodes as the arg

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -96,10 +96,19 @@ public interface SemanticModel {
      * Retrieves the type of the expression in the specified text range. If it's not a valid expression, returns an
      * empty {@link Optional} value!.
      *
-     * @param range    the text range of the expression
+     * @param range the text range of the expression
      * @return the type of the expression
      */
     Optional<TypeSymbol> type(LineRange range);
+
+    /**
+     * Given a syntax tree node, returns the type of that node, if it is an expression node. For any other node, this
+     * will return empty.
+     *
+     * @param node The expression node of which the type is needed
+     * @return The type if it's a valid expression node, if not, returns empty
+     */
+    Optional<TypeSymbol> type(Node node);
 
     /**
      * Get the diagnostics within the given text Span.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -224,15 +224,7 @@ public class BallerinaSemanticModel implements SemanticModel {
             return Optional.empty();
         }
 
-        BLangCompilationUnit compilationUnit = getCompilationUnit(node.location().lineRange().filePath());
-        NodeFinder nodeFinder = new NodeFinder();
-        BLangNode astNode = nodeFinder.lookup(compilationUnit, node.location().lineRange());
-
-        if (astNode == null) {
-            return Optional.empty();
-        }
-
-        return Optional.ofNullable(typesFactory.getTypeDescriptor(astNode.type));
+        return type(node.location().lineRange());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -217,6 +217,28 @@ public class BallerinaSemanticModel implements SemanticModel {
      * {@inheritDoc}
      */
     @Override
+    public Optional<TypeSymbol> type(Node node) {
+        Optional<Location> nodeIdentifierLocation = node.apply(new SyntaxNodeToLocationMapper());
+
+        if (nodeIdentifierLocation.isEmpty()) {
+            return Optional.empty();
+        }
+
+        BLangCompilationUnit compilationUnit = getCompilationUnit(node.location().lineRange().filePath());
+        NodeFinder nodeFinder = new NodeFinder();
+        BLangNode astNode = nodeFinder.lookup(compilationUnit, node.location().lineRange());
+
+        if (astNode == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(typesFactory.getTypeDescriptor(astNode.type));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public List<Diagnostic> diagnostics(LineRange range) {
         List<Diagnostic> allDiagnostics = this.bLangPackage.getDiagnostics();
         List<Diagnostic> filteredDiagnostics = new ArrayList<>();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -841,7 +841,6 @@ class NodeFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangTableMultiKeyExpr tableMultiKeyExpr) {
-        lookupNode(tableMultiKeyExpr.expr);
         lookupNodes(tableMultiKeyExpr.multiKeyIndexExprs);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -17,42 +17,74 @@
 
 package io.ballerina.compiler.api.impl;
 
+import io.ballerina.compiler.syntax.tree.AnnotAccessExpressionNode;
 import io.ballerina.compiler.syntax.tree.AnnotationDeclarationNode;
 import io.ballerina.compiler.syntax.tree.AnnotationNode;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.BracedExpressionNode;
+import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.ByteArrayLiteralNode;
 import io.ballerina.compiler.syntax.tree.CaptureBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ConditionalExpressionNode;
 import io.ballerina.compiler.syntax.tree.ConstantDeclarationNode;
 import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
 import io.ballerina.compiler.syntax.tree.EnumDeclarationNode;
 import io.ballerina.compiler.syntax.tree.EnumMemberNode;
+import io.ballerina.compiler.syntax.tree.ErrorConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExplicitAnonymousFunctionExpressionNode;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.IdentifierToken;
+import io.ballerina.compiler.syntax.tree.ImplicitAnonymousFunctionExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ImportDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ImportPrefixNode;
+import io.ballerina.compiler.syntax.tree.IndexedExpressionNode;
+import io.ballerina.compiler.syntax.tree.LetExpressionNode;
 import io.ballerina.compiler.syntax.tree.LetVariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.ListConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.MethodDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleVariableDeclarationNode;
 import io.ballerina.compiler.syntax.tree.ModuleXMLNamespaceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.NamedWorkerDeclarationNode;
+import io.ballerina.compiler.syntax.tree.NilLiteralNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NodeTransformer;
+import io.ballerina.compiler.syntax.tree.ObjectConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.ObjectFieldNode;
+import io.ballerina.compiler.syntax.tree.OptionalFieldAccessExpressionNode;
 import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.QueryExpressionNode;
 import io.ballerina.compiler.syntax.tree.RecordFieldNode;
 import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.TableConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.TemplateExpressionNode;
 import io.ballerina.compiler.syntax.tree.Token;
+import io.ballerina.compiler.syntax.tree.TransactionalExpressionNode;
+import io.ballerina.compiler.syntax.tree.TrapExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
 import io.ballerina.compiler.syntax.tree.TypeDefinitionNode;
 import io.ballerina.compiler.syntax.tree.TypeReferenceNode;
 import io.ballerina.compiler.syntax.tree.TypeReferenceTypeDescNode;
+import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
 import io.ballerina.compiler.syntax.tree.TypedBindingPatternNode;
+import io.ballerina.compiler.syntax.tree.TypeofExpressionNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import io.ballerina.compiler.syntax.tree.XMLFilterExpressionNode;
 import io.ballerina.compiler.syntax.tree.XMLNamespaceDeclarationNode;
+import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
 import io.ballerina.tools.diagnostics.Location;
 
 import java.util.Optional;
@@ -258,6 +290,170 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
     @Override
     public Optional<Location> transform(IdentifierToken identifier) {
         return Optional.of(identifier.location());
+    }
+
+    // Nodes relevant for type()
+
+    @Override
+    public Optional<Location> transform(NilLiteralNode nilLiteralNode) {
+        return Optional.of(nilLiteralNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(BasicLiteralNode basicLiteralNode) {
+        return basicLiteralNode.literalToken().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(ByteArrayLiteralNode byteArrayLiteralNode) {
+        return Optional.of(byteArrayLiteralNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TemplateExpressionNode templateExpressionNode) {
+        return Optional.of(templateExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(ListConstructorExpressionNode listConstructorExpressionNode) {
+        return Optional.of(listConstructorExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TableConstructorExpressionNode tableConstructorExpressionNode) {
+        return Optional.of(tableConstructorExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(MappingConstructorExpressionNode mappingConstructorExpressionNode) {
+        return Optional.of(mappingConstructorExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(ObjectConstructorExpressionNode objectConstructorExpressionNode) {
+        return Optional.of(objectConstructorExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(ExplicitNewExpressionNode explicitNewExpressionNode) {
+        return Optional.of(explicitNewExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(ImplicitNewExpressionNode implicitNewExpressionNode) {
+        return Optional.of(implicitNewExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode) {
+        return builtinSimpleNameReferenceNode.name().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(FieldAccessExpressionNode fieldAccessExpressionNode) {
+        return Optional.of(fieldAccessExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(OptionalFieldAccessExpressionNode optionalFieldAccessExpressionNode) {
+        return Optional.of(optionalFieldAccessExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(AnnotAccessExpressionNode annotAccessExpressionNode) {
+        return Optional.of(annotAccessExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(IndexedExpressionNode indexedExpressionNode) {
+        return Optional.of(indexedExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(ErrorConstructorExpressionNode errorConstructorExpressionNode) {
+        return Optional.of(errorConstructorExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(
+            ExplicitAnonymousFunctionExpressionNode explicitAnonymousFunctionExpressionNode) {
+        return Optional.of(explicitAnonymousFunctionExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(
+            ImplicitAnonymousFunctionExpressionNode implicitAnonymousFunctionExpressionNode) {
+        return Optional.of(implicitAnonymousFunctionExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(LetExpressionNode letExpressionNode) {
+        return Optional.of(letExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TypeCastExpressionNode typeCastExpressionNode) {
+        return Optional.of(typeCastExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TypeofExpressionNode typeofExpressionNode) {
+        return Optional.of(typeofExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(UnaryExpressionNode unaryExpressionNode) {
+        return Optional.of(unaryExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TypeTestExpressionNode typeTestExpressionNode) {
+        return Optional.of(typeTestExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(BinaryExpressionNode binaryExpressionNode) {
+        return Optional.of(binaryExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(ConditionalExpressionNode conditionalExpressionNode) {
+        return Optional.of(conditionalExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(CheckExpressionNode checkExpressionNode) {
+        return Optional.of(checkExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TrapExpressionNode trapExpressionNode) {
+        return Optional.of(trapExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(QueryExpressionNode queryExpressionNode) {
+        return Optional.of(queryExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(XMLFilterExpressionNode xmlFilterExpressionNode) {
+        return Optional.of(xmlFilterExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(XMLStepExpressionNode xmlStepExpressionNode) {
+        return Optional.of(xmlStepExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(TransactionalExpressionNode transactionalExpressionNode) {
+        return Optional.of(transactionalExpressionNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(BracedExpressionNode bracedExpressionNode) {
+        return bracedExpressionNode.expression().apply(this);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -29,6 +29,7 @@ import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnyType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BAnydataType;
@@ -57,6 +58,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLSubType;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BXMLType;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -294,7 +296,7 @@ public class TypesFactory {
         final TypeKind kind = bType.getKind();
         return kind == RECORD || kind == OBJECT || bType.tsymbol.isLabel
                 || bType instanceof BIntSubType || bType instanceof BStringSubType || bType instanceof BXMLSubType
-                || bType.tsymbol.kind == SymbolKind.ENUM;
+                || bType.tsymbol.kind == SymbolKind.ENUM || isCustomError(bType.tsymbol);
     }
 
     public static TypeDescKind getTypeDescKind(TypeKind bTypeKind) {
@@ -364,5 +366,9 @@ public class TypesFactory {
             default:
                 return null;
         }
+    }
+
+    private static boolean isCustomError(BTypeSymbol tSymbol) {
+        return tSymbol.kind == SymbolKind.ERROR && !Names.ERROR.equals(tSymbol.name);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2699,6 +2699,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             BLangConstrainedType constrainedType = (BLangConstrainedType) TreeBuilder.createConstrainedTypeNode();
             constrainedType.type = refType;
             constrainedType.constraint = createTypeNode(node.get().typeNode());
+            constrainedType.pos = getPosition(typedescTypeDescriptorNode);
             return constrainedType;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -526,6 +526,16 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                 endPos.offset());
     }
 
+    private Location getPosition(Node startNode, Node endNode) {
+        if (startNode == null || endNode == null) {
+            return null;
+        }
+        LinePosition startPos = startNode.lineRange().startLine();
+        LinePosition endPos = endNode.lineRange().endLine();
+        return new BLangDiagnosticLocation(currentCompUnitName, startPos.line(), endPos.line(),
+                                           startPos.offset(), endPos.offset());
+    }
+
     private Location getPositionWithoutMetadata(Node node) {
         if (node == null) {
             return null;
@@ -2123,7 +2133,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         } else {
             BLangTableMultiKeyExpr multiKeyExpr =
                     (BLangTableMultiKeyExpr) TreeBuilder.createTableMultiKeyExpressionNode();
-            multiKeyExpr.pos = getPosition(indexedExpressionNode);
+            multiKeyExpr.pos = getPosition(keys.get(0), keys.get(keys.size() - 1));
             List<BLangExpression> multiKeyIndexExprs = new ArrayList<>();
             for (io.ballerina.compiler.syntax.tree.ExpressionNode keyExpr : keys) {
                 multiKeyIndexExprs.add(createExpression(keyExpr));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByAccessExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByAccessExprTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.AnnotAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.IndexedExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.OptionalFieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of access exprs.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByAccessExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_access_expr.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(FieldAccessExpressionNode fieldAccessExpressionNode) {
+                if (((SimpleNameReferenceNode) fieldAccessExpressionNode.fieldName()).name().text().equals("name")) {
+                    assertType(fieldAccessExpressionNode, model, STRING);
+                } else {
+                    Optional<TypeSymbol> type = assertType(fieldAccessExpressionNode, model, UNION);
+                    assertUnionMembers((UnionTypeSymbol) type.get(), STRING, ERROR);
+                }
+            }
+
+            @Override
+            public void visit(OptionalFieldAccessExpressionNode optionalFieldAccessExpressionNode) {
+                TypeDescKind[] kinds;
+                if (((SimpleNameReferenceNode) optionalFieldAccessExpressionNode.fieldName())
+                        .name().text().equals("age")) {
+                    kinds = new TypeDescKind[]{INT, NIL};
+                } else {
+                    kinds = new TypeDescKind[]{STRING, ERROR, NIL};
+                }
+
+                Optional<TypeSymbol> type = assertType(optionalFieldAccessExpressionNode, model, UNION);
+                assertUnionMembers((UnionTypeSymbol) type.get(), kinds);
+            }
+
+            @Override
+            public void visit(IndexedExpressionNode indexedExpressionNode) {
+                if (indexedExpressionNode.keyExpression().size() == 1) {
+                    assertType(indexedExpressionNode, model, STRING);
+                } else {
+                    Optional<TypeSymbol> type = assertType(indexedExpressionNode, model, TYPE_REFERENCE);
+                    assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "Person");
+                    assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), RECORD);
+                }
+            }
+
+            @Override
+            public void visit(AnnotAccessExpressionNode annotAccessExpressionNode) {
+                Optional<TypeSymbol> type = assertType(annotAccessExpressionNode, model, UNION);
+                List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
+                assertEquals(members.get(0).typeKind(), TYPE_REFERENCE);
+                assertEquals(((TypeReferenceTypeSymbol) members.get(0)).name(), "Annot");
+                assertEquals(members.get(1).typeKind(), NIL);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 7);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+
+    private void assertUnionMembers(UnionTypeSymbol type, TypeDescKind... kinds) {
+        List<TypeSymbol> members = type.memberTypeDescriptors();
+        for (int i = 0; i < kinds.length; i++) {
+            assertEquals(members.get(i).typeKind(), kinds[i]);
+        }
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByAnonFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByAnonFunctionTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExplicitAnonymousFunctionExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitAnonymousFunctionExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FUNCTION;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of anonymous functions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByAnonFunctionTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_anon_function.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(ExplicitAnonymousFunctionExpressionNode explicitAnonymousFunctionExpressionNode) {
+                assertType(explicitAnonymousFunctionExpressionNode, model, FUNCTION);
+            }
+
+            @Override
+            public void visit(ImplicitAnonymousFunctionExpressionNode implicitAnonymousFunctionExpressionNode) {
+                assertType(implicitAnonymousFunctionExpressionNode, model, FUNCTION);
+                assertType(implicitAnonymousFunctionExpressionNode.params(), model, STRING);
+            }
+
+            @Override
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertType(functionCallExpressionNode, model, FUNCTION);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 4);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByCallExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByCallExprTest.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of call expressions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByCallExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_call_expr.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(FunctionCallExpressionNode functionCallExpressionNode) {
+                assertType(functionCallExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(MethodCallExpressionNode methodCallExpressionNode) {
+                assertType(methodCallExpressionNode, model, STRING);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 2);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByConstructorExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByConstructorExprTest.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ErrorConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.ListConstructorExpressionNode;
@@ -34,6 +35,7 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
@@ -92,11 +94,22 @@ public class TypeByConstructorExprTest extends TypeByNodeTest {
                 assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "PersonObj");
                 assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
             }
+
+            @Override
+            public void visit(ErrorConstructorExpressionNode errorConstructorExpressionNode) {
+                if (errorConstructorExpressionNode.typeReference().isEmpty()) {
+                    assertType(errorConstructorExpressionNode, model, ERROR);
+                } else {
+                    Optional<TypeSymbol> type = assertType(errorConstructorExpressionNode, model, TYPE_REFERENCE);
+                    assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "TimeOutError");
+                    assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), ERROR);
+                }
+            }
         };
     }
 
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 6);
+        assertEquals(getAssertCount(), 8);
     }
 
     private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByConstructorExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByConstructorExprTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ImplicitNewExpressionNode;
+import io.ballerina.compiler.syntax.tree.ListConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.MappingConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.ObjectConstructorExpressionNode;
+import io.ballerina.compiler.syntax.tree.TableConstructorExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.RECORD;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TABLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of constructor expressions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByConstructorExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_constructor_expr_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(ListConstructorExpressionNode listConstructorExpressionNode) {
+                assertType(listConstructorExpressionNode, model, TUPLE);
+            }
+
+            @Override
+            public void visit(MappingConstructorExpressionNode mappingConstructorExpressionNode) {
+                assertType(mappingConstructorExpressionNode, model, RECORD);
+            }
+
+            @Override
+            public void visit(TableConstructorExpressionNode tableConstructorExpressionNode) {
+                assertType(tableConstructorExpressionNode, model, TABLE);
+            }
+
+            @Override
+            public void visit(ObjectConstructorExpressionNode objectConstructorExpressionNode) {
+                assertType(objectConstructorExpressionNode, model, OBJECT);
+            }
+
+            @Override
+            public void visit(ExplicitNewExpressionNode explicitNewExpressionNode) {
+                Optional<TypeSymbol> type = assertType(explicitNewExpressionNode, model, TYPE_REFERENCE);
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "PersonObj");
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
+            }
+
+            @Override
+            public void visit(ImplicitNewExpressionNode implicitNewExpressionNode) {
+                Optional<TypeSymbol> type = assertType(implicitNewExpressionNode, model, TYPE_REFERENCE);
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "PersonObj");
+                assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 6);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByErrorHandlingExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByErrorHandlingExprTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.CheckExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TrapExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of checking exprs, trap expr etc.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByErrorHandlingExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_error_handling_exprs.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(CheckExpressionNode checkExpressionNode) {
+                assertType(checkExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(TrapExpressionNode trapExpressionNode) {
+                Optional<TypeSymbol> type = assertType(trapExpressionNode, model, UNION);
+                List<TypeSymbol> members = ((UnionTypeSymbol) type.get()).memberTypeDescriptors();
+                assertEquals(members.get(0).typeKind(), NIL);
+                assertEquals(members.get(1).typeKind(), ERROR);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByLiteralTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByLiteralTest.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.BasicLiteralNode;
+import io.ballerina.compiler.syntax.tree.ByteArrayLiteralNode;
+import io.ballerina.compiler.syntax.tree.NilLiteralNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BYTE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of basic literals.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByLiteralTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_literal.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        Map<String, TypeDescKind> literalKinds = new HashMap<>();
+        literalKinds.put("5", INT);
+        literalKinds.put("12.34", FLOAT);
+        literalKinds.put("34.5d", DECIMAL);
+        literalKinds.put("true", BOOLEAN);
+        literalKinds.put("\"foo\"", STRING);
+        literalKinds.put("null", NIL);
+        literalKinds.put("base64 `SGVsbG8gQmFsbGVyaW5h`", ARRAY);
+
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(NilLiteralNode nilLiteralNode) {
+                assertType(nilLiteralNode, model, NIL);
+            }
+
+            @Override
+            public void visit(ByteArrayLiteralNode byteArrayLiteralNode) {
+                Optional<TypeSymbol> type = assertType(byteArrayLiteralNode, model, ARRAY);
+                assertEquals(((ArrayTypeSymbol) type.get()).memberTypeDescriptor().typeKind(), BYTE);
+                incrementAssertCount();
+            }
+
+            @Override
+            public void visit(BasicLiteralNode basicLiteralNode) {
+                assertType(basicLiteralNode, model, literalKinds.get(basicLiteralNode.literalToken().text()));
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 9);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByMiscExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByMiscExprTest.java
@@ -30,6 +30,7 @@ import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
 import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
 import io.ballerina.compiler.syntax.tree.XMLFilterExpressionNode;
 import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
+import org.ballerinalang.model.tree.OperatorKind;
 import org.testng.annotations.Test;
 
 import java.util.Optional;
@@ -66,20 +67,20 @@ public class TypeByMiscExprTest extends TypeByNodeTest {
             @Override
             public void visit(BinaryExpressionNode binaryExpressionNode) {
                 TypeDescKind typeKind;
-                switch (binaryExpressionNode.operator().text()) {
-                    case "-":
-                    case "*":
-                    case "+":
-                    case "/":
+                switch (OperatorKind.valueFrom(binaryExpressionNode.operator().text())) {
+                    case SUB:
+                    case MUL:
+                    case ADD:
+                    case DIV:
                         typeKind = INT;
                         break;
-                    case ">=":
-                    case "!=":
-                    case "==":
-                    case "&&":
+                    case GREATER_EQUAL:
+                    case NOT_EQUAL:
+                    case EQUAL:
+                    case AND:
                         typeKind = BOOLEAN;
                         break;
-                    case "...":
+                    case CLOSED_RANGE:
                         typeKind = OBJECT;
                         break;
                     default:

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByMiscExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByMiscExprTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.BinaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.ConditionalExpressionNode;
+import io.ballerina.compiler.syntax.tree.LetExpressionNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
+import io.ballerina.compiler.syntax.tree.UnaryExpressionNode;
+import io.ballerina.compiler.syntax.tree.XMLFilterExpressionNode;
+import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of misc. exprs.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByMiscExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_misc_exprs.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+            @Override
+            public void visit(UnaryExpressionNode unaryExpressionNode) {
+                assertType(unaryExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(BinaryExpressionNode binaryExpressionNode) {
+                TypeDescKind typeKind;
+                switch (binaryExpressionNode.operator().text()) {
+                    case "-":
+                    case "*":
+                    case "+":
+                    case "/":
+                        typeKind = INT;
+                        break;
+                    case ">=":
+                    case "!=":
+                    case "==":
+                    case "&&":
+                        typeKind = BOOLEAN;
+                        break;
+                    case "...":
+                        typeKind = OBJECT;
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+
+                assertType(binaryExpressionNode, model, typeKind);
+                binaryExpressionNode.rhsExpr().accept(this);
+                binaryExpressionNode.lhsExpr().accept(this);
+            }
+
+            @Override
+            public void visit(TypeTestExpressionNode typeTestExpressionNode) {
+                assertType(typeTestExpressionNode, model, BOOLEAN);
+            }
+
+            @Override
+            public void visit(ConditionalExpressionNode conditionalExpressionNode) {
+                assertType(conditionalExpressionNode, model, STRING);
+                conditionalExpressionNode.lhsExpression().accept(this);
+            }
+
+            @Override
+            public void visit(LetExpressionNode letExpressionNode) {
+                assertType(letExpressionNode, model, INT);
+            }
+
+            @Override
+            public void visit(XMLFilterExpressionNode xmlFilterExpressionNode) {
+                assertType(xmlFilterExpressionNode, model, XML);
+            }
+
+            @Override
+            public void visit(XMLStepExpressionNode xmlStepExpressionNode) {
+                assertType(xmlStepExpressionNode, model, XML);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 16);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByNodeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByNodeTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.SyntaxTree;
+import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.ModuleId;
+import io.ballerina.projects.Package;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for getting the type of an expression by giving the relevant syntax tree node as an arg.
+ *
+ * @since 2.0.0
+ */
+public abstract class TypeByNodeTest {
+
+    private int assertCount = 0;
+
+    @Test
+    public void testLookup() {
+        Project project = BCompileUtil.loadProject(getTestSourcePath());
+        Package currentPackage = project.currentPackage();
+        ModuleId defaultModuleId = currentPackage.getDefaultModule().moduleId();
+        DocumentId docId = currentPackage.getDefaultModule().documentIds().iterator().next();
+        SyntaxTree syntaxTree = currentPackage.getDefaultModule().document(docId).syntaxTree();
+        SemanticModel model = currentPackage.getCompilation().getSemanticModel(defaultModuleId);
+        syntaxTree.rootNode().accept(getNodeVisitor(model));
+        verifyAssertCount();
+    }
+
+    abstract String getTestSourcePath();
+
+    abstract NodeVisitor getNodeVisitor(SemanticModel model);
+
+    abstract void verifyAssertCount();
+
+    void incrementAssertCount() {
+        this.assertCount++;
+    }
+
+    int getAssertCount() {
+        return this.assertCount;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByReferenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByReferenceTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.BuiltinSimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.QualifiedNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of name references.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByReferenceTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_reference_test.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(SimpleNameReferenceNode simpleNameReferenceNode) {
+                assertType(simpleNameReferenceNode, model, FLOAT);
+            }
+
+            @Override
+            public void visit(QualifiedNameReferenceNode qualifiedNameReferenceNode) {
+                assertType(qualifiedNameReferenceNode, model, INT);
+            }
+
+            @Override
+            public void visit(BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode) {
+                TypeDescKind typeKind;
+                switch (builtinSimpleNameReferenceNode.kind()) {
+                    case FLOAT_TYPE_DESC:
+                        typeKind = FLOAT;
+                        break;
+                    case INT_TYPE_DESC:
+                        typeKind = INT;
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+                assertType(builtinSimpleNameReferenceNode, model, typeKind);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 4);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByTemplateExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByTemplateExprTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TemplateExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of template expressions.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByTemplateExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_template_expr.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(TemplateExpressionNode templateExpressionNode) {
+                TypeDescKind expTypeKind;
+                switch (templateExpressionNode.kind()) {
+                    case STRING_TEMPLATE_EXPRESSION:
+                        expTypeKind = STRING;
+                        break;
+                    case XML_TEMPLATE_EXPRESSION:
+                        expTypeKind = XML;
+                        break;
+                    case RAW_TEMPLATE_EXPRESSION:
+                        expTypeKind = TYPE_REFERENCE;
+                        break;
+                    default:
+                        throw new IllegalStateException();
+                }
+
+                assertType(templateExpressionNode, model, expTypeKind);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
+    private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+
+        if (typeKind == TYPE_REFERENCE) {
+            assertEquals(((TypeReferenceTypeSymbol) type.get()).name(), "RawTemplate");
+            assertEquals(((TypeReferenceTypeSymbol) type.get()).typeDescriptor().typeKind(), OBJECT);
+        }
+
+        incrementAssertCount();
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByTypeExprTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByTypeExprTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typebynode;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NodeVisitor;
+import io.ballerina.compiler.syntax.tree.TypeCastExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeTestExpressionNode;
+import io.ballerina.compiler.syntax.tree.TypeofExpressionNode;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.BOOLEAN;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPEDESC;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests for getting the type of typeof and type cast exprs.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class TypeByTypeExprTest extends TypeByNodeTest {
+
+    @Override
+    String getTestSourcePath() {
+        return "test-src/type-by-node/type_by_type_exprs.bal";
+    }
+
+    @Override
+    NodeVisitor getNodeVisitor(SemanticModel model) {
+        return new NodeVisitor() {
+
+            @Override
+            public void visit(TypeCastExpressionNode typeCastExpressionNode) {
+                assertType(typeCastExpressionNode, model, STRING);
+            }
+
+            @Override
+            public void visit(TypeofExpressionNode typeofExpressionNode) {
+                assertType(typeofExpressionNode, model, TYPEDESC);
+            }
+
+            @Override
+            public void visit(TypeTestExpressionNode typeTestExpressionNode) {
+                assertType(typeTestExpressionNode, model, BOOLEAN);
+            }
+        };
+    }
+
+    void verifyAssertCount() {
+        assertEquals(getAssertCount(), 3);
+    }
+
+    private Optional<TypeSymbol> assertType(Node node, SemanticModel model, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(node);
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        incrementAssertCount();
+        return type;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_access_expr.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_access_expr.bal
@@ -1,0 +1,58 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+
+type Person record {
+    readonly int id;
+    readonly string name;
+    string lname;
+};
+
+type Annot record {
+    string foo;
+};
+
+@v1 {
+    foo: "bar"
+}
+public type T1 record {
+    string name;
+};
+
+public annotation Annot v1 on type;
+
+function test() {
+    record {|
+        string name;
+        int age?;
+    |} person = {name: "John", age: 20};
+
+    string name = person.name;
+    int? age = person?.age;
+    string optName = person["name"];
+
+    table<Person> key(id, name) tbl = table [{ id: 13 , name: "Sanjiva", lname: "Weerawarana" },
+                                             { id: 23 , name: "James" , lname: "Clark" }];
+    Person p = tbl[13, "Sanjiva"];
+
+    xml x = xml `<root attr="attr-val"><a></a><b></b></root>`;
+    string|error val1 = x.attr;
+    string|error|() val2 = x?.attr;
+
+    T1 a = { name: "John" };
+    typedesc<any> t = typeof a;
+    Annot? annot = t.@v1;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_anon_function.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_anon_function.bal
@@ -1,0 +1,24 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    var fn = function (int x, int y) returns int => x + y;
+    var fn2 = foo();
+}
+
+function foo() returns function (string s) returns int {
+    return s => 20;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_call_expr.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_call_expr.bal
@@ -15,32 +15,14 @@
 // under the License.
 
 function test() {
-    [int, string, float] tup = [10, "foo", 12.34];
-
-    record {|
-        string name;
-        int age;
-    |} person = {name: "John Doe", age: 20};
-
-    var tab = table [{"name":"John Doe", age:24}];
-
-    object {
-        string name;
-        function getName() returns string;
-    } person = object {
-        string name = "Anon";
-
-        function getName() returns string => self.name;
-    };
-
-    PersonObj p1 = new("Pubudu");
-    PersonObj p2 = new PersonObj("Pubudu");
-
-    error err1 = error("IOError");
-    TimeOutError err2 = error TimeOutError("TimeOutError", url = "https://ballerina.io");
+    int sum = add(10, 20);
+    Person p = new("Pubudu");
+    string name = p.getName();
 }
 
-class PersonObj {
+function add(int x, int y) returns int => x + y;
+
+class Person {
     string name;
 
     function init(string name) {
@@ -49,11 +31,3 @@ class PersonObj {
 
     function getName() returns string => self.name;
 }
-
-type TimeOutErrorData record {|
-    string message = "";
-    error cause?;
-    string url;
-|};
-
-type TimeOutError error<TimeOutErrorData>;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_constructor_expr_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_constructor_expr_test.bal
@@ -1,0 +1,48 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    [int, string, float] tup = [10, "foo", 12.34];
+
+    record {|
+        string name;
+        int age;
+    |} person = {name: "John Doe", age: 20};
+
+    var tab = table [{"name":"John Doe", age:24}];
+
+    object {
+        string name;
+        function getName() returns string;
+    } person = object {
+        string name = "Anon";
+
+        function getName() returns string => self.name;
+    };
+
+    PersonObj p1 = new("Pubudu");
+    PersonObj p2 = new PersonObj("Pubudu");
+}
+
+class PersonObj {
+    string name;
+
+    function init(string name) {
+        self.name = name;
+    }
+
+    function getName() returns string => self.name;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_error_handling_exprs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_error_handling_exprs.bal
@@ -14,40 +14,17 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function test() {
-    [int, string, float] tup = [10, "foo", 12.34];
-
-    record {|
-        string name;
-        int age;
-    |} person = {name: "John Doe", age: 20};
-
-    var tab = table [{"name":"John Doe", age:24}];
-
-    object {
-        string name;
-        function getName() returns string;
-    } person = object {
-        string name = "Anon";
-
-        function getName() returns string => self.name;
-    };
-
-    PersonObj p1 = new("Pubudu");
-    PersonObj p2 = new PersonObj("Pubudu");
-
-    error err1 = error("IOError");
-    TimeOutError err2 = error TimeOutError("TimeOutError", url = "https://ballerina.io");
+function test() returns error {
+    var x = check foo();
+    var y = checkpanic foo();
+    var z = trap bar();
 }
 
-class PersonObj {
-    string name;
+function foo() returns int|error => 10;
 
-    function init(string name) {
-        self.name = name;
-    }
-
-    function getName() returns string => self.name;
+function bar() {
+    TimeOutError terr = error TimeOutError("TimeOutError", url = "https://ballerina.io");
+    panic terr;
 }
 
 type TimeOutErrorData record {|

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_literal.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_literal.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    anydata[] arr = [5, 12.34, 34.5d, true, (), "foo"];
+    json j = null;
+    byte[] b = base64 `SGVsbG8gQmFsbGVyaW5h`;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_misc_exprs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_misc_exprs.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    int x = -20;
+    int y = 10 * 20 / 5;
+    int z = 10 + 20 - 5;
+    boolean b = y >= z;
+    anydata ad = "foo";
+
+    if (ad is string && y != 0) {
+        string s = ad;
+    }
+
+    string greeting = ad == "" ? "Hello" : string:concat("Hello ", ad.toString());
+
+    _ = let int e = 4 in 3 * x;
+
+    var range = 1...10;
+
+    xmlns "http://ballerina.io/c" as ns1;
+
+    xml x1 = xml `<root ns0:id="456">
+                    <foo>123</foo>
+                    <bar ns1:status="complete"></bar>
+                  </root>`;
+
+    xml x2 = x1.<ns0:*>;
+    xml x3 = x1.<ns0:*|ns1:*>;
+    xml x4 = x1/<ns1:child>;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_reference_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_reference_test.bal
@@ -1,0 +1,22 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const PI = 3.14;
+
+function test() {
+    float area = PI * 10 * 10;
+    int max = 'int:MAX_VALUE;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_template_expr.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_template_expr.bal
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    string s = string `Hello World!`;
+    xml x = xml `<Greeting>Hello!</Greeting>`;
+    'object:RawTemplate rt = `${s} from Ballerina`;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_type_exprs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_type_exprs.bal
@@ -1,0 +1,26 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    any a = "Hello World!";
+    string s = <string>a;
+
+    typedesc<any> td = typeof a;
+
+    if (a is string) {
+        a = "Hello Pubudu!";
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -64,10 +64,16 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByWorkerTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByXMLNSTest" />
 
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByAccessExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByAnonFunctionTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByCallExprTest" />
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByConstructorExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByErrorHandlingExprTest" />
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByLiteralTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByMiscExprTest" />
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByReferenceTest" />
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByTemplateExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByTypeExprTest" />
         </classes>
     </test>
 </suite>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -63,6 +63,11 @@
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByVarDeclNegativeTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByWorkerTest" />
             <class name="io.ballerina.semantic.api.test.symbolbynode.SymbolByXMLNSTest" />
+
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByConstructorExprTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByLiteralTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByReferenceTest" />
+            <class name="io.ballerina.semantic.api.test.typebynode.TypeByTemplateExprTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR adds an overloaded version of `type()` which accepts a syntax tree node as the argument. If the node is a valid expression node, this method will return its type. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
