### PR TITLE
Add ballerina builtin types to API Docs

### DIFF
--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BuiltInType.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/BuiltInType.java
@@ -13,23 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.ballerinalang.docgen.generator.model;
 
 import com.google.gson.annotations.Expose;
 
-import java.util.ArrayList;
-import java.util.List;
-
 /**
- * Contains all the packages of the Ballerina Standard Library.
+ * Represents ballerina builtin types.
+ *
+ * @since 2.0.0
  */
-public class PackageLibrary {
+public class BuiltInType {
     @Expose
-    public String libVersion;
+    public String name = "";
     @Expose
     public String description;
-    @Expose
-    public List<DocPackage> packages = new ArrayList<>();
-    @Expose
-    public List<BuiltInType> builtinTypesAndKeywords = new ArrayList<>();
+
+    public BuiltInType(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/CentralStdLibrary.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/CentralStdLibrary.java
@@ -33,5 +33,6 @@ public class CentralStdLibrary {
     public List<DocPackageMetadata> stdLibs = new ArrayList<>();
     @Expose
     public List<DocPackage> langLibs = new ArrayList<>();
-
+    @Expose
+    public List<BuiltInType> builtinTypesAndKeywords = new ArrayList<>();
 }

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/generator/model/Type.java
@@ -226,11 +226,13 @@ public class Type {
         } else if (node instanceof ObjectTypeDescriptorNode) {
             ObjectTypeDescriptorNode objectType = (ObjectTypeDescriptorNode) node;
             type.name = objectType.toString();
-            type.category = "builtin";
+            type.category = "other";
+            type.generateUserDefinedTypeLink = false;
         } else if (node instanceof SingletonTypeDescriptorNode) {
             SingletonTypeDescriptorNode singletonTypeDesc = (SingletonTypeDescriptorNode) node;
             type.name = singletonTypeDesc.simpleContExprNode().toString();
-            type.category = "builtin";
+            type.category = "other";
+            type.generateUserDefinedTypeLink = false;
         } else if (node instanceof ParenthesisedTypeDescriptorNode) {
             ParenthesisedTypeDescriptorNode parenthesisedNode = (ParenthesisedTypeDescriptorNode) node;
             type.elementType = fromNode(parenthesisedNode.typedesc(), semanticModel);

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/any.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/any.md
@@ -1,0 +1,1 @@
+The `any` data type represents all the available data types.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/boolean.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/boolean.md
@@ -1,0 +1,1 @@
+The `boolean` data type has only two possible values of `true` and `false`. A variable of `boolean` type defaults to `true`.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/byte.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/byte.md
@@ -1,0 +1,1 @@
+int in the range 0 to 255 inclusive.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/decimal.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/decimal.md
@@ -1,0 +1,1 @@
+Decimal floating point numbers.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/error.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/error.md
@@ -1,0 +1,10 @@
+An indication that there has been an error, with a string identifying the reason for the error, and a mapping giving additional details about the error.
+
+An error value provides information about an error that has occurred. Error values belong to a separate basic type; this makes it possible for language constructs to handle errors differently from other values.
+
+The error type is inherently immutable. An error value contains the following information:
+
+- a message, which is a string containing a human-readable message describing the error
+- a cause, which is either nil or another error value that was the cause of this error
+- a detail, which is an immutable mapping providing additional information about the error
+- a stack trace, which is an immutable snapshot of the state of the execution stack

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/float.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/float.md
@@ -1,0 +1,1 @@
+The `float` data type is a double-precision 64-bit IEEE 754 floating point.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/future.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/future.md
@@ -1,0 +1,1 @@
+A value to be returned by a function execution

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/handle.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/handle.md
@@ -1,0 +1,1 @@
+Reference to externally managed storage.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/int.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/int.md
@@ -1,0 +1,1 @@
+The `int` data type is a 64-bit two's complement integer. 

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/json.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/json.md
@@ -1,0 +1,1 @@
+The `json` data type which represents the standard `JSON` format. It is a collection of `numbers`, `string`, `true`, `false`, `null`,  an `array` of `JSON`, or an `object` with key-value pairs where value is another `JSON`.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/map.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/map.md
@@ -1,0 +1,1 @@
+A mapping from keys, which are strings, to values; specifies mappings in terms of a single type to which all keys are mapped.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/never.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/never.md
@@ -1,0 +1,3 @@
+The type descriptor never describes the type that does not contain any shapes. No value ever belongs to the never.
+
+This can be useful to describe for the return type of a function, if the function never returns. It can also be useful as a type parameter. For example, xml<never> describes the an xml type that has no constituents, i.e. the empty xml value.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/nil.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/nil.md
@@ -1,0 +1,3 @@
+The nil type contains a single value, called nil, which is used to represent the absence of any other value. The nil value is written (). The nil value can also be written null, for compatibility with JSON; the use of null should be restricted to JSON-related contexts.
+
+The nil type is special, in that it is the only basic type that consists of a single value. The type descriptor for the nil type is not written using a keyword, but is instead written () like the value.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/readonly.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/readonly.md
@@ -1,0 +1,23 @@
+A shape belongs to the type readonly if its read-only bit is on.
+
+A value belonging to an inherently immutable basic type will always have its read-only bit on. These basic types are:
+
+all simple types
+- nil
+- boolean
+- int
+- float
+- decimal
+- string
+- error
+- function
+- typedesc
+- handle
+
+A value belonging to a selectively immutable basic type may have its read-only bit on. These basic types are:
+
+- xml
+- list
+- mapping
+- table
+- object

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/stream.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/stream.md
@@ -1,0 +1,2 @@
+A sequence of values that can be generated lazily.
+A stream is an object-like value that can generate a sequence of values. There is also a value associated with the completion of the generation of the sequence, which is either nil, indicating the generation of the sequence completed successfully, or an error. 

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/string.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/string.md
@@ -1,0 +1,1 @@
+The `string` data type is a series of characters gathered together. 

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/typedesc.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/typedesc.md
@@ -1,0 +1,1 @@
+A type descriptor. A type descriptor value is an immutable value representing a resolved type descriptor. The type typedesc contains all values with basic type typedesc. A typedesc value t belongs to a type typedesc<T> if and only if the type described by t is a subtype of T. The typedesc type is thus covariant with its type parameter.

--- a/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/xml.md
+++ b/misc/docerina/src/main/resources/builtin-types-keywords-descriptions/xml.md
@@ -1,0 +1,1 @@
+The `xml` data type represents an immutable sequence of zero or more `XML` elements, comments, text or processing instructions.


### PR DESCRIPTION
## Purpose
> Adds ballerina builtin types and keywords to API docs

Fixes https://github.com/ballerina-platform/ballerina-dev-tools/issues/40

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
