### PR TITLE
Persist enum symbol info in BIR

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.api.impl.symbols;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -29,8 +30,10 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope.ScopeEntry;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
@@ -59,6 +62,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
     private List<ClassSymbol> classes;
     private List<FunctionSymbol> functions;
     private List<ConstantSymbol> constants;
+    private List<EnumSymbol> enums;
     private List<Symbol> allSymbols;
 
     protected BallerinaModule(CompilerContext context, String name, PackageID moduleID, BPackageSymbol packageSymbol) {
@@ -167,6 +171,28 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
         this.constants = Collections.unmodifiableList(constants);
         return this.constants;
+    }
+
+    @Override
+    public List<EnumSymbol> enums() {
+        if (this.enums != null) {
+            return this.enums;
+        }
+
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+        List<EnumSymbol> enums = new ArrayList<>();
+
+        for (Map.Entry<Name, ScopeEntry> entry : this.packageSymbol.scope.entries.entrySet()) {
+            ScopeEntry scopeEntry = entry.getValue();
+
+            if (scopeEntry.symbol instanceof BEnumSymbol && Symbols.isFlagOn(scopeEntry.symbol.flags, Flags.PUBLIC)) {
+                String constName = scopeEntry.symbol.getName().getValue();
+                enums.add(symbolFactory.createEnumSymbol((BEnumSymbol) scopeEntry.symbol, constName));
+            }
+        }
+
+        this.enums = Collections.unmodifiableList(enums);
+        return this.enums;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ModuleSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ModuleSymbol.java
@@ -55,6 +55,13 @@ public interface ModuleSymbol extends Symbol {
     List<ConstantSymbol> constants();
 
     /**
+     * Get the public enums defined within the module.
+     *
+     * @return {@link List} of enums
+     */
+    List<EnumSymbol> enums();
+
+    /**
      * Get all public the symbols within the module.
      *
      * @return {@link List} of type definitions

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -44,6 +44,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BErrorTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
@@ -1168,6 +1169,11 @@ public class BIRPackageSymbolEnter {
                     var poppedUnionType = compositeStack.pop();
                     assert poppedUnionType == unionType;
 
+                    boolean isEnum = inputStream.readBoolean();
+                    if (isEnum) {
+                        readAndSetEnumSymbol(unionType, flags);
+                    }
+
                     if (hasName) {
                         if (unionsPkgId.equals(env.pkgSymbol.pkgID)) {
                             return unionType;
@@ -1434,6 +1440,29 @@ public class BIRPackageSymbolEnter {
                 typeInclusions.add(inclusion);
             }
             return typeInclusions;
+        }
+
+        private void readAndSetEnumSymbol(BUnionType unionType, long flags) throws IOException {
+            PackageID enumPkgId = getPackageId(inputStream.readInt());
+            String enumName = getStringCPEntryValue(inputStream);
+            int memberCount = inputStream.readInt();
+            BSymbol pkgSymbol = packageCache.getSymbol(enumPkgId);
+            SymbolEnv enumPkgEnv = symTable.pkgEnvMap.get(pkgSymbol);
+
+            // pkg env will be null if it's an enum in the current module.
+            if (enumPkgEnv == null) {
+                enumPkgEnv = SymbolEnv.createPkgEnv(null, env.pkgSymbol.scope, null);
+            }
+
+            List<BConstantSymbol> members = new ArrayList<>();
+            for (int i = 0; i < memberCount; i++) {
+                String memName = getStringCPEntryValue(inputStream);
+                BSymbol sym = symbolResolver.lookupSymbolInMainSpace(enumPkgEnv, names.fromString(memName));
+                members.add((BConstantSymbol) sym);
+            }
+
+            unionType.tsymbol = new BEnumSymbol(members, flags, names.fromString(enumName), enumPkgId, unionType,
+                    pkgSymbol, symTable.builtinPos, COMPILED_SOURCE);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -1447,6 +1447,12 @@ public class BIRPackageSymbolEnter {
             String enumName = getStringCPEntryValue(inputStream);
             int memberCount = inputStream.readInt();
             BSymbol pkgSymbol = packageCache.getSymbol(enumPkgId);
+
+            // pkg symbol will be null if it's an enum in the current module.
+            if (pkgSymbol == null) {
+                pkgSymbol = env.pkgSymbol;
+            }
+
             SymbolEnv enumPkgEnv = symTable.pkgEnvMap.get(pkgSymbol);
 
             // pkg env will be null if it's an enum in the current module.
@@ -1461,8 +1467,8 @@ public class BIRPackageSymbolEnter {
                 members.add((BConstantSymbol) sym);
             }
 
-            unionType.tsymbol = new BEnumSymbol(members, flags, names.fromString(enumName), enumPkgId, unionType,
-                    pkgSymbol, symTable.builtinPos, COMPILED_SOURCE);
+            unionType.tsymbol = new BEnumSymbol(members, flags, names.fromString(enumName), pkgSymbol.pkgID, unionType,
+                                                pkgSymbol, symTable.builtinPos, COMPILED_SOURCE);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -30,6 +30,8 @@ import org.wso2.ballerinalang.compiler.semantics.analyzer.IsAnydataUniqueVisitor
 import org.wso2.ballerinalang.compiler.semantics.analyzer.IsPureTypeUniqueVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BEnumSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -294,6 +296,24 @@ public class BIRTypeWriter implements TypeVisitor {
         buff.writeInt(bUnionType.getMemberTypes().size());
         for (BType memberType : bUnionType.getMemberTypes()) {
             writeTypeCpIndex(memberType);
+        }
+
+        if (tsymbol instanceof BEnumSymbol) {
+            buff.writeBoolean(true);
+            writeEnumSymbolInfo((BEnumSymbol) tsymbol);
+        } else {
+            buff.writeBoolean(false);
+        }
+    }
+
+    private void writeEnumSymbolInfo(BEnumSymbol symbol) {
+        writePackageIndex(symbol);
+
+        buff.writeInt(addStringCPEntry(symbol.name.value));
+
+        buff.writeInt(symbol.members.size());
+        for (BConstantSymbol member : symbol.members) {
+            buff.writeInt(addStringCPEntry(member.name.value));
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -25,9 +25,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 54;
-    public static final short MIN_SUPPORTED_VERSION = 54;
-    public static final short MAX_SUPPORTED_VERSION = 54;
+    public static final int BIR_VERSION_NUMBER = 55;
+    public static final short MIN_SUPPORTED_VERSION = 55;
+    public static final short MAX_SUPPORTED_VERSION = 55;
 
     // todo move this to a proper place
     public static final String IMPLEMENTATION_VERSION = "2020r2";

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -295,6 +295,22 @@ types:
         type: s4
         repeat: expr
         repeat-expr: member_types_count
+      - id: is_enum_type
+        type: u1
+      - id: pkg_cp_index
+        type: s4
+        if: is_enum_type == 1
+      - id: enum_name
+        type: s4
+        if: is_enum_type == 1
+      - id: enum_members_size
+        type: s4
+        if: is_enum_type == 1
+      - id: enum_members
+        type: s4
+        repeat: expr
+        repeat-expr: enum_members_size
+        if: is_enum_type == 1
   type_tuple:
     seq:
       - id: tuple_types_count

--- a/docs/bir-spec/src/test/resources/test-src/typedefs.bal
+++ b/docs/bir-spec/src/test/resources/test-src/typedefs.bal
@@ -178,3 +178,7 @@ type DistinctCustomError distinct error<record { int i; }>;
 
 // ---------------------------------------------------------------------------------------------------------------------
 type cyclicType int|float|cyclicType[];
+
+enum Colour {
+    RED, GREEN, BLUE
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -103,9 +103,11 @@ public class SymbolBIRTest {
 
         List<String> fooTypeDefs = getSymbolNames(getSymbolNames(fooPkgSymbol, SymTag.TYPE_DEF), "Digit");
         fooTypeDefs.remove("PersonObj");
+        fooTypeDefs.remove("Colour");
         SemanticAPITestUtils.assertList(fooModule.typeDefinitions(), fooTypeDefs);
 
         SemanticAPITestUtils.assertList(fooModule.classes(), List.of("PersonObj"));
+        SemanticAPITestUtils.assertList(fooModule.enums(), List.of("Colour"));
 
         List<String> allSymbols = getSymbolNames(fooPkgSymbol, 0);
         SemanticAPITestUtils.assertList(fooModule.allSymbols(), allSymbols);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
@@ -47,3 +47,7 @@ public type FileNotFoundError distinct error;
 public type EofError distinct error;
 
 public type Error FileNotFoundError|EofError;
+
+public enum Colour {
+   RED, GREEN, BLUE
+}


### PR DESCRIPTION
## Purpose
This PR adds enum symbol info to the BIR. So that enums coming from a BIR source can be identified at the semantic API level and create enum symbols for them. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
