### PR TITLE
Fix Invalid Resource Code Action Snippet issue

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/kubernetes/AbstractInvalidResourceCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/kubernetes/AbstractInvalidResourceCodeAction.java
@@ -94,7 +94,9 @@ public abstract class AbstractInvalidResourceCodeAction extends ProbeBasedDiagno
         String tomlPath = TomlSyntaxTreeUtil.trimResourcePath(probe.getPath().getValue());
         String serviceName = TomlSyntaxTreeUtil.trimResourcePath(service.getServiceName());
         String serviceResourcePath;
-        if (tomlPath.startsWith(serviceName)) {
+        if (tomlPath.equals(serviceName)) {
+            serviceResourcePath = ".";
+        } else if (tomlPath.startsWith(serviceName)) {
             serviceResourcePath = tomlPath.substring(serviceName.length() + 1);
         } else {
             serviceResourcePath = tomlPath;


### PR DESCRIPTION
## Purpose
Fix Invalid Resource Code Action Snippet issue when resource name is empty. See the example below.

Fixes #28152 

## Samples
Before Code Action
```ballerina
service /helloWorld on helloEP {
    resource function get sayHello(http:Caller caller, http:Request request) {
        http:Response response = new;
        response.setTextPayload("Hello, World from service helloWorld ! ");
        var responseResult = caller->respond(response);
        if (responseResult is error) {
            log:printError("error responding back to client.", err = responseResult);
        }
    }
}

```
```toml
[cloud.deployment.probes.readiness]
port = 9090
path = "/helloWorld"
```

After Code Action
```ballerina
service /helloWorld on helloEP {
    resource function get sayHello(http:Caller caller, http:Request request) {
        http:Response response = new;
        response.setTextPayload("Hello, World from service helloWorld ! ");
        var responseResult = caller->respond(response);
        if (responseResult is error) {
            log:printError("error responding back to client.", err = responseResult);
        }
    }

    resource function get . (http:Caller caller) returns error? {
        check caller->respond("Resource is Ready");
    }
}
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
