### PR TITLE
Revert "Fix path undefined error at file open"

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -20,7 +20,6 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
-import io.ballerina.projects.directory.ProjectLoader;
 import org.ballerinalang.diagramutil.DiagramUtil;
 import org.ballerinalang.langserver.LSClientLogger;
 import org.ballerinalang.langserver.LSContextOperation;
@@ -150,11 +149,14 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
                 if (filePath.isEmpty()) {
                     return ballerinaProject;
                 }
-                Project project = ProjectLoader.loadProject(filePath.get());
-                ballerinaProject.setPath(project.sourceRoot().toString());
-                ProjectKind projectKind = project.kind();
+                Optional<Project> project = this.workspaceManager.project(filePath.get());
+                if (project.isEmpty()) {
+                    return ballerinaProject;
+                }
+                ballerinaProject.setPath(project.get().sourceRoot().toString());
+                ProjectKind projectKind = project.get().kind();
                 if (projectKind != ProjectKind.SINGLE_FILE_PROJECT) {
-                    ballerinaProject.setPackageName(project.currentPackage().packageName().value());
+                    ballerinaProject.setPackageName(project.get().currentPackage().packageName().value());
                 }
                 ballerinaProject.setKind(projectKind.name());
             } catch (Throwable e) {


### PR DESCRIPTION
Reverts ballerina-platform/ballerina-lang#27993

This is due to the following error when re-initializing the project.

```
FileSystemAlreadyExistsException'}
java.nio.file.FileSystemAlreadyExistsException
	at jdk.zipfs/jdk.nio.zipfs.ZipFileSystemProvider.newFileSystem(ZipFileSystemProvider.java:102)
	at java.base/java.nio.file.FileSystems.newFileSystem(FileSystems.java:337)
	at java.base/java.nio.file.FileSystems.newFileSystem(FileSystems.java:286)
	at io.ballerina.projects.internal.BaloFiles.createManifest(BaloFiles.java:154)
	at io.ballerina.projects.internal.BaloFiles.createPackageManifest(BaloFiles.java:146)
	at io.ballerina.projects.internal.PackageConfigCreator.createBalrProjectConfig(PackageConfigCreator.java:83)
	at io.ballerina.projects.balo.BaloProject.loadProject(BaloProject.java:44)
	at io.ballerina.projects.internal.repositories.FileSystemRepository.getPackage(FileSystemRepository.java:104)
	at io.ballerina.projects.internal.environment.DefaultPackageResolver.resolveLangLibPackage(DefaultPackageResolver.java:166)
	at io.ballerina.projects.internal.environment.DefaultPackageResolver.resolveFromRepository(DefaultPackageResolver.java:115)
	at io.ballerina.projects.internal.environment.DefaultPackageResolver.resolvePackages(DefaultPackageResolver.java:79)
	at io.ballerina.projects.internal.environment.DefaultPackageResolver.resolvePackages(DefaultPackageResolver.java:97)
	at io.ballerina.projects.Bootstrap.loadLangLibFromBalr(Bootstrap.java:176)
	at io.ballerina.projects.Bootstrap.loadLangLibFromBalr(Bootstrap.java:170)
	at io.ballerina.projects.Bootstrap.loadLangLibSymbols(Bootstrap.java:138)
	at io.ballerina.projects.internal.environment.BallerinaDistribution.loadLangLibPackages(BallerinaDistribution.java:69)
	at io.ballerina.projects.environment.EnvironmentBuilder.build(EnvironmentBuilder.java:96)
	at io.ballerina.projects.environment.EnvironmentBuilder.buildDefault(EnvironmentBuilder.java:50)
	at io.ballerina.projects.ProjectEnvironmentBuilder.getDefaultBuilder(ProjectEnvironmentBuilder.java:49)
	at io.ballerina.projects.directory.ProjectLoader.loadProject(ProjectLoader.java:40)
	at org.ballerinalang.langserver.extensions.ballerina.document.BallerinaDocumentServiceImpl.lambda$project$7(BallerinaDocumentServiceImpl.java:153)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1700)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.exec(CompletableFuture.java:1692)
	at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
	at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
	at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
	at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
	at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:183)
```
