### PR TITLE
Introduce dotted key support for Toml parser

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/api/Toml.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/api/Toml.java
@@ -86,7 +86,7 @@ public class Toml {
     /**
      * Read TOML File using Path and validate it against a json schema.
      *
-     * @param path   Path of the TOML file
+     * @param path Path of the TOML file
      * @param schema json schema to validate the toml against
      * @return TOML Object
      * @throws IOException if file is not accessible
@@ -114,7 +114,7 @@ public class Toml {
      * Read TOML File using InputStream and validate against a json schema.
      *
      * @param inputStream InputStream of the TOML file
-     * @param schema      json schema to validate the toml against
+     * @param schema json schema to validate the toml against
      * @return TOML Object
      * @throws IOException if file is not accessible
      */
@@ -125,13 +125,13 @@ public class Toml {
     /**
      * Parse TOML file using TOML String.
      *
-     * @param content  String representation of the TOML file content.
-     * @param filePath path of the TOML file
+     * @param content String representation of the TOML file content.
+     * @param fileName file name of the TOML file
      * @return TOML Object
      */
-    public static Toml read(String content, String filePath) {
+    public static Toml read(String content, String fileName) {
         TextDocument textDocument = TextDocuments.from(content);
-        SyntaxTree syntaxTree = SyntaxTree.from(textDocument, filePath);
+        SyntaxTree syntaxTree = SyntaxTree.from(textDocument, fileName);
         TomlTransformer nodeTransformer = new TomlTransformer();
         TomlTableNode
                 transformedTable = (TomlTableNode) nodeTransformer.transform((DocumentNode) syntaxTree.rootNode());
@@ -142,14 +142,14 @@ public class Toml {
     /**
      * Parse TOML file using TOML String and validate against a json schema.
      *
-     * @param content  String representation of the TOML file content.
-     * @param schema   json schema to validate the toml against
-     * @param filePath path of the TOML file
+     * @param content String representation of the TOML file content.
+     * @param schema json schema to validate the toml against
+     * @param fileName file name of the TOML file
      * @return TOML Object
      */
-    public static Toml read(String content, String filePath, Schema schema) {
+    public static Toml read(String content, String fileName, Schema schema) {
         TextDocument textDocument = TextDocuments.from(content);
-        SyntaxTree syntaxTree = SyntaxTree.from(textDocument, filePath);
+        SyntaxTree syntaxTree = SyntaxTree.from(textDocument, fileName);
         TomlTransformer nodeTransformer = new TomlTransformer();
         TomlTableNode
                 transformedTable = (TomlTableNode) nodeTransformer.transform((DocumentNode) syntaxTree.rootNode());
@@ -177,7 +177,7 @@ public class Toml {
      * Get value from a key of a Key Value pair.
      *
      * @param dottedKey key name
-     * @param <T>       Type of the AST Value Node
+     * @param <T> Type of the AST Value Node
      * @return AST Value Node
      */
     public <T extends TomlValueNode> Optional<T> get(String dottedKey) {

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -43,12 +43,12 @@ public class TomlKeyNode extends TomlNode {
 
     public String name() {
         List<String> list = new ArrayList<>();
-        for (TomlKeyEntryNode keyEntryNode:keys) {
-//            if (keyEntryNode.kind() != TomlType.STRING) {
-//                list.add("\""+keyEntryNode.name().toString()+"\"");
-//            } else {
+        for (TomlKeyEntryNode keyEntryNode : keys) {
+            if (keyEntryNode.kind() == TomlType.STRING) {
+                list.add("\"" + keyEntryNode.name().toString() + "\"");
+            } else {
                 list.add(keyEntryNode.name().toString());
-//            }
+            }
         }
         return String.join(".", list);
     }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -42,7 +42,7 @@ public class TomlKeyNode extends TomlNode {
     }
 
     public String name() {
-        List<String> list = new ArrayList<>();
+        List<String> list = new ArrayList<>(keys.size());
         for (TomlKeyEntryNode keyEntryNode : keys) {
             if (keyEntryNode.kind() == TomlType.STRING) {
                 list.add("\"" + keyEntryNode.name().toString() + "\"");

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -44,7 +44,11 @@ public class TomlKeyNode extends TomlNode {
     public String name() {
         List<String> list = new ArrayList<>();
         for (TomlKeyEntryNode keyEntryNode:keys) {
-            list.add(keyEntryNode.name().toString());
+//            if (keyEntryNode.kind() != TomlType.STRING) {
+//                list.add("\""+keyEntryNode.name().toString()+"\"");
+//            } else {
+                list.add(keyEntryNode.name().toString());
+//            }
         }
         return String.join(".", list);
     }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
@@ -226,7 +226,9 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
                 if ((targetTable).generated()) {
                     parentTable.replaceGeneratedTable(newTableNode);
                 } else {
-                    appendEntriesToTable(targetTable, tableChild);
+                    TomlDiagnostic nodeExists = dlog.error(tableChild.location(),
+                            DiagnosticErrorCode.ERROR_EXISTING_NODE, newTableNode.key().name());
+                    parentTable.addDiagnostic(nodeExists);
                 }
             } else if (topLevelNode instanceof TomlKeyValueNode) {
                 TomlDiagnostic nodeExist = dlog.error(newTableNode.location(),
@@ -234,20 +236,6 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
                 parentTable.addDiagnostic(nodeExist);
             } else {
                 throw new UnsupportedOperationException();
-            }
-        }
-    }
-
-    private void appendEntriesToTable(TomlTableNode targetTable, TomlTableNode newTable) {
-        for (Map.Entry<String, TopLevelNode> entry : newTable.entries().entrySet()) {
-            String key = entry.getKey();
-            TopLevelNode value = entry.getValue();
-            boolean isExist = targetTable.entries().containsKey(key);
-            if (!isExist) {
-                targetTable.entries().put(key, value);
-            } else {
-                TomlDiagnostic nodeExists = dlog.error(value.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE, key);
-                targetTable.addDiagnostic(nodeExists);
             }
         }
     }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
@@ -104,21 +104,38 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
             String newTable = parentTables.get(i);
             TopLevelNode dottedParentNode = parentTable.entries().get(newTable);
             if (dottedParentNode != null) {
-                //TOOD fix
+                if (dottedParentNode.kind() == TomlType.TABLE) {
+                    parentTable = (TomlTableNode) dottedParentNode;
+                } else {
+                    TomlDiagnostic nodeExists =
+                            dlog.error(dottedParentNode.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE, newTable);
+                    parentTable.addDiagnostic(nodeExists);
+                }
             } else {
                 //create the table
                 TomlKeyEntryNode tomlKeyEntryNode = keys.get(i);
                 parentTable = createDottedKeyParentTable(parentTable, tomlKeyEntryNode);
             }
         }
-        if (keys.size() > 1) {
+        if (isDottedKey(keys)) {
             List<TomlKeyEntryNode> list = new ArrayList<>();
             list.add(keys.get(keys.size() - 1));
             TomlKeyNode newKey = new TomlKeyNode(list);
             transformedKeyValuePair = new TomlKeyValueNode(newKey, transformedKeyValuePair.value(),
                     transformedKeyValuePair.location());
         }
-        parentTable.entries().put(transformedKeyValuePair.key().name(), transformedKeyValuePair);
+        addChildToTableAST(parentTable, transformedKeyValuePair);
+    }
+
+    private void addChildToTableAST(TomlTableNode parentTable, TopLevelNode value) {
+        Map<String, TopLevelNode> entries = parentTable.entries();
+        String key = value.key().name();
+        if (entries.containsKey(key)) {
+            TomlDiagnostic nodeExists = dlog.error(value.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE, key);
+            parentTable.addDiagnostic(nodeExists);
+        } else {
+            entries.put(key, value);
+        }
     }
 
     private TomlTableNode createDottedKeyParentTable(TomlTableNode parentTable, TomlKeyEntryNode dottedKey) {
@@ -126,7 +143,7 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         list.add(dottedKey);
         TomlKeyNode newTableKey = new TomlKeyNode(list);
         TomlTableNode newTomlTableNode = new TomlTableNode(newTableKey, null);
-        parentTable.entries().put(dottedKey.name().toString(), newTomlTableNode);
+        addChildToTableAST(parentTable, newTomlTableNode);
         return newTomlTableNode;
     }
 
@@ -141,14 +158,14 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
                 tableArrayChild.location(), tableArrayChild.children());
         TopLevelNode topLevelNode = parentTable.entries().get(newTomlTableArray.key().name());
         if (topLevelNode == null) {
-            parentTable.entries().put(newTomlTableArray.key().name(), newTomlTableArray);
+            addChildToTableAST(parentTable, newTomlTableArray);
         } else {
             //generated false?
             if (topLevelNode instanceof TomlTableArrayNode) {
                 ((TomlTableArrayNode) topLevelNode).addChild(newTomlTableArray.children().get(0));
             } else if (topLevelNode instanceof TomlKeyValueNode) {
-                TomlDiagnostic nodeExists =
-                        dlog.error(newTomlTableArray.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE);
+                TomlDiagnostic nodeExists = dlog.error(newTomlTableArray.location(),
+                        DiagnosticErrorCode.ERROR_EXISTING_NODE, newTomlTableArray.key().name());
                 parentTable.addDiagnostic(nodeExists);
 
             } else {
@@ -177,9 +194,9 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
             } else {
                 TomlKeyEntryNode tomlKeyEntryNode = childNode.key().keys().get(i);
                 if (childNode instanceof TomlTableArrayNode) {
-                    parentTable = generateTable(parentTable.entries(), tomlKeyEntryNode, false);
+                    parentTable = generateTable(parentTable, tomlKeyEntryNode, false);
                 } else {
-                    parentTable = generateTable(parentTable.entries(), tomlKeyEntryNode, true);
+                    parentTable = generateTable(parentTable, tomlKeyEntryNode, true);
                 }
             }
         }
@@ -187,8 +204,7 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         TopLevelNode lastNode = parentTable.entries().get(tableLeadName);
         if (lastNode instanceof TomlKeyValueNode) {
             TomlDiagnostic nodeExists =
-                    dlog.error(childNode.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE);
-            //TODO revisit dotted.
+                    dlog.error(childNode.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE, tableLeadName);
             parentTable.addDiagnostic(nodeExists);
         }
         return parentTable;
@@ -203,19 +219,18 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         TomlTableNode newTableNode = new TomlTableNode(new TomlKeyNode(entries),
                 tableChild.generated(), tableChild.location(), tableChild.entries());
         if (topLevelNode == null) {
-            parentTable.entries().put(newTableNode.key().name(), newTableNode);
+            addChildToTableAST(parentTable, newTableNode);
         } else {
-            //generated false?
             if (topLevelNode instanceof TomlTableNode) {
-                if (((TomlTableNode) topLevelNode).generated()) {
+                TomlTableNode targetTable = (TomlTableNode) topLevelNode;
+                if ((targetTable).generated()) {
                     parentTable.replaceGeneratedTable(newTableNode);
                 } else {
-                    TomlDiagnostic nodeExist = dlog.error(newTableNode.location(),
-                            DiagnosticErrorCode.ERROR_EXISTING_NODE);
-                    parentTable.addDiagnostic(nodeExist);
+                    appendEntriesToTable(targetTable, tableChild);
                 }
             } else if (topLevelNode instanceof TomlKeyValueNode) {
-                TomlDiagnostic nodeExist = dlog.error(newTableNode.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE);
+                TomlDiagnostic nodeExist = dlog.error(newTableNode.location(),
+                        DiagnosticErrorCode.ERROR_EXISTING_NODE, tableChild.key().name());
                 parentTable.addDiagnostic(nodeExist);
             } else {
                 throw new UnsupportedOperationException();
@@ -223,13 +238,26 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         }
     }
 
-    private TomlTableNode generateTable(Map<String, TopLevelNode> childs, TomlKeyEntryNode parentString,
-                                        boolean isGenerated) {
+    private void appendEntriesToTable(TomlTableNode targetTable, TomlTableNode newTable) {
+        for (Map.Entry<String, TopLevelNode> entry : newTable.entries().entrySet()) {
+            String key = entry.getKey();
+            TopLevelNode value = entry.getValue();
+            boolean isExist = targetTable.entries().containsKey(key);
+            if (!isExist) {
+                targetTable.entries().put(key, value);
+            } else {
+                TomlDiagnostic nodeExists = dlog.error(value.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE, key);
+                targetTable.addDiagnostic(nodeExists);
+            }
+        }
+    }
+
+    private TomlTableNode generateTable(TomlTableNode parentTable, TomlKeyEntryNode parentString, boolean isGenerated) {
         List<TomlKeyEntryNode> list = new ArrayList<>();
         list.add(parentString);
         TomlKeyNode newTableKey = new TomlKeyNode(list); //TODO Revisit
         TomlTableNode newTomlTableNode = new TomlTableNode(newTableKey, isGenerated, null);
-        childs.put(parentString.name().toString(), newTomlTableNode);
+        addChildToTableAST(parentTable, newTomlTableNode);
         return newTomlTableNode;
     }
 
@@ -242,25 +270,30 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         return tomlTableNode;
     }
 
-    private void addChildToTable(TableNode tableNode, TomlTableNode tomlTableNode) {
-        NodeList<KeyValueNode> children = tableNode.fields();
+    private void addChildToTable(TableNode stTableNode, TomlTableNode astTomlTableNode) {
+        NodeList<KeyValueNode> children = stTableNode.fields();
         for (KeyValueNode child : children) {
-            TomlNode transformedChild = child.apply(this); //todo dotted
-            if (transformedChild instanceof TopLevelNode) {
+            TomlNode transformedChild = child.apply(this);
+            if (transformedChild instanceof TomlKeyValueNode) {
                 TopLevelNode topLevelChild = (TopLevelNode) transformedChild;
-                checkExistingNodes(tomlTableNode, topLevelChild);
-                tomlTableNode.entries().put(topLevelChild.key().name(), topLevelChild);
+                checkExistingNodes(astTomlTableNode, topLevelChild);
+                addChildKeyValueToParent(astTomlTableNode, (TomlKeyValueNode) transformedChild);
             } else {
                 throw new UnsupportedOperationException();
             }
         }
     }
 
+    private boolean isDottedKey(List<TomlKeyEntryNode> keys) {
+        return keys.size() > 1;
+    }
+
     private void checkExistingNodes(TomlTableNode tomlTableNode, TopLevelNode topLevelChild) {
         Map<String, TopLevelNode> childs = tomlTableNode.entries();
         String childName = topLevelChild.key().name();
         if (childs.get(childName) != null) {
-            TomlDiagnostic nodeExists = dlog.error(topLevelChild.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE);
+            TomlDiagnostic nodeExists = dlog.error(topLevelChild.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE,
+                    childName);
             tomlTableNode.addDiagnostic(nodeExists);
         }
     }
@@ -271,7 +304,7 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         TomlKeyNode tomlKeyNode = getTomlKeyNode(identifierList);
         TomlTableArrayNode tomlTableArrayNode = new TomlTableArrayNode(tomlKeyNode, getPosition(tableArrayNode));
         TomlTableNode anonTable = addChildsToTableArray(tableArrayNode);
-        tomlTableArrayNode.addChild(anonTable);
+        tomlTableArrayNode.addChild(anonTable); //As Syntax tree follows a flat hierarchy and contains only one table
         return tomlTableArrayNode;
     }
 
@@ -281,11 +314,9 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         TomlKeyNode anonKey = new TomlKeyNode(null);
         TomlTableNode anonTable = new TomlTableNode(anonKey, position);
         for (KeyValueNode child : children) {
-            TomlNode transformedChild = child.apply(this); //todo dotted
-            if (transformedChild instanceof TopLevelNode) {
-                TopLevelNode topLevelChild = (TopLevelNode) transformedChild;
-//                checkExistingNodes(tomlTableArray,topLevelChild);
-                anonTable.entries().put(topLevelChild.key().name(), topLevelChild);
+            TomlNode transformedChild = child.apply(this);
+            if (transformedChild instanceof TomlKeyValueNode) {
+                addChildKeyValueToParent(anonTable, (TomlKeyValueNode) transformedChild);
             } else {
                 throw new UnsupportedOperationException();
             }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/diagnostics/DiagnosticLog.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/diagnostics/DiagnosticLog.java
@@ -40,8 +40,8 @@ public class DiagnosticLog {
         return instance;
     }
 
-    public TomlDiagnostic error(TomlNodeLocation location, DiagnosticCode code) {
+    public TomlDiagnostic error(TomlNodeLocation location, DiagnosticCode code, Object... args) {
         DiagnosticInfo info = new DiagnosticInfo(code.diagnosticId(), code.messageKey(), code.severity());
-        return new TomlDiagnostic(location, info , DiagnosticMessageHelper.getDiagnosticMessage(code));
+        return new TomlDiagnostic(location, info , DiagnosticMessageHelper.getDiagnosticMessage(code, args));
     }
 }

--- a/misc/toml-parser/src/main/resources/toml_diagnostic_message.properties
+++ b/misc/toml-parser/src/main/resources/toml_diagnostic_message.properties
@@ -60,5 +60,5 @@ error.invalid.qualifier=invalid qualifier ''{0}''
 error.missing.value=missing value
 error.missing.open.double.bracket=missing open double brackets
 error.missing.close.double.bracket=missing close double brackets
-error.existing.node=existing node
+error.existing.node=existing node ''{0}''
 error.missing.new.line=missing new line

--- a/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
@@ -20,6 +20,7 @@ package toml.parser.test;
 
 import io.ballerina.toml.api.Toml;
 import io.ballerina.toml.semantic.ast.TomlStringValueNode;
+import io.ballerina.toml.semantic.ast.TomlValueNode;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
 import java.io.FileInputStream;
@@ -50,7 +51,7 @@ public class TestToml {
             OUT.println(diagnostic.message());
         }
 
-        TomlStringValueNode key1 = read.get("key");
+        TomlStringValueNode key1 = (TomlStringValueNode) read.getEntry("key").get();
 
         OUT.println(key1.getValue());
     }

--- a/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
@@ -50,8 +50,7 @@ public class TestToml {
             OUT.println(diagnostic.message());
         }
 
-        TomlStringValueNode key1 = (TomlStringValueNode) read.get("\"key\"").get();
-
+        TomlStringValueNode key1 = (TomlStringValueNode) read.get("key").get();
         OUT.println(key1.getValue());
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
@@ -20,7 +20,6 @@ package toml.parser.test;
 
 import io.ballerina.toml.api.Toml;
 import io.ballerina.toml.semantic.ast.TomlStringValueNode;
-import io.ballerina.toml.semantic.ast.TomlValueNode;
 import io.ballerina.tools.diagnostics.Diagnostic;
 
 import java.io.FileInputStream;
@@ -51,7 +50,7 @@ public class TestToml {
             OUT.println(diagnostic.message());
         }
 
-        TomlStringValueNode key1 = (TomlStringValueNode) read.getEntry("\"key\"").get();
+        TomlStringValueNode key1 = (TomlStringValueNode) read.get("\"key\"").get();
 
         OUT.println(key1.getValue());
     }

--- a/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/TestToml.java
@@ -51,7 +51,7 @@ public class TestToml {
             OUT.println(diagnostic.message());
         }
 
-        TomlStringValueNode key1 = (TomlStringValueNode) read.getEntry("key").get();
+        TomlStringValueNode key1 = (TomlStringValueNode) read.getEntry("\"key\"").get();
 
         OUT.println(key1.getValue());
     }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -25,6 +25,7 @@ import io.ballerina.toml.semantic.ast.TomlDoubleValueNodeNode;
 import io.ballerina.toml.semantic.ast.TomlLongValueNode;
 import io.ballerina.toml.semantic.ast.TomlStringValueNode;
 import org.testng.Assert;
+import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
@@ -211,5 +212,30 @@ public class KeyValueTest {
 
         Assert.assertEquals(cfirst, Long.valueOf(5L));
         Assert.assertEquals(csecond, Long.valueOf(6L));
+    }
+
+    @Test(enabled = false)
+    public void testDottedKey() throws IOException {
+        InputStream inputStream = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("syntax/key-value/new-api.toml");
+        Toml read = Toml.read(inputStream);
+
+        TomlStringValueNode plainKey = (TomlStringValueNode) read.getEntry("key").get();
+        Assert.assertEquals(plainKey.getValue(), "no quote");
+//TODO Fixme
+//        TomlStringValueNode simpleQuotedKey = (TomlStringValueNode) read.getEntry("\"key\"").get();
+//        Assert.assertEquals(simpleQuotedKey.getValue(), "quoted key");
+
+        TomlStringValueNode plainNestedChild = (TomlStringValueNode) read.getEntry("table.hi").get();
+        Assert.assertEquals(plainNestedChild.getValue(), "hii");
+
+//        //TODO fixme
+//        TomlStringValueNode shortChild = (TomlStringValueNode) read.getEntry("table1.child").get();
+//        Assert.assertEquals(shortChild.getValue(), "hello");
+
+        TomlStringValueNode quotedSingle = (TomlStringValueNode) read.getEntry("\"foo bar\"").get();
+        Assert.assertEquals(quotedSingle.getValue(), "boo");
+
+
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -219,7 +219,7 @@ public class KeyValueTest {
     @Test
     public void testDottedKey() throws IOException {
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("syntax/key-value/new-api.toml");
+                .getResourceAsStream("syntax/key-value/dotted.toml");
         Toml read = Toml.read(inputStream);
 
         Optional<TomlValueNode> noneExistKey = read.get("none");
@@ -249,5 +249,34 @@ public class KeyValueTest {
         List<Toml> envList = read.getTables("cloud.config.envs");
         Assert.assertEquals(envList.size(), 2);
 
+        TomlStringValueNode appleType = (TomlStringValueNode) read.get("apple.type").get();
+        Assert.assertEquals(appleType.getValue(), "fruit");
+
+        TomlStringValueNode orangeType = (TomlStringValueNode) read.get("orange.type").get();
+        Assert.assertEquals(orangeType.getValue(), "fruit");
+
+        TomlStringValueNode appleSkin = (TomlStringValueNode) read.get("apple.skin").get();
+        Assert.assertEquals(appleSkin.getValue(), "thin");
+
+        TomlStringValueNode orangeSkin = (TomlStringValueNode) read.get("orange.skin").get();
+        Assert.assertEquals(orangeSkin.getValue(), "thick");
+
+        TomlStringValueNode appleColor = (TomlStringValueNode) read.get("apple.color").get();
+        Assert.assertEquals(appleColor.getValue(), "red");
+
+        TomlStringValueNode orangeColor = (TomlStringValueNode) read.get("orange.color").get();
+        Assert.assertEquals(orangeColor.getValue(), "orange");
+
+        TomlStringValueNode nestedDottedKey = (TomlStringValueNode) read.get("root.first.second").get();
+        Assert.assertEquals(nestedDottedKey.getValue(), "value");
+
+        TomlStringValueNode nestedDottedKey1 = (TomlStringValueNode) read.get("root.first.third").get();
+        Assert.assertEquals(nestedDottedKey1.getValue(), "value1");
+
+        TomlStringValueNode mixedDotted = (TomlStringValueNode) read.get("foo.bar").get();
+        Assert.assertEquals(mixedDotted.getValue(), "test");
+
+        TomlStringValueNode mixedTable = (TomlStringValueNode) read.get("foo.fee").get();
+        Assert.assertEquals(mixedTable.getValue(), "wew");
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -275,8 +275,5 @@ public class KeyValueTest {
 
         TomlStringValueNode mixedDotted = (TomlStringValueNode) read.get("foo.bar").get();
         Assert.assertEquals(mixedDotted.getValue(), "test");
-
-        TomlStringValueNode mixedTable = (TomlStringValueNode) read.get("foo.fee").get();
-        Assert.assertEquals(mixedTable.getValue(), "wew");
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/KeyValueTest.java
@@ -24,12 +24,14 @@ import io.ballerina.toml.semantic.ast.TomlBooleanValueNode;
 import io.ballerina.toml.semantic.ast.TomlDoubleValueNodeNode;
 import io.ballerina.toml.semantic.ast.TomlLongValueNode;
 import io.ballerina.toml.semantic.ast.TomlStringValueNode;
+import io.ballerina.toml.semantic.ast.TomlValueNode;
 import org.testng.Assert;
-import org.testng.annotations.Optional;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
+import java.util.Optional;
 
 /**
  * Basic Test for TOML Key Value Pairs.
@@ -42,17 +44,17 @@ public class KeyValueTest {
                 .getResourceAsStream("syntax/key-value/keys.toml");
 
         Toml read = Toml.read(inputStream);
-        String basicKey = ((TomlStringValueNode) read.get("key")).getValue();
-        String underscoreKey = ((TomlStringValueNode) read.get("underscore_key")).getValue();
-        String dashKey = ((TomlStringValueNode) read.get("dash-key")).getValue();
-        String intKey = ((TomlStringValueNode) read.get("1234")).getValue();
+        String basicKey = ((TomlStringValueNode) read.get("key").get()).getValue();
+        String underscoreKey = ((TomlStringValueNode) read.get("underscore_key").get()).getValue();
+        String dashKey = ((TomlStringValueNode) read.get("dash-key").get()).getValue();
+        String intKey = ((TomlStringValueNode) read.get("1234").get()).getValue();
 
         String dottedString =
-                ((TomlStringValueNode) read.get("127.0.0.1")).getValue();
-        String spacing = ((TomlStringValueNode) read.get("character encoding")).getValue();
-        String unicode = ((TomlStringValueNode) read.get("ʎǝʞ")).getValue();
-        String general = ((TomlStringValueNode) read.get("key2")).getValue();
-        String escape = ((TomlStringValueNode) read.get("quoted \"value\"")).getValue();
+                ((TomlStringValueNode) read.get("\"127.0.0.1\"").get()).getValue();
+        String spacing = ((TomlStringValueNode) read.get("\"character encoding\"").get()).getValue();
+        String unicode = ((TomlStringValueNode) read.get("\"ʎǝʞ\"").get()).getValue();
+        String general = ((TomlStringValueNode) read.get("\"key2\"").get()).getValue();
+        String escape = ((TomlStringValueNode) read.get("\"quoted \"value\"\"").get()).getValue();
 
         Assert.assertEquals(basicKey, "basic key");
         Assert.assertEquals(underscoreKey, "Underscore Key");
@@ -71,12 +73,12 @@ public class KeyValueTest {
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/values.toml");
         Toml read = Toml.read(inputStream);
-        String stringValue = ((TomlStringValueNode) read.get("key1")).getValue();
-        Long longValue = ((TomlLongValueNode) read.get("key2")).getValue();
-        Double doubleValue = ((TomlDoubleValueNodeNode) read.get("key3")).getValue();
-        String multiString = ((TomlStringValueNode) read.get("key4")).getValue();
-        boolean boolfalse = ((TomlBooleanValueNode) read.get("key6")).getValue();
-        boolean booltrue = ((TomlBooleanValueNode) read.get("key7")).getValue();
+        String stringValue = ((TomlStringValueNode) read.get("key1").get()).getValue();
+        Long longValue = ((TomlLongValueNode) read.get("key2").get()).getValue();
+        Double doubleValue = ((TomlDoubleValueNodeNode) read.get("key3").get()).getValue();
+        String multiString = ((TomlStringValueNode) read.get("key4").get()).getValue();
+        boolean boolfalse = ((TomlBooleanValueNode) read.get("key6").get()).getValue();
+        boolean booltrue = ((TomlBooleanValueNode) read.get("key7").get()).getValue();
 
         Assert.assertEquals(stringValue, "hello");
         Assert.assertEquals(longValue, Long.valueOf(123L));
@@ -86,98 +88,98 @@ public class KeyValueTest {
         Assert.assertFalse(boolfalse);
         Assert.assertTrue(booltrue);
 
-        Long int1 = ((TomlLongValueNode) read.get("int1")).getValue();
+        Long int1 = ((TomlLongValueNode) read.get("int1").get()).getValue();
         Assert.assertEquals(int1, Long.valueOf(99L));
-        Long int2 = ((TomlLongValueNode) read.get("int2")).getValue();
+        Long int2 = ((TomlLongValueNode) read.get("int2").get()).getValue();
         Assert.assertEquals(int2, Long.valueOf(42L));
-        Long int3 = ((TomlLongValueNode) read.get("int3")).getValue();
+        Long int3 = ((TomlLongValueNode) read.get("int3").get()).getValue();
         Assert.assertEquals(int3, Long.valueOf(0L));
-        Long int4 = ((TomlLongValueNode) read.get("int4")).getValue();
+        Long int4 = ((TomlLongValueNode) read.get("int4").get()).getValue();
         Assert.assertEquals(int4, Long.valueOf(-17L));
 
-        Long int5 = ((TomlLongValueNode) read.get("int5")).getValue();
+        Long int5 = ((TomlLongValueNode) read.get("int5").get()).getValue();
         Assert.assertEquals(int5, Long.valueOf(1000L));
-        Long int6 = ((TomlLongValueNode) read.get("int6")).getValue();
+        Long int6 = ((TomlLongValueNode) read.get("int6").get()).getValue();
         Assert.assertEquals(int6, Long.valueOf(5349221L));
-        Long int7 = ((TomlLongValueNode) read.get("int7")).getValue();
+        Long int7 = ((TomlLongValueNode) read.get("int7").get()).getValue();
         Assert.assertEquals(int7, Long.valueOf(5349221L));
-        Long int8 = ((TomlLongValueNode) read.get("int8")).getValue();
+        Long int8 = ((TomlLongValueNode) read.get("int8").get()).getValue();
         Assert.assertEquals(int8, Long.valueOf(12345L));
 
-        Long hex1 = ((TomlLongValueNode) read.get("hex1")).getValue();
+        Long hex1 = ((TomlLongValueNode) read.get("hex1").get()).getValue();
         Assert.assertEquals(hex1, Long.valueOf(3735928559L));
-        Long hex2 = ((TomlLongValueNode) read.get("hex2")).getValue();
+        Long hex2 = ((TomlLongValueNode) read.get("hex2").get()).getValue();
         Assert.assertEquals(hex2, Long.valueOf(3735928559L));
-        Long hex3 = ((TomlLongValueNode) read.get("hex3")).getValue();
+        Long hex3 = ((TomlLongValueNode) read.get("hex3").get()).getValue();
         Assert.assertEquals(hex3, Long.valueOf(3735928559L));
 
-        Long oct1 = ((TomlLongValueNode) read.get("oct1")).getValue();
+        Long oct1 = ((TomlLongValueNode) read.get("oct1").get()).getValue();
         Assert.assertEquals(oct1, Long.valueOf(342391L));
-        Long oct2 = ((TomlLongValueNode) read.get("oct2")).getValue();
+        Long oct2 = ((TomlLongValueNode) read.get("oct2").get()).getValue();
         Assert.assertEquals(oct2, Long.valueOf(493L));
 
-        Long bin1 = ((TomlLongValueNode) read.get("bin1")).getValue();
+        Long bin1 = ((TomlLongValueNode) read.get("bin1").get()).getValue();
         Assert.assertEquals(bin1, Long.valueOf(214L));
 
-        Double flt1 = ((TomlDoubleValueNodeNode) read.get("flt1")).getValue();
+        Double flt1 = ((TomlDoubleValueNodeNode) read.get("flt1").get()).getValue();
         Assert.assertEquals(flt1, 1.0);
-        Double flt2 = ((TomlDoubleValueNodeNode) read.get("flt2")).getValue();
+        Double flt2 = ((TomlDoubleValueNodeNode) read.get("flt2").get()).getValue();
         Assert.assertEquals(flt2, 3.1415);
-        Double flt3 = ((TomlDoubleValueNodeNode) read.get("flt3")).getValue();
+        Double flt3 = ((TomlDoubleValueNodeNode) read.get("flt3").get()).getValue();
         Assert.assertEquals(flt3, -0.01);
 
-        Double flt4 = ((TomlDoubleValueNodeNode) read.get("flt4")).getValue();
+        Double flt4 = ((TomlDoubleValueNodeNode) read.get("flt4").get()).getValue();
         Assert.assertEquals(flt4, 5e+22);
-        Double flt5 = ((TomlDoubleValueNodeNode) read.get("flt5")).getValue();
+        Double flt5 = ((TomlDoubleValueNodeNode) read.get("flt5").get()).getValue();
         Assert.assertEquals(flt5, 1e06);
-        Double flt6 = ((TomlDoubleValueNodeNode) read.get("flt6")).getValue();
+        Double flt6 = ((TomlDoubleValueNodeNode) read.get("flt6").get()).getValue();
         Assert.assertEquals(flt6, -2E-2);
 
-        Double flt7 = ((TomlDoubleValueNodeNode) read.get("flt7")).getValue();
+        Double flt7 = ((TomlDoubleValueNodeNode) read.get("flt7").get()).getValue();
         Assert.assertEquals(flt7, 6.626e-34);
 
-        Double flt8 = ((TomlDoubleValueNodeNode) read.get("flt8")).getValue();
+        Double flt8 = ((TomlDoubleValueNodeNode) read.get("flt8").get()).getValue();
         Assert.assertEquals(flt8, 224617.445991228);
 
-        String stringEscape = ((TomlStringValueNode) read.get("str0")).getValue();
+        String stringEscape = ((TomlStringValueNode) read.get("str0").get()).getValue();
         Assert.assertEquals(stringEscape, "I'm a string. \"You can quote me\". Name\tJosé\n" +
                 "Location\tSF.");
 
-        String basicString = ((TomlStringValueNode) read.get("str1")).getValue();
+        String basicString = ((TomlStringValueNode) read.get("str1").get()).getValue();
         Assert.assertEquals(basicString, "The quick brown fox jumps over the lazy dog.");
-        String backslashWithWhitespace = ((TomlStringValueNode) read.get("str2")).getValue();
+        String backslashWithWhitespace = ((TomlStringValueNode) read.get("str2").get()).getValue();
         Assert.assertEquals(backslashWithWhitespace, "The quick brown fox jumps over the lazy dog.");
-        String multilineBasklash = ((TomlStringValueNode) read.get("str3")).getValue();
+        String multilineBasklash = ((TomlStringValueNode) read.get("str3").get()).getValue();
         Assert.assertEquals(multilineBasklash, "The quick brown fox jumps over the lazy dog.");
 
-        String twoEscapes = ((TomlStringValueNode) read.get("str4")).getValue();
+        String twoEscapes = ((TomlStringValueNode) read.get("str4").get()).getValue();
         Assert.assertEquals(twoEscapes, "Here are two quotation marks: \"\". Simple enough.");
-        String threeQuotesEscapes = ((TomlStringValueNode) read.get("str5")).getValue();
+        String threeQuotesEscapes = ((TomlStringValueNode) read.get("str5").get()).getValue();
         Assert.assertEquals(threeQuotesEscapes, "Here are three quotation marks: \"\"\".");
-        String fifteenQuotes = ((TomlStringValueNode) read.get("str6")).getValue();
+        String fifteenQuotes = ((TomlStringValueNode) read.get("str6").get()).getValue();
         Assert.assertEquals(fifteenQuotes, "Here are fifteen quotation marks: \"\"\"\"\"\"\"\"\"\"\"\"\"\"\".");
-        String mixedEscape = ((TomlStringValueNode) read.get("str7")).getValue();
+        String mixedEscape = ((TomlStringValueNode) read.get("str7").get()).getValue();
         Assert.assertEquals(mixedEscape, "\"This,\" she said, \"is just a pointless statement.");
 
-        String absPathLiteralString = ((TomlStringValueNode) read.get("lit1")).getValue();
+        String absPathLiteralString = ((TomlStringValueNode) read.get("lit1").get()).getValue();
         Assert.assertEquals(absPathLiteralString, "C:\\Users\\nodejs\\templates");
-        String windowsPathLiteralString = ((TomlStringValueNode) read.get("lit2")).getValue();
+        String windowsPathLiteralString = ((TomlStringValueNode) read.get("lit2").get()).getValue();
         Assert.assertEquals(windowsPathLiteralString, "\\\\ServerX\\admin$\\system32\\");
-        String doubeQuoteLiteralString = ((TomlStringValueNode) read.get("lit3")).getValue();
+        String doubeQuoteLiteralString = ((TomlStringValueNode) read.get("lit3").get()).getValue();
         Assert.assertEquals(doubeQuoteLiteralString, "Tom \"Dubs\" Preston-Werner");
-        String regexLiteralString = ((TomlStringValueNode) read.get("lit4")).getValue();
+        String regexLiteralString = ((TomlStringValueNode) read.get("lit4").get()).getValue();
         Assert.assertEquals(regexLiteralString, "<\\i\\c*\\s*>");
-        String regex2LiteralString = ((TomlStringValueNode) read.get("lit5")).getValue();
+        String regex2LiteralString = ((TomlStringValueNode) read.get("lit5").get()).getValue();
         Assert.assertEquals(regex2LiteralString, "I [dw]on't need \\d{2} apples");
 
-        String multilineLiteralString = ((TomlStringValueNode) read.get("lit6")).getValue();
+        String multilineLiteralString = ((TomlStringValueNode) read.get("lit6").get()).getValue();
         Assert.assertEquals(multilineLiteralString, String.format(
                 "The first newline is%strimmed in raw strings.%s   All other whitespace%s   is preserved.%s",
                 System.lineSeparator(), System.lineSeparator(), System.lineSeparator(), System.lineSeparator()));
-        String fifteenQuotesWithLiteral = ((TomlStringValueNode) read.get("lit7")).getValue();
+        String fifteenQuotesWithLiteral = ((TomlStringValueNode) read.get("lit7").get()).getValue();
         Assert.assertEquals(fifteenQuotesWithLiteral,
                 "Here are fifteen quotation marks: \"\"\"\"\"\"\"\"\"\"\"\"\"\"\"");
-        String fifteenSingleQuotes = ((TomlStringValueNode) read.get("lit8")).getValue();
+        String fifteenSingleQuotes = ((TomlStringValueNode) read.get("lit8").get()).getValue();
         Assert.assertEquals(fifteenSingleQuotes, "Here are fifteen apostrophes: '''''''''''''''");
     }
 
@@ -187,7 +189,7 @@ public class KeyValueTest {
                 .getResourceAsStream("syntax/key-value/array.toml");
         Toml read = Toml.read(inputStream);
 
-        TomlArrayValueNode mixedType = read.get("mixed_type");
+        TomlArrayValueNode mixedType = (TomlArrayValueNode) read.get("mixed_type").get();
         Long first = ((TomlLongValueNode) mixedType.get(0)).getValue();
         Long second = ((TomlLongValueNode) mixedType.get(1)).getValue();
         String third = ((TomlStringValueNode) mixedType.get(2)).getValue();
@@ -198,7 +200,7 @@ public class KeyValueTest {
         Assert.assertEquals(fourth, Long.valueOf(3L));
         Assert.assertEquals(third, "test string");
 
-        TomlArrayValueNode nestedArray = read.get("nested_array");
+        TomlArrayValueNode nestedArray = (TomlArrayValueNode) read.get("nested_array").get();
         Long nfirst = ((TomlLongValueNode) nestedArray.get(0)).getValue();
         Long nsecond = ((TomlLongValueNode) nestedArray.get(1)).getValue();
         Long nfourth = ((TomlLongValueNode) nestedArray.get(3)).getValue();
@@ -214,28 +216,38 @@ public class KeyValueTest {
         Assert.assertEquals(csecond, Long.valueOf(6L));
     }
 
-    @Test(enabled = false)
+    @Test
     public void testDottedKey() throws IOException {
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/key-value/new-api.toml");
         Toml read = Toml.read(inputStream);
 
-        TomlStringValueNode plainKey = (TomlStringValueNode) read.getEntry("key").get();
-        Assert.assertEquals(plainKey.getValue(), "no quote");
-//TODO Fixme
-//        TomlStringValueNode simpleQuotedKey = (TomlStringValueNode) read.getEntry("\"key\"").get();
-//        Assert.assertEquals(simpleQuotedKey.getValue(), "quoted key");
+        Optional<TomlValueNode> noneExistKey = read.get("none");
+        Assert.assertTrue(noneExistKey.isEmpty());
 
-        TomlStringValueNode plainNestedChild = (TomlStringValueNode) read.getEntry("table.hi").get();
+        Optional<TomlValueNode> noneExistKeyNextedTable = read.get("table.none");
+        Assert.assertTrue(noneExistKeyNextedTable.isEmpty());
+
+        TomlStringValueNode plainKey = (TomlStringValueNode) read.get("key").get();
+        Assert.assertEquals(plainKey.getValue(), "no quote");
+
+        TomlStringValueNode simpleQuotedKey = (TomlStringValueNode) read.get("\"key\"").get();
+        Assert.assertEquals(simpleQuotedKey.getValue(), "quoted key");
+
+        TomlStringValueNode plainNestedChild = (TomlStringValueNode) read.get("table.hi").get();
         Assert.assertEquals(plainNestedChild.getValue(), "hii");
 
-//        //TODO fixme
-//        TomlStringValueNode shortChild = (TomlStringValueNode) read.getEntry("table1.child").get();
-//        Assert.assertEquals(shortChild.getValue(), "hello");
-
-        TomlStringValueNode quotedSingle = (TomlStringValueNode) read.getEntry("\"foo bar\"").get();
+        TomlStringValueNode quotedSingle = (TomlStringValueNode) read.get("table.\"foo bar\"").get();
         Assert.assertEquals(quotedSingle.getValue(), "boo");
 
+        TomlBooleanValueNode dotted1 = (TomlBooleanValueNode) read.get("site.\"google.com\"").get();
+        Assert.assertTrue(dotted1.getValue());
+
+        TomlStringValueNode nestedTable = (TomlStringValueNode) read.get("table.hello.child").get();
+        Assert.assertEquals(nestedTable.getValue(), "new");
+
+        List<Toml> envList = read.getTables("cloud.config.envs");
+        Assert.assertEquals(envList.size(), 2);
 
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/core/TableTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/core/TableTest.java
@@ -21,7 +21,6 @@ package toml.parser.test.api.core;
 import io.ballerina.toml.api.Toml;
 import io.ballerina.toml.semantic.ast.TomlLongValueNode;
 import io.ballerina.toml.semantic.ast.TomlStringValueNode;
-import io.ballerina.toml.semantic.ast.TomlValueNode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -40,20 +39,22 @@ public class TableTest {
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/tables/table.toml");
         Toml read = Toml.read(inputStream);
-        Long rootKey = ((TomlLongValueNode) read.get("rootKey")).getValue();
-        String dotNotation = ((TomlStringValueNode) read.getTable("first").get("key")).getValue();
-        Toml firstTable = read.getTable("first");
-        String queryFromSubTable = ((TomlStringValueNode) firstTable.get("key")).getValue();
-
-        String subDotNotation = ((TomlStringValueNode) read.getTable("first").getTable("sub").get("key")).getValue();
-        Toml subTable = read.getTable("first").getTable("sub");
-        String queryFromDeepSubTable = ((TomlStringValueNode) subTable.get("key")).getValue();
-
+        Long rootKey = ((TomlLongValueNode) read.get("rootKey").get()).getValue();
         Assert.assertEquals(rootKey, Long.valueOf(22L));
-        Assert.assertEquals(dotNotation, "sdsad");
+
+        Toml firstTable = read.getTable("first").get();
+        String queryFromSubTable = ((TomlStringValueNode) firstTable.get("key").get()).getValue();
         Assert.assertEquals(queryFromSubTable, "sdsad");
 
+        String dotNotation = ((TomlStringValueNode) read.get("first.key").get()).getValue();
+        Assert.assertEquals(dotNotation, "sdsad");
+
+
+        String subDotNotation = ((TomlStringValueNode) read.get("first.sub.key").get()).getValue();
+        Toml subTable = read.getTable("first.sub").get();
         Assert.assertEquals(subDotNotation, "ewww");
+
+        String queryFromDeepSubTable = ((TomlStringValueNode) subTable.get("key").get()).getValue();
         Assert.assertEquals(queryFromDeepSubTable, "ewww");
     }
 
@@ -63,16 +64,16 @@ public class TableTest {
         InputStream inputStream = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("syntax/tables/array-of-tables.toml");
         Toml read = Toml.read(inputStream);
-        String valueInTable = ((TomlStringValueNode) read.getTable("products").get("hello1")).getValue();
+        String valueInTable = ((TomlStringValueNode) read.getTable("products").get().get("hello1").get()).getValue();
         Assert.assertEquals(valueInTable, "hi");
 
-        List<Toml> tables = read.getTable("products").getTables("hello");
-        String firstElement = ((TomlStringValueNode) tables.get(0).get("name")).getValue();
-        TomlValueNode nullElement = tables.get(1).get("name");
-        String thridElement = ((TomlStringValueNode) tables.get(2).get("name")).getValue();
+        List<Toml> tables = read.getTable("products").get().getTables("hello");
+        String firstElement = ((TomlStringValueNode) tables.get(0).get("name").get()).getValue();
+        boolean nullElement = tables.get(1).get("name").isEmpty();
+        String thridElement = ((TomlStringValueNode) tables.get(2).get("name").get()).getValue();
 
         Assert.assertEquals(firstElement, "Hammer");
-        Assert.assertNull(nullElement);
+        Assert.assertTrue(nullElement);
         Assert.assertEquals(thridElement, "Nail");
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/errors/TableTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/errors/TableTest.java
@@ -91,9 +91,9 @@ public class TableTest {
         ErrorTestUtils.validateDiagnostic(actualDiagOfDupKey, expectedLineRangeOfDupKey,  "existing node 'key'",
                 DiagnosticSeverity.ERROR);
 
-        LineRange expectedLineRangeOfDupTable = ErrorTestUtils.toLineRange(22, 22, 1, 12);
+        LineRange expectedLineRangeOfDupTable = ErrorTestUtils.toLineRange(21, 22, 1, 12);
         Diagnostic actualDiagOfDupTable = diagnostics.get(1);
-        ErrorTestUtils.validateDiagnostic(actualDiagOfDupTable, expectedLineRangeOfDupTable,  "existing node 'mow'",
+        ErrorTestUtils.validateDiagnostic(actualDiagOfDupTable, expectedLineRangeOfDupTable,  "existing node 'foo'",
                 DiagnosticSeverity.ERROR);
     }
 }

--- a/misc/toml-parser/src/test/java/toml/parser/test/api/errors/TableTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/api/errors/TableTest.java
@@ -77,4 +77,23 @@ public class TableTest {
         ErrorTestUtils.validateDiagnostic(actualDiag, expectedLineRange, "missing close bracket token",
                 DiagnosticSeverity.ERROR);
     }
+
+    @Test
+    public void testExistingNode() throws IOException {
+
+        InputStream inputStream = Thread.currentThread().getContextClassLoader()
+                .getResourceAsStream("semantic/existing-node.toml");
+        Toml read = Toml.read(inputStream);
+        List<Diagnostic> diagnostics = read.diagnostics();
+
+        LineRange expectedLineRangeOfDupKey = ErrorTestUtils.toLineRange(18, 18, 1, 15);
+        Diagnostic actualDiagOfDupKey = diagnostics.get(0);
+        ErrorTestUtils.validateDiagnostic(actualDiagOfDupKey, expectedLineRangeOfDupKey,  "existing node 'key'",
+                DiagnosticSeverity.ERROR);
+
+        LineRange expectedLineRangeOfDupTable = ErrorTestUtils.toLineRange(22, 22, 1, 12);
+        Diagnostic actualDiagOfDupTable = diagnostics.get(1);
+        ErrorTestUtils.validateDiagnostic(actualDiagOfDupTable, expectedLineRangeOfDupTable,  "existing node 'mow'",
+                DiagnosticSeverity.ERROR);
+    }
 }

--- a/misc/toml-parser/src/test/resources/basic-toml.toml
+++ b/misc/toml-parser/src/test/resources/basic-toml.toml
@@ -14,4 +14,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-key = ""
+#key = "hello"
+key."hello.lul" = "new"

--- a/misc/toml-parser/src/test/resources/basic-toml.toml
+++ b/misc/toml-parser/src/test/resources/basic-toml.toml
@@ -14,5 +14,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-"key" = "hello"
-#key."hello.lul" = "new"
+key = "lul"
+key = "hello"

--- a/misc/toml-parser/src/test/resources/basic-toml.toml
+++ b/misc/toml-parser/src/test/resources/basic-toml.toml
@@ -14,5 +14,5 @@
 # specific language governing permissions and limitations
 # under the License.
 
-#key = "hello"
-key."hello.lul" = "new"
+"key" = "hello"
+#key."hello.lul" = "new"

--- a/misc/toml-parser/src/test/resources/basic-toml.toml
+++ b/misc/toml-parser/src/test/resources/basic-toml.toml
@@ -14,4 +14,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-key = "value"
+key = ""

--- a/misc/toml-parser/src/test/resources/semantic/existing-node.toml
+++ b/misc/toml-parser/src/test/resources/semantic/existing-node.toml
@@ -14,12 +14,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
-key"value"
+key = "first"
+key = "second"
+foo.mow = "test"
 
-key1 = 12
-
-="value"
-
-key2 = 33
-
-key3 =
+[foo]
+mow = "wew"

--- a/misc/toml-parser/src/test/resources/syntax/key-value/dotted.toml
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/dotted.toml
@@ -31,5 +31,3 @@ key= "BAR"
 first.second = "value"
 first.third = "value1"
 
-[foo]
-fee = "wew"

--- a/misc/toml-parser/src/test/resources/syntax/key-value/dotted.toml
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/dotted.toml
@@ -2,12 +2,21 @@ key = "no quote"
 "key" = "quoted key" #Should come to the tree but give error with semantic analyzer
 site."google.com" = true
 
+apple.type = "fruit"
+orange.type = "fruit"
+
+apple.skin = "thin"
+orange.skin = "thick"
+
+apple.color = "red"
+orange.color = "orange"
+foo.bar = "test"
+
 [table]
 hi = "hii"
 "foo bar" = "boo"
 [table.hello]
 child = "new"
-
 
 [[cloud.config.envs]]
 config_name= "module-foo"
@@ -17,3 +26,10 @@ key= "FOO"
 name= "bar"
 config_name= "module-bar"
 key= "BAR"
+
+[root]
+first.second = "value"
+first.third = "value1"
+
+[foo]
+fee = "wew"

--- a/misc/toml-parser/src/test/resources/syntax/key-value/new-api.toml
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/new-api.toml
@@ -1,10 +1,19 @@
 key = "no quote"
-#"key" = "quoted key" #Should come to the tree but give error with semantic analyzer
+"key" = "quoted key" #Should come to the tree but give error with semantic analyzer
+site."google.com" = true
 
 [table]
 hi = "hii"
-
-table1.child = "hello"
-
 "foo bar" = "boo"
+[table.hello]
+child = "new"
 
+
+[[cloud.config.envs]]
+config_name= "module-foo"
+key= "FOO"
+
+[[cloud.config.envs]]
+name= "bar"
+config_name= "module-bar"
+key= "BAR"

--- a/misc/toml-parser/src/test/resources/syntax/key-value/new-api.toml
+++ b/misc/toml-parser/src/test/resources/syntax/key-value/new-api.toml
@@ -1,0 +1,10 @@
+key = "no quote"
+#"key" = "quoted key" #Should come to the tree but give error with semantic analyzer
+
+[table]
+hi = "hii"
+
+table1.child = "hello"
+
+"foo bar" = "boo"
+


### PR DESCRIPTION
## Purpose
$Subject. Removes Deprecated status from `Toml` class. Contains breaking changes to `Toml` class. AFAIK only code to cloud uses this class for now, i'll be updating that code once this is merged.

Earlier Toml Parser API followed query chaining approach instead. `read.getTable("key").get("hi")` The main issue with approach is if you get NPE in the middle of the chain it becomes really hard to capture it. The reason for going for this chaining method was quoted string keys in toml spec.

However, with this PR, quoted string keys will be treated differently from regular keys. If you want to query a key value pair with quoted string key you have to include quotes with the key. 
Retrieving Key that has quoted string key.
`read.get("\"key\"")`

Toml API now also supports dotted keys for easy retrieval.
`read.get("key.hi");`

In order to avoid the NPE issue stated above, the API now supports Optionals as chaining is not needed.
`TomlStringValueNode key1 = (TomlStringValueNode) read.get("key").get();`

This PR also fixes some bugs related to dotted Keys and existing node diagnostics
Fixes #27789
Fixes #27769


## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
