### PR TITLE
Fix langlib empty package summaries

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -166,7 +166,7 @@ public class BallerinaDocGenerator {
                 .orElse("");
         if (!docPackage.description.equals("")) {
             docPackage.summary = BallerinaDocUtils.getSummary(docPackage.description);
-        } else if (moduleDocMap.get(docPackage.name) != null){
+        } else if (moduleDocMap.get(docPackage.name) != null) {
             // Use summary of the default module
             docPackage.summary = moduleDocMap.get(docPackage.name).summary;
         }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -164,8 +164,12 @@ public class BallerinaDocGenerator {
         docPackage.description = packageMdPath
                 .map(packageMd -> new String(packageMd.mdDocumentContext().textDocument().toCharArray()))
                 .orElse("");
-        docPackage.summary = !docPackage.description.equals("") ?
-                             BallerinaDocUtils.getSummary(docPackage.description) : "";
+        if (!docPackage.description.equals("")) {
+            docPackage.summary = BallerinaDocUtils.getSummary(docPackage.description);
+        } else if (moduleDocMap.get(docPackage.name) != null){
+            // Use summary of the default module
+            docPackage.summary = moduleDocMap.get(docPackage.name).summary;
+        }
         if (!docPackage.modules.isEmpty()) {
             PackageLibrary packageLib = new PackageLibrary();
             packageLib.packages.add(docPackage);

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/BallerinaDocGenerator.java
@@ -23,6 +23,7 @@ import com.google.gson.GsonBuilder;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.projects.Document;
+import io.ballerina.projects.MdDocument;
 import io.ballerina.projects.PackageMd;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.util.ProjectConstants;
@@ -432,6 +433,7 @@ public class BallerinaDocGenerator {
         Map<String, ModuleDoc> moduleDocMap = new HashMap<>();
         for (io.ballerina.projects.Module module : project.currentPackage().modules()) {
             String moduleName;
+            MdDocument moduleMd = module.moduleMd().isPresent() ? module.moduleMd().get() : null;
             Path modulePath;
             if (module.isDefaultModule()) {
                 moduleName = module.moduleName().packageName().toString();
@@ -441,11 +443,6 @@ public class BallerinaDocGenerator {
                 modulePath = project.sourceRoot().resolve(ProjectConstants.MODULES_ROOT).resolve(module.moduleName()
                         .moduleNamePart());
             }
-            // find the Module.md file
-            Path moduleMd = getModuleDocPath(modulePath, ProjectConstants.MODULE_MD_FILE_NAME);
-            if (moduleMd == null && module.isDefaultModule()) {
-                moduleMd = getModuleDocPath(modulePath, ProjectConstants.PACKAGE_MD_FILE_NAME);
-            }
             // find the resources of the package
             List<Path> resources = getResourcePaths(modulePath);
             Map<String, SyntaxTree> syntaxTreeMap = new HashMap<>();
@@ -453,7 +450,8 @@ public class BallerinaDocGenerator {
                 Document document = module.document(documentId);
                 syntaxTreeMap.put(document.name(), document.syntaxTree());
             });
-            ModuleDoc moduleDoc = new ModuleDoc(moduleMd == null ? null : moduleMd.toAbsolutePath(), resources,
+            ModuleDoc moduleDoc = new ModuleDoc(moduleMd == null ? null
+                    : new String(moduleMd.textDocument().toCharArray()), resources,
                     syntaxTreeMap, module.getCompilation().getSemanticModel());
             moduleDocMap.put(moduleName, moduleDoc);
         }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/utils/BallerinaDocUtils.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/docs/utils/BallerinaDocUtils.java
@@ -18,33 +18,32 @@
 
 package org.ballerinalang.docgen.docs.utils;
 
+import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.docgen.docs.BallerinaDocConstants;
-import org.ballerinalang.docgen.generator.model.ModuleDoc;
 import org.commonmark.Extension;
 import org.commonmark.ext.gfm.tables.TablesExtension;
+import org.commonmark.node.AbstractVisitor;
 import org.commonmark.node.BlockQuote;
 import org.commonmark.node.FencedCodeBlock;
 import org.commonmark.node.Heading;
 import org.commonmark.node.HtmlBlock;
 import org.commonmark.node.ListBlock;
 import org.commonmark.node.Node;
+import org.commonmark.node.Paragraph;
+import org.commonmark.node.Text;
 import org.commonmark.node.ThematicBreak;
 import org.commonmark.parser.Parser;
+import org.commonmark.renderer.text.TextContentRenderer;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
-import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystemNotFoundException;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -144,7 +143,7 @@ public class BallerinaDocUtils {
     public static String getSummary(String description) {
         if (description != null) {
             Node document = BallerinaDocUtils.parseMD(description);
-            ModuleDoc.SummaryVisitor summaryVisitor = new ModuleDoc.SummaryVisitor();
+            SummaryVisitor summaryVisitor = new SummaryVisitor();
             document.accept(summaryVisitor);
             return summaryVisitor.getSummary();
         }
@@ -159,37 +158,26 @@ public class BallerinaDocUtils {
     }
 
     /**
-     * Visits a folder recursively and copy folders and files to a target directory.
+     * Used to get a summary of a module or a package.
      */
-    static class RecursiveFileVisitor extends SimpleFileVisitor<Path> {
-        Path source;
-        Path target;
-
-        public RecursiveFileVisitor(Path aSource, Path aTarget) {
-            this.source = aSource;
-            this.target = aTarget;
+    public static class SummaryVisitor extends AbstractVisitor {
+        protected Node summary;
+        @Override
+        public void visit(Heading heading) {
+            if (heading.getFirstChild() instanceof Text
+                    && (StringUtils.equalsIgnoreCase(((Text) heading.getFirstChild()).getLiteral(), "module overview")
+                    || StringUtils.equalsIgnoreCase(((Text) heading.getFirstChild()).getLiteral(), "package overview"))
+                    && heading.getNext() instanceof Paragraph
+            ) {
+                summary = heading.getNext();
+            }
         }
 
-        @Override
-        public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) throws IOException {
-            Path targetdir = target.resolve(source.relativize(dir).toString());
-            try {
-                Files.copy(dir, targetdir);
-            } catch (FileAlreadyExistsException e) {
-                if (!Files.isDirectory(targetdir)) {
-                    throw e;
-                }
+        public String getSummary() {
+            if (summary != null) {
+                return TextContentRenderer.builder().build().render(summary);
             }
-            return FileVisitResult.CONTINUE;
-        }
-
-        @Override
-        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
-            Files.copy(file, target.resolve(source.relativize(file).toString()), StandardCopyOption.REPLACE_EXISTING);
-            if (BallerinaDocUtils.isDebugEnabled()) {
-                out.println("File copied: " + file.toString());
-            }
-            return FileVisitResult.CONTINUE;
+            return "";
         }
     }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/ModuleDoc.java
@@ -19,17 +19,9 @@ package org.ballerinalang.docgen.generator.model;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import org.apache.commons.lang3.StringUtils;
 import org.ballerinalang.docgen.docs.utils.BallerinaDocUtils;
-import org.commonmark.node.AbstractVisitor;
-import org.commonmark.node.Heading;
-import org.commonmark.node.Node;
-import org.commonmark.node.Paragraph;
-import org.commonmark.node.Text;
-import org.commonmark.renderer.text.TextContentRenderer;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -47,61 +39,18 @@ public class ModuleDoc {
     /**
      * Constructor.
      *
-     * @param descriptionPath description of the package in markdown format.
+     * @param moduleMd md content of the Module.md.
      * @param resources       resources of this package.
      * @param syntaxTreeMap a hash map of bal file names and syntax trees.
      * @param semanticModel the semantic model
      * @throws IOException on error.
      */
-    public ModuleDoc(Path descriptionPath, List<Path> resources, Map<String, SyntaxTree> syntaxTreeMap,
+    public ModuleDoc(String moduleMd, List<Path> resources, Map<String, SyntaxTree> syntaxTreeMap,
                      SemanticModel semanticModel) throws IOException {
-        this.description = getDescription(descriptionPath);
-        this.summary = getSummary(descriptionPath);
+        this.description = moduleMd;
+        this.summary = BallerinaDocUtils.getSummary(moduleMd);
         this.resources = resources;
         this.syntaxTreeMap = syntaxTreeMap;
         this.semanticModel = semanticModel;
     }
-
-    private String getDescription(Path descriptionPath) throws IOException {
-        if (descriptionPath != null) {
-            return new String(Files.readAllBytes(descriptionPath), "UTF-8");
-        }
-        return null;
-    }
-
-    private String getSummary(Path descriptionPath) throws IOException {
-        if (descriptionPath != null) {
-            String mdContent = new String(Files.readAllBytes(descriptionPath), "UTF-8");
-            Node document = BallerinaDocUtils.parseMD(mdContent);
-            SummaryVisitor summaryVisitor = new SummaryVisitor();
-            document.accept(summaryVisitor);
-            return summaryVisitor.getSummary();
-        }
-        return null;
-    }
-
-    /**
-     * Used to get a summary of a module or a package.
-     */
-    public static class SummaryVisitor extends AbstractVisitor {
-        protected Node summary;
-        @Override
-        public void visit(Heading heading) {
-            if (heading.getFirstChild() instanceof Text
-                    && (StringUtils.equalsIgnoreCase(((Text) heading.getFirstChild()).getLiteral(), "module overview")
-                    || StringUtils.equalsIgnoreCase(((Text) heading.getFirstChild()).getLiteral(), "package overview"))
-                    && heading.getNext() instanceof Paragraph
-            ) {
-                summary = heading.getNext();
-            }
-        }
-
-        public String getSummary() {
-            if (summary != null) {
-                return TextContentRenderer.builder().build().render(summary);
-            }
-            return "";
-        }
-    }
-
 }


### PR DESCRIPTION
## Purpose
>- If the Package.md is missing, there wont be package summaries as shown below in the issue. This PR fixes it by using the default module summary as the package summary in such cases.
>- Refactor getting module.md content through the project api

Fixes #28100

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
