### PR TITLE
Deprecate moduleID() method

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -39,9 +39,12 @@ public interface Symbol {
 
     /**
      * Get the moduleID of the symbol.
-     * 
+     *
      * @return {@link ModuleID} of the symbol
+     * @deprecated This method will be removed in a later version and be replaced with a new method which will return
+     * the module symbol instead.
      */
+    @Deprecated
     ModuleID moduleID();
 
     /**


### PR DESCRIPTION
## Purpose
$subject. Because `moduleID()` will be replaced with a new method which returns the module symbol instead of the module ID.
