### PR TITLE
Add "cloud" to build options

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/BuildOptions.java
@@ -59,6 +59,10 @@ public class BuildOptions {
         return this.compilationOptions.observabilityIncluded();
     }
 
+    public String cloud() {
+        return this.compilationOptions.getCloud();
+    }
+
     CompilationOptions compilationOptions() {
         return compilationOptions;
     }


### PR DESCRIPTION
## Purpose
Currently, compiler extensions are only able to retrieve build options using compiler context. This easily allows to retrieve the build options using `Project`.

## Samples
`String cloud = project.buildOptions().cloud();`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
