### PR TITLE
Add wait for ports to open in Observability Test Cases

### DIFF
--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/ObservabilityBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/ObservabilityBaseTest.java
@@ -21,6 +21,7 @@ package org.ballerinalang.test.observability;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BServerInstance;
 import org.ballerinalang.test.context.BallerinaTestException;
+import org.ballerinalang.test.context.Utils;
 import org.testng.Assert;
 
 import java.io.IOException;
@@ -74,6 +75,7 @@ public class ObservabilityBaseTest extends BaseTest {
         // Don't use 9898 port here. It is used in metrics test cases.
         servicesServerInstance = new BServerInstance(balServer);
         servicesServerInstance.startServer(sourcesDir, packageName, null, null, env, requiredPorts);
+        Utils.waitForPortsToOpen(requiredPorts, 1000 * 60, false, "localhost");
     }
 
     protected void cleanupServer() throws BallerinaTestException {


### PR DESCRIPTION
## Purpose
> The BServerInstance does not wait for all ports to Open and this causes tests to sometimes fail intermittently.

## Approach
> This had been addressed by adding a wait in the Observability Test Cases separately.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
