### PR TITLE
Fix debug session hang issue when we do a STEP_OVER / STEP_IN or STEP_OUT in the last line of main() method

### DIFF
--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/JDIEventProcessor.java
@@ -263,6 +263,9 @@ public class JDIEventProcessor {
     private void createStepRequest(long threadId, int stepType) {
         context.getDebuggee().eventRequestManager().deleteEventRequests(stepEventRequests);
         ThreadReference threadReference = getThreadsMap().get(threadId);
+        if (threadReference == null) {
+            return;
+        }
         StepRequest request = context.getDebuggee().eventRequestManager().createStepRequest(threadReference,
                 StepRequest.STEP_LINE, stepType);
         request.setSuspendPolicy(StepRequest.SUSPEND_ALL);


### PR DESCRIPTION
## Purpose
This PR will fix the debug session hang issue when we do the following debug actions in the last line of `main()` method:

- [x] STEP_IN
- [x] STEP_OUT
- [x] STEP_OVER

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28364

