### PR TITLE
Introduce --includes flag to include necessary classes when generating code coverage

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -87,6 +87,7 @@ public class RunTestsTask implements Task {
     private final PrintStream out;
     private final PrintStream err;
     private final List<String> args;
+    private final String includesInCoverage;
     private List<String> groupList;
     private List<String> disableGroupList;
     private boolean report;
@@ -96,19 +97,19 @@ public class RunTestsTask implements Task {
     private List<String> singleExecTests;
     TestReport testReport;
 
-    public RunTestsTask(PrintStream out, PrintStream err, String[] args) {
+    public RunTestsTask(PrintStream out, PrintStream err, String[] args, String includes) {
         this.out = out;
         this.err = err;
         this.args = Lists.of(args);
+        this.includesInCoverage = includes;
     }
 
     public RunTestsTask(PrintStream out, PrintStream err, String[] args, boolean rerunTests, List<String> groupList,
-                        List<String> disableGroupList, List<String> testList) {
+                        List<String> disableGroupList, List<String> testList, String includes) {
         this.out = out;
         this.err = err;
         this.args = Lists.of(args);
         this.isSingleTestExecution = false;
-
         this.isRerunTestExecution = rerunTests;
 
         // If rerunTests is true, we get the rerun test list and assign it to 'testList'
@@ -124,6 +125,7 @@ public class RunTestsTask implements Task {
             isSingleTestExecution = true;
             singleExecTests = testList;
         }
+        this.includesInCoverage = includes;
     }
 
     @Override
@@ -364,8 +366,10 @@ public class RunTestsTask implements Task {
                     + "=destfile="
                     + target.getTestsCachePath().resolve(TesterinaConstants.COVERAGE_DIR)
                     .resolve(TesterinaConstants.EXEC_FILE_NAME).toString();
-            if (!TesterinaConstants.DOT.equals(packageName)) {
+            if (!TesterinaConstants.DOT.equals(packageName) && this.includesInCoverage == null) {
                 agentCommand += ",includes=" + orgName + ".*";
+            } else {
+                agentCommand += ",includes=" + this.includesInCoverage;
             }
             cmdArgs.add(agentCommand);
         }

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -201,10 +201,20 @@ check {
     dependsOn createJavadoc
 }
 
+def getCheckedOutGitCommitHash() {
+    'git rev-parse --verify --short HEAD'.execute().text.trim()
+}
+
 publishing {
+    def artifactCodeCoverageReport = file("$buildDir/jacoco/test.exec")
     publications {
         mavenJava {
             from components.java
+        }
+        if (artifactCodeCoverageReport.exists()) {
+            maven(MavenPublication) {
+                artifact source: artifactCodeCoverageReport, classifier: getCheckedOutGitCommitHash()
+            }
         }
     }
 }

--- a/gradle/javaProject.gradle
+++ b/gradle/javaProject.gradle
@@ -213,7 +213,7 @@ publishing {
         }
         if (artifactCodeCoverageReport.exists()) {
             maven(MavenPublication) {
-                artifact source: artifactCodeCoverageReport, classifier: getCheckedOutGitCommitHash()
+                artifact source: artifactCodeCoverageReport, classifier: 'jacoco'
             }
         }
     }


### PR DESCRIPTION
## Purpose
> Introduce `--includes` flag to include all classes when generating code coverage

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
