### PR TITLE
Remove the redundant jObjToString function in the java module

### DIFF
--- a/langlib/jballerina.java/src/main/ballerina/JObject.bal
+++ b/langlib/jballerina.java/src/main/ballerina/JObject.bal
@@ -22,17 +22,3 @@ public type JObject object {
 
     public handle jObj;
 };
-
-# Returns the string representation of a Java object stored in a handle reference.
-#
-# + jObj - The `handle` reference to the corresponding Java object.
-# + return - The `string` representation of the Java object.
-public function jObjToString(handle jObj) returns string {
-    handle jStringValue = toStringInternal(jObj);
-    return toString(jStringValue) ?: "null";
-}
-
-function toStringInternal(handle jObj) returns handle = @Method {
-    name: "toString",
-    'class: "java.lang.Object"
-} external;

--- a/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
+++ b/misc/ballerina-bindgen/src/main/resources/templates/bridge_class.mustache
@@ -37,7 +37,7 @@ import {{balPackageName}}.{{#escapeReservedWord this ""}}{{/escapeReservedWord}}
     #
     # + return - The `string` form of the object instance.
     {{accessModifier}}function toString() returns string {
-        return java:jObjToString(self.jObj);
+        return java:toString(self.jObj) ?: "null";
     }{{#methodList}}{{#unless isStatic}}
 
     # The function that maps to the `{{javaMethodName}}` method of `{{className}}`.{{#if parameters}}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
@@ -97,7 +97,7 @@ public class String1 {
     }
 
     public function toString() returns string {
-        return java:jObjToString(self.jObj);
+        return java:toString(self.jObj) ?: "null";
     }
 }
 
@@ -146,7 +146,7 @@ public class String2 {
     }
 
     public function toString() returns string {
-        return java:jObjToString(self.jObj);
+        return java:toString(self.jObj) ?: "null";
     }
 }
 
@@ -195,7 +195,7 @@ public class String3 {
     }
 
     public function toString() returns string {
-        return java:jObjToString(self.jObj);
+        return java:toString(self.jObj) ?: "null";
     }
 }
 
@@ -247,7 +247,7 @@ public class String4 {
     }
 
     public function toString() returns string {
-        return java:jObjToString(self.jObj);
+        return java:toString(self.jObj) ?: "null";
     }
 }
 


### PR DESCRIPTION
## Purpose
Removes the `jObjToString` function in the `jballerina.java` module, since this use case could be achieved using the `toString` function as well. This will be a breaking change, but it is assumed that the usages are minimal since the established approach is to use the `toString` function for this purpose.

Fixes #27470

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
