### PR TITLE
Improve invalid import declaration handling in single file projects

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -262,6 +262,10 @@ class ModuleContext {
             for (ModuleLoadRequest modLoadRequest : moduleLoadRequests) {
                 PackageOrg packageOrg;
                 if (modLoadRequest.orgName().isEmpty()) {
+                    if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
+                        // This is an invalid import in a single file project.
+                        continue;
+                    }
                     packageOrg = descriptor().org();
                 } else {
                     packageOrg = modLoadRequest.orgName().get();

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageResolution.java
@@ -222,6 +222,10 @@ public class PackageResolution {
             PackageOrg packageOrg;
             Optional<PackageOrg> optionalOrgName = moduleLoadRequest.orgName();
             if (optionalOrgName.isEmpty()) {
+                if (rootPackageContext.project().kind() == ProjectKind.SINGLE_FILE_PROJECT) {
+                    // This is an invalid import in a single file project.
+                    continue;
+                }
                 // At the moment we don't check whether the requested module is available
                 // in the current package or not. This error will be reported during the SymbolEnter pass.
                 packageOrg = rootPackageContext.packageOrg();


### PR DESCRIPTION
This PR fixes a test failure that has occurred after the hierarchical package name change.

TestSingleFileProject.testDiagnostics()

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
