### PR TITLE
Disable shell-cli integrator tests

### DIFF
--- a/ballerina-shell/modules/shell-cli/src/test/resources/testng.xml
+++ b/ballerina-shell/modules/shell-cli/src/test/resources/testng.xml
@@ -17,7 +17,7 @@ under the License.
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 
 <suite name="ballerina-shell-cli-test-suite">
-    <test name="ballerina-shell-cli-test" preserve-order="true" parallel="false">
+    <test name="ballerina-shell-cli-test" preserve-order="true" parallel="false" enabled="false">
         <packages>
             <package name="io.ballerina.shell.cli.test.*"/>
         </packages>


### PR DESCRIPTION
## Purpose
Ballerina shell cli tests fails on some oses. This pull request will disable the shell-cli tests until the issue is solved.

## Approach
Disabled shell-cli module tests.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
