### PR TITLE
Fix type match for nil type initialized as finite type and finite type inside union

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -647,6 +647,10 @@ public class TypeChecker {
             return checkIsType(sourceType, PredefinedTypes.ANY_AND_READONLY_OR_ERROR_TYPE, unresolvedTypes);
         }
 
+        if (sourceTypeTag == TypeTags.UNION_TAG) {
+            return isUnionTypeMatch((BUnionType) sourceType, targetType, unresolvedTypes);
+        }
+
         switch (targetTypeTag) {
             case TypeTags.BYTE_TAG:
             case TypeTags.SIGNED32_INT_TAG:

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -787,7 +787,7 @@ public class TypeChecker {
             case TypeTags.OBJECT_TYPE_TAG:
                 return checkObjectEquivalency(sourceType, (BObjectType) targetType, unresolvedTypes);
             case TypeTags.FINITE_TYPE_TAG:
-                return checkIsFiniteType(sourceType, (BFiniteType) targetType, unresolvedTypes);
+                return checkIsFiniteType(sourceType, (BFiniteType) targetType);
             case TypeTags.FUTURE_TAG:
                 return checkIsFutureType(sourceType, (BFutureType) targetType, unresolvedTypes);
             case TypeTags.ERROR_TAG:
@@ -1563,7 +1563,7 @@ public class TypeChecker {
         return true;
     }
 
-    private static boolean checkIsFiniteType(Type sourceType, BFiniteType targetType, List<TypePair> unresolvedTypes) {
+    private static boolean checkIsFiniteType(Type sourceType, BFiniteType targetType) {
         if (sourceType.getTag() != TypeTags.FINITE_TYPE_TAG) {
             return false;
         }
@@ -2494,11 +2494,6 @@ public class TypeChecker {
     }
 
     private static boolean checkFiniteTypeAssignable(Object sourceValue, Type sourceType, BFiniteType targetType) {
-        if (sourceValue == null) {
-            // we should not reach here
-            return false;
-        }
-
         for (Object valueSpaceItem : targetType.valueSpace) {
             // TODO: 8/13/19 Maryam fix for conversion
             if (isFiniteTypeValue(sourceValue, sourceType, valueSpaceItem)) {
@@ -2511,7 +2506,8 @@ public class TypeChecker {
     protected static boolean isFiniteTypeValue(Object sourceValue, Type sourceType, Object valueSpaceItem) {
         Type valueSpaceItemType = getType(valueSpaceItem);
         if (valueSpaceItemType.getTag() > TypeTags.FLOAT_TAG) {
-            return valueSpaceItemType.getTag() == sourceType.getTag() && valueSpaceItem.equals(sourceValue);
+            return valueSpaceItemType.getTag() == sourceType.getTag() &&
+                    (valueSpaceItem == sourceValue || valueSpaceItem.equals(sourceValue));
         }
 
         switch (sourceType.getTag()) {
@@ -3009,5 +3005,8 @@ public class TypeChecker {
             }
         }
         return true;
+    }
+
+    private TypeChecker() {
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -383,6 +383,12 @@ public class FiniteTypeTest {
     public void testNilFiniteType() {
         BRunUtil.invoke(result, "testNilFiniteType");
     }
+
+    @Test
+    public void testRecordStringEquality() {
+        BRunUtil.invoke(result, "testRecordStringEquality");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/finite/FiniteTypeTest.java
@@ -379,6 +379,10 @@ public class FiniteTypeTest {
         BRunUtil.invoke(result, "testFiniteTypesWithPositiveFloats");
     }
 
+    @Test
+    public void testNilFiniteType() {
+        BRunUtil.invoke(result, "testNilFiniteType");
+    }
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -496,6 +496,43 @@ public function testNilFiniteType() {
     assertEquality(a, mah);
 }
 
+type FooString "foo";
+
+type BarString "bar";
+
+type FooInt 1;
+
+type BarInt 2;
+
+type FooBoolean true;
+
+type BarBoolean false;
+
+type RecString1 record {|
+    FooString|BarString a;
+    FooInt|BarInt b;
+    FooBoolean|BarBoolean c;
+|};
+
+type RecString2 record {|
+    string a;
+    int b;
+    boolean c;
+|};
+
+public function testRecordStringEquality() {
+    RecString1 rec1 = {a: "foo", b: 1, c: true};
+
+    RecString2 rec2 = rec1;
+
+    string a = "";
+    string mah = "match";
+    if (<any>rec1 is RecString2) {
+        a = mah;
+    }
+    assertEquality(a, mah);
+}
+
 const ASSERTION_ERROR_REASON = "TypeAssertionError";
 
 function assertEquality(any|error expected, any|error actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/finite/finite-type.bal
@@ -484,6 +484,18 @@ function testFiniteTypesWithPositiveFloats() {
     assertEquality(1.5,n);
 }
 
+const CONST3 = ();
+
+public function testNilFiniteType() {
+    any v = CONST3;
+    string a = "";
+    string mah = "match";
+    if (v is CONST3) {
+        a = mah;
+    }
+    assertEquality(a, mah);
+}
+
 const ASSERTION_ERROR_REASON = "TypeAssertionError";
 
 function assertEquality(any|error expected, any|error actual) {
@@ -499,13 +511,3 @@ function assertEquality(any|error expected, any|error actual) {
     panic error(ASSERTION_ERROR_REASON,
                 message = "expected '" + expectedValAsString + "', found '" + tActual.toString() + "'");
 }
-
-//public const '\- = "-";
-//public const d = "d";
-//public const s = "s";
-//public type FT '\-|s|d;
-//
-//function testEscapedTypeName() returns FT {
-//    FT f = '\-;
-//    return f;
-//}


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/ballerina-platform/ballerina-lang/issues/25371
> Resolve https://github.com/ballerina-platform/ballerina-lang/issues/27627

## Approach
> Fix an issue in the TypeChecker

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
