### PR TITLE
Fix configuration argument passing inconsistency in tests

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -381,7 +381,7 @@ public class RunTestsTask implements Task {
         cmdArgs.add(target.path().toString());
         cmdArgs.add(orgName);
         cmdArgs.add(packageName);
-        cmdArgs.add(moduleName.isEmpty() ? "\"\"" : moduleName); // see JDK-7028124
+        cmdArgs.add("\"" + moduleName + "\""); // see JDK-7028124
         ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
         Process proc = processBuilder.start();
         return proc.waitFor();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -381,7 +381,7 @@ public class RunTestsTask implements Task {
         cmdArgs.add(target.path().toString());
         cmdArgs.add(orgName);
         cmdArgs.add(packageName);
-        cmdArgs.add(moduleName.isEmpty() ? "''" : moduleName); // see JDK-7028124
+        cmdArgs.add(moduleName.isEmpty() ? "\"\"" : moduleName); // see JDK-7028124
         ProcessBuilder processBuilder = new ProcessBuilder(cmdArgs).inheritIO();
         Process proc = processBuilder.start();
         return proc.waitFor();

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
@@ -56,9 +56,9 @@ public class Main {
     }
 
     private static String filterModuleName(String argument) {
-        //Empty string needs to be passed for default module
-        if (argument.startsWith("\"") && argument.endsWith("\"") && argument.length() == 2) {
-            return "";
+        //The module argument is always wrapped with a `\"` at start and end
+        if (argument.startsWith("\"") && argument.endsWith("\"") && argument.length() >= 2) {
+            return argument.substring(1, argument.length() - 1);
         }
         return argument;
     }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
@@ -50,9 +50,17 @@ public class Main {
             //convert the json string back to object
             Gson gson = new Gson();
             TestSuite response = gson.fromJson(br, TestSuite.class);
-            response.setModuleName(args[args.length - 1]);
+            response.setModuleName(filterModuleName(args[args.length - 1]));
             startTestSuit(Paths.get(response.getSourceRootPath()), response, jsonTmpSummaryPath);
         }
+    }
+
+    private static String filterModuleName(String argument) {
+        //Empty string needs to be passed for default module
+        if (argument.startsWith("\"") && argument.endsWith("\"") && argument.length() == 2) {
+            return "";
+        }
+        return argument;
     }
 
     private static void startTestSuit(Path sourceRootPath, TestSuite testSuite, Path jsonTmpSummaryPath)


### PR DESCRIPTION
## Purpose
$subject 
This fixes the inconsistency between windows & ubuntu builds in test argument passing
Fixes build failures in [#174](https://github.com/ballerina-platform/module-ballerina-http/pull/174) 

## Approach
Since the build failures are due to a test argument passed as an empty string for module name. 
This created inconsistencies in windows and ubuntu systems. 
The fix uses `\"\"` instead of empty string for default modules.

## Samples
N/A

## Remarks
N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
