### PR TITLE
[Testerina] Display warning when other flags are used with list-groups

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/TestCommand.java
@@ -185,13 +185,17 @@ public class TestCommand implements BLauncherCmd {
         if (this.debugPort != null) {
             System.setProperty(SYSTEM_PROP_BAL_DEBUG, this.debugPort);
         }
-
+        //Display warning if any other options are provided with list-groups flag.
+        boolean displayWarning = false;
+        if (listGroups && (rerunTests || groupList != null || disableGroupList != null || testList != null)) {
+            displayWarning = true;
+        }
         TaskExecutor taskExecutor = new TaskExecutor.TaskBuilder()
                 .addTask(new CleanTargetDirTask(), isSingleFile)   // clean the target directory(projects only)
                 .addTask(new ResolveMavenDependenciesTask(outStream)) // resolve maven dependencies in Ballerina.toml
                 .addTask(new CompileTask(outStream, errStream)) // compile the modules
 //                .addTask(new CopyResourcesTask(), listGroups) // merged with CreateJarTask
-                .addTask(new ListTestGroupsTask(outStream), !listGroups) // list the available test groups
+                .addTask(new ListTestGroupsTask(outStream, displayWarning), !listGroups) // list available test groups
                 .addTask(new RunTestsTask(outStream, errStream, args, rerunTests, groupList, disableGroupList,
                         testList), listGroups)
                 .build();

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ListTestGroupsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/ListTestGroupsTask.java
@@ -40,16 +40,22 @@ import java.util.stream.Collectors;
 public class ListTestGroupsTask implements Task {
 
     private final PrintStream out;
+    private boolean displayWarning;
 
-    public ListTestGroupsTask(PrintStream out) {
+    public ListTestGroupsTask(PrintStream out, boolean displayWarning) {
         this.out = out;
+        this.displayWarning = displayWarning;
     }
+
     @Override
     public void execute(Project project) {
         for (ModuleId moduleId : project.currentPackage().moduleIds()) {
             Module module = project.currentPackage().module(moduleId);
             TestProcessor testProcessor = new TestProcessor();
             Optional<TestSuite> suite = testProcessor.testSuite(module);
+            if (displayWarning) {
+                out.println("\nWarning: Other flags are skipped when list-groups flag is provided.\n");
+            }
             if (!project.currentPackage().packageOrg().anonymous()) {
                 out.println();
                 out.println("\t" + module.moduleName().toString());

--- a/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/GroupingTest.java
+++ b/tests/testerina-integration-test/src/test/java/org/ballerinalang/testerina/test/GroupingTest.java
@@ -109,6 +109,15 @@ public class GroupingTest extends BaseTestCase {
     }
 
     @Test
+    public void testListGroupsWithOtherFlags() throws BallerinaTestException {
+        String msg = "Warning: Other flags are skipped when list-groups flag is provided.";
+        LogLeecher clientLeecher = new LogLeecher(msg);
+        balClient.runMain("test", new String[]{"--groups", "g1", "--list-groups", "groups-test.bal"},
+                null, new String[]{}, new LogLeecher[]{clientLeecher}, projectPath);
+        clientLeecher.waitForText(20000);
+    }
+
+    @Test
     public void beforeGroupsAfterGroups1() throws BallerinaTestException {
         String errorOutput = balClient.runMainAndReadStdOut("test", new String[]{"before-groups-after-groups-test.bal"},
                 new HashMap<>(), projectPath, true);


### PR DESCRIPTION
## Purpose
Display warning when other flags are used with list-groups

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
