### PR TITLE
Add Diagnostic clear method for AST nodes in Toml Parser

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlArrayValueNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlArrayValueNode.java
@@ -72,4 +72,12 @@ public class TomlArrayValueNode extends TomlValueNode {
         }
         return tomlDiagnostics;
     }
+
+    @Override
+    public void clearDiagnostics() {
+        super.diagnostics.clear();
+        for (TomlValueNode child : elements) {
+            child.clearDiagnostics();
+        }
+    }
 }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyValueNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyValueNode.java
@@ -50,6 +50,12 @@ public class TomlKeyValueNode extends TopLevelNode {
     }
 
     @Override
+    public void clearDiagnostics() {
+        super.diagnostics.clear();
+        value.clearDiagnostics();
+    }
+
+    @Override
     public String toString() {
         return "TomlKeyValue{" +
                 "key=" + key().name() +

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlNode.java
@@ -49,6 +49,10 @@ public abstract class TomlNode implements Node {
         return diagnostics;
     }
 
+    public void clearDiagnostics() {
+        diagnostics.clear();
+    }
+
     public void addDiagnostic(Diagnostic diagnostic) {
         this.diagnostics.add(diagnostic);
     }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTableArrayNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTableArrayNode.java
@@ -67,6 +67,14 @@ public class TomlTableArrayNode extends TopLevelNode {
     }
 
     @Override
+    public void clearDiagnostics() {
+        super.diagnostics.clear();
+        for (TomlTableNode childTable : children) {
+            childTable.clearDiagnostics();
+        }
+    }
+
+    @Override
     public void accept(TomlNodeVisitor visitor) {
         visitor.visit(this);
     }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTableNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTableNode.java
@@ -72,6 +72,14 @@ public class TomlTableNode extends TopLevelNode {
         return tomlDiagnostics;
     }
 
+    @Override
+    public void clearDiagnostics() {
+        super.diagnostics.clear();
+        for (Map.Entry<String, TopLevelNode> child : entries.entrySet()) {
+            child.getValue().clearDiagnostics();
+        }
+    }
+
     public void replaceGeneratedTable(TomlTableNode tomlTableNode) {
         TopLevelNode childNode = entries.get(tomlTableNode.key().name());
         if (childNode instanceof TomlTableNode) {


### PR DESCRIPTION
## Purpose
Adds the feature to clear diagnostics for every node in the Toml AST. 

## Related Issues 
#28158

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
