### PR TITLE
Fix duplicate existing node diagnostic in Toml Parser

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
@@ -179,7 +179,6 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
     }
 
     private TomlTableNode getParentTable(TomlTableNode rootTable, TopLevelNode childNode) {
-        String tableLeadName = getLastKeyEntry(childNode).name().toString();
         List<String> parentTables = new ArrayList<>();
         for (int i = 0; i < (childNode.key().keys().size() - 1); i++) {
             parentTables.add(childNode.key().keys().get(i).name().toString());
@@ -199,13 +198,6 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
                     parentTable = generateTable(parentTable, tomlKeyEntryNode, true);
                 }
             }
-        }
-
-        TopLevelNode lastNode = parentTable.entries().get(tableLeadName);
-        if (lastNode instanceof TomlKeyValueNode) {
-            TomlDiagnostic nodeExists =
-                    dlog.error(childNode.location(), DiagnosticErrorCode.ERROR_EXISTING_NODE, tableLeadName);
-            parentTable.addDiagnostic(nodeExists);
         }
         return parentTable;
     }


### PR DESCRIPTION
## Purpose
$Subject. This only happens with the nodes that has dotted key value pairs. 
This PR Removes the duplication check in the getParentTable() as existing node checking happens in future steps while appending nodes.

Fixes #28400 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
