### PR TITLE
Fix using check with union containing readonly

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -3941,12 +3941,16 @@ public class CodeAnalyzer extends BLangNodeVisitor {
             LinkedHashSet<BType> errTypes = new LinkedHashSet<>();
             Set<BType> memTypes = ((BUnionType) bType).getMemberTypes();
             for (BType memType : memTypes) {
-                if (memType.tag == TypeTags.ERROR) {
-                    errTypes.add(memType);
+                BType memErrType = getErrorTypes(memType);
+
+                if (memErrType != symTable.semanticError) {
+                    errTypes.add(memErrType);
                 }
             }
 
-            errorType = errTypes.size() == 1 ? errTypes.iterator().next() : BUnionType.create(null, errTypes);
+            if (!errTypes.isEmpty()) {
+                errorType = errTypes.size() == 1 ? errTypes.iterator().next() : BUnionType.create(null, errTypes);
+            }
         }
 
         return errorType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExprNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExprNegativeTest.java
@@ -70,4 +70,15 @@ public class CheckedExprNegativeTest {
         BAssertUtil.validateError(compile, 0, ERROR_MISMATCH_ERR_MSG, 24, 13);
         BAssertUtil.validateError(compile, 1, ERROR_MISMATCH_ERR_MSG, 45, 17);
     }
+
+    @Test
+    public void testCheckedErrorsWithReadOnlyInUnionNegative() {
+        CompileResult compile = BCompileUtil.compile(
+                "test-src/expressions/checkedexpr/checked_expression_with_readonly_in_union_negative.bal");
+        int index = 0;
+        BAssertUtil.validateError(compile, index++, ERROR_MISMATCH_ERR_MSG, 23, 13);
+        BAssertUtil.validateError(compile, index++, ERROR_MISMATCH_ERR_MSG, 29, 13);
+        BAssertUtil.validateError(compile, index++, ERROR_MISMATCH_ERR_MSG, 37, 13);
+        Assert.assertEquals(compile.getErrorCount(), index);
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExpressionOperatorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/checkedexpr/CheckedExpressionOperatorTest.java
@@ -248,6 +248,11 @@ public class CheckedExpressionOperatorTest {
         Assert.assertFalse(((BBoolean) returns[0]).booleanValue());
     }
 
+    @Test
+    public void testCheckedErrorsWithReadOnlyInUnion() {
+        BRunUtil.invoke(result, "testCheckedErrorsWithReadOnlyInUnion");
+    }
+
     @Test(description = "Test service resource that returns an error containing check expression",
             groups = "brokenOnErrorChange")
     public void testSemanticErrorsWithResources() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expr_operator_basics.bal
@@ -1,4 +1,4 @@
-
+import ballerina/lang.value;
 function openFileSuccess(string path) returns (boolean | error) {
     return true;
 }
@@ -196,4 +196,52 @@ function testCheckInBinaryLTExpression() returns boolean|error {
     int|error a = 10;
     int|error b = 20;
     return check b < check a;
+}
+
+function baz() returns boolean|error {
+    value:Cloneable x = error("error one!");
+    any y = check x;
+    return true;
+}
+
+type CyclicUnion readonly|boolean[]|CyclicUnion[];
+
+function corge(boolean bool) returns error|int {
+    CyclicUnion x = bool ? error("error two!") : 1234;
+    any y = check x;
+    return y is int ? y : 0;
+}
+
+function testCheckedErrorsWithReadOnlyInUnion() {
+    boolean|error x = baz();
+    assertTrue(x is error);
+    error errVal = <error> x;
+    assertEquality("error one!", errVal.message());
+    assertTrue(errVal.cause() is ());
+    assertEquality(0, errVal.detail().length());
+
+    int|error y = corge(true);
+    assertTrue(y is error);
+    errVal = <error> y;
+    assertEquality("error two!", errVal.message());
+    assertTrue(errVal.cause() is ());
+    assertEquality(0, errVal.detail().length());
+
+    y = corge(false);
+    assertTrue(y is int);
+    assertEquality(1234, checkpanic y);
+}
+
+const ASSERTION_ERROR_REASON = "AssertionError";
+
+function assertTrue(anydata actual) {
+    assertEquality(true, actual);
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expression_with_readonly_in_union_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/checkedexpr/checked_expression_with_readonly_in_union_negative.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+import ballerina/lang.'value;
+
+type MyError error<record {int code;}>;
+
+function foo() returns boolean {
+    value:Cloneable x = error("error!");
+    any y = check x;
+    return true;
+}
+
+function bar() returns MyError|boolean {
+    value:Cloneable x = error("error!");
+    any y = check x;
+    return true;
+}
+
+type CyclicUnion readonly|boolean[]|CyclicUnion[];
+
+function baz() returns MyError? {
+    CyclicUnion x = <boolean[]> [true, false];
+    any y = check x;
+}


### PR DESCRIPTION
## Purpose
Fix compilation error not being logged when the return type of the enclosing function does not include error.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28081

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
