### PR TITLE
Refactor Symbol interface

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ClassLoadInvoker.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ClassLoadInvoker.java
@@ -345,7 +345,7 @@ public class ClassLoadInvoker extends Invoker implements ImportProcessor {
         for (Symbol symbol : symbols) {
             HashedSymbol hashedSymbol = new HashedSymbol(symbol);
             // TODO: After name alternative is implemented use it.
-            String variableName = symbol.name();
+            String variableName = symbol.getName().get();
 
             boolean ignoreSymbol = knownSymbols.contains(hashedSymbol)
                     || GlobalVariable.isDefined(foundVariables, variableName)
@@ -405,7 +405,7 @@ public class ClassLoadInvoker extends Invoker implements ImportProcessor {
                 if (!symbol.kind().equals(SymbolKind.MODULE)) {
                     this.newSymbols.add(new HashedSymbol(symbol));
                     // TODO: After name alternative is implemented use it.
-                    return Map.entry(symbol.name(), newSnippet.toString());
+                    return Map.entry(symbol.getName().get(), newSnippet.toString());
                 }
             }
         }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ClassLoadInvoker.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/ClassLoadInvoker.java
@@ -343,8 +343,12 @@ public class ClassLoadInvoker extends Invoker implements ImportProcessor {
 
         Set<GlobalVariable> foundVariables = new HashSet<>();
         for (Symbol symbol : symbols) {
+            if (symbol.getName().isEmpty()) {
+                // Do not process symbols without a name
+                continue;
+            }
+
             HashedSymbol hashedSymbol = new HashedSymbol(symbol);
-            // TODO: After name alternative is implemented use it.
             String variableName = symbol.getName().get();
 
             boolean ignoreSymbol = knownSymbols.contains(hashedSymbol)
@@ -402,9 +406,12 @@ public class ClassLoadInvoker extends Invoker implements ImportProcessor {
             return Map.entry(enumName.get(), newSnippet.toString());
         } else {
             for (Symbol symbol : symbols) {
+                if (symbol.getName().isEmpty()) {
+                    // A valid module dcln symbol has a name
+                    continue;
+                }
                 if (!symbol.kind().equals(SymbolKind.MODULE)) {
                     this.newSymbols.add(new HashedSymbol(symbol));
-                    // TODO: After name alternative is implemented use it.
                     return Map.entry(symbol.getName().get(), newSnippet.toString());
                 }
             }
@@ -637,6 +644,7 @@ public class ClassLoadInvoker extends Invoker implements ImportProcessor {
 
         return compilation.getSemanticModel(moduleId)
                 .visibleSymbols(document, cursorPos).stream()
+                .filter((s) -> s.getName().isPresent())
                 .filter((s) -> !knownSymbols.contains(new HashedSymbol(s)))
                 .collect(Collectors.toList());
     }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/HashedSymbol.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/HashedSymbol.java
@@ -36,11 +36,13 @@ public class HashedSymbol {
 
     /**
      * Wraps symbol with hashed symbol to make is hashable.
+     * Symbol must have a name to be created a hashed symbol.
+     * If the symbol does not have a name {@code NoSuchElementException} will be thrown.
      *
      * @param symbol Symbol to wrap.
      */
     public HashedSymbol(Symbol symbol) {
-        this.name = symbol.getName().get();
+        this.name = symbol.getName().orElseThrow();
         this.kind = symbol.kind();
     }
 

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/HashedSymbol.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/HashedSymbol.java
@@ -40,7 +40,7 @@ public class HashedSymbol {
      * @param symbol Symbol to wrap.
      */
     public HashedSymbol(Symbol symbol) {
-        this.name = symbol.name();
+        this.name = symbol.getName().get();
         this.kind = symbol.kind();
     }
 

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
@@ -107,7 +107,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
         StringJoiner joiner = new StringJoiner(" ");
         fieldSymbol.qualifiers().forEach(qualifier -> joiner.add(qualifier.getValue()));
         String signature = joiner.add(transformType(fieldSymbol.typeDescriptor()))
-                .add(fieldSymbol.name()).toString();
+                .add(fieldSymbol.getName().get()).toString();
         this.setState(signature);
     }
 
@@ -117,7 +117,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
         fieldSymbol.qualifiers().forEach(qualifier -> joiner.add(qualifier.getValue()));
 
         String signature = joiner.add(transformType(fieldSymbol.typeDescriptor()))
-                .add(fieldSymbol.name()).toString();
+                .add(fieldSymbol.getName().get()).toString();
         if (fieldSymbol.isOptional()) {
             signature += "?";
         }
@@ -132,7 +132,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
 
         StringBuilder signature = new StringBuilder(qualifierJoiner.toString());
         StringJoiner joiner = new StringJoiner(", ");
-        signature.append(methodSymbol.name()).append("(");
+        signature.append(methodSymbol.getName().get()).append("(");
 
         methodSymbol.typeDescriptor().parameters().stream().map(this::transformParameter).forEach(joiner::add);
         methodSymbol.typeDescriptor().restParam().map(this::transformParameter).ifPresent(joiner::add);
@@ -329,7 +329,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
     private String transformExternalRefType(TypeSymbol typeSymbol) {
         // If the module is not anon, imports module.
 
-        String typeName = typeSymbol.name();
+        String typeName = typeSymbol.getName().get();
         if (typeName.isBlank()) {
             String typeSignature = typeSymbol.signature();
             typeName = typeSignature.substring(typeSignature.lastIndexOf(':') + 1);

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
@@ -329,8 +329,9 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
     private String transformExternalRefType(TypeSymbol typeSymbol) {
         // If the module is not anon, imports module.
 
-        String typeName = typeSymbol.getName().get();
+        String typeName = typeSymbol.getName().orElse("");
         if (typeName.isBlank()) {
+            // Name was null or blank
             String typeSignature = typeSymbol.signature();
             typeName = typeSignature.substring(typeSignature.lastIndexOf(':') + 1);
         }

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.shell.invoker.classload.visitors;
 
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
 import io.ballerina.compiler.api.symbols.ErrorTypeSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
@@ -336,18 +337,18 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
             typeName = typeSignature.substring(typeSignature.lastIndexOf(':') + 1);
         }
 
-        if (typeSymbol.moduleID().orgName().equals(ANON_MODULE)
-                || (typeSymbol.moduleID().moduleName().equals("lang.annotations")
-                && typeSymbol.moduleID().orgName().equals("ballerina"))) {
+        ModuleID moduleID = typeSymbol.getModule().isPresent() ? typeSymbol.getModule().get().id() : null;
+
+        if (moduleID == null || moduleID.orgName().equals(ANON_MODULE)
+                || (moduleID.moduleName().equals("lang.annotations") && moduleID.orgName().equals("ballerina"))) {
             // No import required. If the name is not found,
             // signature can be used without module parts.
             return typeName;
-
         } else {
-            String moduleName = Arrays.stream(typeSymbol.moduleID().moduleName().split("\\."))
+            String moduleName = Arrays.stream(moduleID.moduleName().split("\\."))
                     .map(StringUtils::quoted).collect(Collectors.joining("."));
-            String fullModuleName = typeSymbol.moduleID().orgName() + "/" + moduleName;
-            String defaultPrefix = StringUtils.quoted(typeSymbol.moduleID().modulePrefix());
+            String fullModuleName = moduleID.orgName() + "/" + moduleName;
+            String defaultPrefix = StringUtils.quoted(moduleID.modulePrefix());
             try {
                 String importPrefix = importProcessor.processImplicitImport(fullModuleName, defaultPrefix);
                 implicitImportPrefixes.add(importPrefix);

--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
@@ -331,7 +331,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
         // If the module is not anon, imports module.
 
         String typeName = typeSymbol.getName().orElse("");
-        if (typeName.isBlank()) {
+        if (typeName.isEmpty()) {
             // Name was null or blank
             String typeSignature = typeSymbol.signature();
             typeName = typeSignature.substring(typeSignature.lastIndexOf(':') + 1);
@@ -340,7 +340,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
         ModuleID moduleID = typeSymbol.getModule().isPresent() ? typeSymbol.getModule().get().id() : null;
 
         if (moduleID == null || moduleID.orgName().equals(ANON_MODULE)
-                || (moduleID.moduleName().equals("lang.annotations") && moduleID.orgName().equals("ballerina"))) {
+                || ("lang.annotations".equals(moduleID.moduleName()) && "ballerina".equals(moduleID.orgName()))) {
             // No import required. If the name is not found,
             // signature can be used without module parts.
             return typeName;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -165,14 +165,14 @@ public class BallerinaSemanticModel implements SemanticModel {
      */
     @Override
     public List<Location> references(Symbol symbol) {
-        Location symbolLocation = symbol.location();
+        Optional<Location> symbolLocation = symbol.getLocation();
 
         // Assumption is that the location will be null for regular type symbols
-        if (symbolLocation == null) {
+        if (symbolLocation.isEmpty()) {
             return Collections.unmodifiableList(new ArrayList<>());
         }
 
-        BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolLocation.lineRange());
+        BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolLocation.get().lineRange());
 
         ReferenceFinder refFinder = new ReferenceFinder();
         return refFinder.findReferences(node, getInternalSymbol(symbol));

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -169,7 +169,7 @@ public class BallerinaSemanticModel implements SemanticModel {
 
         // Assumption is that the location will be null for regular type symbols
         if (symbolLocation.isEmpty()) {
-            return Collections.unmodifiableList(new ArrayList<>());
+            return Collections.emptyList();
         }
 
         BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolLocation.get().lineRange());
@@ -188,7 +188,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
 
         if (symbolAtCursor == null) {
-            return Collections.unmodifiableList(new ArrayList<>());
+            return Collections.emptyList();
         }
 
         BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolAtCursor.pos.lineRange());

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -175,7 +175,7 @@ public class SymbolFactory {
     public BallerinaFunctionSymbol createFunctionSymbol(BInvokableSymbol invokableSymbol, String name) {
         PackageID pkgID = invokableSymbol.pkgID;
         BallerinaFunctionSymbol.FunctionSymbolBuilder builder =
-                new BallerinaFunctionSymbol.FunctionSymbolBuilder(name, pkgID, invokableSymbol);
+                new BallerinaFunctionSymbol.FunctionSymbolBuilder(name, pkgID, invokableSymbol, this.context);
         boolean isResourceMethod = isFlagOn(invokableSymbol.flags, Flags.RESOURCE);
         boolean isRemoteMethod = isFlagOn(invokableSymbol.flags, Flags.REMOTE);
 
@@ -247,7 +247,7 @@ public class SymbolFactory {
     public BallerinaVariableSymbol createVariableSymbol(BVarSymbol symbol, String name) {
         PackageID pkgID = symbol.pkgID;
         BallerinaVariableSymbol.VariableSymbolBuilder symbolBuilder =
-                new BallerinaVariableSymbol.VariableSymbolBuilder(name, pkgID, symbol);
+                new BallerinaVariableSymbol.VariableSymbolBuilder(name, pkgID, symbol, this.context);
 
         if (isFlagOn(symbol.flags, Flags.FINAL) || isFlagOn(symbol.flags, Flags.FUNCTION_FINAL)) {
             symbolBuilder.withQualifier(Qualifier.FINAL);
@@ -288,7 +288,7 @@ public class SymbolFactory {
 
     public BallerinaWorkerSymbol createWorkerSymbol(BVarSymbol symbol, String name) {
         BallerinaWorkerSymbol.WorkerSymbolBuilder builder =
-                new BallerinaWorkerSymbol.WorkerSymbolBuilder(name, symbol.pkgID, symbol);
+                new BallerinaWorkerSymbol.WorkerSymbolBuilder(name, symbol.pkgID, symbol, this.context);
 
         for (org.ballerinalang.model.symbols.AnnotationSymbol annot : symbol.getAnnotations()) {
             builder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
@@ -332,7 +332,8 @@ public class SymbolFactory {
      */
     public BallerinaTypeDefinitionSymbol createTypeDefinition(BTypeSymbol typeSymbol, String name) {
         BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder symbolBuilder =
-                new BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder(name, typeSymbol.pkgID, typeSymbol);
+                new BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder(name, typeSymbol.pkgID, typeSymbol,
+                                                                       this.context);
 
         if (isFlagOn(typeSymbol.flags, Flags.PUBLIC)) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
@@ -343,7 +344,7 @@ public class SymbolFactory {
 
     public BallerinaEnumSymbol createEnumSymbol(BEnumSymbol enumSymbol, String name) {
         BallerinaEnumSymbol.EnumSymbolBuilder symbolBuilder =
-                new BallerinaEnumSymbol.EnumSymbolBuilder(name, enumSymbol.pkgID, enumSymbol);
+                new BallerinaEnumSymbol.EnumSymbolBuilder(name, enumSymbol.pkgID, enumSymbol, this.context);
 
         if (isFlagOn(enumSymbol.flags, Flags.PUBLIC)) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
@@ -400,7 +401,8 @@ public class SymbolFactory {
      */
     public BallerinaConstantSymbol createConstantSymbol(BConstantSymbol constantSymbol, String name) {
         BallerinaConstantSymbol.ConstantSymbolBuilder symbolBuilder =
-                new BallerinaConstantSymbol.ConstantSymbolBuilder(name, constantSymbol.pkgID, constantSymbol);
+                new BallerinaConstantSymbol.ConstantSymbolBuilder(name, constantSymbol.pkgID, constantSymbol,
+                                                                  this.context);
         symbolBuilder.withConstValue(constantSymbol.getConstValue())
                 .withTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.type))
                 .withBroaderTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.literalType));
@@ -424,7 +426,8 @@ public class SymbolFactory {
      */
     public BallerinaAnnotationSymbol createAnnotationSymbol(BAnnotationSymbol symbol) {
         BallerinaAnnotationSymbol.AnnotationSymbolBuilder symbolBuilder =
-                new BallerinaAnnotationSymbol.AnnotationSymbolBuilder(symbol.name.getValue(), symbol.pkgID, symbol);
+                new BallerinaAnnotationSymbol.AnnotationSymbolBuilder(symbol.name.getValue(), symbol.pkgID, symbol,
+                                                                      this.context);
         if ((symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
         }
@@ -447,7 +450,7 @@ public class SymbolFactory {
      */
     public BallerinaXMLNSSymbol createXMLNamespaceSymbol(BXMLNSSymbol symbol) {
         BallerinaXMLNSSymbol.XmlNSSymbolBuilder symbolBuilder =
-                new BallerinaXMLNSSymbol.XmlNSSymbolBuilder(symbol.name.getValue(), symbol.pkgID, symbol);
+                new BallerinaXMLNSSymbol.XmlNSSymbolBuilder(symbol.name.getValue(), symbol.pkgID, symbol, this.context);
 
         return symbolBuilder.build();
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -175,7 +175,7 @@ public class SymbolFactory {
     public BallerinaFunctionSymbol createFunctionSymbol(BInvokableSymbol invokableSymbol, String name) {
         PackageID pkgID = invokableSymbol.pkgID;
         BallerinaFunctionSymbol.FunctionSymbolBuilder builder =
-                new BallerinaFunctionSymbol.FunctionSymbolBuilder(name, pkgID, invokableSymbol, this.context);
+                new BallerinaFunctionSymbol.FunctionSymbolBuilder(name, invokableSymbol, this.context);
         boolean isResourceMethod = isFlagOn(invokableSymbol.flags, Flags.RESOURCE);
         boolean isRemoteMethod = isFlagOn(invokableSymbol.flags, Flags.REMOTE);
 
@@ -247,7 +247,7 @@ public class SymbolFactory {
     public BallerinaVariableSymbol createVariableSymbol(BVarSymbol symbol, String name) {
         PackageID pkgID = symbol.pkgID;
         BallerinaVariableSymbol.VariableSymbolBuilder symbolBuilder =
-                new BallerinaVariableSymbol.VariableSymbolBuilder(name, pkgID, symbol, this.context);
+                new BallerinaVariableSymbol.VariableSymbolBuilder(name, symbol, this.context);
 
         if (isFlagOn(symbol.flags, Flags.FINAL) || isFlagOn(symbol.flags, Flags.FUNCTION_FINAL)) {
             symbolBuilder.withQualifier(Qualifier.FINAL);
@@ -288,7 +288,7 @@ public class SymbolFactory {
 
     public BallerinaWorkerSymbol createWorkerSymbol(BVarSymbol symbol, String name) {
         BallerinaWorkerSymbol.WorkerSymbolBuilder builder =
-                new BallerinaWorkerSymbol.WorkerSymbolBuilder(name, symbol.pkgID, symbol, this.context);
+                new BallerinaWorkerSymbol.WorkerSymbolBuilder(name, symbol, this.context);
 
         for (org.ballerinalang.model.symbols.AnnotationSymbol annot : symbol.getAnnotations()) {
             builder.withAnnotation(createAnnotationSymbol((BAnnotationSymbol) annot));
@@ -332,7 +332,7 @@ public class SymbolFactory {
      */
     public BallerinaTypeDefinitionSymbol createTypeDefinition(BTypeSymbol typeSymbol, String name) {
         BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder symbolBuilder =
-                new BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder(name, typeSymbol.pkgID, typeSymbol,
+                new BallerinaTypeDefinitionSymbol.TypeDefSymbolBuilder(name, typeSymbol,
                                                                        this.context);
 
         if (isFlagOn(typeSymbol.flags, Flags.PUBLIC)) {
@@ -344,7 +344,7 @@ public class SymbolFactory {
 
     public BallerinaEnumSymbol createEnumSymbol(BEnumSymbol enumSymbol, String name) {
         BallerinaEnumSymbol.EnumSymbolBuilder symbolBuilder =
-                new BallerinaEnumSymbol.EnumSymbolBuilder(name, enumSymbol.pkgID, enumSymbol, this.context);
+                new BallerinaEnumSymbol.EnumSymbolBuilder(name, enumSymbol, this.context);
 
         if (isFlagOn(enumSymbol.flags, Flags.PUBLIC)) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
@@ -372,7 +372,7 @@ public class SymbolFactory {
 
     public BallerinaClassSymbol createClassSymbol(BClassSymbol classSymbol, String name, TypeSymbol type) {
         BallerinaClassSymbol.ClassSymbolBuilder symbolBuilder =
-                new BallerinaClassSymbol.ClassSymbolBuilder(this.context, name, classSymbol.pkgID, classSymbol);
+                new BallerinaClassSymbol.ClassSymbolBuilder(this.context, name, classSymbol);
 
         addIfFlagSet(symbolBuilder, classSymbol.flags, Flags.PUBLIC, Qualifier.PUBLIC);
         addIfFlagSet(symbolBuilder, classSymbol.flags, Flags.DISTINCT, Qualifier.DISTINCT);
@@ -401,7 +401,7 @@ public class SymbolFactory {
      */
     public BallerinaConstantSymbol createConstantSymbol(BConstantSymbol constantSymbol, String name) {
         BallerinaConstantSymbol.ConstantSymbolBuilder symbolBuilder =
-                new BallerinaConstantSymbol.ConstantSymbolBuilder(name, constantSymbol.pkgID, constantSymbol,
+                new BallerinaConstantSymbol.ConstantSymbolBuilder(name, constantSymbol,
                                                                   this.context);
         symbolBuilder.withConstValue(constantSymbol.getConstValue())
                 .withTypeDescriptor(typesFactory.getTypeDescriptor(constantSymbol.type))
@@ -426,7 +426,7 @@ public class SymbolFactory {
      */
     public BallerinaAnnotationSymbol createAnnotationSymbol(BAnnotationSymbol symbol) {
         BallerinaAnnotationSymbol.AnnotationSymbolBuilder symbolBuilder =
-                new BallerinaAnnotationSymbol.AnnotationSymbolBuilder(symbol.name.getValue(), symbol.pkgID, symbol,
+                new BallerinaAnnotationSymbol.AnnotationSymbolBuilder(symbol.name.getValue(), symbol,
                                                                       this.context);
         if ((symbol.flags & Flags.PUBLIC) == Flags.PUBLIC) {
             symbolBuilder.withQualifier(Qualifier.PUBLIC);
@@ -450,7 +450,7 @@ public class SymbolFactory {
      */
     public BallerinaXMLNSSymbol createXMLNamespaceSymbol(BXMLNSSymbol symbol) {
         BallerinaXMLNSSymbol.XmlNSSymbolBuilder symbolBuilder =
-                new BallerinaXMLNSSymbol.XmlNSSymbolBuilder(symbol.name.getValue(), symbol.pkgID, symbol, this.context);
+                new BallerinaXMLNSSymbol.XmlNSSymbolBuilder(symbol.name.getValue(), symbol, this.context);
 
         return symbolBuilder.build();
     }
@@ -463,7 +463,7 @@ public class SymbolFactory {
      * @return {@link BallerinaModule} symbol generated
      */
     public BallerinaModule createModuleSymbol(BPackageSymbol symbol, String name) {
-        return new BallerinaModule.ModuleSymbolBuilder(this.context, name, symbol.pkgID, symbol).build();
+        return new BallerinaModule.ModuleSymbolBuilder(this.context, name, symbol).build();
     }
 
     // Private methods

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -45,7 +45,6 @@ import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAttachedFunction;
@@ -173,7 +172,6 @@ public class SymbolFactory {
      * @return {@link Symbol} generated
      */
     public BallerinaFunctionSymbol createFunctionSymbol(BInvokableSymbol invokableSymbol, String name) {
-        PackageID pkgID = invokableSymbol.pkgID;
         BallerinaFunctionSymbol.FunctionSymbolBuilder builder =
                 new BallerinaFunctionSymbol.FunctionSymbolBuilder(name, invokableSymbol, this.context);
         boolean isResourceMethod = isFlagOn(invokableSymbol.flags, Flags.RESOURCE);
@@ -245,7 +243,6 @@ public class SymbolFactory {
      * @return {@link BallerinaVariableSymbol} generated
      */
     public BallerinaVariableSymbol createVariableSymbol(BVarSymbol symbol, String name) {
-        PackageID pkgID = symbol.pkgID;
         BallerinaVariableSymbol.VariableSymbolBuilder symbolBuilder =
                 new BallerinaVariableSymbol.VariableSymbolBuilder(name, symbol, this.context);
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -19,6 +19,7 @@ package io.ballerina.compiler.api.impl.symbols;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.LangLibrary;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
@@ -30,6 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a Ballerina Type Descriptor.
@@ -58,6 +60,16 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     }
 
     @Override
+    public Optional<String> getName() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        return Optional.empty();
+    }
+
+    @Override
     public ModuleID moduleID() {
         return moduleID;
     }
@@ -78,6 +90,11 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     @Override
     public Location location() {
         return null;
+    }
+
+    @Override
+    public Optional<Location> getLocation() {
+        return Optional.empty();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -78,11 +78,6 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     public abstract String signature();
 
     @Override
-    public String name() {
-        return "";
-    }
-
-    @Override
     public SymbolKind kind() {
         return SymbolKind.TYPE;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -70,11 +70,6 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     }
 
     @Override
-    public ModuleID moduleID() {
-        return moduleID;
-    }
-
-    @Override
     public abstract String signature();
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.LangLibrary;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -44,13 +43,11 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
     protected List<FunctionSymbol> langLibFunctions;
 
     private final TypeDescKind typeDescKind;
-    private final ModuleID moduleID;
     private final BType bType;
 
-    public AbstractTypeSymbol(CompilerContext context, TypeDescKind typeDescKind, ModuleID moduleID, BType bType) {
+    public AbstractTypeSymbol(CompilerContext context, TypeDescKind typeDescKind, BType bType) {
         this.context = context;
         this.typeDescKind = typeDescKind;
-        this.moduleID = moduleID;
         this.bType = bType;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -27,6 +27,7 @@ import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.AttachPoints;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -51,8 +52,8 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
 
     private BallerinaAnnotationSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
                                       TypeSymbol typeDescriptor, List<AnnotationAttachPoint> attachPoints,
-                                      List<AnnotationSymbol> annots, BSymbol bSymbol) {
-        super(name, moduleID, SymbolKind.ANNOTATION, bSymbol);
+                                      List<AnnotationSymbol> annots, BSymbol bSymbol, CompilerContext context) {
+        super(name, moduleID, SymbolKind.ANNOTATION, bSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.typeDescriptor = typeDescriptor;
         this.attachPoints = Collections.unmodifiableList(attachPoints);
@@ -118,14 +119,15 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
         private List<AnnotationAttachPoint> attachPoints;
         private List<AnnotationSymbol> annots = new ArrayList<>();
 
-        public AnnotationSymbolBuilder(String name, PackageID moduleID, BAnnotationSymbol annotationSymbol) {
-            super(name, moduleID, SymbolKind.ANNOTATION, annotationSymbol);
+        public AnnotationSymbolBuilder(String name, PackageID moduleID, BAnnotationSymbol annotationSymbol,
+                                       CompilerContext context) {
+            super(name, moduleID, SymbolKind.ANNOTATION, annotationSymbol, context);
             withAttachPoints(annotationSymbol);
         }
 
         public BallerinaAnnotationSymbol build() {
             return new BallerinaAnnotationSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
-                                                 this.attachPoints, this.annots, this.bSymbol);
+                                                 this.attachPoints, this.annots, this.bSymbol, this.context);
         }
 
         /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnnotationSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BAnnotationSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
@@ -50,10 +49,10 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
     private final Documentation docAttachment;
     private final boolean deprecated;
 
-    private BallerinaAnnotationSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
-                                      TypeSymbol typeDescriptor, List<AnnotationAttachPoint> attachPoints,
-                                      List<AnnotationSymbol> annots, BSymbol bSymbol, CompilerContext context) {
-        super(name, moduleID, SymbolKind.ANNOTATION, bSymbol, context);
+    private BallerinaAnnotationSymbol(String name, List<Qualifier> qualifiers, TypeSymbol typeDescriptor,
+                                      List<AnnotationAttachPoint> attachPoints, List<AnnotationSymbol> annots,
+                                      BSymbol bSymbol, CompilerContext context) {
+        super(name, SymbolKind.ANNOTATION, bSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.typeDescriptor = typeDescriptor;
         this.attachPoints = Collections.unmodifiableList(attachPoints);
@@ -119,15 +118,14 @@ public class BallerinaAnnotationSymbol extends BallerinaSymbol implements Annota
         private List<AnnotationAttachPoint> attachPoints;
         private List<AnnotationSymbol> annots = new ArrayList<>();
 
-        public AnnotationSymbolBuilder(String name, PackageID moduleID, BAnnotationSymbol annotationSymbol,
-                                       CompilerContext context) {
-            super(name, moduleID, SymbolKind.ANNOTATION, annotationSymbol, context);
+        public AnnotationSymbolBuilder(String name, BAnnotationSymbol annotationSymbol, CompilerContext context) {
+            super(name, SymbolKind.ANNOTATION, annotationSymbol, context);
             withAttachPoints(annotationSymbol);
         }
 
         public BallerinaAnnotationSymbol build() {
-            return new BallerinaAnnotationSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
-                                                 this.attachPoints, this.annots, this.bSymbol, this.context);
+            return new BallerinaAnnotationSymbol(this.name, this.qualifiers, this.typeDescriptor, this.attachPoints,
+                                                 this.annots, this.bSymbol, this.context);
         }
 
         /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnyTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaAnyTypeSymbol extends AbstractTypeSymbol implements AnyTypeSymbol {
 
     public BallerinaAnyTypeSymbol(CompilerContext context, ModuleID moduleID, BAnyType anyType) {
-        super(context, TypeDescKind.ANY, moduleID, anyType);
+        super(context, TypeDescKind.ANY, anyType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaAnydataTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaAnydataTypeSymbol extends AbstractTypeSymbol implements AnydataTypeSymbol {
 
     public BallerinaAnydataTypeSymbol(CompilerContext context, ModuleID moduleID, BAnydataType anydataType) {
-        super(context, TypeDescKind.ANYDATA, moduleID, anydataType);
+        super(context, TypeDescKind.ANYDATA, anydataType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaArrayTypeSymbol.java
@@ -35,7 +35,7 @@ public class BallerinaArrayTypeSymbol extends AbstractTypeSymbol implements Arra
     private TypeSymbol memberTypeDesc;
 
     public BallerinaArrayTypeSymbol(CompilerContext context, ModuleID moduleID, BArrayType arrayType) {
-        super(context, TypeDescKind.ARRAY, moduleID, arrayType);
+        super(context, TypeDescKind.ARRAY, arrayType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaBooleanTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaBooleanTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaBooleanTypeSymbol extends AbstractTypeSymbol implements BooleanTypeSymbol {
 
     public BallerinaBooleanTypeSymbol(CompilerContext context, ModuleID moduleID, BType booleanType) {
-        super(context, TypeDescKind.BOOLEAN, moduleID, booleanType);
+        super(context, TypeDescKind.BOOLEAN, booleanType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
@@ -35,11 +35,6 @@ public class BallerinaByteTypeSymbol extends AbstractTypeSymbol implements ByteT
     }
 
     @Override
-    public String name() {
-        return "byte";
-    }
-
-    @Override
     public String signature() {
         return "byte";
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaByteTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaByteTypeSymbol extends AbstractTypeSymbol implements ByteTypeSymbol {
 
     public BallerinaByteTypeSymbol(CompilerContext context, ModuleID moduleID, BType byteType) {
-        super(context, TypeDescKind.BYTE, moduleID, byteType);
+        super(context, TypeDescKind.BYTE, byteType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -132,10 +132,10 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
 
     @Override
     public String signature() {
-        if (this.name().startsWith("$anonType$")) {
+        if (this.getName().get().startsWith("$anonType$")) {
             return typeDescriptor.signature();
         }
-        return this.name();
+        return this.getName().get();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -67,7 +67,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     protected BallerinaClassSymbol(CompilerContext context, String name, PackageID moduleID, List<Qualifier> qualifiers,
                                    List<AnnotationSymbol> annots, ObjectTypeSymbol typeDescriptor,
                                    BClassSymbol classSymbol) {
-        super(name, moduleID, SymbolKind.CLASS, classSymbol);
+        super(name, moduleID, SymbolKind.CLASS, classSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
         this.docAttachment = getDocAttachment(classSymbol);
@@ -181,11 +181,9 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         protected List<Qualifier> qualifiers = new ArrayList<>();
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected ObjectTypeSymbol typeDescriptor;
-        protected CompilerContext context;
 
         public ClassSymbolBuilder(CompilerContext context, String name, PackageID moduleID, BSymbol symbol) {
-            super(name, moduleID, SymbolKind.CLASS, symbol);
-            this.context = context;
+            super(name, moduleID, SymbolKind.CLASS, symbol, context);
         }
 
         public BallerinaClassSymbol.ClassSymbolBuilder withTypeDescriptor(ObjectTypeSymbol typeDescriptor) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaClassSymbol.java
@@ -29,7 +29,6 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -64,10 +63,10 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
     private MethodSymbol initMethod;
     private Map<String, ClassFieldSymbol> classFields;
 
-    protected BallerinaClassSymbol(CompilerContext context, String name, PackageID moduleID, List<Qualifier> qualifiers,
+    protected BallerinaClassSymbol(CompilerContext context, String name, List<Qualifier> qualifiers,
                                    List<AnnotationSymbol> annots, ObjectTypeSymbol typeDescriptor,
                                    BClassSymbol classSymbol) {
-        super(name, moduleID, SymbolKind.CLASS, classSymbol, context);
+        super(name, SymbolKind.CLASS, classSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
         this.docAttachment = getDocAttachment(classSymbol);
@@ -182,8 +181,8 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected ObjectTypeSymbol typeDescriptor;
 
-        public ClassSymbolBuilder(CompilerContext context, String name, PackageID moduleID, BSymbol symbol) {
-            super(name, moduleID, SymbolKind.CLASS, symbol, context);
+        public ClassSymbolBuilder(CompilerContext context, String name, BSymbol symbol) {
+            super(name, SymbolKind.CLASS, symbol, context);
         }
 
         public BallerinaClassSymbol.ClassSymbolBuilder withTypeDescriptor(ObjectTypeSymbol typeDescriptor) {
@@ -203,7 +202,7 @@ public class BallerinaClassSymbol extends BallerinaSymbol implements ClassSymbol
 
         @Override
         public BallerinaClassSymbol build() {
-            return new BallerinaClassSymbol(this.context, this.name, this.moduleID, this.qualifiers, this.annots,
+            return new BallerinaClassSymbol(this.context, this.name, this.qualifiers, this.annots,
                                             this.typeDescriptor, (BClassSymbol) this.bSymbol);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaCompilationErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaCompilationErrorTypeSymbol.java
@@ -38,7 +38,7 @@ public class BallerinaCompilationErrorTypeSymbol extends AbstractTypeSymbol impl
     private static final List<FunctionSymbol> langLibMethods = Collections.unmodifiableList(new ArrayList<>());
 
     public BallerinaCompilationErrorTypeSymbol(CompilerContext context, ModuleID moduleID, BType error) {
-        super(context, TypeDescKind.COMPILATION_ERROR, moduleID, error);
+        super(context, TypeDescKind.COMPILATION_ERROR, error);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.List;
 
@@ -39,15 +40,10 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     private final Object constValue;
     private TypeSymbol broaderType;
 
-    private BallerinaConstantSymbol(String name,
-                                    PackageID moduleID,
-                                    List<Qualifier> qualifiers,
-                                    List<AnnotationSymbol> annots,
-                                    TypeSymbol typeDescriptor,
-                                    TypeSymbol broaderType,
-                                    Object constValue,
-                                    BSymbol bSymbol) {
-        super(name, moduleID, SymbolKind.CONSTANT, qualifiers, annots, typeDescriptor, bSymbol);
+    private BallerinaConstantSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
+                                    List<AnnotationSymbol> annots, TypeSymbol typeDescriptor, TypeSymbol broaderType,
+                                    Object constValue, BSymbol bSymbol, CompilerContext context) {
+        super(name, moduleID, SymbolKind.CONSTANT, qualifiers, annots, typeDescriptor, bSymbol, context);
         this.constValue = constValue;
         this.broaderType = broaderType;
     }
@@ -95,13 +91,14 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
         private Object constantValue;
         private TypeSymbol broaderType;
 
-        public ConstantSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
-            super(name, moduleID, symbol);
+        public ConstantSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
+            super(name, moduleID, symbol, context);
         }
 
         public BallerinaConstantSymbol build() {
             return new BallerinaConstantSymbol(this.name, this.moduleID, this.qualifiers, this.annots,
-                                               this.typeDescriptor, this.broaderType, this.constantValue, this.bSymbol);
+                                               this.typeDescriptor, this.broaderType, this.constantValue,
+                                               this.bSymbol, this.context);
         }
 
         public ConstantSymbolBuilder withConstValue(Object constValue) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
@@ -40,10 +39,10 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     private final Object constValue;
     private TypeSymbol broaderType;
 
-    private BallerinaConstantSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
-                                    List<AnnotationSymbol> annots, TypeSymbol typeDescriptor, TypeSymbol broaderType,
-                                    Object constValue, BSymbol bSymbol, CompilerContext context) {
-        super(name, moduleID, SymbolKind.CONSTANT, qualifiers, annots, typeDescriptor, bSymbol, context);
+    private BallerinaConstantSymbol(String name, List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
+                                    TypeSymbol typeDescriptor, TypeSymbol broaderType, Object constValue,
+                                    BSymbol bSymbol, CompilerContext context) {
+        super(name, SymbolKind.CONSTANT, qualifiers, annots, typeDescriptor, bSymbol, context);
         this.constValue = constValue;
         this.broaderType = broaderType;
     }
@@ -91,14 +90,13 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
         private Object constantValue;
         private TypeSymbol broaderType;
 
-        public ConstantSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
-            super(name, moduleID, symbol, context);
+        public ConstantSymbolBuilder(String name, BSymbol symbol, CompilerContext context) {
+            super(name, symbol, context);
         }
 
         public BallerinaConstantSymbol build() {
-            return new BallerinaConstantSymbol(this.name, this.moduleID, this.qualifiers, this.annots,
-                                               this.typeDescriptor, this.broaderType, this.constantValue,
-                                               this.bSymbol, this.context);
+            return new BallerinaConstantSymbol(this.name, this.qualifiers, this.annots, this.typeDescriptor,
+                                               this.broaderType, this.constantValue, this.bSymbol, this.context);
         }
 
         public ConstantSymbolBuilder withConstValue(Object constValue) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDecimalTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDecimalTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaDecimalTypeSymbol extends AbstractTypeSymbol implements DecimalTypeSymbol {
 
     public BallerinaDecimalTypeSymbol(CompilerContext context, ModuleID moduleID, BType decimalType) {
-        super(context, TypeDescKind.DECIMAL, moduleID, decimalType);
+        super(context, TypeDescKind.DECIMAL, decimalType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,8 +44,8 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
 
     protected BallerinaEnumSymbol(String name, PackageID moduleID, List<ConstantSymbol> members,
                                   List<Qualifier> qualifiers, List<AnnotationSymbol> annots, TypeSymbol typeDescriptor,
-                                  BSymbol bSymbol) {
-        super(name, moduleID, qualifiers, typeDescriptor, bSymbol);
+                                  BSymbol bSymbol, CompilerContext context) {
+        super(name, moduleID, qualifiers, typeDescriptor, bSymbol, context);
         this.members = Collections.unmodifiableList(members);
         this.annots = annots;
     }
@@ -76,8 +77,8 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
-        public EnumSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
-            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol);
+        public EnumSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
+            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol, context);
         }
 
         public EnumSymbolBuilder withMembers(List<ConstantSymbol> members) {
@@ -103,7 +104,7 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
         @Override
         public BallerinaEnumSymbol build() {
             return new BallerinaEnumSymbol(this.name, this.moduleID, this.members, this.qualifiers, this.annots,
-                                           this.typeDescriptor, this.bSymbol);
+                                           this.typeDescriptor, this.bSymbol, this.context);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaEnumSymbol.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.api.symbols.EnumSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
@@ -42,10 +41,10 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
     private List<ConstantSymbol> members;
     private List<AnnotationSymbol> annots;
 
-    protected BallerinaEnumSymbol(String name, PackageID moduleID, List<ConstantSymbol> members,
-                                  List<Qualifier> qualifiers, List<AnnotationSymbol> annots, TypeSymbol typeDescriptor,
-                                  BSymbol bSymbol, CompilerContext context) {
-        super(name, moduleID, qualifiers, typeDescriptor, bSymbol, context);
+    protected BallerinaEnumSymbol(String name, List<ConstantSymbol> members, List<Qualifier> qualifiers,
+                                  List<AnnotationSymbol> annots, TypeSymbol typeDescriptor, BSymbol bSymbol,
+                                  CompilerContext context) {
+        super(name, qualifiers, typeDescriptor, bSymbol, context);
         this.members = Collections.unmodifiableList(members);
         this.annots = annots;
     }
@@ -77,8 +76,8 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
-        public EnumSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
-            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol, context);
+        public EnumSymbolBuilder(String name, BSymbol symbol, CompilerContext context) {
+            super(name, SymbolKind.TYPE_DEFINITION, symbol, context);
         }
 
         public EnumSymbolBuilder withMembers(List<ConstantSymbol> members) {
@@ -103,7 +102,7 @@ public class BallerinaEnumSymbol extends BallerinaTypeDefinitionSymbol implement
 
         @Override
         public BallerinaEnumSymbol build() {
-            return new BallerinaEnumSymbol(this.name, this.moduleID, this.members, this.qualifiers, this.annots,
+            return new BallerinaEnumSymbol(this.name, this.members, this.qualifiers, this.annots,
                                            this.typeDescriptor, this.bSymbol, this.context);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -35,7 +35,7 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
     private String signature;
 
     public BallerinaErrorTypeSymbol(CompilerContext context, ModuleID moduleID, BErrorType errorType) {
-        super(context, TypeDescKind.ERROR, moduleID, errorType);
+        super(context, TypeDescKind.ERROR, errorType);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -32,6 +32,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements ErrorTypeSymbol {
 
     private TypeSymbol detail;
+    private String signature;
 
     public BallerinaErrorTypeSymbol(CompilerContext context, ModuleID moduleID, BErrorType errorType) {
         super(context, TypeDescKind.ERROR, moduleID, errorType);
@@ -53,12 +54,25 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
 
     @Override
     public String signature() {
-        String definitionName = getBType().tsymbol.name.value;
-        if (this.moduleID().moduleName().equals("lang.annotations") && this.moduleID().orgName().equals("ballerina")) {
-            return definitionName;
+        if (this.signature != null) {
+            return this.signature;
         }
-        return this.moduleID().orgName() + Names.ORG_NAME_SEPARATOR +
-                this.moduleID().moduleName() + Names.VERSION_SEPARATOR + this.moduleID().version() + ":" +
-                definitionName;
+
+        String definitionName = getBType().tsymbol.name.value;
+
+        if (this.getModule().isEmpty()) {
+            this.signature = definitionName;
+            return this.signature;
+        }
+
+        ModuleID moduleID = this.getModule().get().id();
+        if (moduleID.moduleName().equals("lang.annotations") && moduleID.orgName().equals("ballerina")) {
+            this.signature = definitionName;
+        } else {
+            this.signature = moduleID.orgName() + Names.ORG_NAME_SEPARATOR + moduleID.moduleName() +
+                    Names.VERSION_SEPARATOR + moduleID.version() + ":" + definitionName;
+        }
+
+        return this.signature;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaErrorTypeSymbol.java
@@ -66,7 +66,7 @@ public class BallerinaErrorTypeSymbol extends AbstractTypeSymbol implements Erro
         }
 
         ModuleID moduleID = this.getModule().get().id();
-        if (moduleID.moduleName().equals("lang.annotations") && moduleID.orgName().equals("ballerina")) {
+        if ("lang.annotations".equals(moduleID.moduleName()) && "ballerina".equals(moduleID.orgName())) {
             this.signature = definitionName;
         } else {
             this.signature = moduleID.orgName() + Names.ORG_NAME_SEPARATOR + moduleID.moduleName() +

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFloatTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFloatTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaFloatTypeSymbol extends AbstractTypeSymbol implements FloatTypeSymbol {
 
     public BallerinaFloatTypeSymbol(CompilerContext context, ModuleID moduleID, BType floatType) {
-        super(context, TypeDescKind.FLOAT, moduleID, floatType);
+        super(context, TypeDescKind.FLOAT, floatType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.SymbolKind;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -47,13 +48,10 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     private final boolean isExternal;
     private final boolean deprecated;
 
-    protected BallerinaFunctionSymbol(String name,
-                                      PackageID moduleID,
-                                      List<Qualifier> qualifiers,
-                                      List<AnnotationSymbol> annots,
-                                      FunctionTypeSymbol typeDescriptor,
-                                      BInvokableSymbol invokableSymbol) {
-        super(name, moduleID, SymbolKind.FUNCTION, invokableSymbol);
+    protected BallerinaFunctionSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
+                                      List<AnnotationSymbol> annots, FunctionTypeSymbol typeDescriptor,
+                                      BInvokableSymbol invokableSymbol, CompilerContext context) {
+        super(name, moduleID, SymbolKind.FUNCTION, invokableSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
         this.docAttachment = getDocAttachment(invokableSymbol);
@@ -106,12 +104,14 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected FunctionTypeSymbol typeDescriptor;
 
-        public FunctionSymbolBuilder(String name, PackageID moduleID, BInvokableSymbol bSymbol) {
-            this(name, moduleID, SymbolKind.FUNCTION, bSymbol);
+        public FunctionSymbolBuilder(String name, PackageID moduleID, BInvokableSymbol bSymbol,
+                                     CompilerContext context) {
+            this(name, moduleID, SymbolKind.FUNCTION, bSymbol, context);
         }
 
-        public FunctionSymbolBuilder(String name, PackageID moduleID, SymbolKind kind, BInvokableSymbol bSymbol) {
-            super(name, moduleID, kind, bSymbol);
+        public FunctionSymbolBuilder(String name, PackageID moduleID, SymbolKind kind, BInvokableSymbol bSymbol,
+                                     CompilerContext context) {
+            super(name, moduleID, kind, bSymbol, context);
         }
 
         public FunctionSymbolBuilder withTypeDescriptor(FunctionTypeSymbol typeDescriptor) {
@@ -137,7 +137,7 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
         @Override
         public BallerinaFunctionSymbol build() {
             return new BallerinaFunctionSymbol(this.name, this.moduleID, this.qualifiers, this.annots,
-                                               this.typeDescriptor, (BInvokableSymbol) this.bSymbol);
+                                               this.typeDescriptor, (BInvokableSymbol) this.bSymbol, this.context);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -48,10 +47,10 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
     private final boolean isExternal;
     private final boolean deprecated;
 
-    protected BallerinaFunctionSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
-                                      List<AnnotationSymbol> annots, FunctionTypeSymbol typeDescriptor,
-                                      BInvokableSymbol invokableSymbol, CompilerContext context) {
-        super(name, moduleID, SymbolKind.FUNCTION, invokableSymbol, context);
+    protected BallerinaFunctionSymbol(String name, List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
+                                      FunctionTypeSymbol typeDescriptor, BInvokableSymbol invokableSymbol,
+                                      CompilerContext context) {
+        super(name, SymbolKind.FUNCTION, invokableSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
         this.docAttachment = getDocAttachment(invokableSymbol);
@@ -104,14 +103,12 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected FunctionTypeSymbol typeDescriptor;
 
-        public FunctionSymbolBuilder(String name, PackageID moduleID, BInvokableSymbol bSymbol,
-                                     CompilerContext context) {
-            this(name, moduleID, SymbolKind.FUNCTION, bSymbol, context);
+        public FunctionSymbolBuilder(String name, BInvokableSymbol bSymbol, CompilerContext context) {
+            this(name, SymbolKind.FUNCTION, bSymbol, context);
         }
 
-        public FunctionSymbolBuilder(String name, PackageID moduleID, SymbolKind kind, BInvokableSymbol bSymbol,
-                                     CompilerContext context) {
-            super(name, moduleID, kind, bSymbol, context);
+        public FunctionSymbolBuilder(String name, SymbolKind kind, BInvokableSymbol bSymbol, CompilerContext context) {
+            super(name, kind, bSymbol, context);
         }
 
         public FunctionSymbolBuilder withTypeDescriptor(FunctionTypeSymbol typeDescriptor) {
@@ -136,7 +133,7 @@ public class BallerinaFunctionSymbol extends BallerinaSymbol implements Function
 
         @Override
         public BallerinaFunctionSymbol build() {
-            return new BallerinaFunctionSymbol(this.name, this.moduleID, this.qualifiers, this.annots,
+            return new BallerinaFunctionSymbol(this.name, this.qualifiers, this.annots,
                                                this.typeDescriptor, (BInvokableSymbol) this.bSymbol, this.context);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -51,7 +51,7 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
 
     public BallerinaFunctionTypeSymbol(CompilerContext context, ModuleID moduleID,
                                        BInvokableTypeSymbol invokableSymbol) {
-        super(context, TypeDescKind.FUNCTION, moduleID, invokableSymbol.type);
+        super(context, TypeDescKind.FUNCTION, invokableSymbol.type);
         this.typeSymbol = invokableSymbol;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFutureTypeSymbol.java
@@ -35,7 +35,7 @@ public class BallerinaFutureTypeSymbol extends AbstractTypeSymbol implements Fut
     private TypeSymbol memberTypeDesc;
 
     public BallerinaFutureTypeSymbol(CompilerContext context, ModuleID moduleID, BFutureType futureType) {
-        super(context, TypeDescKind.FUTURE, moduleID, futureType);
+        super(context, TypeDescKind.FUTURE, futureType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaHandleTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaHandleTypeSymbol extends AbstractTypeSymbol implements HandleTypeSymbol {
 
     public BallerinaHandleTypeSymbol(CompilerContext context, ModuleID moduleID, BHandleType handleType) {
-        super(context, TypeDescKind.HANDLE, moduleID, handleType);
+        super(context, TypeDescKind.HANDLE, handleType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the int:Signed16 type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaIntSigned16TypeSymbol extends AbstractTypeSymbol implement
     @Override
     public String name() {
         return Names.STRING_SIGNED16;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_SIGNED16);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaIntSigned16TypeSymbol extends AbstractTypeSymbol implement
     }
 
     @Override
-    public String name() {
-        return Names.STRING_SIGNED16;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_SIGNED16);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned16TypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaIntSigned16TypeSymbol extends AbstractTypeSymbol implements IntSigned16TypeSymbol {
 
     public BallerinaIntSigned16TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType signed16Type) {
-        super(context, TypeDescKind.INT_SIGNED16, moduleID, signed16Type);
+        super(context, TypeDescKind.INT_SIGNED16, signed16Type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the int:Signed32 type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaIntSigned32TypeSymbol extends AbstractTypeSymbol implement
     @Override
     public String name() {
         return Names.STRING_SIGNED32;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_SIGNED32);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaIntSigned32TypeSymbol extends AbstractTypeSymbol implement
     }
 
     @Override
-    public String name() {
-        return Names.STRING_SIGNED32;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_SIGNED32);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned32TypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaIntSigned32TypeSymbol extends AbstractTypeSymbol implements IntSigned32TypeSymbol {
 
     public BallerinaIntSigned32TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType signed32Type) {
-        super(context, TypeDescKind.INT_SIGNED32, moduleID, signed32Type);
+        super(context, TypeDescKind.INT_SIGNED32, signed32Type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the int:Signed8 type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaIntSigned8TypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String name() {
         return Names.STRING_SIGNED8;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_SIGNED8);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaIntSigned8TypeSymbol extends AbstractTypeSymbol implements
     }
 
     @Override
-    public String name() {
-        return Names.STRING_SIGNED8;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_SIGNED8);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntSigned8TypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaIntSigned8TypeSymbol extends AbstractTypeSymbol implements IntSigned8TypeSymbol {
 
     public BallerinaIntSigned8TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType signed8Type) {
-        super(context, TypeDescKind.INT_SIGNED8, moduleID, signed8Type);
+        super(context, TypeDescKind.INT_SIGNED8, signed8Type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaIntTypeSymbol extends AbstractTypeSymbol implements IntTypeSymbol {
 
     public BallerinaIntTypeSymbol(CompilerContext context, ModuleID moduleID, BType intType) {
-        super(context, TypeDescKind.INT, moduleID, intType);
+        super(context, TypeDescKind.INT, intType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaIntUnsigned16TypeSymbol extends AbstractTypeSymbol impleme
     }
 
     @Override
-    public String name() {
-        return Names.STRING_UNSIGNED16;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_UNSIGNED16);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the int:Unsigned16 type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaIntUnsigned16TypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public String name() {
         return Names.STRING_UNSIGNED16;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_UNSIGNED16);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned16TypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaIntUnsigned16TypeSymbol extends AbstractTypeSymbol implements IntUnsigned16TypeSymbol {
 
     public BallerinaIntUnsigned16TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType unsigned16Type) {
-        super(context, TypeDescKind.INT_UNSIGNED16, moduleID, unsigned16Type);
+        super(context, TypeDescKind.INT_UNSIGNED16, unsigned16Type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the int:Unsigned32 type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaIntUnsigned32TypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public String name() {
         return Names.STRING_UNSIGNED32;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_UNSIGNED32);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaIntUnsigned32TypeSymbol extends AbstractTypeSymbol impleme
     }
 
     @Override
-    public String name() {
-        return Names.STRING_UNSIGNED32;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_UNSIGNED32);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned32TypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaIntUnsigned32TypeSymbol extends AbstractTypeSymbol implements IntUnsigned32TypeSymbol {
 
     public BallerinaIntUnsigned32TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType unsigned32Type) {
-        super(context, TypeDescKind.INT_UNSIGNED32, moduleID, unsigned32Type);
+        super(context, TypeDescKind.INT_UNSIGNED32, unsigned32Type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the int:Unsigned8 type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaIntUnsigned8TypeSymbol extends AbstractTypeSymbol implemen
     @Override
     public String name() {
         return Names.STRING_UNSIGNED8;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_UNSIGNED8);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaIntUnsigned8TypeSymbol extends AbstractTypeSymbol implemen
     }
 
     @Override
-    public String name() {
-        return Names.STRING_UNSIGNED8;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_UNSIGNED8);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntUnsigned8TypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaIntUnsigned8TypeSymbol extends AbstractTypeSymbol implements IntUnsigned8TypeSymbol {
 
     public BallerinaIntUnsigned8TypeSymbol(CompilerContext context, ModuleID moduleID, BIntSubType unsigned8Type) {
-        super(context, TypeDescKind.INT_UNSIGNED8, moduleID, unsigned8Type);
+        super(context, TypeDescKind.INT_UNSIGNED8, unsigned8Type);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
@@ -44,7 +44,7 @@ public class BallerinaIntersectionTypeSymbol extends AbstractTypeSymbol implemen
 
     public BallerinaIntersectionTypeSymbol(CompilerContext context, ModuleID moduleID,
                                            BIntersectionType intersectionType) {
-        super(context, TypeDescKind.INTERSECTION, moduleID, intersectionType);
+        super(context, TypeDescKind.INTERSECTION, intersectionType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaJSONTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaJSONTypeSymbol extends AbstractTypeSymbol implements JSONTypeSymbol {
 
     public BallerinaJSONTypeSymbol(CompilerContext context, ModuleID moduleID, BJSONType jsonType) {
-        super(context, TypeDescKind.JSON, moduleID, jsonType);
+        super(context, TypeDescKind.JSON, jsonType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -35,7 +35,7 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
     private TypeSymbol memberTypeDesc;
 
     public BallerinaMapTypeSymbol(CompilerContext context, ModuleID moduleID, BMapType mapType) {
-        super(context, TypeDescKind.MAP, moduleID, mapType);
+        super(context, TypeDescKind.MAP, mapType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -52,11 +52,6 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     }
 
     @Override
-    public String name() {
-        return this.functionSymbol.name();
-    }
-
-    @Override
     public Optional<String> getName() {
         return this.functionSymbol.getName();
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -23,6 +23,7 @@ import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -53,6 +54,16 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     @Override
     public String name() {
         return this.functionSymbol.name();
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return this.functionSymbol.getName();
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        return this.functionSymbol.getModule();
     }
 
     @Override
@@ -93,6 +104,11 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     @Override
     public Location location() {
         return this.functionSymbol.location();
+    }
+
+    @Override
+    public Optional<Location> getLocation() {
+        return this.functionSymbol.getLocation();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -119,7 +119,7 @@ public class BallerinaMethodSymbol implements MethodSymbol {
 
         StringBuilder signature = new StringBuilder(qualifierJoiner.toString());
         StringJoiner joiner = new StringJoiner(", ");
-        signature.append(this.functionSymbol.name()).append("(");
+        signature.append(this.functionSymbol.getName().get()).append("(");
         for (ParameterSymbol requiredParam : this.typeDescriptor().parameters()) {
             String ballerinaParameterSignature = requiredParam.signature();
             joiner.add(ballerinaParameterSignature);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -17,7 +17,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
@@ -59,11 +58,6 @@ public class BallerinaMethodSymbol implements MethodSymbol {
     @Override
     public Optional<ModuleSymbol> getModule() {
         return this.functionSymbol.getModule();
-    }
-
-    @Override
-    public ModuleID moduleID() {
-        return this.functionSymbol.moduleID();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -28,7 +28,6 @@ import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.Scope.ScopeEntry;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BConstantSymbol;
@@ -68,8 +67,8 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
     private List<Symbol> allSymbols;
     private ModuleID id;
 
-    protected BallerinaModule(CompilerContext context, String name, PackageID moduleID, BPackageSymbol packageSymbol) {
-        super(name, moduleID, SymbolKind.MODULE, packageSymbol, context);
+    protected BallerinaModule(CompilerContext context, String name, BPackageSymbol packageSymbol) {
+        super(name, SymbolKind.MODULE, packageSymbol, context);
         this.packageSymbol = packageSymbol;
     }
 
@@ -266,11 +265,8 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
      */
     public static class ModuleSymbolBuilder extends SymbolBuilder<ModuleSymbolBuilder> {
 
-        private final CompilerContext context;
-
-        public ModuleSymbolBuilder(CompilerContext context, String name,
-                                   PackageID moduleID, BPackageSymbol packageSymbol) {
-            super(name, moduleID, SymbolKind.MODULE, packageSymbol, context);
+        public ModuleSymbolBuilder(CompilerContext context, String name, BPackageSymbol packageSymbol) {
+            super(name, SymbolKind.MODULE, packageSymbol, context);
             this.context = context;
         }
 
@@ -282,7 +278,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
             if (this.bSymbol == null) {
                 throw new AssertionError("Package Symbol cannot be null");
             }
-            return new BallerinaModule(this.context, this.name, this.moduleID, (BPackageSymbol) this.bSymbol);
+            return new BallerinaModule(this.context, this.name, (BPackageSymbol) this.bSymbol);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.ballerinalang.model.symbols.SymbolOrigin.BUILTIN;
@@ -58,7 +59,6 @@ import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.is
  */
 public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
-    private final CompilerContext context;
     private BPackageSymbol packageSymbol;
     private List<TypeDefinitionSymbol> typeDefs;
     private List<ClassSymbol> classes;
@@ -69,9 +69,13 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
     private ModuleID id;
 
     protected BallerinaModule(CompilerContext context, String name, PackageID moduleID, BPackageSymbol packageSymbol) {
-        super(name, moduleID, SymbolKind.MODULE, packageSymbol);
-        this.context = context;
+        super(name, moduleID, SymbolKind.MODULE, packageSymbol, context);
         this.packageSymbol = packageSymbol;
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        return Optional.of(this);
     }
 
     @Override
@@ -266,7 +270,7 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
 
         public ModuleSymbolBuilder(CompilerContext context, String name,
                                    PackageID moduleID, BPackageSymbol packageSymbol) {
-            super(name, moduleID, SymbolKind.MODULE, packageSymbol);
+            super(name, moduleID, SymbolKind.MODULE, packageSymbol, context);
             this.context = context;
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaModule.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
+import io.ballerina.compiler.api.ModuleID;
+import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
@@ -64,11 +66,22 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
     private List<ConstantSymbol> constants;
     private List<EnumSymbol> enums;
     private List<Symbol> allSymbols;
+    private ModuleID id;
 
     protected BallerinaModule(CompilerContext context, String name, PackageID moduleID, BPackageSymbol packageSymbol) {
         super(name, moduleID, SymbolKind.MODULE, packageSymbol);
         this.context = context;
         this.packageSymbol = packageSymbol;
+    }
+
+    @Override
+    public ModuleID id() {
+        if (this.id != null) {
+            return this.id;
+        }
+
+        this.id = new BallerinaModuleID(this.packageSymbol.pkgID);
+        return this.id;
     }
 
     /**
@@ -234,12 +247,12 @@ public class BallerinaModule extends BallerinaSymbol implements ModuleSymbol {
         }
 
         ModuleSymbol symbol = (ModuleSymbol) obj;
-        return this.moduleID().equals(symbol.moduleID());
+        return this.id().equals(symbol.id());
     }
 
     @Override
     public int hashCode() {
-        return this.moduleID().hashCode();
+        return this.id().hashCode();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNeverTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNeverTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaNeverTypeSymbol extends AbstractTypeSymbol implements NeverTypeSymbol {
 
     public BallerinaNeverTypeSymbol(CompilerContext context, ModuleID moduleID, BNeverType neverType) {
-        super(context, TypeDescKind.NEVER, moduleID, neverType);
+        super(context, TypeDescKind.NEVER, neverType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaNilTypeSymbol.java
@@ -30,7 +30,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaNilTypeSymbol extends AbstractTypeSymbol implements NilTypeSymbol {
 
     public BallerinaNilTypeSymbol(CompilerContext context, ModuleID moduleID, BNilType nilType) {
-        super(context, TypeDescKind.NIL, moduleID, nilType);
+        super(context, TypeDescKind.NIL, nilType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -68,8 +68,8 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     }
 
     @Override
-    public String name() {
-        return this.bField.getName().getValue();
+    public Optional<String> getName() {
+        return Optional.of(this.bField.getName().getValue());
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -135,7 +135,7 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
             joiner.add(qualifier.getValue());
         }
 
-        this.signature = joiner.add(this.typeDescriptor().signature()).add(this.name()).toString();
+        this.signature = joiner.add(this.typeDescriptor().signature()).add(this.getName().get()).toString();
         return this.signature;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -55,7 +55,7 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     private boolean deprecated;
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField, SymbolKind kind) {
-        super(bField.name.value, bField.symbol.pkgID, kind, bField.symbol, context);
+        super(bField.name.value, kind, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectFieldSymbol.java
@@ -49,15 +49,13 @@ public class BallerinaObjectFieldSymbol extends BallerinaSymbol implements Objec
     protected final BField bField;
     protected List<Qualifier> qualifiers;
     private final Documentation docAttachment;
-    private final CompilerContext context;
     private TypeSymbol typeDescriptor;
     private List<AnnotationSymbol> annots;
     private String signature;
     private boolean deprecated;
 
     public BallerinaObjectFieldSymbol(CompilerContext context, BField bField, SymbolKind kind) {
-        super(bField.name.value, bField.symbol.pkgID, kind, bField.symbol);
-        this.context = context;
+        super(bField.name.value, bField.symbol.pkgID, kind, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -53,7 +53,7 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
     private List<TypeSymbol> typeInclusions;
 
     public BallerinaObjectTypeSymbol(CompilerContext context, ModuleID moduleID, BObjectType objectType) {
-        super(context, TypeDescKind.OBJECT, moduleID, objectType);
+        super(context, TypeDescKind.OBJECT, objectType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaReadonlyTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaReadonlyTypeSymbol extends AbstractTypeSymbol implements ReadonlyTypeSymbol {
 
     public BallerinaReadonlyTypeSymbol(CompilerContext context, ModuleID moduleID, BReadonlyType readonlyType) {
-        super(context, TypeDescKind.READONLY, moduleID, readonlyType);
+        super(context, TypeDescKind.READONLY, readonlyType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -160,7 +160,7 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
             joiner.add(qualifier.getValue());
         }
 
-        this.signature = joiner.add(this.typeDescriptor().signature()).add(this.name()).toString();
+        this.signature = joiner.add(this.typeDescriptor().signature()).add(this.getName().get()).toString();
 
         if (this.isOptional()) {
             this.signature += "?";

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -62,12 +62,9 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public String name() {
-        return this.bField.getName().getValue();
+    public Optional<String> getName() {
+        return Optional.of(this.bField.getName().getValue());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -54,7 +54,7 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
     private boolean deprecated;
 
     public BallerinaRecordFieldSymbol(CompilerContext context, BField bField) {
-        super(bField.name.value, bField.symbol.pkgID, SymbolKind.RECORD_FIELD, bField.symbol, context);
+        super(bField.name.value, SymbolKind.RECORD_FIELD, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordFieldSymbol.java
@@ -47,7 +47,6 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
 
     private final Documentation docAttachment;
     private final BField bField;
-    private final CompilerContext context;
     private TypeSymbol typeDescriptor;
     private List<AnnotationSymbol> annots;
     private List<Qualifier> qualifiers;
@@ -55,8 +54,7 @@ public class BallerinaRecordFieldSymbol extends BallerinaSymbol implements Recor
     private boolean deprecated;
 
     public BallerinaRecordFieldSymbol(CompilerContext context, BField bField) {
-        super(bField.name.value, bField.symbol.pkgID, SymbolKind.RECORD_FIELD, bField.symbol);
-        this.context = context;
+        super(bField.name.value, bField.symbol.pkgID, SymbolKind.RECORD_FIELD, bField.symbol, context);
         this.bField = bField;
         this.docAttachment = new BallerinaDocumentation(bField.symbol.markdownDocumentation);
         this.deprecated = Symbols.isFlagOn(bField.symbol.flags, Flags.DEPRECATED);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaRecordTypeSymbol.java
@@ -47,7 +47,7 @@ public class BallerinaRecordTypeSymbol extends AbstractTypeSymbol implements Rec
     private List<TypeSymbol> typeInclusions;
 
     public BallerinaRecordTypeSymbol(CompilerContext context, ModuleID moduleID, BRecordType recordType) {
-        super(context, TypeDescKind.RECORD, moduleID, recordType);
+        super(context, TypeDescKind.RECORD, recordType);
         this.isInclusive = !recordType.sealed;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSingletonTypeSymbol.java
@@ -39,7 +39,7 @@ public class BallerinaSingletonTypeSymbol extends AbstractTypeSymbol implements 
 
     public BallerinaSingletonTypeSymbol(CompilerContext context, ModuleID moduleID, BLangExpression shape,
                                         BType bType) {
-        super(context, TypeDescKind.SINGLETON, moduleID, bType);
+        super(context, TypeDescKind.SINGLETON, bType);
         this.typeName = shape.toString();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStreamTypeSymbol.java
@@ -36,7 +36,7 @@ public class BallerinaStreamTypeSymbol extends AbstractTypeSymbol implements Str
     private String signature;
 
     public BallerinaStreamTypeSymbol(CompilerContext context, ModuleID moduleID, BStreamType streamType) {
-        super(context, TypeDescKind.STREAM, moduleID, streamType);
+        super(context, TypeDescKind.STREAM, streamType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -38,11 +38,6 @@ public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements
     }
 
     @Override
-    public String name() {
-        return Names.STRING_CHAR;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_CHAR);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BStringSubType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents the string:Char type descriptor.
  *
@@ -38,6 +40,11 @@ public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements
     @Override
     public String name() {
         return Names.STRING_CHAR;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_CHAR);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringCharTypeSymbol.java
@@ -34,7 +34,7 @@ import java.util.Optional;
 public class BallerinaStringCharTypeSymbol extends AbstractTypeSymbol implements StringCharTypeSymbol {
 
     public BallerinaStringCharTypeSymbol(CompilerContext context, ModuleID moduleID, BStringSubType charType) {
-        super(context, TypeDescKind.STRING_CHAR, moduleID, charType);
+        super(context, TypeDescKind.STRING_CHAR, charType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaStringTypeSymbol.java
@@ -31,7 +31,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 public class BallerinaStringTypeSymbol extends AbstractTypeSymbol implements StringTypeSymbol {
 
     public BallerinaStringTypeSymbol(CompilerContext context, ModuleID moduleID, BType stringType) {
-        super(context, TypeDescKind.STRING, moduleID, stringType);
+        super(context, TypeDescKind.STRING, stringType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -117,7 +117,7 @@ public class BallerinaSymbol implements Symbol {
 
         Symbol symbol = (Symbol) obj;
 
-        return this.name().equals(symbol.name())
+        return this.getName().get().equals(symbol.getName().get())
                 && this.moduleID().equals(symbol.moduleID())
                 && this.kind().equals(symbol.kind())
                 && this.location().lineRange().equals(symbol.location().lineRange());
@@ -125,7 +125,7 @@ public class BallerinaSymbol implements Symbol {
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.name(), this.moduleID(), this.kind(), this.location().lineRange());
+        return Objects.hash(this.getName().get(), this.moduleID(), this.kind(), this.location().lineRange());
     }
 
     public BSymbol getInternalSymbol() {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -20,6 +20,7 @@ package io.ballerina.compiler.api.impl.symbols;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.tools.diagnostics.Location;
@@ -28,6 +29,7 @@ import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents the implementation of a Compiled Ballerina Symbol.
@@ -67,6 +69,16 @@ public class BallerinaSymbol implements Symbol {
         return this.name;
     }
 
+    @Override
+    public Optional<String> getName() {
+        return Optional.ofNullable(this.name);
+    }
+
+    @Override
+    public Optional<ModuleSymbol> getModule() {
+        return Optional.empty();
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -86,6 +98,11 @@ public class BallerinaSymbol implements Symbol {
     @Override
     public Location location() {
         return this.position;
+    }
+
+    @Override
+    public Optional<Location> getLocation() {
+        return Optional.ofNullable(this.position);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -61,14 +61,6 @@ public class BallerinaSymbol implements Symbol {
                                                     symbol.pos.lineRange().endLine().offset());
     }
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String name() {
-        return this.name;
-    }
-
     @Override
     public Optional<String> getName() {
         return Optional.ofNullable(this.name);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -17,8 +17,6 @@
  */
 package io.ballerina.compiler.api.impl.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
-import io.ballerina.compiler.api.impl.BallerinaModuleID;
 import io.ballerina.compiler.api.symbols.Documentation;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
@@ -69,14 +67,6 @@ public class BallerinaSymbol implements Symbol {
     @Override
     public Optional<ModuleSymbol> getModule() {
         return Optional.empty();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ModuleID moduleID() {
-        return new BallerinaModuleID(this.moduleID);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -109,15 +109,15 @@ public class BallerinaSymbol implements Symbol {
 
         Symbol symbol = (Symbol) obj;
 
-        return this.getName().get().equals(symbol.getName().get())
-                && this.moduleID().equals(symbol.moduleID())
+        return isSameName(this.getName(), symbol.getName())
+                && isSameModule(this.getModule(), symbol.getModule())
                 && this.kind().equals(symbol.kind())
                 && this.location().lineRange().equals(symbol.location().lineRange());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.getName().get(), this.moduleID(), this.kind(), this.location().lineRange());
+        return Objects.hash(this.getName().orElse(null), this.getModule(), this.kind(), this.location().lineRange());
     }
 
     public BSymbol getInternalSymbol() {
@@ -126,6 +126,22 @@ public class BallerinaSymbol implements Symbol {
 
     Documentation getDocAttachment(BSymbol symbol) {
         return symbol == null ? null : new BallerinaDocumentation(symbol.markdownDocumentation);
+    }
+
+    private boolean isSameName(Optional<String> name1, Optional<String> name2) {
+        if (name1.isEmpty() || name2.isEmpty()) {
+            return false;
+        }
+
+        return name1.get().equals(name2.get());
+    }
+
+    private boolean isSameModule(Optional<ModuleSymbol> mod1, Optional<ModuleSymbol> mod2) {
+        if (mod1.isEmpty() || mod2.isEmpty()) {
+            return false;
+        }
+
+        return mod1.get().id().equals(mod2.get().id());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.ModuleSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.tools.diagnostics.Location;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLocation;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
@@ -44,14 +43,11 @@ public class BallerinaSymbol implements Symbol {
     private final SymbolKind symbolKind;
     private final Location position;
     private final BSymbol internalSymbol;
-    private final PackageID moduleID;
     private ModuleSymbol module;
     private boolean moduleEvaluated;
 
-    protected BallerinaSymbol(String name, PackageID moduleID, SymbolKind symbolKind, BSymbol symbol,
-                              CompilerContext context) {
+    protected BallerinaSymbol(String name, SymbolKind symbolKind, BSymbol symbol, CompilerContext context) {
         this.name = name;
-        this.moduleID = moduleID;
         this.symbolKind = symbolKind;
         this.context = context;
 
@@ -169,7 +165,6 @@ public class BallerinaSymbol implements Symbol {
     protected abstract static class SymbolBuilder<T extends SymbolBuilder<T>> {
 
         protected String name;
-        protected PackageID moduleID;
         protected SymbolKind ballerinaSymbolKind;
         protected BSymbol bSymbol;
         protected CompilerContext context;
@@ -178,15 +173,12 @@ public class BallerinaSymbol implements Symbol {
          * Symbol Builder Constructor.
          *
          * @param name       Symbol Name
-         * @param moduleID   module ID of the symbol
          * @param symbolKind symbol kind
          * @param bSymbol    symbol to evaluate
          * @param context    context of the compilation
          */
-        public SymbolBuilder(String name, PackageID moduleID, SymbolKind symbolKind, BSymbol bSymbol,
-                             CompilerContext context) {
+        public SymbolBuilder(String name, SymbolKind symbolKind, BSymbol bSymbol, CompilerContext context) {
             this.name = name;
-            this.moduleID = moduleID;
             this.ballerinaSymbolKind = symbolKind;
             this.bSymbol = bSymbol;
             this.context = context;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaSymbol.java
@@ -121,16 +121,17 @@ public class BallerinaSymbol implements Symbol {
         }
 
         Symbol symbol = (Symbol) obj;
-
         return isSameName(this.getName(), symbol.getName())
                 && isSameModule(this.getModule(), symbol.getModule())
-                && this.kind().equals(symbol.kind())
-                && this.location().lineRange().equals(symbol.location().lineRange());
+                && isSameLocation(this.getLocation(), symbol.getLocation())
+                && this.kind().equals(symbol.kind());
+
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(this.getName().orElse(null), this.getModule(), this.kind(), this.location().lineRange());
+        return Objects.hash(this.getName().orElse(null), this.getModule().orElse(null), this.kind(),
+                            this.getLocation().isPresent() ? this.getLocation().get().lineRange() : null);
     }
 
     public BSymbol getInternalSymbol() {
@@ -155,6 +156,14 @@ public class BallerinaSymbol implements Symbol {
         }
 
         return mod1.get().id().equals(mod2.get().id());
+    }
+
+    private boolean isSameLocation(Optional<Location> loc1, Optional<Location> loc2) {
+        if (loc1.isEmpty() || loc2.isEmpty()) {
+            return false;
+        }
+
+        return loc1.get().lineRange().equals(loc2.get().lineRange());
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTableTypeSymbol.java
@@ -43,7 +43,7 @@ public class BallerinaTableTypeSymbol extends AbstractTypeSymbol implements Tabl
     private String signature;
 
     public BallerinaTableTypeSymbol(CompilerContext context, ModuleID moduleID, BTableType tableType) {
-        super(context, TypeDescKind.TABLE, moduleID, tableType);
+        super(context, TypeDescKind.TABLE, tableType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTupleTypeSymbol.java
@@ -41,7 +41,7 @@ public class BallerinaTupleTypeSymbol extends AbstractTypeSymbol implements Tupl
     private TypeSymbol restTypeDesc;
 
     public BallerinaTupleTypeSymbol(CompilerContext context, ModuleID moduleID, BTupleType tupleType) {
-        super(context, TypeDescKind.TUPLE, moduleID, tupleType);
+        super(context, TypeDescKind.TUPLE, tupleType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -61,7 +61,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
 
     @Override
     public String moduleQualifiedName() {
-        return this.moduleID().moduleName() + ":" + this.name();
+        return this.moduleID().moduleName() + ":" + this.getName().get();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -61,7 +61,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
 
     @Override
     public String moduleQualifiedName() {
-        return this.moduleID().moduleName() + ":" + this.getName().get();
+        return this.getModule().get().id().modulePrefix() + ":" + this.getName().get();
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -47,9 +47,9 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
     private final boolean deprecated;
     private final boolean readonly;
 
-    protected BallerinaTypeDefinitionSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
-                                            TypeSymbol typeDescriptor, BSymbol bSymbol, CompilerContext context) {
-        super(name, moduleID, SymbolKind.TYPE_DEFINITION, bSymbol, context);
+    protected BallerinaTypeDefinitionSymbol(String name, List<Qualifier> qualifiers, TypeSymbol typeDescriptor,
+                                            BSymbol bSymbol, CompilerContext context) {
+        super(name, SymbolKind.TYPE_DEFINITION, bSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.typeDescriptor = typeDescriptor;
         this.docAttachment = getDocAttachment(bSymbol);
@@ -102,8 +102,8 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
         protected List<Qualifier> qualifiers = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
-        public TypeDefSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
-            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol, context);
+        public TypeDefSymbolBuilder(String name, BSymbol symbol, CompilerContext context) {
+            super(name, SymbolKind.TYPE_DEFINITION, symbol, context);
         }
 
         public TypeDefSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
@@ -118,7 +118,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
 
         @Override
         public BallerinaTypeDefinitionSymbol build() {
-            return new BallerinaTypeDefinitionSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
+            return new BallerinaTypeDefinitionSymbol(this.name, this.qualifiers, this.typeDescriptor,
                                                      this.bSymbol, this.context);
         }
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDefinitionSymbol.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -46,12 +47,9 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
     private final boolean deprecated;
     private final boolean readonly;
 
-    protected BallerinaTypeDefinitionSymbol(String name,
-                                            PackageID moduleID,
-                                            List<Qualifier> qualifiers,
-                                            TypeSymbol typeDescriptor,
-                                            BSymbol bSymbol) {
-        super(name, moduleID, SymbolKind.TYPE_DEFINITION, bSymbol);
+    protected BallerinaTypeDefinitionSymbol(String name, PackageID moduleID, List<Qualifier> qualifiers,
+                                            TypeSymbol typeDescriptor, BSymbol bSymbol, CompilerContext context) {
+        super(name, moduleID, SymbolKind.TYPE_DEFINITION, bSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.typeDescriptor = typeDescriptor;
         this.docAttachment = getDocAttachment(bSymbol);
@@ -104,8 +102,8 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
         protected List<Qualifier> qualifiers = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
-        public TypeDefSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
-            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol);
+        public TypeDefSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
+            super(name, moduleID, SymbolKind.TYPE_DEFINITION, symbol, context);
         }
 
         public TypeDefSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {
@@ -121,7 +119,7 @@ public class BallerinaTypeDefinitionSymbol extends BallerinaSymbol implements Ty
         @Override
         public BallerinaTypeDefinitionSymbol build() {
             return new BallerinaTypeDefinitionSymbol(this.name, this.moduleID, this.qualifiers, this.typeDescriptor,
-                                                     this.bSymbol);
+                                                     this.bSymbol, this.context);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeDescTypeSymbol.java
@@ -35,7 +35,7 @@ public class BallerinaTypeDescTypeSymbol extends AbstractTypeSymbol implements T
     private TypeSymbol typeParameter;
 
     public BallerinaTypeDescTypeSymbol(CompilerContext context, ModuleID moduleID, BTypedescType typedescType) {
-        super(context, TypeDescKind.TYPEDESC, moduleID, typedescType);
+        super(context, TypeDescKind.TYPEDESC, typedescType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Represents a TypeReference type descriptor.
@@ -64,6 +65,11 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public String name() {
         return this.definitionName;
+    }
+
+    @Override
+    public Optional<String> getName() {
+        return Optional.of(this.definitionName);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -117,6 +117,17 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     }
 
     @Override
+    public Optional<Location> getLocation() {
+        if (this.location != null) {
+            return Optional.of(this.location);
+        }
+
+        BType type = this.getBType();
+        this.location = type.tsymbol.pos;
+        return Optional.of(this.location);
+    }
+
+    @Override
     public String signature() {
         if (this.signature != null) {
             return this.signature;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -24,7 +24,6 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -134,16 +133,13 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
             return this.signature;
         }
 
-        // TODO: depending on PackageID due to https://github.com/ballerina-platform/ballerina-lang/issues/28482
-        BType type = this.getBType();
-        PackageID pkgID = type.tsymbol.pkgID;
-
-        if (pkgID == null || ("lang.annotations".equals(pkgID.getName().getValue()) &&
-                "ballerina".equals(pkgID.getOrgName().getValue()))) {
+        ModuleID moduleID = this.getModule().get().id();
+        if (moduleID == null || (moduleID.moduleName().equals("lang.annotations") &&
+                moduleID.orgName().equals("ballerina"))) {
             this.signature = this.definitionName;
         } else {
-            this.signature = !this.isAnonOrg(pkgID) ? pkgID.getOrgName().getValue() + Names.ORG_NAME_SEPARATOR +
-                    pkgID.getName().getValue() + Names.VERSION_SEPARATOR + pkgID.getPackageVersion().getValue() + ":" +
+            this.signature = !this.isAnonOrg(moduleID) ? moduleID.orgName() + Names.ORG_NAME_SEPARATOR +
+                    moduleID.moduleName() + Names.VERSION_SEPARATOR + moduleID.version() + ":" +
                     this.definitionName
                     : this.definitionName;
         }
@@ -151,7 +147,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         return this.signature;
     }
 
-    private boolean isAnonOrg(PackageID moduleID) {
-        return ANON_ORG.equals(moduleID.getOrgName().getValue());
+    private boolean isAnonOrg(ModuleID moduleID) {
+        return ANON_ORG.equals(moduleID.orgName());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -24,6 +24,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BPackageSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
@@ -133,13 +134,16 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
             return this.signature;
         }
 
-        ModuleID moduleID = this.getModule().get().id();
-        if (moduleID == null || (moduleID.moduleName().equals("lang.annotations") &&
-                moduleID.orgName().equals("ballerina"))) {
+        // TODO: depending on PackageID due to https://github.com/ballerina-platform/ballerina-lang/issues/28482
+        BType type = this.getBType();
+        PackageID pkgID = type.tsymbol.pkgID;
+
+        if (pkgID == null || ("lang.annotations".equals(pkgID.getName().getValue()) &&
+                "ballerina".equals(pkgID.getOrgName().getValue()))) {
             this.signature = this.definitionName;
         } else {
-            this.signature = !this.isAnonOrg(moduleID) ? moduleID.orgName() + Names.ORG_NAME_SEPARATOR +
-                    moduleID.moduleName() + Names.VERSION_SEPARATOR + moduleID.version() + ":" +
+            this.signature = !this.isAnonOrg(pkgID) ? pkgID.getOrgName().getValue() + Names.ORG_NAME_SEPARATOR +
+                    pkgID.getName().getValue() + Names.VERSION_SEPARATOR + pkgID.getPackageVersion().getValue() + ":" +
                     this.definitionName
                     : this.definitionName;
         }
@@ -147,7 +151,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
         return this.signature;
     }
 
-    private boolean isAnonOrg(ModuleID moduleID) {
-        return ANON_ORG.equals(moduleID.orgName());
+    private boolean isAnonOrg(PackageID moduleID) {
+        return ANON_ORG.equals(moduleID.getOrgName().getValue());
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -50,7 +50,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
 
     public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
                                             String definitionName) {
-        super(context, TypeDescKind.TYPE_REFERENCE, moduleID, bType);
+        super(context, TypeDescKind.TYPE_REFERENCE, bType);
         this.definitionName = definitionName;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -40,6 +40,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     private final String definitionName;
     private TypeSymbol typeDescriptorImpl;
     private Location location;
+    private String signature;
 
     public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
                                             String definitionName) {
@@ -87,14 +88,22 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
 
     @Override
     public String signature() {
-        if (this.moduleID() == null || (this.moduleID().moduleName().equals("lang.annotations") &&
-                this.moduleID().orgName().equals("ballerina"))) {
-            return this.definitionName;
+        if (this.signature != null) {
+            return this.signature;
         }
-        return !this.isAnonOrg(this.moduleID()) ? this.moduleID().orgName() + Names.ORG_NAME_SEPARATOR +
-                this.moduleID().moduleName() + Names.VERSION_SEPARATOR + this.moduleID().version() + ":" +
-                this.definitionName
-                : this.definitionName;
+
+        ModuleID moduleID = this.getModule().get().id();
+        if (moduleID == null || (moduleID.moduleName().equals("lang.annotations") &&
+                moduleID.orgName().equals("ballerina"))) {
+            this.signature = this.definitionName;
+        } else {
+            this.signature = !this.isAnonOrg(moduleID) ? moduleID.orgName() + Names.ORG_NAME_SEPARATOR +
+                    moduleID.moduleName() + Names.VERSION_SEPARATOR + moduleID.version() + ":" +
+                    this.definitionName
+                    : this.definitionName;
+        }
+
+        return this.signature;
     }
 
     private boolean isAnonOrg(ModuleID moduleID) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
@@ -35,11 +35,6 @@ public class BallerinaTypeSymbol extends AbstractTypeSymbol {
     }
 
     @Override
-    public String name() {
-        return this.typeName;
-    }
-
-    @Override
     public String signature() {
         return this.typeName;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeSymbol.java
@@ -30,7 +30,7 @@ public class BallerinaTypeSymbol extends AbstractTypeSymbol {
     private final String typeName;
 
     public BallerinaTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType) {
-        super(context, TypesFactory.getTypeDescKind(bType.getKind()), moduleID, bType);
+        super(context, TypesFactory.getTypeDescKind(bType.getKind()), bType);
         this.typeName = bType.getKind().typeName();
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -74,7 +74,8 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
                 }
             } else {
                 for (BLangExpression value : ((BFiniteType) this.getBType()).getValueSpace()) {
-                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID(), value, value.type));
+                    ModuleID moduleID = getModule().isPresent() ? getModule().get().id() : null;
+                    members.add(new BallerinaSingletonTypeSymbol(this.context, moduleID, value, value.type));
                 }
             }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -54,11 +54,11 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
     private String signature;
 
     public BallerinaUnionTypeSymbol(CompilerContext context, ModuleID moduleID, BUnionType unionType) {
-        super(context, TypeDescKind.UNION, moduleID, unionType);
+        super(context, TypeDescKind.UNION, unionType);
     }
 
     public BallerinaUnionTypeSymbol(CompilerContext context, ModuleID moduleID, BFiniteType finiteType) {
-        super(context, TypeDescKind.UNION, moduleID, finiteType);
+        super(context, TypeDescKind.UNION, finiteType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -47,10 +47,10 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     private final TypeSymbol typeDescriptorImpl;
     private final boolean deprecated;
 
-    protected BallerinaVariableSymbol(String name, PackageID moduleID, SymbolKind ballerinaSymbolKind,
-                                      List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
-                                      TypeSymbol typeDescriptorImpl, BSymbol bSymbol, CompilerContext context) {
-        super(name, moduleID, ballerinaSymbolKind, bSymbol, context);
+    protected BallerinaVariableSymbol(String name, SymbolKind ballerinaSymbolKind, List<Qualifier> qualifiers,
+                                      List<AnnotationSymbol> annots, TypeSymbol typeDescriptorImpl, BSymbol bSymbol,
+                                      CompilerContext context) {
+        super(name, ballerinaSymbolKind, bSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
         this.docAttachment = getDocAttachment(bSymbol);
@@ -102,13 +102,13 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
-        public VariableSymbolBuilder(String name, PackageID moduleID, BSymbol bSymbol, CompilerContext context) {
-            super(name, moduleID, SymbolKind.VARIABLE, bSymbol, context);
+        public VariableSymbolBuilder(String name, BSymbol bSymbol, CompilerContext context) {
+            super(name, SymbolKind.VARIABLE, bSymbol, context);
         }
 
         @Override
         public BallerinaVariableSymbol build() {
-            return new BallerinaVariableSymbol(this.name, this.moduleID, this.ballerinaSymbolKind, this.qualifiers,
+            return new BallerinaVariableSymbol(this.name, this.ballerinaSymbolKind, this.qualifiers,
                                                this.annots, this.typeDescriptor, this.bSymbol, this.context);
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -26,6 +26,7 @@ import io.ballerina.compiler.api.symbols.VariableSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.ArrayList;
@@ -46,14 +47,10 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
     private final TypeSymbol typeDescriptorImpl;
     private final boolean deprecated;
 
-    protected BallerinaVariableSymbol(String name,
-                                      PackageID moduleID,
-                                      SymbolKind ballerinaSymbolKind,
-                                      List<Qualifier> qualifiers,
-                                      List<AnnotationSymbol> annots,
-                                      TypeSymbol typeDescriptorImpl,
-                                      BSymbol bSymbol) {
-        super(name, moduleID, ballerinaSymbolKind, bSymbol);
+    protected BallerinaVariableSymbol(String name, PackageID moduleID, SymbolKind ballerinaSymbolKind,
+                                      List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
+                                      TypeSymbol typeDescriptorImpl, BSymbol bSymbol, CompilerContext context) {
+        super(name, moduleID, ballerinaSymbolKind, bSymbol, context);
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
         this.docAttachment = getDocAttachment(bSymbol);
@@ -105,14 +102,14 @@ public class BallerinaVariableSymbol extends BallerinaSymbol implements Variable
         protected List<AnnotationSymbol> annots = new ArrayList<>();
         protected TypeSymbol typeDescriptor;
 
-        public VariableSymbolBuilder(String name, PackageID moduleID, BSymbol bSymbol) {
-            super(name, moduleID, SymbolKind.VARIABLE, bSymbol);
+        public VariableSymbolBuilder(String name, PackageID moduleID, BSymbol bSymbol, CompilerContext context) {
+            super(name, moduleID, SymbolKind.VARIABLE, bSymbol, context);
         }
 
         @Override
         public BallerinaVariableSymbol build() {
             return new BallerinaVariableSymbol(this.name, this.moduleID, this.ballerinaSymbolKind, this.qualifiers,
-                                               this.annots, this.typeDescriptor, this.bSymbol);
+                                               this.annots, this.typeDescriptor, this.bSymbol, this.context);
         }
 
         public VariableSymbolBuilder withTypeDescriptor(TypeSymbol typeDescriptor) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaVariableSymbol.java
@@ -23,7 +23,6 @@ import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.WorkerSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
@@ -38,10 +37,9 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
     private TypeSymbol returnType;
     private List<AnnotationSymbol> annots;
 
-    private BallerinaWorkerSymbol(String name, PackageID moduleID, SymbolKind ballerinaSymbolKind,
-                                  TypeSymbol returnType, List<AnnotationSymbol> annots, BSymbol symbol,
-                                  CompilerContext context) {
-        super(name, moduleID, ballerinaSymbolKind, symbol, context);
+    private BallerinaWorkerSymbol(String name, SymbolKind ballerinaSymbolKind, TypeSymbol returnType,
+                                  List<AnnotationSymbol> annots, BSymbol symbol, CompilerContext context) {
+        super(name, ballerinaSymbolKind, symbol, context);
         this.returnType = returnType;
         this.annots = annots;
     }
@@ -69,14 +67,14 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
         protected TypeSymbol returnType;
         protected List<AnnotationSymbol> annots = new ArrayList<>();
 
-        public WorkerSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
-            super(name, moduleID, SymbolKind.WORKER, symbol, context);
+        public WorkerSymbolBuilder(String name, BSymbol symbol, CompilerContext context) {
+            super(name, SymbolKind.WORKER, symbol, context);
         }
 
         @Override
         public BallerinaWorkerSymbol build() {
-            return new BallerinaWorkerSymbol(this.name, this.moduleID, this.ballerinaSymbolKind, this.returnType,
-                                             this.annots, this.bSymbol, this.context);
+            return new BallerinaWorkerSymbol(this.name, this.ballerinaSymbolKind, this.returnType, this.annots,
+                                             this.bSymbol, this.context);
         }
 
         public WorkerSymbolBuilder withReturnType(TypeSymbol typeDescriptor) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaWorkerSymbol.java
@@ -23,6 +23,7 @@ import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.WorkerSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -38,8 +39,9 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
     private List<AnnotationSymbol> annots;
 
     private BallerinaWorkerSymbol(String name, PackageID moduleID, SymbolKind ballerinaSymbolKind,
-                                  TypeSymbol returnType, List<AnnotationSymbol> annots, BSymbol symbol) {
-        super(name, moduleID, ballerinaSymbolKind, symbol);
+                                  TypeSymbol returnType, List<AnnotationSymbol> annots, BSymbol symbol,
+                                  CompilerContext context) {
+        super(name, moduleID, ballerinaSymbolKind, symbol, context);
         this.returnType = returnType;
         this.annots = annots;
     }
@@ -67,14 +69,14 @@ public class BallerinaWorkerSymbol extends BallerinaSymbol implements WorkerSymb
         protected TypeSymbol returnType;
         protected List<AnnotationSymbol> annots = new ArrayList<>();
 
-        public WorkerSymbolBuilder(String name, PackageID moduleID, BSymbol symbol) {
-            super(name, moduleID, SymbolKind.WORKER, symbol);
+        public WorkerSymbolBuilder(String name, PackageID moduleID, BSymbol symbol, CompilerContext context) {
+            super(name, moduleID, SymbolKind.WORKER, symbol, context);
         }
 
         @Override
         public BallerinaWorkerSymbol build() {
             return new BallerinaWorkerSymbol(this.name, this.moduleID, this.ballerinaSymbolKind, this.returnType,
-                                             this.annots, this.bSymbol);
+                                             this.annots, this.bSymbol, this.context);
         }
 
         public WorkerSymbolBuilder withReturnType(TypeSymbol typeDescriptor) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
@@ -49,6 +49,11 @@ public class BallerinaXMLCommentTypeSymbol extends AbstractTypeSymbol implements
     }
 
     @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_XML_COMMENT);
+    }
+
+    @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_COMMENT;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
@@ -44,11 +44,6 @@ public class BallerinaXMLCommentTypeSymbol extends AbstractTypeSymbol implements
     }
 
     @Override
-    public String name() {
-        return Names.STRING_XML_COMMENT;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_XML_COMMENT);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLCommentTypeSymbol.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 public class BallerinaXMLCommentTypeSymbol extends AbstractTypeSymbol implements XMLCommentTypeSymbol {
 
     public BallerinaXMLCommentTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType commentType) {
-        super(context, TypeDescKind.XML_COMMENT, moduleID, commentType);
+        super(context, TypeDescKind.XML_COMMENT, commentType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
@@ -44,11 +44,6 @@ public class BallerinaXMLElementTypeSymbol extends AbstractTypeSymbol implements
     }
 
     @Override
-    public String name() {
-        return Names.STRING_XML_ELEMENT;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_XML_ELEMENT);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
@@ -49,6 +49,11 @@ public class BallerinaXMLElementTypeSymbol extends AbstractTypeSymbol implements
     }
 
     @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_XML_ELEMENT);
+    }
+
+    @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_ELEMENT;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLElementTypeSymbol.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 public class BallerinaXMLElementTypeSymbol extends AbstractTypeSymbol implements XMLElementTypeSymbol {
 
     public BallerinaXMLElementTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType elementType) {
-        super(context, TypeDescKind.XML_ELEMENT, moduleID, elementType);
+        super(context, TypeDescKind.XML_ELEMENT, elementType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
@@ -19,7 +19,6 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.XMLNamespaceSymbol;
-import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
@@ -33,9 +32,8 @@ public class BallerinaXMLNSSymbol extends BallerinaSymbol implements XMLNamespac
 
     private final String namespaceUri;
 
-    private BallerinaXMLNSSymbol(String name, PackageID moduleID, BSymbol symbol, String namespaceUri,
-                                 CompilerContext context) {
-        super(name, moduleID, SymbolKind.XMLNS, symbol, context);
+    private BallerinaXMLNSSymbol(String name, BSymbol symbol, String namespaceUri, CompilerContext context) {
+        super(name, SymbolKind.XMLNS, symbol, context);
         this.namespaceUri = namespaceUri;
     }
 
@@ -54,19 +52,18 @@ public class BallerinaXMLNSSymbol extends BallerinaSymbol implements XMLNamespac
         /**
          * Symbol Builder's Constructor.
          *
-         * @param name     Symbol Name
-         * @param moduleID module ID of the symbol
-         * @param symbol   namespace symbol
-         * @param context  context of the compilation
+         * @param name    Symbol Name
+         * @param symbol  namespace symbol
+         * @param context context of the compilation
          */
-        public XmlNSSymbolBuilder(String name, PackageID moduleID, BXMLNSSymbol symbol, CompilerContext context) {
-            super(name, moduleID, SymbolKind.XMLNS, symbol, context);
+        public XmlNSSymbolBuilder(String name, BXMLNSSymbol symbol, CompilerContext context) {
+            super(name, SymbolKind.XMLNS, symbol, context);
             this.uri = symbol.namespaceURI;
         }
 
         @Override
         public BallerinaXMLNSSymbol build() {
-            return new BallerinaXMLNSSymbol(this.name, this.moduleID, this.bSymbol, this.uri, this.context);
+            return new BallerinaXMLNSSymbol(this.name, this.bSymbol, this.uri, this.context);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLNSSymbol.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.XMLNamespaceSymbol;
 import org.ballerinalang.model.elements.PackageID;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BXMLNSSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 /**
  * Represents an XML Namespace Symbol.
@@ -32,8 +33,9 @@ public class BallerinaXMLNSSymbol extends BallerinaSymbol implements XMLNamespac
 
     private final String namespaceUri;
 
-    private BallerinaXMLNSSymbol(String name, PackageID moduleID, BSymbol symbol, String namespaceUri) {
-        super(name, moduleID, SymbolKind.XMLNS, symbol);
+    private BallerinaXMLNSSymbol(String name, PackageID moduleID, BSymbol symbol, String namespaceUri,
+                                 CompilerContext context) {
+        super(name, moduleID, SymbolKind.XMLNS, symbol, context);
         this.namespaceUri = namespaceUri;
     }
 
@@ -55,15 +57,16 @@ public class BallerinaXMLNSSymbol extends BallerinaSymbol implements XMLNamespac
          * @param name     Symbol Name
          * @param moduleID module ID of the symbol
          * @param symbol   namespace symbol
+         * @param context  context of the compilation
          */
-        public XmlNSSymbolBuilder(String name, PackageID moduleID, BXMLNSSymbol symbol) {
-            super(name, moduleID, SymbolKind.XMLNS, symbol);
+        public XmlNSSymbolBuilder(String name, PackageID moduleID, BXMLNSSymbol symbol, CompilerContext context) {
+            super(name, moduleID, SymbolKind.XMLNS, symbol, context);
             this.uri = symbol.namespaceURI;
         }
 
         @Override
         public BallerinaXMLNSSymbol build() {
-            return new BallerinaXMLNSSymbol(this.name, this.moduleID, this.bSymbol, this.uri);
+            return new BallerinaXMLNSSymbol(this.name, this.moduleID, this.bSymbol, this.uri, this.context);
         }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
@@ -46,11 +46,6 @@ public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractTypeSym
     }
 
     @Override
-    public String name() {
-        return Names.STRING_XML_PI;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_XML_PI);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
@@ -51,6 +51,11 @@ public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractTypeSym
     }
 
     @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_XML_PI);
+    }
+
+    @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_PI;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLProcessingInstructionTypeSymbol.java
@@ -37,7 +37,7 @@ public class BallerinaXMLProcessingInstructionTypeSymbol extends AbstractTypeSym
 
     public BallerinaXMLProcessingInstructionTypeSymbol(CompilerContext context, ModuleID moduleID,
                                                        BXMLSubType piType) {
-        super(context, TypeDescKind.XML_PROCESSING_INSTRUCTION, moduleID, piType);
+        super(context, TypeDescKind.XML_PROCESSING_INSTRUCTION, piType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
@@ -44,11 +44,6 @@ public class BallerinaXMLTextTypeSymbol extends AbstractTypeSymbol implements XM
     }
 
     @Override
-    public String name() {
-        return Names.STRING_XML_TEXT;
-    }
-
-    @Override
     public Optional<String> getName() {
         return Optional.of(Names.STRING_XML_TEXT);
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
@@ -49,6 +49,11 @@ public class BallerinaXMLTextTypeSymbol extends AbstractTypeSymbol implements XM
     }
 
     @Override
+    public Optional<String> getName() {
+        return Optional.of(Names.STRING_XML_TEXT);
+    }
+
+    @Override
     public String signature() {
         return "xml:" + Names.STRING_XML_TEXT;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTextTypeSymbol.java
@@ -35,7 +35,7 @@ import java.util.Optional;
 public class BallerinaXMLTextTypeSymbol extends AbstractTypeSymbol implements XMLTextTypeSymbol {
 
     public BallerinaXMLTextTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLSubType textType) {
-        super(context, TypeDescKind.XML_TEXT, moduleID, textType);
+        super(context, TypeDescKind.XML_TEXT, textType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -68,6 +68,22 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
     }
 
     @Override
+    public Optional<String> getName() {
+        if (this.typeName == null) {
+            BXMLType xmlType = (BXMLType) this.getBType();
+            SymbolTable symbolTable = SymbolTable.getInstance(this.context);
+
+            if (xmlType == symbolTable.xmlType || this.typeParameter().isEmpty()) {
+                this.typeName = "xml";
+            } else {
+                this.typeName = "xml<" + this.typeParameter().get().name() + ">";
+            }
+        }
+
+        return Optional.of(this.typeName);
+    }
+
+    @Override
     public String signature() {
         return getName().get();
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -69,6 +69,6 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
 
     @Override
     public String signature() {
-        return name();
+        return getName().get();
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -52,22 +52,6 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
     }
 
     @Override
-    public String name() {
-        if (this.typeName == null) {
-            BXMLType xmlType = (BXMLType) this.getBType();
-            SymbolTable symbolTable = SymbolTable.getInstance(this.context);
-
-            if (xmlType == symbolTable.xmlType || this.typeParameter().isEmpty()) {
-                this.typeName = "xml";
-            } else {
-                this.typeName = "xml<" + this.typeParameter().get().name() + ">";
-            }
-        }
-
-        return this.typeName;
-    }
-
-    @Override
     public Optional<String> getName() {
         if (this.typeName == null) {
             BXMLType xmlType = (BXMLType) this.getBType();
@@ -76,7 +60,7 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
             if (xmlType == symbolTable.xmlType || this.typeParameter().isEmpty()) {
                 this.typeName = "xml";
             } else {
-                this.typeName = "xml<" + this.typeParameter().get().name() + ">";
+                this.typeName = "xml<" + this.typeParameter().get().getName().orElse("") + ">";
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaXMLTypeSymbol.java
@@ -38,7 +38,7 @@ public class BallerinaXMLTypeSymbol extends AbstractTypeSymbol implements XMLTyp
     private String typeName;
 
     public BallerinaXMLTypeSymbol(CompilerContext context, ModuleID moduleID, BXMLType xmlType) {
-        super(context, TypeDescKind.XML, moduleID, xmlType);
+        super(context, TypeDescKind.XML, xmlType);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ModuleSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ModuleSymbol.java
@@ -17,6 +17,8 @@
  */
 package io.ballerina.compiler.api.symbols;
 
+import io.ballerina.compiler.api.ModuleID;
+
 import java.util.List;
 
 /**
@@ -25,6 +27,14 @@ import java.util.List;
  * @since 2.0.0
  */
 public interface ModuleSymbol extends Symbol {
+
+    /**
+     * Returns a {@link ModuleID} instance which contains organization, name, version and module prefix info of the
+     * module.
+     *
+     * @return The ID of the module
+     */
+    ModuleID id();
 
     /**
      * Get the public functions defined within the module.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -20,6 +20,8 @@ package io.ballerina.compiler.api.symbols;
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.tools.diagnostics.Location;
 
+import java.util.Optional;
+
 /**
  * Represents a compiled language symbol.
  *
@@ -38,6 +40,13 @@ public interface Symbol {
     String name();
 
     /**
+     * Retrieves the name of the symbol if it is associated with an identifier.
+     *
+     * @return The name of the symbol if applicable
+     */
+    Optional<String> getName();
+
+    /**
      * Get the moduleID of the symbol.
      *
      * @return {@link ModuleID} of the symbol
@@ -46,6 +55,13 @@ public interface Symbol {
      */
     @Deprecated
     ModuleID moduleID();
+
+    /**
+     * Retrieves the symbol of the module this symbol belongs to.
+     *
+     * @return The {@link ModuleSymbol} of the module
+     */
+    Optional<ModuleSymbol> getModule();
 
     /**
      * Get the Symbol Kind.
@@ -59,6 +75,15 @@ public interface Symbol {
      * the definition of the symbol.
      *
      * @return The position information of the symbol
+     * @deprecated This method will be removed in a later version and be replaced with the getLocation() method.
      */
+    @Deprecated
     Location location();
+
+    /**
+     * Retrieves the location of the symbol if the symbol is associated with an identifier in a source file.
+     *
+     * @return The location of the symbol if applicable
+     */
+    Optional<Location> getLocation();
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -30,16 +30,6 @@ import java.util.Optional;
 public interface Symbol {
 
     /**
-     * Get the symbol name.
-     *
-     * @return {@link String} name of the symbol
-     * @deprecated This method is expected to be removed from this interface. The plan is to make this method available
-     * only to symbols actually associated with a name.
-     */
-    @Deprecated
-    String name();
-
-    /**
      * Retrieves the name of the symbol if it is associated with an identifier.
      *
      * @return The name of the symbol if applicable

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -47,7 +47,8 @@ public interface Symbol {
     ModuleID moduleID();
 
     /**
-     * Retrieves the symbol of the module this symbol belongs to.
+     * Retrieves the symbol of the module this symbol belongs to if the symbol is defined in a module. Type symbols will
+     * typically return empty except for {@link TypeReferenceTypeSymbol}.
      *
      * @return The {@link ModuleSymbol} of the module
      */

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -17,7 +17,6 @@
  */
 package io.ballerina.compiler.api.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.tools.diagnostics.Location;
 
 import java.util.Optional;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Symbol.java
@@ -37,16 +37,6 @@ public interface Symbol {
     Optional<String> getName();
 
     /**
-     * Get the moduleID of the symbol.
-     *
-     * @return {@link ModuleID} of the symbol
-     * @deprecated This method will be removed in a later version and be replaced with a new method which will return
-     * the module symbol instead.
-     */
-    @Deprecated
-    ModuleID moduleID();
-
-    /**
      * Retrieves the symbol of the module this symbol belongs to if the symbol is defined in a module. Type symbols will
      * typically return empty except for {@link TypeReferenceTypeSymbol}.
      *

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeSymbol.java
@@ -16,8 +16,6 @@
  */
 package io.ballerina.compiler.api.symbols;
 
-import io.ballerina.compiler.api.ModuleID;
-
 import java.util.List;
 
 /**
@@ -33,13 +31,6 @@ public interface TypeSymbol extends Symbol {
      * @return {@link TypeDescKind} represented by the model
      */
     TypeDescKind typeKind();
-
-    /**
-     * Get the module ID.
-     *
-     * @return {@link ModuleID} of the Type
-     */
-    ModuleID moduleID();
 
     /**
      * Get the signature of the type descriptor.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/Bootstrap.java
@@ -110,6 +110,8 @@ public class Bootstrap {
             symbolTable.langTableModuleSymbol = loadLangLibFromBala(TABLE, compilerContext);
             symbolTable.langStreamModuleSymbol = loadLangLibFromBala(STREAM, compilerContext);
             symbolTable.langValueModuleSymbol = loadLangLibFromBala(VALUE, compilerContext);
+            symbolTable.updateStringSubtypeOwners();
+            symbolTable.updateXMLSubtypeOwners();
         }
 
         if (langLib.equals(TRANSACTION)) {
@@ -119,6 +121,7 @@ public class Bootstrap {
             symbolTable.langStringModuleSymbol = loadLangLibFromBala(STRING, compilerContext);
             symbolTable.langErrorModuleSymbol = loadLangLibFromBala(ERROR, compilerContext);
             symbolTable.langValueModuleSymbol = loadLangLibFromBala(VALUE, compilerContext);
+            symbolTable.updateStringSubtypeOwners();
         }
 
         if (langLib.equals(ERROR)) {
@@ -162,6 +165,7 @@ public class Bootstrap {
         symbolTable.langQueryModuleSymbol = loadLangLibFromBala(QUERY, compilerContext);
         symbolTable.langTransactionModuleSymbol = loadLangLibFromBala(TRANSACTION, compilerContext);
         symbolTable.loadPredeclaredModules();
+        symbolTable.updateBuiltinSubtypeOwners();
         symResolver.defineOperators();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilerDriver.java
@@ -174,6 +174,7 @@ public class CompilerDriver {
             symbolTable.langRuntimeModuleSymbol = pkgLoader.loadPackageSymbol(RUNTIME, null, null);
             symbolTable.langTransactionModuleSymbol = pkgLoader.loadPackageSymbol(TRANSACTION, null, null);
             symbolTable.loadPredeclaredModules();
+            symbolTable.updateBuiltinSubtypeOwners();
             return;
         }
 
@@ -222,6 +223,8 @@ public class CompilerDriver {
             symbolTable.langXmlModuleSymbol = pkgLoader.loadPackageSymbol(XML, null, null);
             symbolTable.langTableModuleSymbol = pkgLoader.loadPackageSymbol(TABLE, null, null);
             symbolTable.langStreamModuleSymbol = pkgLoader.loadPackageSymbol(STREAM, null, null);
+            symbolTable.updateStringSubtypeOwners();
+            symbolTable.updateXMLSubtypeOwners();
         }
 
         if (langLib.equals(TRANSACTION)) {
@@ -231,6 +234,7 @@ public class CompilerDriver {
             symbolTable.langStringModuleSymbol = pkgLoader.loadPackageSymbol(STRING, null, null);
             symbolTable.langValueModuleSymbol = pkgLoader.loadPackageSymbol(VALUE, null, null);
             symbolTable.langErrorModuleSymbol = pkgLoader.loadPackageSymbol(ERROR, null, null);
+            symbolTable.updateStringSubtypeOwners();
         }
 
         if (langLib.equals(ERROR)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -2031,6 +2031,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
         if (langLib.equals(INT)) {
             symTable.langIntModuleSymbol = packageSymbol;
+            symTable.updateIntSubtypeOwners();
             return;
         }
         if (langLib.equals(MAP)) {
@@ -2047,6 +2048,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
         if (langLib.equals(STRING)) {
             symTable.langStringModuleSymbol = packageSymbol;
+            symTable.updateStringSubtypeOwners();
             return;
         }
         if (langLib.equals(TABLE)) {
@@ -2063,6 +2065,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
         if (langLib.equals(XML)) {
             symTable.langXmlModuleSymbol = packageSymbol;
+            symTable.updateXMLSubtypeOwners();
             return;
         }
         if (langLib.equals(BOOLEAN)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/SymbolTable.java
@@ -412,6 +412,32 @@ public class SymbolTable {
         rootScope.define(tSymbol.name, tSymbol);
     }
 
+    public void updateBuiltinSubtypeOwners() {
+        updateIntSubtypeOwners();
+        updateStringSubtypeOwners();
+        updateXMLSubtypeOwners();
+    }
+
+    public void updateIntSubtypeOwners() {
+        this.signed8IntType.tsymbol.owner = this.langIntModuleSymbol;
+        this.unsigned8IntType.tsymbol.owner = this.langIntModuleSymbol;
+        this.signed16IntType.tsymbol.owner = this.langIntModuleSymbol;
+        this.unsigned16IntType.tsymbol.owner = this.langIntModuleSymbol;
+        this.signed32IntType.tsymbol.owner = this.langIntModuleSymbol;
+        this.unsigned32IntType.tsymbol.owner = this.langIntModuleSymbol;
+    }
+
+    public void updateStringSubtypeOwners() {
+        this.charStringType.tsymbol.owner = this.langStringModuleSymbol;
+    }
+
+    public void updateXMLSubtypeOwners() {
+        this.xmlElementType.tsymbol.owner = this.langXmlModuleSymbol;
+        this.xmlCommentType.tsymbol.owner = this.langXmlModuleSymbol;
+        this.xmlPIType.tsymbol.owner = this.langXmlModuleSymbol;
+        this.xmlTextType.tsymbol.owner = this.langXmlModuleSymbol;
+    }
+
     public void defineOperators() {
         // Binary arithmetic operators
         defineIntegerArithmeticOperations();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/LSAnnotationCache.java
@@ -333,11 +333,11 @@ public class LSAnnotationCache {
     private void addAttachment(AnnotationSymbol annotationSymbol,
                                       Map<ModuleID, List<AnnotationSymbol>> map) {
         // TODO: Check the map contains is valid
-        if (map.containsKey(annotationSymbol.moduleID())) {
-            map.get(annotationSymbol.moduleID()).add(annotationSymbol);
+        if (map.containsKey(annotationSymbol.getModule().get().id())) {
+            map.get(annotationSymbol.getModule().get().id()).add(annotationSymbol);
             return;
         }
-        map.put(annotationSymbol.moduleID(), new ArrayList<>(Collections.singletonList(annotationSymbol)));
+        map.put(annotationSymbol.getModule().get().id(), new ArrayList<>(Collections.singletonList(annotationSymbol)));
     }
 
     private boolean isAttachPointPresent(List<AnnotationAttachPoint> attachPoints, AnnotationAttachPoint mask) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -193,7 +193,7 @@ public class CodeActionUtil {
      */
     public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, List<TextEdit> edits,
                                                 DocumentServiceContext context) {
-        if (typeDescriptor.name().startsWith("$")) {
+        if (typeDescriptor.getName().isPresent() && typeDescriptor.getName().get().startsWith("$")) {
             typeDescriptor = CommonUtil.getRawType(typeDescriptor);
         }
         ImportsAcceptor importsAcceptor = new ImportsAcceptor(context);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ImplementFunctionCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/ImplementFunctionCodeAction.java
@@ -104,7 +104,7 @@ public class ImplementFunctionCodeAction extends AbstractCodeActionProvider {
         String editText = offsetStr + typeName + " {" + LINE_SEPARATOR + offsetStr + "}" + LINE_SEPARATOR;
         Position editPos = CommonUtil.toPosition(classDefNode.closeBrace().lineRange().startLine());
         edits.add(new TextEdit(new Range(editPos, editPos), editText));
-        String commandTitle = String.format(CommandConstants.IMPLEMENT_FUNCS_TITLE, unimplMethod.name());
+        String commandTitle = String.format(CommandConstants.IMPLEMENT_FUNCS_TITLE, unimplMethod.getName().get());
         CodeAction quickFixCodeAction = createQuickFixCodeAction(commandTitle, edits, context.fileUri());
         quickFixCodeAction.setDiagnostics(CodeActionUtil.toDiagnostics(Collections.singletonList((diagnostic))));
         return Collections.singletonList(quickFixCodeAction);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
@@ -109,7 +109,8 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
         for (String type : types) {
             List<TextEdit> edits = new ArrayList<>();
             edits.add(new TextEdit(paramTypeRange.get(), type));
-            String commandTitle = String.format(CommandConstants.CHANGE_PARAM_TYPE_TITLE, paramSymbol.name(), type);
+            String commandTitle = String.format(CommandConstants.CHANGE_PARAM_TYPE_TITLE, paramSymbol.getName().get(),
+                                                type);
             actions.add(createQuickFixCodeAction(commandTitle, edits, context.fileUri()));
         }
         return actions;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/CreateVariableCodeAction.java
@@ -91,7 +91,8 @@ public class CreateVariableCodeAction extends AbstractCodeActionProvider {
 
         Position position = CommonUtil.toPosition(context.positionDetails().matchedNode().lineRange().startLine());
         Set<String> allNameEntries = context.visibleSymbols(position).stream()
-                .map(Symbol::name)
+                .filter(s -> s.getName().isPresent())
+                .map(s -> s.getName().get())
                 .collect(Collectors.toSet());
 
         String name = CommonUtil.generateVariableName(matchedSymbol, typeDescriptor, allNameEntries);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -74,7 +74,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         CreateVariableOut createVarTextEdits = getCreateVariableTextEdits(range, context);
 
         // Add type guard code action
-        String commandTitle = String.format(CommandConstants.CREATE_VAR_TYPE_GUARD_TITLE, matchedSymbol.name());
+        String commandTitle = String.format(CommandConstants.CREATE_VAR_TYPE_GUARD_TITLE,
+                                            matchedSymbol.getName().get());
         List<TextEdit> edits = CodeActionUtil.getTypeGuardCodeActionEdits(createVarTextEdits.name, range, unionType,
                                                                           context);
         if (edits.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -77,7 +77,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         edits.addAll(getAddCheckTextEdits(CommonUtil.toRange(diagnostic.location().lineRange()).getStart(), context));
 
         String commandTitle = String.format(CommandConstants.CREATE_VAR_ADD_CHECK_TITLE,
-                                            context.positionDetails().matchedSymbol().name());
+                                            context.positionDetails().matchedSymbol().getName().get());
         return Collections.singletonList(AbstractCodeActionProvider.createQuickFixCodeAction(commandTitle, edits, uri));
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/AnnotationUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/AnnotationUtil.java
@@ -185,7 +185,7 @@ public class AnnotationUtil {
             annotationStart.append(aliasComponent).append(PKG_DELIMITER_KEYWORD);
         }
         if (annotationSymbol.typeDescriptor().isPresent()) {
-            annotationStart.append(annotationSymbol.name());
+            annotationStart.append(annotationSymbol.getName().get());
             Optional<TypeSymbol> attachedType
                     = Optional.ofNullable(CommonUtil.getRawType(annotationSymbol.typeDescriptor().get()));
             Optional<TypeSymbol> resultType;
@@ -213,7 +213,7 @@ public class AnnotationUtil {
                 annotationStart.append(LINE_SEPARATOR).append(CLOSE_BRACE_KEY);
             }
         } else {
-            annotationStart.append(annotationSymbol.name());
+            annotationStart.append(annotationSymbol.getName().get());
         }
 
         return annotationStart.toString();
@@ -238,7 +238,7 @@ public class AnnotationUtil {
      */
     private static String getAnnotationLabel(@Nonnull String aliasComponent, AnnotationSymbol annotation) {
         String pkgComponent = !aliasComponent.isEmpty() ? aliasComponent + PKG_DELIMITER_KEYWORD : "";
-        return pkgComponent + annotation.name();
+        return pkgComponent + annotation.getName().get();
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -85,6 +85,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.BiFunction;
@@ -344,13 +345,13 @@ public class CommonUtil {
 
         ModuleSymbol moduleSymbol = module.get();
         for (TypeDefinitionSymbol typeDefinitionSymbol : moduleSymbol.typeDefinitions()) {
-            if (typeDefinitionSymbol.name().equals(typeName)) {
+            if (typeDefinitionSymbol.getName().get().equals(typeName)) {
                 return Optional.of(typeDefinitionSymbol.typeDescriptor());
             }
         }
 
         for (ClassSymbol clazz : moduleSymbol.classes()) {
-            if (clazz.name().equals(typeName)) {
+            if (clazz.getName().get().equals(typeName)) {
                 return Optional.of(clazz);
             }
         }
@@ -368,7 +369,7 @@ public class CommonUtil {
     public static Optional<ModuleSymbol> searchModuleForAlias(PositionedOperationContext context, String alias) {
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         for (Symbol symbol : visibleSymbols) {
-            if (symbol.kind() == MODULE && symbol.name().equals(alias)) {
+            if (symbol.kind() == MODULE && Objects.equals(symbol.getName().orElse(null), alias)) {
                 return Optional.of((ModuleSymbol) symbol);
             }
         }
@@ -452,7 +453,7 @@ public class CommonUtil {
      */
     public static String getRecordFieldCompletionInsertText(RecordFieldSymbol bField, int tabOffset) {
         TypeSymbol fieldType = CommonUtil.getRawType(bField.typeDescriptor());
-        StringBuilder insertText = new StringBuilder(bField.name() + ": ");
+        StringBuilder insertText = new StringBuilder(bField.getName().get() + ": ");
         if (fieldType.typeKind() == TypeDescKind.RECORD) {
             List<RecordFieldSymbol> requiredFields = getMandatoryRecordFields((RecordTypeSymbol) fieldType);
             if (requiredFields.isEmpty()) {
@@ -560,12 +561,12 @@ public class CommonUtil {
     public static String generateVariableName(Symbol symbol, TypeSymbol typeSymbol, Set<String> names) {
         if (symbol != null) {
             // Start naming with symbol-name
-            return generateVariableName(1, symbol.name(), names);
+            return generateVariableName(1, symbol.getName().orElse(""), names);
         } else if (typeSymbol != null) {
             // If symbol is null, try typeSymbol
             String name;
-            if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE && !typeSymbol.name().startsWith("$")) {
-                name = typeSymbol.name();
+            if (typeSymbol.typeKind() == TypeDescKind.TYPE_REFERENCE && !typeSymbol.getName().get().startsWith("$")) {
+                name = typeSymbol.getName().get();
             } else {
                 TypeSymbol rawType = CommonUtil.getRawType(typeSymbol);
                 switch (rawType.typeKind()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -806,8 +806,12 @@ public class CommonUtil {
      * @return {@link NonTerminalNode}
      */
     public static NonTerminalNode findNode(Symbol symbol, SyntaxTree syntaxTree) {
+        if (symbol.getLocation().isEmpty()) {
+            return null;
+        }
+
         TextDocument textDocument = syntaxTree.textDocument();
-        LineRange symbolRange = symbol.location().lineRange();
+        LineRange symbolRange = symbol.getLocation().get().lineRange();
         int start = textDocument.textPositionFrom(symbolRange.startLine());
         int len = symbolRange.endLine().offset() - symbolRange.startLine().offset();
         return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, len));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
@@ -87,7 +87,7 @@ public class BLangRecordLiteralUtil {
         if (canSpread && symbol.kind() == SymbolKind.FUNCTION) {
             cItem = FunctionCompletionItemBuilder.build((FunctionSymbol) symbol, context);
         } else if (canSpread) {
-            cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbol.name(),
+            cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbol.getName().get(),
                     CommonUtil.getModifiedTypeName(context, typeDescriptor.get()));
         } else {
             return Optional.empty();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ConstantCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ConstantCompletionItemBuilder.java
@@ -45,8 +45,8 @@ public class ConstantCompletionItemBuilder {
      */
     public static CompletionItem build(ConstantSymbol constantSymbol, CompletionContext context) {
         CompletionItem completionItem = new CompletionItem();
-        completionItem.setLabel(constantSymbol.name());
-        completionItem.setInsertText(constantSymbol.name());
+        completionItem.setLabel(constantSymbol.getName().get());
+        completionItem.setInsertText(constantSymbol.getName().get());
         completionItem.setDetail(CommonUtil.getModifiedTypeName(context, constantSymbol.typeDescriptor()));
         completionItem.setDocumentation(getDocumentation(constantSymbol));
         completionItem.setKind(CompletionItemKind.Variable);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -153,7 +153,7 @@ public final class FunctionCompletionItemBuilder {
     private static Either<String, MarkupContent> getDocumentation(FunctionSymbol functionSymbol,
                                                                   boolean skipFirstParam,
                                                                   BallerinaCompletionContext ctx) {
-        String pkgID = functionSymbol.moduleID().toString();
+        String pkgID = functionSymbol.getModule().get().id().toString();
         FunctionTypeSymbol functionTypeDesc = functionSymbol.typeDescriptor();
 
         Optional<Documentation> docAttachment = functionSymbol.documentation();
@@ -293,7 +293,7 @@ public final class FunctionCompletionItemBuilder {
      */
     private static boolean skipFirstParam(BallerinaCompletionContext context, FunctionSymbol functionSymbol) {
         NonTerminalNode nodeAtCursor = context.getNodeAtCursor();
-        return CommonUtil.isLangLib(functionSymbol.moduleID())
+        return CommonUtil.isLangLib(functionSymbol.getModule().get().id())
                 && nodeAtCursor.kind() != SyntaxKind.QUALIFIED_NAME_REFERENCE;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -90,7 +90,7 @@ public final class FunctionCompletionItemBuilder {
         setMeta(item, functionSymbol, context);
         if (functionSymbol != null) {
             // Override function signature
-            String funcName = functionSymbol.name();
+            String funcName = functionSymbol.getName().get();
             Pair<String, String> functionSignature = getFunctionInvocationSignature(functionSymbol, funcName, context);
             item.setInsertText(functionSignature.getLeft());
             item.setLabel(functionSignature.getRight());
@@ -108,7 +108,7 @@ public final class FunctionCompletionItemBuilder {
         setMeta(item, initMethod, ctx);
         String functionName;
         if (mode == InitializerBuildMode.EXPLICIT) {
-            functionName = typeDesc.name();
+            functionName = typeDesc.getName().get();
 //            Optional<BLangIdentifier> moduleAlias = ctx.get(DocumentServiceKeys.CURRENT_DOC_IMPORTS_KEY).stream()
 //                    .filter(pkg -> pkg.symbol != null && pkg.symbol.pkgID == typeDesc.pkgID)
 //                    .map(BLangImportPackage::getAlias)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/WorkerCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/WorkerCompletionItemBuilder.java
@@ -39,7 +39,7 @@ public final class WorkerCompletionItemBuilder {
      */
     public static CompletionItem build(WorkerSymbol workerSymbol) {
         CompletionItem item = new CompletionItem();
-        String name = workerSymbol.name();
+        String name = workerSymbol.getName().get();
         item.setLabel(name);
         item.setInsertText(name);
         item.setDetail(ItemResolverConstants.WORKER);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/XMLNSCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/XMLNSCompletionItemBuilder.java
@@ -38,8 +38,8 @@ public class XMLNSCompletionItemBuilder {
      */
     public static CompletionItem build(XMLNamespaceSymbol namespaceSymbol) {
         CompletionItem completionItem = new CompletionItem();
-        completionItem.setLabel(namespaceSymbol.name());
-        completionItem.setInsertText(namespaceSymbol.name());
+        completionItem.setLabel(namespaceSymbol.getName().orElse(""));
+        completionItem.setInsertText(namespaceSymbol.getName().orElse(""));
         completionItem.setDetail(namespaceSymbol.namespaceUri());
         completionItem.setKind(CompletionItemKind.Unit);
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -152,7 +152,8 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                 VariableSymbol varSymbol = (VariableSymbol) symbol;
                 TypeSymbol typeDesc = (varSymbol).typeDescriptor();
                 String typeName = typeDesc == null ? "" : CommonUtil.getModifiedTypeName(ctx, typeDesc);
-                CompletionItem variableCItem = VariableCompletionItemBuilder.build(varSymbol, symbol.name(), typeName);
+                CompletionItem variableCItem = VariableCompletionItemBuilder.build(varSymbol, varSymbol.getName().get(),
+                                                                                   typeName);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
             } else if (symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS) {
                 // Here skip all the package symbols since the package is added separately
@@ -183,7 +184,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
         visibleSymbols.forEach(bSymbol -> {
             if (bSymbol.kind() == SymbolKind.TYPE_DEFINITION || bSymbol.kind() == SymbolKind.CLASS
                     || bSymbol.kind() == ENUM) {
-                CompletionItem cItem = TypeCompletionItemBuilder.build(bSymbol, bSymbol.name());
+                CompletionItem cItem = TypeCompletionItemBuilder.build(bSymbol, bSymbol.getName().get());
                 completionItems.add(new SymbolCompletionItem(context, bSymbol, cItem));
             }
         });

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -157,7 +157,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
             } else if (symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS) {
                 // Here skip all the package symbols since the package is added separately
-                CompletionItem typeCItem = TypeCompletionItemBuilder.build(symbol, symbol.name());
+                CompletionItem typeCItem = TypeCompletionItemBuilder.build(symbol, symbol.getName().get());
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, typeCItem));
             } else if (symbol.kind() == SymbolKind.WORKER) {
                 CompletionItem workerItem = WorkerCompletionItemBuilder.build((WorkerSymbol) symbol);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationAccessExpressionNodeContext.java
@@ -47,6 +47,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BTypedescType;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.ANNOTATION;
@@ -142,8 +143,8 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
                                                           AnnotationSymbol annotationSymbol) {
         Optional<TypeSymbol> attachedType = annotationSymbol.typeDescriptor();
         CompletionItem item = new CompletionItem();
-        item.setInsertText(annotationSymbol.name());
-        item.setLabel(annotationSymbol.name());
+        item.setInsertText(annotationSymbol.getName().get());
+        item.setLabel(annotationSymbol.getName().get());
         item.setInsertTextFormat(InsertTextFormat.Snippet);
         item.setDetail(ItemResolverConstants.ANNOTATION_TYPE);
         item.setKind(CompletionItemKind.Property);
@@ -165,7 +166,7 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
             case SIMPLE_NAME_REFERENCE:
                 String nameRef = ((SimpleNameReferenceNode) expressionNode).name().text();
                 for (Symbol symbol : visibleSymbols) {
-                    if (symbol.name().equals(nameRef)) {
+                    if (Objects.equals(symbol.getName().orElse(null), nameRef)) {
                         return Optional.of(symbol);
                     }
                 }
@@ -180,7 +181,7 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
                         return Optional.empty();
                     }
                     for (FunctionSymbol functionSymbol : moduleSymbol.get().functions()) {
-                        if (functionSymbol.name().equals(fName)) {
+                        if (functionSymbol.getName().get().equals(fName)) {
                             return Optional.of(functionSymbol);
                         }
                     }
@@ -188,7 +189,7 @@ public class AnnotationAccessExpressionNodeContext extends AbstractCompletionPro
                 } else if (refName.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                     String funcName = ((SimpleNameReferenceNode) refName).name().text();
                     for (Symbol symbol : visibleSymbols) {
-                        if (symbol.kind() == FUNCTION && symbol.name().equals(funcName)) {
+                        if (symbol.kind() == FUNCTION && symbol.getName().get().equals(funcName)) {
                             return Optional.of(symbol);
                         }
                     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AnnotationNodeContext.java
@@ -96,7 +96,7 @@ public class AnnotationNodeContext extends AbstractCompletionProvider<Annotation
         return visibleSymbols.stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION
                         && this.matchingAnnotation((AnnotationSymbol) symbol, kind)
-                        && !CommonUtil.isLangLib(symbol.moduleID()))
+                        && !CommonUtil.isLangLib(symbol.getModule().get().id()))
                 .map(symbol -> AnnotationUtil.getAnnotationItem((AnnotationSymbol) symbol, ctx))
                 .collect(Collectors.toList());
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AssignmentStatementNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/AssignmentStatementNodeContext.java
@@ -37,6 +37,7 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 
@@ -101,7 +102,8 @@ public class AssignmentStatementNodeContext extends AbstractCompletionProvider<A
         if (varRef.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) varRef).name().text();
             objectType = visibleSymbols.stream()
-                    .filter(symbol -> symbol.name().equals(identifier) && SymbolUtil.isClass(symbol))
+                    .filter(symbol -> Objects.equals(symbol.getName().orElse(null), identifier)
+                            && SymbolUtil.isClass(symbol))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -238,10 +238,12 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                         return false;
                     }
                     TypeSymbol typeDesc = ((VariableSymbol) symbol).typeDescriptor();
-                    return typeDesc.typeKind() == TypeDescKind.UNION && !capturedSymbols.contains(symbol.name());
+                    return typeDesc.typeKind() == TypeDescKind.UNION
+                            && !capturedSymbols.contains(symbol.getName().get());
                 })
                 .map(symbol -> {
-                    capturedSymbols.add(symbol.name());
+                    String symbolName = symbol.getName().get();
+                    capturedSymbols.add(symbolName);
                     List<TypeSymbol> errorTypes = new ArrayList<>();
                     List<TypeSymbol> resultTypes = new ArrayList<>();
                     List<TypeSymbol> members
@@ -257,7 +259,6 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                     if (errorTypes.size() == 1) {
                         resultTypes.addAll(errorTypes);
                     }
-                    String symbolName = symbol.name();
                     String label = symbolName + " - typeguard " + symbolName;
                     String detail = "Destructure the variable " + symbolName + " with typeguard";
                     StringBuilder snippet = new StringBuilder();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -48,6 +48,7 @@ import org.eclipse.lsp4j.CompletionItem;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -166,7 +167,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         String name = ((SimpleNameReferenceNode) referenceNode).name().text();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         Optional<Symbol> symbolRef = visibleSymbols.stream()
-                .filter(symbol -> symbol.name().equals(name))
+                .filter(symbol -> Objects.equals(symbol.getName().orElse(null), name))
                 .findFirst();
         if (symbolRef.isEmpty()) {
             return Optional.empty();
@@ -180,7 +181,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         String fName = ((SimpleNameReferenceNode) expr.functionName()).name().text();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         Optional<FunctionSymbol> symbolRef = visibleSymbols.stream()
-                .filter(symbol -> symbol.name().equals(fName) && symbol.kind() == SymbolKind.FUNCTION)
+                .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION && symbol.getName().get().equals(fName))
                 .map(symbol -> (FunctionSymbol) symbol)
                 .findFirst();
         if (symbolRef.isEmpty()) {
@@ -205,7 +206,7 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
             visibleMethods.addAll(((ObjectTypeSymbol) rawType).methods().values());
         }
         Optional<FunctionSymbol> filteredMethod = visibleMethods.stream()
-                .filter(methodSymbol -> methodSymbol.name().equals(methodName))
+                .filter(methodSymbol -> methodSymbol.getName().get().equals(methodName))
                 .findFirst();
 
         if (filteredMethod.isEmpty()) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ImplicitNewExpressionNodeContext.java
@@ -38,6 +38,7 @@ import org.ballerinalang.langserver.completions.providers.AbstractCompletionProv
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -98,12 +99,13 @@ public class ImplicitNewExpressionNodeContext extends AbstractCompletionProvider
                 return Optional.empty();
             }
             nameReferenceSymbol = pkgSymbol.get().allSymbols().stream()
-                    .filter(symbol -> symbol.name().equals(nameReferenceNode.identifier().text()))
+                    .filter(symbol -> Objects
+                            .equals(symbol.getName().orElse(null), nameReferenceNode.identifier().text()))
                     .findFirst();
         } else if (typeDescriptor.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             SimpleNameReferenceNode nameReferenceNode = (SimpleNameReferenceNode) typeDescriptor;
             nameReferenceSymbol = visibleSymbols.stream()
-                    .filter(symbol -> symbol.name().equals(nameReferenceNode.name().text()))
+                    .filter(symbol -> Objects.equals(symbol.getName().orElse(null), nameReferenceNode.name().text()))
                     .findFirst();
         }
 
@@ -121,7 +123,7 @@ public class ImplicitNewExpressionNodeContext extends AbstractCompletionProvider
         }
         String varName = ((SimpleNameReferenceNode) varRefNode).name().text();
         Optional<Symbol> varEntry = visibleSymbols.stream()
-                .filter(symbol -> symbol.name().equals(varName))
+                .filter(symbol -> Objects.equals(symbol.getName().orElse(null), varName))
                 .findFirst();
 
         if (varEntry.isEmpty() || !SymbolUtil.isObject(varEntry.get())) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ListenerDeclarationNodeContext.java
@@ -43,6 +43,7 @@ import org.eclipse.lsp4j.Position;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -166,7 +167,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
         ArrayList<LSCompletionItem> completionItems = new ArrayList<>();
         List<Symbol> visibleSymbols = context.visibleSymbols(context.getCursorPosition());
         Optional<ModuleSymbol> moduleSymbol = visibleSymbols.stream()
-                .filter(symbol -> symbol.kind() == MODULE && symbol.name().equals(modulePrefix))
+                .filter(symbol -> symbol.kind() == MODULE && symbol.getName().get().equals(modulePrefix))
                 .map(symbol -> (ModuleSymbol) symbol)
                 .findAny();
 
@@ -271,7 +272,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
             Stream<Symbol> objsAndClasses = Stream.concat(module.classes().stream(), module.typeDefinitions().stream());
             typeSymbol = objsAndClasses
                     .filter(type -> SymbolUtil.isListener(type)
-                            && type.name().equals(nameReferenceNode.identifier().text()))
+                            && Objects.equals(type.getName().orElse(null), nameReferenceNode.identifier().text()))
                     .map(symbol -> (ClassSymbol) symbol)
                     .findAny();
 
@@ -279,7 +280,7 @@ public class ListenerDeclarationNodeContext extends AbstractCompletionProvider<L
             SimpleNameReferenceNode nameReferenceNode = (SimpleNameReferenceNode) typeDescriptor;
             typeSymbol = visibleSymbols.stream()
                     .filter(visibleSymbol -> SymbolUtil.isListener(visibleSymbol)
-                            && visibleSymbol.name().equals(nameReferenceNode.name().text()))
+                            && Objects.equals(visibleSymbol.getName().orElse(null), nameReferenceNode.name().text()))
                     .map(symbol -> (ClassSymbol) symbol)
                     .findAny();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MappingConstructorExpressionNodeContext.java
@@ -58,6 +58,7 @@ import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -161,7 +162,8 @@ public class MappingConstructorExpressionNodeContext extends
             if (typeDesc.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                 String varName = ((SimpleNameReferenceNode) typeDesc).name().text();
                 return visibleSymbols.stream()
-                        .filter(symbol -> SymbolUtil.isRecord(symbol) && symbol.name().equals(varName))
+                        .filter(symbol -> SymbolUtil.isRecord(symbol)
+                                && Objects.equals(symbol.getName().orElse(null), varName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst();
             }
@@ -171,7 +173,8 @@ public class MappingConstructorExpressionNodeContext extends
                 String recName = nameRef.identifier().text();
                 Optional<ModuleSymbol> module = CommonUtil.searchModuleForAlias(context, modulePrefix);
                 return module.flatMap(value -> value.typeDefinitions().stream()
-                        .filter(typeSymbol -> SymbolUtil.isRecord(typeSymbol) && typeSymbol.name().equals(recName))
+                        .filter(typeSymbol -> SymbolUtil.isRecord(typeSymbol)
+                                && Objects.equals(typeSymbol.getName().orElse(null), recName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst());
             }
@@ -188,7 +191,8 @@ public class MappingConstructorExpressionNodeContext extends
             if (bPattern.kind() == SyntaxKind.CAPTURE_BINDING_PATTERN) {
                 String variableName = ((CaptureBindingPatternNode) bPattern).variableName().text();
                 return visibleSymbols.stream()
-                        .filter(symbol -> SymbolUtil.isRecord(symbol) && symbol.name().equals(variableName))
+                        .filter(symbol -> SymbolUtil.isRecord(symbol)
+                                && Objects.equals(symbol.getName().orElse(null), variableName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst();
             }
@@ -197,7 +201,8 @@ public class MappingConstructorExpressionNodeContext extends
             if (varRef.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
                 String varName = ((SimpleNameReferenceNode) varRef).name().text();
                 return visibleSymbols.stream()
-                        .filter(symbol -> SymbolUtil.isRecord(symbol) && symbol.name().equals(varName))
+                        .filter(symbol -> SymbolUtil.isRecord(symbol)
+                                && Objects.equals(symbol.getName().orElse(null), varName))
                         .map(SymbolUtil::getTypeDescForRecordSymbol)
                         .findFirst();
             }
@@ -219,7 +224,7 @@ public class MappingConstructorExpressionNodeContext extends
                 return;
             }
             TypeSymbol typeDescriptor = ((VariableSymbol) symbol).typeDescriptor();
-            String symbolName = symbol.name();
+            String symbolName = symbol.getName().get();
             if (recFields.containsKey(symbolName)
                     && recFields.get(symbolName).typeDescriptor().typeKind() == typeDescriptor.typeKind()) {
                 CompletionItem cItem = VariableCompletionItemBuilder.build((VariableSymbol) symbol, symbolName, 
@@ -300,7 +305,8 @@ public class MappingConstructorExpressionNodeContext extends
         }
 
         Optional<TypeSymbol> bTypeSymbol = searchableEntries.stream()
-                .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION && symbol.name().equals(annotationName))
+                .filter(symbol -> symbol.kind() == SymbolKind.ANNOTATION
+                        && symbol.getName().get().equals(annotationName))
                 .map(entry -> ((AnnotationSymbol) entry).typeDescriptor().orElse(null))
                 .findAny();
         if (bTypeSymbol.isEmpty() || CommonUtil.getRawType(bTypeSymbol.get()).typeKind() != TypeDescKind.RECORD) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RecordFieldWithDefaultValueNodeContext.java
@@ -38,6 +38,7 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -100,13 +101,15 @@ public class RecordFieldWithDefaultValueNodeContext extends
             Stream<Symbol> classesAndTypes = Stream.concat(moduleSymbol.classes().stream(),
                     moduleSymbol.typeDefinitions().stream());
             objectType = classesAndTypes
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && symbol.name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol)
+                            && Objects.equals(symbol.getName().orElse(null), identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else if (typeNameNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) typeNameNode).name().text();
             objectType = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && symbol.name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol)
+                            && Objects.equals(symbol.getName().orElse(null), identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/RightArrowActionNodeContext.java
@@ -35,6 +35,7 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -58,12 +59,14 @@ public abstract class RightArrowActionNodeContext<T extends Node> extends Abstra
         switch (node.kind()) {
             case SIMPLE_NAME_REFERENCE:
                 predicate = symbol -> symbol.kind() != SymbolKind.FUNCTION
-                        && symbol.name().equals(((SimpleNameReferenceNode) node).name().text());
+                        && Objects.equals(symbol.getName().orElse(null),
+                                          ((SimpleNameReferenceNode) node).name().text());
                 break;
             case FUNCTION_CALL:
                 predicate = symbol -> symbol.kind() == SymbolKind.FUNCTION
-                        && symbol.name().equals(((SimpleNameReferenceNode) ((FunctionCallExpressionNode) node)
-                        .functionName()).name().text());
+                        && Objects.equals(symbol.getName().orElse(null),
+                                          ((SimpleNameReferenceNode) ((FunctionCallExpressionNode) node)
+                                                  .functionName()).name().text());
                 break;
             default:
                 return completionItems;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/VariableDeclarationProvider.java
@@ -37,6 +37,7 @@ import org.ballerinalang.langserver.completions.util.Snippet;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -99,13 +100,15 @@ public abstract class VariableDeclarationProvider<T extends Node> extends Abstra
             Stream<Symbol> classesAndTypes = Stream.concat(moduleSymbol.classes().stream(),
                     moduleSymbol.typeDefinitions().stream());
             classSymbol = classesAndTypes
-                    .filter(typeSymbol -> SymbolUtil.isClass(typeSymbol) && typeSymbol.name().equals(identifier))
+                    .filter(typeSymbol -> SymbolUtil.isClass(typeSymbol)
+                            && Objects.equals(typeSymbol.getName().orElse(null), identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else if (typeDescriptorNode.kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String identifier = ((SimpleNameReferenceNode) typeDescriptorNode).name().text();
             classSymbol = visibleSymbols.stream()
-                    .filter(symbol -> SymbolUtil.isClass(symbol) && symbol.name().equals(identifier))
+                    .filter(symbol -> SymbolUtil.isClass(symbol)
+                            && Objects.equals(symbol.getName().orElse(null), identifier))
                     .map(SymbolUtil::getTypeDescForClassSymbol)
                     .findAny();
         } else {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
@@ -244,7 +244,7 @@ public class SortingUtil {
         if (typeDesc.get().kind() == SyntaxKind.SIMPLE_NAME_REFERENCE) {
             String nameRef = ((SimpleNameReferenceNode) typeDesc.get()).name().text();
             for (Symbol symbol : visibleSymbols) {
-                if (symbol.kind() == SymbolKind.TYPE_DEFINITION && symbol.name().equals(nameRef)) {
+                if (symbol.kind() == SymbolKind.TYPE_DEFINITION && symbol.getName().get().equals(nameRef)) {
                     TypeDefinitionSymbol typeDefinitionSymbol = (TypeDefinitionSymbol) symbol;
                     return Optional.of(typeDefinitionSymbol.typeDescriptor());
                 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/BallerinaConnectorServiceImpl.java
@@ -209,19 +209,19 @@ public class BallerinaConnectorServiceImpl implements BallerinaConnectorService 
                 if (parameterNode instanceof RequiredParameterNode) {
                     Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode);
                     if (paramSymbol.isPresent()) {
-                        parameterTypeName = String.format("%s:%s", paramSymbol.get().moduleID(),
+                        parameterTypeName = String.format("%s:%s", paramSymbol.get().getModule().get().id(),
                                 ((RequiredParameterNode) parameterNode).typeName());
                     }
                 } else if (parameterNode instanceof DefaultableParameterNode) {
                     Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode);
                     if (paramSymbol.isPresent()) {
-                        parameterTypeName = String.format("%s:%s", paramSymbol.get().moduleID(),
+                        parameterTypeName = String.format("%s:%s", paramSymbol.get().getModule().get().id(),
                                 ((DefaultableParameterNode) parameterNode).typeName());
                     }
                 } else if (parameterNode instanceof RestParameterNode) {
                     Optional<Symbol> paramSymbol = semanticModel.symbol(parameterNode);
                     if (paramSymbol.isPresent()) {
-                        parameterTypeName = String.format("%s:%s", paramSymbol.get().moduleID(),
+                        parameterTypeName = String.format("%s:%s", paramSymbol.get().getModule().get().id(),
                                 ((RestParameterNode) parameterNode).typeName());
                     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
@@ -92,7 +92,8 @@ public class ConnectorNodeVisitor extends NodeVisitor {
 
         if (typeSymbol.isPresent() && typeSymbol.get() instanceof TypeDefinitionSymbol) {
             TypeSymbol rawType = getRawType(((TypeDefinitionSymbol) typeSymbol.get()).typeDescriptor());
-            String typeName = String.format("%s:%s", typeSymbol.get().moduleID().toString(), typeSymbol.get().name());
+            String typeName = String.format("%s:%s", typeSymbol.get().moduleID().toString(),
+                                            typeSymbol.get().getName().get());
             if (rawType.typeKind() == TypeDescKind.RECORD || rawType.typeKind() == TypeDescKind.UNION) {
                 this.records.put(typeName, typeDefinitionNode);
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/connector/ConnectorNodeVisitor.java
@@ -92,7 +92,7 @@ public class ConnectorNodeVisitor extends NodeVisitor {
 
         if (typeSymbol.isPresent() && typeSymbol.get() instanceof TypeDefinitionSymbol) {
             TypeSymbol rawType = getRawType(((TypeDefinitionSymbol) typeSymbol.get()).typeDescriptor());
-            String typeName = String.format("%s:%s", typeSymbol.get().moduleID().toString(),
+            String typeName = String.format("%s:%s", typeSymbol.get().getModule().get().id().toString(),
                                             typeSymbol.get().getName().get());
             if (rawType.typeKind() == TypeDescKind.RECORD || rawType.typeKind() == TypeDescKind.UNION) {
                 this.records.put(typeName, typeDefinitionNode);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -209,7 +209,7 @@ public class HoverUtil {
 
     private static Hover getTypeRefHoverMarkupContent(TypeReferenceTypeSymbol typeSymbol, SemanticModel model,
                                                       Document srcFile, HoverContext context) {
-        Optional<Symbol> associatedDef = model.symbol(srcFile, typeSymbol.location().lineRange().startLine());
+        Optional<Symbol> associatedDef = model.symbol(srcFile, typeSymbol.getLocation().get().lineRange().startLine());
 
         if (associatedDef.isEmpty()) {
             return getDefaultHoverObject();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -177,7 +177,8 @@ public class SignatureHelpUtil {
                 .forEach(param -> parameters.add(new Parameter(param, false, false, context)));
         Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
         restParam.ifPresent(parameter -> parameters.add(new Parameter(parameter, false, true, context)));
-        boolean skipFirstParam = functionSymbol.kind() == METHOD && CommonUtil.isLangLib(functionSymbol.moduleID());
+        boolean skipFirstParam = functionSymbol.kind() == METHOD
+                && CommonUtil.isLangLib(functionSymbol.getModule().get().id());
         // Create a list of param info models
         for (int i = 0; i < parameters.size(); i++) {
             if (i == 0 && skipFirstParam) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/DefinitionUtil.java
@@ -15,6 +15,7 @@
  */
 package org.ballerinalang.langserver.util.definition;
 
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.projects.Document;
@@ -80,15 +81,20 @@ public class DefinitionUtil {
         Range range = new Range(start, end);
         String uri;
 
-        if (project.get().kind() == ProjectKind.SINGLE_FILE_PROJECT && symbol.moduleID().moduleName().equals(".")) {
-            uri = projectRoot.toUri().toString();
-        } else if (!project.get().currentPackage().packageOrg().value().equals(symbol.moduleID().orgName())) {
+        if (symbol.getModule().isEmpty()) {
             return Optional.empty();
-        } else if (project.get().currentPackage().packageName().value().equals(symbol.moduleID().moduleName())) {
+        }
+
+        ModuleID moduleID = symbol.getModule().get().id();
+        if (project.get().kind() == ProjectKind.SINGLE_FILE_PROJECT && moduleID.moduleName().equals(".")) {
+            uri = projectRoot.toUri().toString();
+        } else if (!project.get().currentPackage().packageOrg().value().equals(moduleID.orgName())) {
+            return Optional.empty();
+        } else if (project.get().currentPackage().packageName().value().equals(moduleID.moduleName())) {
             // Symbol is within the default module
             uri = projectRoot.resolve(symbol.location().lineRange().filePath()).toUri().toString();
         } else {
-            String moduleName = symbol.moduleID().modulePrefix();
+            String moduleName = moduleID.modulePrefix();
             String fileName = symbol.location().lineRange().filePath();
             uri = projectRoot.resolve("modules").resolve(moduleName).resolve(fileName).toUri().toString();
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/DefinitionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/definition/DefinitionUtil.java
@@ -69,12 +69,13 @@ public class DefinitionUtil {
         Path projectRoot = context.workspace().projectRoot(context.filePath());
         Optional<Project> project = context.workspace().project(context.filePath());
 
-        if (project.isEmpty()) {
+        if (project.isEmpty() || symbol.getLocation().isEmpty()) {
             return Optional.empty();
         }
 
-        LinePosition startLine = symbol.location().lineRange().startLine();
-        LinePosition endLine = symbol.location().lineRange().endLine();
+        io.ballerina.tools.diagnostics.Location symbolLocation = symbol.getLocation().get();
+        LinePosition startLine = symbolLocation.lineRange().startLine();
+        LinePosition endLine = symbolLocation.lineRange().endLine();
         Position start = new Position(startLine.line(), startLine.offset());
 
         Position end = new Position(endLine.line(), endLine.offset());
@@ -92,10 +93,10 @@ public class DefinitionUtil {
             return Optional.empty();
         } else if (project.get().currentPackage().packageName().value().equals(moduleID.moduleName())) {
             // Symbol is within the default module
-            uri = projectRoot.resolve(symbol.location().lineRange().filePath()).toUri().toString();
+            uri = projectRoot.resolve(symbolLocation.lineRange().filePath()).toUri().toString();
         } else {
             String moduleName = moduleID.modulePrefix();
-            String fileName = symbol.location().lineRange().filePath();
+            String fileName = symbolLocation.lineRange().filePath();
             uri = projectRoot.resolve("modules").resolve(moduleName).resolve(fileName).toUri().toString();
         }
 

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -110,8 +110,8 @@ class AIDataMapperCodeActionUtil {
             Symbol lftTypeSymbol = (Symbol) props.get(LEFT_SYMBOL_INDEX).value();
             Symbol rhsTypeSymbol = (Symbol) props.get(RIGHT_SYMBOL_INDEX).value();
 
-            String foundTypeLeft = lftTypeSymbol.name();
-            String foundTypeRight = rhsTypeSymbol.name();
+            String foundTypeLeft = lftTypeSymbol.getName().get();
+            String foundTypeRight = rhsTypeSymbol.getName().get();
 
             // Get the semantic model
             SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
@@ -123,7 +123,7 @@ class AIDataMapperCodeActionUtil {
 
             // get the symbol at cursor type
             Symbol symbolAtCursor = semanticModel.symbol(srcFile.get(), linePosition).get();
-            String symbolAtCursorName = symbolAtCursor.name();
+            String symbolAtCursorName = symbolAtCursor.getName().get();
             String symbolAtCursorType = "";
             // Check if function return a record type in multi-module project
             if (SymbolUtil.getTypeDescriptor(symbolAtCursor).isEmpty()) {
@@ -151,14 +151,14 @@ class AIDataMapperCodeActionUtil {
                     if ("".equals(foundTypeLeft)) {
                         List<TypeSymbol> leftTypeSymbols = ((UnionTypeSymbol) lftTypeSymbol).memberTypeDescriptors();
                         lftTypeSymbol = findSymbol(leftTypeSymbols);
-                        foundTypeLeft = lftTypeSymbol.name();
+                        foundTypeLeft = lftTypeSymbol.getName().get();
                         foundErrorLeft = true;
                     }
                     // If the check or checkpanic is used
                     if ("".equals(foundTypeRight)) {
                         List<TypeSymbol> rightTypeSymbols = ((UnionTypeSymbol) rhsTypeSymbol).memberTypeDescriptors();
                         rhsTypeSymbol = findSymbol(rightTypeSymbols);
-                        foundTypeRight = rhsTypeSymbol.name();
+                        foundTypeRight = rhsTypeSymbol.getName().get();
                         foundErrorRight = true;
                     }
 
@@ -188,7 +188,7 @@ class AIDataMapperCodeActionUtil {
 
             // Insert function declaration at the bottom of the file
             String functionName = String.format("map%sTo%s", foundTypeRight, foundTypeLeft);
-            boolean found = fileContentSymbols.stream().anyMatch(p -> p.name().contains(functionName));
+            boolean found = fileContentSymbols.stream().anyMatch(p -> p.getName().get().contains(functionName));
             if (found) {
                 return fEdits;
             } else {
@@ -240,7 +240,7 @@ class AIDataMapperCodeActionUtil {
      */
     public static Symbol findSymbol(List<TypeSymbol> fileContentSymbols) {
         for (Symbol symbol : fileContentSymbols) {
-            if (!"ERROR".equals(symbol.name())) {
+            if (!"ERROR".equals(symbol.getName().get())) {
                 return symbol;
             }
         }
@@ -337,7 +337,7 @@ class AIDataMapperCodeActionUtil {
             } else {
                 fieldDetails.addProperty(TYPE, attributeType.typeKind().toString());
             }
-            properties.add(attribute.name(), fieldDetails);
+            properties.add(attribute.getName().get(), fieldDetails);
         }
         return properties;
     }

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -212,15 +212,17 @@ class AIDataMapperCodeActionUtil {
                 if (project.get().kind() == ProjectKind.BUILD_PROJECT) {
                     String moduleName = srcFile.get().module().moduleId().moduleName();
 
-                    ModuleID rhsModule = rhsTypeSymbol.moduleID();
-                    ModuleID lftModule = lftTypeSymbol.moduleID();
+                    ModuleID rhsModule =
+                            rhsTypeSymbol.getModule().isPresent() ? rhsTypeSymbol.getModule().get().id() : null;
+                    ModuleID lftModule =
+                            lftTypeSymbol.getModule().isPresent() ? lftTypeSymbol.getModule().get().id() : null;
 
-                    if (!moduleName.equals(rhsModule.moduleName())) {
+                    if (rhsModule != null && !moduleName.equals(rhsModule.moduleName())) {
                         String rhsType = rhsModule.modulePrefix() + ":" + foundTypeRight;
                         generatedRecordMappingFunction = generatedRecordMappingFunction.replaceAll("\\b" +
                                 foundTypeRight + "\\b", rhsType);
                     }
-                    if (!moduleName.equals(lftModule.moduleName())) {
+                    if (lftModule != null && !moduleName.equals(lftModule.moduleName())) {
                         String lftType = lftModule.modulePrefix() + ":" + foundTypeLeft;
                         generatedRecordMappingFunction = generatedRecordMappingFunction.replaceAll("\\b" +
                                 foundTypeLeft + "\\b", lftType);

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -110,8 +110,8 @@ class AIDataMapperCodeActionUtil {
             Symbol lftTypeSymbol = (Symbol) props.get(LEFT_SYMBOL_INDEX).value();
             Symbol rhsTypeSymbol = (Symbol) props.get(RIGHT_SYMBOL_INDEX).value();
 
-            String foundTypeLeft = lftTypeSymbol.getName().get();
-            String foundTypeRight = rhsTypeSymbol.getName().get();
+            String foundTypeLeft = lftTypeSymbol.getName().orElse("");
+            String foundTypeRight = rhsTypeSymbol.getName().orElse("");
 
             // Get the semantic model
             SemanticModel semanticModel = context.workspace().semanticModel(context.filePath()).orElseThrow();
@@ -123,7 +123,7 @@ class AIDataMapperCodeActionUtil {
 
             // get the symbol at cursor type
             Symbol symbolAtCursor = semanticModel.symbol(srcFile.get(), linePosition).get();
-            String symbolAtCursorName = symbolAtCursor.getName().get();
+            String symbolAtCursorName = symbolAtCursor.getName().orElse("");
             String symbolAtCursorType = "";
             // Check if function return a record type in multi-module project
             if (SymbolUtil.getTypeDescriptor(symbolAtCursor).isEmpty()) {
@@ -151,14 +151,14 @@ class AIDataMapperCodeActionUtil {
                     if ("".equals(foundTypeLeft)) {
                         List<TypeSymbol> leftTypeSymbols = ((UnionTypeSymbol) lftTypeSymbol).memberTypeDescriptors();
                         lftTypeSymbol = findSymbol(leftTypeSymbols);
-                        foundTypeLeft = lftTypeSymbol.getName().get();
+                        foundTypeLeft = lftTypeSymbol.getName().orElse("");
                         foundErrorLeft = true;
                     }
                     // If the check or checkpanic is used
                     if ("".equals(foundTypeRight)) {
                         List<TypeSymbol> rightTypeSymbols = ((UnionTypeSymbol) rhsTypeSymbol).memberTypeDescriptors();
                         rhsTypeSymbol = findSymbol(rightTypeSymbols);
-                        foundTypeRight = rhsTypeSymbol.getName().get();
+                        foundTypeRight = rhsTypeSymbol.getName().orElse("");
                         foundErrorRight = true;
                     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BallerinaTypeResolver.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/BallerinaTypeResolver.java
@@ -122,7 +122,7 @@ public class BallerinaTypeResolver {
         return semanticContext.moduleSymbols()
                 .stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS)
-                .filter(symbol -> encodeIdentifier(symbol.name(), IdentifierModifier.IdentifierType.OTHER)
+                .filter(symbol -> encodeIdentifier(symbol.getName().get(), IdentifierModifier.IdentifierType.OTHER)
                         .equals(typeName))
                 .findAny();
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
@@ -92,7 +92,7 @@ public class FunctionInvocationExpressionEvaluator extends Evaluator {
         List<Symbol> functionMatches = semanticContext.moduleSymbols()
                 .stream()
                 .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION
-                        && modifyName(symbol.name()).equals(functionName))
+                        && modifyName(symbol.getName().get()).equals(functionName))
                 .collect(Collectors.toList());
         if (functionMatches.isEmpty()) {
             return Optional.empty();

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
@@ -102,7 +102,7 @@ public class FunctionInvocationExpressionEvaluator extends Evaluator {
     }
 
     private String constructQualifiedClassNameFrom(FunctionSymbol functionDef) {
-        String className = functionDef.location().lineRange().filePath().replaceAll(BAL_FILE_EXT + "$", "");
+        String className = functionDef.getLocation().get().lineRange().filePath().replaceAll(BAL_FILE_EXT + "$", "");
         // for ballerina single source files,
         // qualified class name ::= <file_name>
         if (context.getSourceType() == DebugSourceType.SINGLE_FILE) {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/FunctionInvocationExpressionEvaluator.java
@@ -110,7 +110,7 @@ public class FunctionInvocationExpressionEvaluator extends Evaluator {
         }
         // for ballerina package source files,
         // qualified class name ::= <package_name>.<module_name>.<package_version>.<file_name>
-        ModuleID moduleMeta = functionDef.moduleID();
+        ModuleID moduleMeta = functionDef.getModule().get().id();
         return new StringJoiner(".")
                 .add(encodeModuleName(moduleMeta.orgName()))
                 .add(encodeModuleName(moduleMeta.moduleName()))

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
@@ -191,7 +191,7 @@ public class MethodCallExpressionEvaluator extends Evaluator {
         SemanticModel semanticContext = context.getDebugCompiler().getSemanticInfo();
         return semanticContext.moduleSymbols()
                 .stream()
-                .filter(symbol -> symbol.kind() == SymbolKind.CLASS && modifyName(symbol.name()).equals(className))
+                .filter(symbol -> symbol.kind() == SymbolKind.CLASS && modifyName(symbol.getName().get()).equals(className))
                 .findFirst()
                 .map(symbol -> (ClassSymbol) symbol);
     }
@@ -199,7 +199,7 @@ public class MethodCallExpressionEvaluator extends Evaluator {
     private Optional<MethodSymbol> findObjectMethodInClass(ClassSymbol classDef, String methodName) {
         return classDef.methods().values()
                 .stream()
-                .filter(methodSymbol -> modifyName(methodSymbol.name()).equals(methodName))
+                .filter(methodSymbol -> modifyName(methodSymbol.getName().get()).equals(methodName))
                 .findFirst();
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/MethodCallExpressionEvaluator.java
@@ -191,7 +191,8 @@ public class MethodCallExpressionEvaluator extends Evaluator {
         SemanticModel semanticContext = context.getDebugCompiler().getSemanticInfo();
         return semanticContext.moduleSymbols()
                 .stream()
-                .filter(symbol -> symbol.kind() == SymbolKind.CLASS && modifyName(symbol.getName().get()).equals(className))
+                .filter(symbol -> symbol.kind() == SymbolKind.CLASS
+                        && modifyName(symbol.getName().get()).equals(className))
                 .findFirst()
                 .map(symbol -> (ClassSymbol) symbol);
     }

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
@@ -103,7 +103,7 @@ public class LangLibUtils {
                                                                         ModuleSymbol langLibDef, String functionName) {
         return langLibDef.functions()
                 .stream()
-                .filter(functionSymbol -> modifyName(functionSymbol.name()).equals(functionName))
+                .filter(functionSymbol -> modifyName(functionSymbol.getName().get()).equals(functionName))
                 .findFirst();
     }
 

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/utils/LangLibUtils.java
@@ -16,6 +16,7 @@
 
 package org.ballerinalang.debugadapter.evaluation.utils;
 
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
@@ -76,7 +77,7 @@ public class LangLibUtils {
             return new StringJoiner(".")
                     .add(LANG_LIB_ORG)
                     .add(encodeModuleName(LANG_LIB_PACKAGE_PREFIX + langLibName))
-                    .add(moduleSymbol.moduleID().version().replaceAll("\\.", "_"))
+                    .add(moduleSymbol.id().version().replaceAll("\\.", "_"))
                     .add(langLibName)
                     .toString();
         } catch (Exception ignored) {
@@ -91,10 +92,16 @@ public class LangLibUtils {
 
         return semanticContext.visibleSymbols(context.getDocument(), position)
                 .stream()
-                .filter(symbol -> symbol.kind() == MODULE
-                        && symbol.moduleID().orgName().equals(LANG_LIB_ORG)
-                        && symbol.moduleID().moduleName().startsWith(LANG_LIB_PACKAGE_PREFIX)
-                        && symbol.moduleID().moduleName().endsWith(langLibName))
+                .filter(symbol -> {
+                    if (symbol.kind() != MODULE) {
+                        return false;
+                    }
+
+                    ModuleID moduleID = ((ModuleSymbol) symbol).id();
+                    return moduleID.orgName().equals(LANG_LIB_ORG)
+                            && moduleID.moduleName().startsWith(LANG_LIB_PACKAGE_PREFIX)
+                            && moduleID.moduleName().endsWith(langLibName);
+                })
                 .findFirst()
                 .map(symbol -> (ModuleSymbol) symbol);
     }

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -195,8 +195,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             RequiredParameterNode requiredParameterNode = (RequiredParameterNode) node;
             Optional<Token> paramName = requiredParameterNode.paramName();
             symbolMetaInfo.addProperty("name", paramName.isPresent() ? paramName.get().text() : "");
-            symbolMetaInfo.addProperty("isCaller", typeSymbol.name().equals("Caller"));
-            symbolMetaInfo.addProperty("typeName", typeSymbol.name());
+            symbolMetaInfo.addProperty("isCaller", "Caller".equals(typeSymbol.getName().orElse(null)));
+            symbolMetaInfo.addProperty("typeName", typeSymbol.getName().orElse(""));
             symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
             symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
         } else if (node.kind() == SyntaxKind.LOCAL_VAR_DECL) {
@@ -204,8 +204,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             CaptureBindingPatternNode captureBindingPatternNode =
                     (CaptureBindingPatternNode) variableDeclarationNode.typedBindingPattern().bindingPattern();
             symbolMetaInfo.addProperty("name", captureBindingPatternNode.variableName().text());
-            symbolMetaInfo.addProperty("isCaller", typeSymbol.name().equals("Caller"));
-            symbolMetaInfo.addProperty("typeName", typeSymbol.name());
+            symbolMetaInfo.addProperty("isCaller", "Caller".equals(typeSymbol.getName().orElse(null)));
+            symbolMetaInfo.addProperty("typeName", typeSymbol.getName().orElse(""));
             symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
             symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
         } else if (node.kind() == SyntaxKind.ASSIGNMENT_STATEMENT) {
@@ -214,8 +214,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 SimpleNameReferenceNode simpleNameReferenceNode =
                         (SimpleNameReferenceNode) assignmentStatementNode.varRef();
                 symbolMetaInfo.addProperty("name", simpleNameReferenceNode.name().text());
-                symbolMetaInfo.addProperty("isCaller", typeSymbol.name().equals("Caller"));
-                symbolMetaInfo.addProperty("typeName", typeSymbol.name());
+                symbolMetaInfo.addProperty("isCaller", "Caller".equals(typeSymbol.getName().orElse(null)));
+                symbolMetaInfo.addProperty("typeName", typeSymbol.getName().orElse(""));
                 symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
                 symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
             }

--- a/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
+++ b/misc/diagram-util/src/main/java/org/ballerinalang/diagramutil/SyntaxTreeMapGenerator.java
@@ -191,14 +191,18 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
 
     private JsonObject visibleEP(Node node, TypeSymbol typeSymbol) {
         JsonObject symbolMetaInfo = new JsonObject();
+        ModuleID moduleID = typeSymbol.getModule().isPresent() ? typeSymbol.getModule().get().id() : null;
+        String orgName = moduleID != null ? moduleID.orgName() : "";
+        String moduleName = moduleID != null ? moduleID.moduleName() : "";
+
         if (node.kind() == SyntaxKind.REQUIRED_PARAM) {
             RequiredParameterNode requiredParameterNode = (RequiredParameterNode) node;
             Optional<Token> paramName = requiredParameterNode.paramName();
             symbolMetaInfo.addProperty("name", paramName.isPresent() ? paramName.get().text() : "");
             symbolMetaInfo.addProperty("isCaller", "Caller".equals(typeSymbol.getName().orElse(null)));
             symbolMetaInfo.addProperty("typeName", typeSymbol.getName().orElse(""));
-            symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
-            symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
+            symbolMetaInfo.addProperty("orgName", orgName);
+            symbolMetaInfo.addProperty("moduleName", moduleName);
         } else if (node.kind() == SyntaxKind.LOCAL_VAR_DECL) {
             VariableDeclarationNode variableDeclarationNode = (VariableDeclarationNode) node;
             CaptureBindingPatternNode captureBindingPatternNode =
@@ -206,8 +210,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
             symbolMetaInfo.addProperty("name", captureBindingPatternNode.variableName().text());
             symbolMetaInfo.addProperty("isCaller", "Caller".equals(typeSymbol.getName().orElse(null)));
             symbolMetaInfo.addProperty("typeName", typeSymbol.getName().orElse(""));
-            symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
-            symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
+            symbolMetaInfo.addProperty("orgName", orgName);
+            symbolMetaInfo.addProperty("moduleName", moduleName);
         } else if (node.kind() == SyntaxKind.ASSIGNMENT_STATEMENT) {
             AssignmentStatementNode assignmentStatementNode = (AssignmentStatementNode) node;
             if (assignmentStatementNode.varRef() instanceof SimpleNameReferenceNode) {
@@ -216,8 +220,8 @@ public class SyntaxTreeMapGenerator extends NodeTransformer<JsonElement> {
                 symbolMetaInfo.addProperty("name", simpleNameReferenceNode.name().text());
                 symbolMetaInfo.addProperty("isCaller", "Caller".equals(typeSymbol.getName().orElse(null)));
                 symbolMetaInfo.addProperty("typeName", typeSymbol.getName().orElse(""));
-                symbolMetaInfo.addProperty("orgName", typeSymbol.moduleID().orgName());
-                symbolMetaInfo.addProperty("moduleName", typeSymbol.moduleID().moduleName());
+                symbolMetaInfo.addProperty("orgName", orgName);
+                symbolMetaInfo.addProperty("moduleName", moduleName);
             }
         }
 

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -451,7 +451,7 @@ public class Generator {
         if (typeSymbol instanceof ObjectTypeSymbol) {
             ObjectTypeSymbol objectTypeSymbol = (ObjectTypeSymbol) typeSymbol;
             objectTypeSymbol.methods().values().forEach(methodSymbol -> {
-                String methodName = methodSymbol.name();
+                String methodName = methodSymbol.getName().get();
                 // Check if the inclusion function is overridden
                 if (members.stream().anyMatch(node -> {
                     if (node instanceof MethodDeclarationNode && ((MethodDeclarationNode) node).methodName()
@@ -472,7 +472,7 @@ public class Generator {
 
                 methodSymbol.typeDescriptor().parameters().forEach(parameterSymbol -> {
                     boolean parameterDeprecated = parameterSymbol.annotations().stream()
-                            .anyMatch(annotationSymbol -> annotationSymbol.name().equals("deprecated"));
+                            .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
                     Type type = new Type(parameterSymbol.typeDescriptor().signature());
                     Type.resolveSymbol(type, parameterSymbol.typeDescriptor());
                     parameters.add(new DefaultableVariable(parameterSymbol.getName().isPresent() ?
@@ -482,7 +482,7 @@ public class Generator {
                 if (methodSymbol.typeDescriptor().restParam().isPresent()) {
                     ParameterSymbol restParam = methodSymbol.typeDescriptor().restParam().get();
                     boolean parameterDeprecated = restParam.annotations().stream()
-                            .anyMatch(annotationSymbol -> annotationSymbol.name().equals("deprecated"));
+                            .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
                     Type type = new Type(restParam.getName().isPresent() ? restParam.getName().get() : "");
                     type.isRestParam = true;
                     Type elemType = new Type(restParam.typeDescriptor().signature());
@@ -604,7 +604,7 @@ public class Generator {
                         Type elemType;
                         String typeName;
                         if (field.typeDescriptor() instanceof TypeReferenceTypeSymbol) {
-                            typeName = field.typeDescriptor().name();
+                            typeName = field.typeDescriptor().getName().get();
                         } else {
                             typeName = field.typeDescriptor().signature();
                         }
@@ -620,7 +620,7 @@ public class Generator {
                         Type elemType;
                         String typeName;
                         if (field.typeDescriptor() instanceof TypeReferenceTypeSymbol) {
-                            typeName = field.typeDescriptor().name();
+                            typeName = field.typeDescriptor().getName().get();
                         } else {
                             typeName = field.typeDescriptor().signature();
                         }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -288,7 +288,7 @@ public class Type {
             if (classSymbol.qualifiers().contains(Qualifier.CLIENT)) {
                 return "clients";
             } else if (classSymbol.qualifiers().contains(Qualifier.LISTENER) ||
-                    typeDescriptor.name().equals("Listener")) {
+                    "Listener".equals(typeDescriptor.getName().orElse(null))) {
                 return "listeners";
             } else {
                 return "classes";

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -16,6 +16,7 @@
 package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
+import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Qualifiable;
@@ -247,9 +248,18 @@ public class Type {
     }
 
     public static void resolveSymbol(Type type, Symbol symbol) {
-        type.moduleName = symbol.moduleID().moduleName();
-        type.orgName = symbol.moduleID().orgName();
-        type.version = symbol.moduleID().version();
+        ModuleID moduleID = symbol.getModule().isPresent() ? symbol.getModule().get().id() : null;
+
+        if (moduleID != null) {
+            type.moduleName = moduleID.moduleName();
+            type.orgName = moduleID.orgName();
+            type.version = moduleID.version();
+        } else {
+            type.moduleName = "";
+            type.orgName = "";
+            type.version = "";
+        }
+
         if (symbol instanceof TypeReferenceTypeSymbol) {
             TypeReferenceTypeSymbol typeSymbol = (TypeReferenceTypeSymbol) symbol;
             if (typeSymbol.typeDescriptor() != null) {

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -255,9 +255,9 @@ public class Type {
             type.orgName = moduleID.orgName();
             type.version = moduleID.version();
         } else {
-            type.moduleName = "";
-            type.orgName = "";
-            type.version = "";
+            type.moduleName = "UNK_MOD";
+            type.orgName = "UNK_ORG";
+            type.version = "UNK_VER";
         }
 
         if (symbol instanceof TypeReferenceTypeSymbol) {

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -147,10 +147,10 @@ public class TestProcessor {
         Map<Document, SyntaxTree> syntaxTreeMap = getTestSyntaxTreeMap(module);
         List<FunctionSymbol> functionSymbolList = getFunctionSymbolList(syntaxTreeMap, module);
         for (FunctionSymbol functionSymbol : functionSymbolList) {
-            String functionName = functionSymbol.name();
+            String functionName = functionSymbol.getName().get();
             List<AnnotationSymbol> annotations = functionSymbol.annotations();
             for (AnnotationSymbol annotationSymbol : annotations) {
-                String annotationName = annotationSymbol.name();
+                String annotationName = annotationSymbol.getName().get();
                 if (annotationName.contains(BEFORE_SUITE_ANNOTATION_NAME)) {
                     suite.addBeforeSuiteFunction(functionName);
                 } else if (annotationName.contains(AFTER_SUITE_ANNOTATION_NAME)) {
@@ -200,7 +200,7 @@ public class TestProcessor {
                                 NodeList<AnnotationNode> annotations = optionalMetadataNode.get().annotations();
                                 for (AnnotationNode annotation : annotations) {
                                     if ((annotation.toString().trim()).contains(
-                                            TEST_PREFIX + annotationSymbol.name())) {
+                                            TEST_PREFIX + annotationSymbol.getName().get())) {
                                         return annotation;
                                     }
                                 }
@@ -230,9 +230,9 @@ public class TestProcessor {
                                       syntaxTreeEntry.getValue().rootNode().location().lineRange().endLine().offset()));
             for (Symbol symbol : symbols) {
                 if (symbol.kind() == SymbolKind.FUNCTION && symbol instanceof FunctionSymbol &&
-                        !functionNamesList.contains(symbol.name())) {
+                        !functionNamesList.contains(symbol.getName().get())) {
                     functionSymbolList.add((FunctionSymbol) symbol);
-                    functionNamesList.add(symbol.name());
+                    functionNamesList.add(symbol.getName().get());
                 }
             }
         }
@@ -273,7 +273,7 @@ public class TestProcessor {
         }
         List<FunctionSymbol> functionSymbolList = getFunctionSymbolList(syntaxTreeMap, module);
         for (FunctionSymbol functionSymbol : functionSymbolList) {
-            String functionName = functionSymbol.name();
+            String functionName = functionSymbol.getName().get();
             Location pos = functionSymbol.location();
             List<Qualifier> qualifiers = functionSymbol.qualifiers();
             boolean isUtility = true;

--- a/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
+++ b/misc/testerina/modules/testerina-core/src/main/java/org/ballerinalang/testerina/core/TestProcessor.java
@@ -274,7 +274,7 @@ public class TestProcessor {
         List<FunctionSymbol> functionSymbolList = getFunctionSymbolList(syntaxTreeMap, module);
         for (FunctionSymbol functionSymbol : functionSymbolList) {
             String functionName = functionSymbol.getName().get();
-            Location pos = functionSymbol.location();
+            Location pos = functionSymbol.getLocation().get();
             List<Qualifier> qualifiers = functionSymbol.qualifiers();
             boolean isUtility = true;
             for (Qualifier qualifier : qualifiers) {
@@ -284,7 +284,7 @@ public class TestProcessor {
                     break;
                 }
             }
-            if (pos != null && isUtility) {
+            if (isUtility) {
                 // Remove the duplicated annotations.
                 String className = pos.lineRange().filePath().replace(ProjectConstants.BLANG_SOURCE_EXT, "")
                         .replace("/", ProjectConstants.DOT);

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -803,7 +803,7 @@ public class TestBuildProject {
 
         // Test symbol
         Optional<Symbol> symbol = semanticModel.symbol(srcFile, LinePosition.from(5, 10));
-        symbol.ifPresent(value -> assertEquals(value.name(), "runServices"));
+        symbol.ifPresent(value -> assertEquals(value.getName().get(), "runServices"));
     }
 
     @Test(description = "tests if other documents exists ie. Ballerina.toml, Package.md", enabled = true)

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -74,7 +74,7 @@ public class AnnotationsTest {
 
         assertEquals(annotSymbols.size(), annots.size());
         for (int i = 0; i < annotSymbols.size(); i++) {
-            assertEquals(annotSymbols.get(i).name(), annots.get(i));
+            assertEquals(annotSymbols.get(i).getName().get(), annots.get(i));
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -71,7 +71,7 @@ public class ClassSymbolTest {
         assertList(symbol.methods(), List.of("getFullName"));
 
         MethodSymbol initMethod = symbol.initMethod().get();
-        assertEquals(initMethod.name(), "init");
+        assertEquals(initMethod.getName().get(), "init");
         assertEquals(initMethod.typeDescriptor().parameters().stream()
                              .map(p -> p.getName().get())
                              .collect(Collectors.toList()), fieldNames);
@@ -80,30 +80,30 @@ public class ClassSymbolTest {
     @Test
     public void testTypeReference() {
         Symbol symbol = model.symbol(srcFile, LinePosition.from(40, 6)).get();
-        assertEquals(symbol.name(), "Person1");
+        assertEquals(symbol.getName().get(), "Person1");
         assertEquals(symbol.kind(), TYPE);
 
         TypeReferenceTypeSymbol tSymbol = (TypeReferenceTypeSymbol) symbol;
         assertEquals(tSymbol.typeKind(), TYPE_REFERENCE);
 
         ClassSymbol clazz = (ClassSymbol) tSymbol.typeDescriptor();
-        assertEquals(clazz.name(), "Person1");
+        assertEquals(clazz.getName().get(), "Person1");
         assertEquals(clazz.kind(), CLASS);
         assertEquals(clazz.typeKind(), OBJECT);
-        assertEquals(clazz.initMethod().get().name(), "init");
+        assertEquals(clazz.initMethod().get().getName().get(), "init");
     }
 
     @Test
     public void testClassWithoutInit() {
         Symbol symbol = model.symbol(srcFile, LinePosition.from(41, 4)).get();
-        assertEquals(symbol.name(), "Person2");
+        assertEquals(symbol.getName().get(), "Person2");
         assertEquals(symbol.kind(), TYPE);
 
         TypeReferenceTypeSymbol tSymbol = (TypeReferenceTypeSymbol) symbol;
         assertEquals(tSymbol.typeKind(), TYPE_REFERENCE);
 
         ClassSymbol clazz = (ClassSymbol) tSymbol.typeDescriptor();
-        assertEquals(clazz.name(), "Person2");
+        assertEquals(clazz.getName().get(), "Person2");
         assertEquals(clazz.kind(), CLASS);
         assertEquals(clazz.typeKind(), OBJECT);
         assertTrue(clazz.initMethod().isEmpty());
@@ -113,7 +113,7 @@ public class ClassSymbolTest {
     public void testTypeInit(int line, int col, String name) {
         Symbol symbol = model.symbol(srcFile, LinePosition.from(line, col)).get();
         ClassSymbol clazz = (ClassSymbol) ((TypeReferenceTypeSymbol) symbol).typeDescriptor();
-        assertEquals(clazz.name(), name);
+        assertEquals(clazz.getName().get(), name);
     }
 
     @DataProvider(name = "TypeInitPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
@@ -101,7 +101,7 @@ public class DocumentationTest {
 
         List<ConstantSymbol> members = ((EnumSymbol) symbol.get()).members();
         for (ConstantSymbol member : members) {
-            assertDescriptionOnly(member.documentation().get(), "Enum member " + member.name());
+            assertDescriptionOnly(member.documentation().get(), "Enum member " + member.getName().get());
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -223,7 +223,7 @@ public class ExpressionTypeTest {
     public void testObjecTypeInit(int sLine, int sCol, int eLine, int eCol) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
         assertEquals(type.typeKind(), TYPE_REFERENCE);
-        assertEquals(((TypeReferenceTypeSymbol) type).name(), "PersonObj");
+        assertEquals(((TypeReferenceTypeSymbol) type).getName().get(), "PersonObj");
         assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), OBJECT);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/FieldSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/FieldSymbolTest.java
@@ -63,7 +63,7 @@ public class FieldSymbolTest {
         assertEquals(symbol.kind(), SymbolKind.RECORD_FIELD);
 
         RecordFieldSymbol fieldSymbol = (RecordFieldSymbol) symbol;
-        assertEquals(fieldSymbol.name(), fieldName);
+        assertEquals(fieldSymbol.getName().get(), fieldName);
         assertEquals(fieldSymbol.typeDescriptor().typeKind(), typeKind);
         assertEquals(fieldSymbol.isOptional(), isOptional);
         assertEquals(fieldSymbol.hasDefaultValue(), hasDefaultValue);
@@ -85,7 +85,7 @@ public class FieldSymbolTest {
         assertEquals(symbol.kind(), SymbolKind.OBJECT_FIELD);
 
         ObjectFieldSymbol fieldSymbol = (ObjectFieldSymbol) symbol;
-        assertEquals(fieldSymbol.name(), fieldName);
+        assertEquals(fieldSymbol.getName().get(), fieldName);
         assertEquals(fieldSymbol.typeDescriptor().typeKind(), typeKind);
         assertEquals(fieldSymbol.signature(), signature);
     }
@@ -105,7 +105,7 @@ public class FieldSymbolTest {
         assertEquals(symbol.kind(), SymbolKind.CLASS_FIELD);
 
         ClassFieldSymbol fieldSymbol = (ClassFieldSymbol) symbol;
-        assertEquals(fieldSymbol.name(), fieldName);
+        assertEquals(fieldSymbol.getName().get(), fieldName);
         assertEquals(fieldSymbol.typeDescriptor().typeKind(), typeKind);
 //        assertEquals(fieldSymbol.hasDefaultValue(), hasDefaultValue);
         assertEquals(fieldSymbol.signature(), signature);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -350,7 +350,7 @@ public class LangLibFunctionTest {
     }
 
     private void assertLangLibList(List<FunctionSymbol> langLib, List<String> expFunctions) {
-        Set<String> langLibSet = langLib.stream().map(FunctionSymbol::name).collect(Collectors.toSet());
+        Set<String> langLibSet = langLib.stream().map(s -> s.getName().get()).collect(Collectors.toSet());
 
         for (String expFunction : expFunctions) {
             assertTrue(langLibSet.contains(expFunction), "Expected function '" + expFunction + "' not found");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -91,16 +91,16 @@ public class ServiceSemanticAPITest {
     public void testServiceDeclTypedesc() {
         TypeSymbol symbol = (TypeSymbol) model.symbol(srcFile, from(66, 8)).get();
         assertEquals(symbol.typeKind(), TYPE_REFERENCE);
-        assertEquals(symbol.name(), "ProcessingService");
+        assertEquals(symbol.getName().get(), "ProcessingService");
         assertEquals(((TypeReferenceTypeSymbol) symbol).typeDescriptor().typeKind(), OBJECT);
     }
 
     @Test
     public void testServiceDeclListener() {
         VariableSymbol symbol = (VariableSymbol) model.symbol(srcFile, from(66, 31)).get();
-        assertEquals(symbol.name(), "lsn");
+        assertEquals(symbol.getName().get(), "lsn");
         assertEquals(symbol.typeDescriptor().typeKind(), TYPE_REFERENCE);
-        assertEquals(symbol.typeDescriptor().name(), "Listener");
+        assertEquals(symbol.typeDescriptor().getName().get(), "Listener");
         assertEquals(symbol.qualifiers().size(), 2);
         assertTrue(symbol.qualifiers().contains(LISTENER));
         assertTrue(symbol.qualifiers().contains(FINAL));
@@ -109,7 +109,7 @@ public class ServiceSemanticAPITest {
     @Test
     public void testServiceDeclField() {
         ClassFieldSymbol symbol = (ClassFieldSymbol) model.symbol(srcFile, from(68, 18)).get();
-        assertEquals(symbol.name(), "magic");
+        assertEquals(symbol.getName().get(), "magic");
         assertEquals(symbol.typeDescriptor().typeKind(), STRING);
         assertEquals(symbol.qualifiers().size(), 1);
         assertTrue(symbol.qualifiers().contains(PUBLIC));
@@ -118,7 +118,7 @@ public class ServiceSemanticAPITest {
     @Test(dataProvider = "ServiceDeclMethodPos")
     public void testServiceDeclMethods(int line, int col, String name, List<Qualifier> quals) {
         MethodSymbol symbol = (MethodSymbol) model.symbol(srcFile, from(line, col)).get();
-        assertEquals(symbol.name(), name);
+        assertEquals(symbol.getName().get(), name);
         assertEquals(symbol.qualifiers().size(), quals.size());
 
         for (Qualifier qual : quals) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -154,7 +154,8 @@ public class ServiceSemanticAPITest {
 
     private List<Symbol> getFilteredSymbolNames(List<Symbol> symbols) {
         return symbols.stream()
-                .filter(s -> !"ballerina".equals(s.getModule().get().organization()))
+                .filter(s -> s.getModule().isPresent() &&
+                        !"ballerina".equals(s.getModule().get().getModule().get().id().orgName()))
                 .collect(Collectors.toList());
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -154,7 +154,7 @@ public class ServiceSemanticAPITest {
 
     private List<Symbol> getFilteredSymbolNames(List<Symbol> symbols) {
         return symbols.stream()
-                .filter(s -> !"ballerina".equals(s.moduleID().orgName()))
+                .filter(s -> !"ballerina".equals(s.getModule().get().organization()))
                 .collect(Collectors.toList());
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -48,7 +48,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(value.getName().get(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -105,7 +105,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(value.getName().get(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -132,7 +132,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(value.getName().get(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -159,7 +159,7 @@ public class SymbolAtCursorTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertTrue(true, "Unexpected symbol: " + value.name()));
+        symbol.ifPresent(value -> assertTrue(true, "Unexpected symbol: " + value.getName().get()));
     }
 
     @DataProvider(name = "MissingConstructPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -148,7 +148,8 @@ public class SymbolBIRTest {
         assertEquals(actualValues.size(), expectedValues.size());
 
         for (SymbolInfo val : expectedValues) {
-            assertTrue(actualValues.stream().anyMatch(sym -> val.equals(new SymbolInfo(sym.getName().get(), sym.kind()))),
+            assertTrue(actualValues.stream()
+                               .anyMatch(sym -> val.equals(new SymbolInfo(sym.getName().get(), sym.kind()))),
                        "Symbol not found: " + val);
 
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -94,7 +94,7 @@ public class SymbolBIRTest {
         assertList(symbolsInScope, expSymbolNames);
 
         BallerinaModule fooModule = (BallerinaModule) symbolsInScope.stream()
-                .filter(sym -> sym.name().equals("testproject")).findAny().get();
+                .filter(sym -> sym.getName().get().equals("testproject")).findAny().get();
         List<String> fooFunctions = getSymbolNames(fooPkgSymbol, SymTag.FUNCTION);
         SemanticAPITestUtils.assertList(fooModule.functions(), fooFunctions);
 
@@ -120,7 +120,7 @@ public class SymbolBIRTest {
         Document srcFile = getDocumentForSingleSource(project);
 
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, column));
-        symbol.ifPresent(value -> assertEquals(value.name(), expSymbolName));
+        symbol.ifPresent(value -> assertEquals(value.getName().get(), expSymbolName));
 
         if (symbol.isEmpty()) {
             assertNull(expSymbolName);
@@ -148,7 +148,7 @@ public class SymbolBIRTest {
         assertEquals(actualValues.size(), expectedValues.size());
 
         for (SymbolInfo val : expectedValues) {
-            assertTrue(actualValues.stream().anyMatch(sym -> val.equals(new SymbolInfo(sym.name(), sym.kind()))),
+            assertTrue(actualValues.stream().anyMatch(sym -> val.equals(new SymbolInfo(sym.getName().get(), sym.kind()))),
                        "Symbol not found: " + val);
 
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -100,7 +100,7 @@ public class SymbolEquivalenceTest {
 
             for (int j = i + 1; j < symbols.size(); j++) {
                 assertFalse(symbol.equals(symbols.get(j)),
-                            "'" + symbol.name() + "' is equal to '" + symbols.get(j).name() + "'");
+                            "'" + symbol.getName().get() + "' is equal to '" + symbols.get(j).getName().get() + "'");
                 assertNotEquals(symbol.hashCode(), symbols.get(j).hashCode());
             }
         }
@@ -164,7 +164,7 @@ public class SymbolEquivalenceTest {
 
             for (int j = i + 1; j < symbols.size(); j++) {
                 assertTrue(symbol.equals(symbols.get(j)),
-                           "'" + symbol.name() + "' not equal to '" + symbols.get(j).name() + "'");
+                           "'" + symbol.getName().get() + "' not equal to '" + symbols.get(j).getName().get() + "'");
                 assertEquals(symbol.hashCode(), symbols.get(j).hashCode());
             }
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -60,7 +60,7 @@ public class SymbolPositionTest {
             assertNull(expSymbolName);
         }
 
-        assertEquals(symbol.get().name(), expSymbolName);
+        assertEquals(symbol.get().getName().get(), expSymbolName);
 
         Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
@@ -93,7 +93,7 @@ public class SymbolPositionTest {
     public void testTypeNarrowedSymbolPositions(int line, int col) {
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
 
-        assertEquals(symbol.get().name(), "val");
+        assertEquals(symbol.get().getName().get(), "val");
 
         Location pos = symbol.get().location();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolPositionTest.java
@@ -62,7 +62,7 @@ public class SymbolPositionTest {
 
         assertEquals(symbol.get().getName().get(), expSymbolName);
 
-        Location pos = symbol.get().location();
+        Location pos = symbol.get().getLocation().get();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
         assertEquals(pos.lineRange().startLine().line(), sLine);
         assertEquals(pos.lineRange().startLine().offset(), sCol);
@@ -95,7 +95,7 @@ public class SymbolPositionTest {
 
         assertEquals(symbol.get().getName().get(), "val");
 
-        Location pos = symbol.get().location();
+        Location pos = symbol.get().getLocation().get();
         assertEquals(pos.lineRange().filePath(), "symbol_position_test.bal");
         assertEquals(pos.lineRange().startLine().line(), 60);
         assertEquals(pos.lineRange().startLine().offset(), 21);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -71,7 +71,7 @@ public class TestSourcesTest {
             assertNull(expSymbolName);
         }
 
-        assertEquals(symbol.get().name(), expSymbolName);
+        assertEquals(symbol.get().getName().get(), expSymbolName);
     }
 
     @DataProvider(name = "SymbolPosProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -87,7 +87,10 @@ public class TestSourcesTest {
     public void testVisibleSymbols(int line, int col, List<String> expSymbols) {
         List<Symbol> symbols = model.visibleSymbols(srcFile, from(line, col)).stream()
                 .filter(sym -> {
-                    String moduleName = sym.getModule().get().getName().get();
+                    if (sym.getModule().isEmpty()) {
+                        return false;
+                    }
+                    String moduleName = sym.getModule().get().id().moduleName();
                     return moduleName.equals("semapi.baz") || !moduleName.startsWith("lang.");
                 })
                 .collect(Collectors.toList());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TestSourcesTest.java
@@ -86,8 +86,10 @@ public class TestSourcesTest {
     @Test(dataProvider = "VisibleSymbolPosProvider")
     public void testVisibleSymbols(int line, int col, List<String> expSymbols) {
         List<Symbol> symbols = model.visibleSymbols(srcFile, from(line, col)).stream()
-                .filter(sym -> sym.moduleID().moduleName().equals("semapi.baz") ||
-                        !sym.moduleID().moduleName().startsWith("lang."))
+                .filter(sym -> {
+                    String moduleName = sym.getModule().get().getName().get();
+                    return moduleName.equals("semapi.baz") || !moduleName.startsWith("lang.");
+                })
                 .collect(Collectors.toList());
 
         assertEquals(symbols.size(), expSymbols.size());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -213,15 +213,15 @@ public class TypedescriptorTest {
         Map<String, ClassFieldSymbol> fields = clazz.fieldDescriptors();
         ObjectFieldSymbol field = fields.get("name");
         assertEquals(fields.size(), 1);
-        assertEquals(field.name(), "name");
+        assertEquals(field.getName().get(), "name");
         assertEquals(field.typeDescriptor().typeKind(), STRING);
 
         Map<String, MethodSymbol> methods = clazz.methods();
         MethodSymbol method = methods.get("getName");
         assertEquals(fields.size(), 1);
-        assertEquals(method.name(), "getName");
+        assertEquals(method.getName().get(), "getName");
 
-        assertEquals(clazz.initMethod().get().name(), "init");
+        assertEquals(clazz.initMethod().get().getName().get(), "init");
     }
 
     @Test
@@ -236,7 +236,7 @@ public class TypedescriptorTest {
         assertTrue(fields.containsKey("path"));
 
         RecordFieldSymbol field = fields.get("path");
-        assertEquals(field.name(), "path");
+        assertEquals(field.getName().get(), "path");
         assertEquals(field.typeDescriptor().typeKind(), STRING);
     }
 
@@ -366,7 +366,7 @@ public class TypedescriptorTest {
         TypeSymbol type = symbol.typeDescriptor();
         assertEquals(type.typeKind(), XML);
         assertEquals(((XMLTypeSymbol) type).typeParameter().get().typeKind(), kind);
-        assertEquals(type.name(), name);
+        assertEquals(type.getName().get(), name);
     }
 
     @DataProvider(name = "XMLPosProvider")
@@ -386,7 +386,7 @@ public class TypedescriptorTest {
 
         TableTypeSymbol tableType = (TableTypeSymbol) type;
         assertEquals(tableType.rowTypeParameter().typeKind(), rowTypeKind);
-        assertEquals(tableType.rowTypeParameter().name(), rowTypeName);
+        assertEquals(tableType.rowTypeParameter().getName().get(), rowTypeName);
         assertEquals(tableType.keySpecifiers(), keySpecifiers);
         tableType.keyConstraintTypeParameter().ifPresent(t -> assertEquals(t.typeKind(), keyConstraintTypeKind));
         assertEquals(type.signature(), signature);
@@ -409,7 +409,7 @@ public class TypedescriptorTest {
 
         TypeSymbol type = ((TypeReferenceTypeSymbol) typeRef).typeDescriptor();
         assertEquals(type.typeKind(), kind);
-        assertEquals(type.name(), name);
+        assertEquals(type.getName().get(), name);
     }
 
     @DataProvider(name = "BuiltinTypePosProvider")
@@ -457,7 +457,7 @@ public class TypedescriptorTest {
 
         for (TypeSymbol inclusion : typeInclusions) {
             assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), typeKind);
-            assertTrue(expTypes.contains(inclusion.name()));
+            assertTrue(expTypes.contains(inclusion.getName().get()));
         }
     }
 
@@ -478,7 +478,7 @@ public class TypedescriptorTest {
 
         for (TypeSymbol inclusion : typeInclusions) {
             assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), OBJECT);
-            assertTrue(expTypes.contains(inclusion.name()));
+            assertTrue(expTypes.contains(inclusion.getName().get()));
         }
     }
 
@@ -491,7 +491,7 @@ public class TypedescriptorTest {
 
         for (TypeSymbol inclusion : typeInclusions) {
             assertEquals(((TypeReferenceTypeSymbol) inclusion).typeDescriptor().typeKind(), OBJECT);
-            assertTrue(expTypes.contains(inclusion.name()));
+            assertTrue(expTypes.contains(inclusion.getName().get()));
         }
     }
 
@@ -500,7 +500,7 @@ public class TypedescriptorTest {
         Optional<TypeSymbol> type =
                 model.type(LineRange.from("typedesc_test.bal", from(160, 37), from(160, 38)));
         assertEquals(type.get().typeKind(), TYPE_REFERENCE);
-        assertEquals(type.get().name(), "Colour");
+        assertEquals(type.get().getName().get(), "Colour");
 
         TypeSymbol enumType = ((TypeReferenceTypeSymbol) type.get()).typeDescriptor();
         assertEquals(enumType.typeKind(), UNION);
@@ -526,7 +526,7 @@ public class TypedescriptorTest {
         List<TypeSymbol> members = ((IntersectionTypeSymbol) type).memberTypeDescriptors();
 
         TypeSymbol mem1 = members.get(0);
-        assertEquals(mem1.name(), "Foo");
+        assertEquals(mem1.getName().get(), "Foo");
         assertEquals(((TypeReferenceTypeSymbol) mem1).typeDescriptor().typeKind(), RECORD);
 
         assertEquals(members.get(1).typeKind(), READONLY);
@@ -599,7 +599,7 @@ public class TypedescriptorTest {
         Symbol symbol = getSymbol(198, 18);
         assertEquals(symbol.kind(), TYPE);
         assertEquals(((TypeSymbol) symbol).typeKind(), TYPE_REFERENCE);
-        assertEquals(((TypeReferenceTypeSymbol) symbol).name(), "CancelledError");
+        assertEquals(((TypeReferenceTypeSymbol) symbol).getName().get(), "CancelledError");
     }
 
     private Symbol getSymbol(int line, int column) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
@@ -69,7 +69,7 @@ public class SymbolByAnnotationTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), ANNOTATION);
-        assertEquals(symbol.get().name(), "v1");
+        assertEquals(symbol.get().getName().get(), "v1");
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
@@ -102,7 +102,7 @@ public class SymbolByClassTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByConstantTest.java
@@ -68,7 +68,7 @@ public class SymbolByConstantTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), CONSTANT);
-        assertEquals(symbol.get().name(), "PI");
+        assertEquals(symbol.get().getName().get(), "PI");
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
@@ -79,7 +79,7 @@ public class SymbolByEnumTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
@@ -103,7 +103,7 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByImportTest.java
@@ -86,7 +86,7 @@ public class SymbolByImportTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByObjectTest.java
@@ -81,7 +81,7 @@ public class SymbolByObjectTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByRecordTest.java
@@ -81,7 +81,7 @@ public class SymbolByRecordTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByVarDeclTest.java
@@ -82,7 +82,7 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
             @Override
             public void visit(TypedBindingPatternNode typedBindingPatternNode) {
                 Optional<Symbol> symbol = model.symbol(typedBindingPatternNode);
-                Object[] expVals = expVarDetails.get(symbol.get().name());
+                Object[] expVals = expVarDetails.get(symbol.get().getName().get());
                 assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
 
                 typedBindingPatternNode.bindingPattern().accept(this);
@@ -91,7 +91,7 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
             @Override
             public void visit(CaptureBindingPatternNode captureBindingPatternNode) {
                 Optional<Symbol> symbol = model.symbol(captureBindingPatternNode);
-                Object[] expVals = expVarDetails.get(symbol.get().name());
+                Object[] expVals = expVarDetails.get(symbol.get().getName().get());
                 assertSymbol(symbol.get(), (String) expVals[0], (TypeDescKind) expVals[1]);
             }
         };
@@ -104,7 +104,7 @@ public class SymbolByVarDeclTest extends SymbolByNodeTest {
 
     private void assertSymbol(Symbol symbol, String name, TypeDescKind typeKind) {
         assertEquals(symbol.kind(), VARIABLE);
-        assertEquals(symbol.name(), name);
+        assertEquals(symbol.getName().get(), name);
         assertEquals(((VariableSymbol) symbol).typeDescriptor().typeKind(), typeKind);
         incrementAssertCount();
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByWorkerTest.java
@@ -71,7 +71,7 @@ public class SymbolByWorkerTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), SymbolKind.WORKER);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByXMLNSTest.java
@@ -76,7 +76,7 @@ public class SymbolByXMLNSTest extends SymbolByNodeTest {
     private void assertSymbol(Node node, SemanticModel model, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), SymbolKind.XMLNS);
-        assertEquals(symbol.get().name(), name);
+        assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -100,7 +100,8 @@ public class SemanticAPITestUtils {
     }
 
     public static void assertList(List<? extends Symbol> actualValues, List<String> expectedValues) {
-        Map<String, Symbol> symbols = actualValues.stream().collect(Collectors.toMap(Symbol::name, s -> s));
+        Map<String, Symbol> symbols = actualValues.stream().collect(
+                Collectors.toMap(s -> s.getName().orElse(""), s -> s));
         assertList(symbols, expectedValues);
     }
 
@@ -117,7 +118,7 @@ public class SemanticAPITestUtils {
         List<Symbol> allInScopeSymbols = model.visibleSymbols(srcFile, LinePosition.from(line, column));
         return allInScopeSymbols.stream()
                 .filter(s -> s.moduleID().equals(moduleID))
-                .collect(Collectors.toMap(Symbol::name, s -> s));
+                .collect(Collectors.toMap(s -> s.getName().orElse(""), s -> s));
     }
 
     public static List<String> getSymbolNames(List<String> mainList, String... args) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/util/SemanticAPITestUtils.java
@@ -117,7 +117,7 @@ public class SemanticAPITestUtils {
                                                        int column, ModuleID moduleID) {
         List<Symbol> allInScopeSymbols = model.visibleSymbols(srcFile, LinePosition.from(line, column));
         return allInScopeSymbols.stream()
-                .filter(s -> s.moduleID().equals(moduleID))
+                .filter(s -> s.getModule().get().id().equals(moduleID))
                 .collect(Collectors.toMap(s -> s.getName().orElse(""), s -> s));
     }
 


### PR DESCRIPTION
## Purpose
This PR refactors the `Symbol` interface to enforce the users to be mindful of when looking up meta info such as name, module, location. 

Fix #27203
Fix #27141
Fix #28482 

## Approach
- Replaced `name()` with `getName()` which returns `Optional<String>` instead of `String`
- Replaced `moduleID()` with `getModule()` which returns `Optional<ModuleSymbol>`
- Replaced `location()` with `getLocation()` which returns `Optional<Location>`

## Remarks
@hasithaa @MaryamZi There was an issue with builtin subtype symbols where their owner was set as the symbol of `lang.annotations`. Addressed that in https://github.com/ballerina-platform/ballerina-lang/pull/28357/commits/75f7d4e8a921e61fb77c88bcb244c1fc8cd9705f as well since I make use of owner symbol to figure out the module of a symbol. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
