### PR TITLE
Restrict loop alteration from separate functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -684,7 +684,10 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
 
     MULTIPLE_RECEIVE_ACTION_NOT_YET_SUPPORTED("BCE3985", "multiple.receive.action.not.yet.supported"),
 
-    INVALID_READONLY_FIELD_TYPE("BCE3986", "invalid.readonly.field.type")
+    INVALID_READONLY_FIELD_TYPE("BCE3986", "invalid.readonly.field.type"),
+
+    CONTINUE_NOT_ALLOWED("BCE3987", "continue.not.allowed"),
+    BREAK_NOT_ALLOWED("BCE3988", "break.not.allowed")
     ;
 
     private String diagnosticId;

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1661,5 +1661,6 @@ error.invalid.field.in.object.constructor.expr.with.readonly.reference=\
 
 error.multiple.receive.action.not.yet.supported=multiple receive action not yet supported
 
-error.invalid.readonly.field.type=\
-  invalid ''readonly'' field, ''{0}'' can never be ''readonly''
+error.continue.not.allowed=continue not allowed here
+
+error.break.not.allowed=break not allowed here

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1661,6 +1661,9 @@ error.invalid.field.in.object.constructor.expr.with.readonly.reference=\
 
 error.multiple.receive.action.not.yet.supported=multiple receive action not yet supported
 
+error.invalid.readonly.field.type=\
+  invalid ''readonly'' field, ''{0}'' can never be ''readonly''
+
 error.continue.not.allowed=continue not allowed here
 
 error.break.not.allowed=break not allowed here

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/breakstatement/BreakStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/breakstatement/BreakStmtTest.java
@@ -107,9 +107,10 @@ public class BreakStmtTest {
 
     @Test(description = "Check not reachable statements.")
     public void testNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 2);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 3);
         BAssertUtil.validateError(negativeCompileResult, 0, "break cannot be used outside of a loop", 15, 5);
         BAssertUtil.validateError(negativeCompileResult, 1, "unreachable code", 31, 13);
+        BAssertUtil.validateError(negativeCompileResult, 2, "break not allowed here", 45, 17);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/continuestatement/ContinueStmtTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/continuestatement/ContinueStmtTest.java
@@ -98,9 +98,10 @@ public class ContinueStmtTest {
 
     @Test(description = "Check invalid continue statement location.")
     public void testNegative() {
-        Assert.assertEquals(negativeCompileResult.getErrorCount(), 2);
+        Assert.assertEquals(negativeCompileResult.getErrorCount(), 3);
         BAssertUtil.validateError(negativeCompileResult, 0, "continue cannot be used outside of a loop", 15, 5);
         BAssertUtil.validateError(negativeCompileResult, 1, "unreachable code", 31, 13);
+        BAssertUtil.validateError(negativeCompileResult, 2, "continue not allowed here", 45, 17);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/breakstatement/break-stmt-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/breakstatement/break-stmt-negative.bal
@@ -34,3 +34,16 @@ function calculateExp2 (int x, int y) returns (int) {
     }
     return z;
 }
+
+function testBreakWithinInternalItr() {
+    int[] a = [1, 2, 3];
+    int[][] b = [a, a];
+
+    foreach int[] intArr in b {
+        intArr.forEach(function(int num) {
+            if num == -1 {
+                break;
+            }
+        });
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/continuestatement/continue-stmt-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/continuestatement/continue-stmt-negative.bal
@@ -34,3 +34,16 @@ function calculateExp2 (int x, int y) returns (int) {
     }
     return z;
 }
+
+function testContinueWithinInternalItr() {
+    int[] a = [1, 2, 3];
+    int[][] b = [a, a];
+
+    foreach int[] intArr in b {
+        intArr.forEach(function(int num) {
+            if num == -1 {
+                continue;
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Purpose
> During BIR generation functions are visited separately. Hence, even though a lambda function is nested within a loop, using a break/continue to alter the loop flow will be restricted from this.

Fixes #27736

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
