### PR TITLE
Automate version update on stdlibs

### DIFF
--- a/.github/workflows/update_dependent_versions.yml
+++ b/.github/workflows/update_dependent_versions.yml
@@ -1,0 +1,24 @@
+name: Update Stdlib Repos on Version Change
+
+on:
+    push:
+        branches:
+            - master
+        paths:
+            - 'gradle.properties'
+
+jobs:
+    update-stdlibs:
+        name: Trigger Standard Library Module Updates
+        if: github.repository_owner == 'ballerina-platform'
+        runs-on: ubuntu-latest
+        steps:
+            -   run: |
+                    curl --request \
+                    POST 'https://api.github.com/repos/ballerina-platform/ballerina-standard-library/dispatches' \
+                    --header 'Accept: application/vnd.github.v3+json' \
+                    --header 'Authorization: Bearer ${{ secrets.BALLERINA_BOT_TOKEN }}' \
+                    --header 'Content-Type: application/json' \
+                    --data-raw '{
+                        "event_type": "lang-version-update"
+                    }'


### PR DESCRIPTION
## Purpose
This will introduce a new workflow to trigger when a change occurs in the `gradle.properties` file. This workflow will trigger another workflow in the ballerina-standard-library repo, which will update all the stdlib modules with the latest ballerina lang version.

Related: [ballerina-standard-library#865](https://github.com/ballerina-platform/ballerina-standard-library/pull/865)

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
