### PR TITLE
Fix to allow Ballerina Shell to accept multiline template strings

### DIFF
--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/ReplShellApplication.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/ReplShellApplication.java
@@ -70,7 +70,8 @@ public class ReplShellApplication {
             DefaultParser parser = new DefaultParser();
             parser.setEofOnUnclosedBracket(DefaultParser.Bracket.CURLY,
                     DefaultParser.Bracket.ROUND, DefaultParser.Bracket.SQUARE);
-            parser.setQuoteChars(new char[]{'"'});
+            parser.setEofOnUnclosedQuote(true);
+            parser.setQuoteChars(new char[]{'"', '`'});
             parser.setEscapeChars(new char[]{});
 
             LineReader lineReader = LineReaderBuilder.builder()

--- a/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/ReplShellApplication.java
+++ b/ballerina-shell/modules/shell-cli/src/main/java/io/ballerina/shell/cli/ReplShellApplication.java
@@ -71,7 +71,7 @@ public class ReplShellApplication {
             parser.setEofOnUnclosedBracket(DefaultParser.Bracket.CURLY,
                     DefaultParser.Bracket.ROUND, DefaultParser.Bracket.SQUARE);
             parser.setEofOnUnclosedQuote(true);
-            parser.setQuoteChars(new char[]{'"', '`'});
+            parser.setQuoteChars(new char[]{'`'});
             parser.setEscapeChars(new char[]{});
 
             LineReader lineReader = LineReaderBuilder.builder()


### PR DESCRIPTION
## Purpose
Ballerina shell will not wait for user input for backtick and quotes.
This will wait for quotes with ` to be closed.

Fixes #28271

## Approach
- Enable waiting on multi-line strings
- Replace " with ` from characters that count as multi-line strings

## Samples
Following is now possible,
```
=$ string data = string `
 > Hello
 > World
 > `

=$ data

Hello
World


=$   
```

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
