### PR TITLE
Deprecate name() and kind() APIs in ParameterSymbol

### DIFF
--- a/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
+++ b/ballerina-shell/modules/shell-core/src/main/java/io/ballerina/shell/invoker/classload/visitors/TypeSignatureTransformer.java
@@ -87,7 +87,7 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
         StringJoiner joiner = new StringJoiner(" ");
         parameterSymbol.qualifiers().forEach(accessModifier -> joiner.add(accessModifier.getValue()));
         String signature;
-        if (parameterSymbol.kind() == ParameterKind.REST) {
+        if (parameterSymbol.paramKind() == ParameterKind.REST) {
             signature = transformType(parameterSymbol.typeDescriptor());
             signature = signature.substring(0, signature.length() - 2) + "...";
         } else {
@@ -95,8 +95,8 @@ public class TypeSignatureTransformer extends TypeSymbolTransformer<String> {
         }
 
         joiner.add(signature);
-        if (parameterSymbol.name().isPresent()) {
-            joiner.add(parameterSymbol.name().get());
+        if (parameterSymbol.getName().isPresent()) {
+            joiner.add(parameterSymbol.getName().get());
         }
 
         this.setState(joiner.toString());

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -61,6 +61,11 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
         return Optional.ofNullable(parameterName);
     }
 
+    @Override
+    public Optional<String> getName() {
+        return Optional.ofNullable(this.parameterName);
+    }
+
     /**
      * Get the type descriptor of the field.
      *
@@ -96,15 +101,15 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
         StringJoiner joiner = new StringJoiner(" ");
         this.qualifiers().forEach(accessModifier -> joiner.add(accessModifier.getValue()));
         String signature;
-        if (this.kind() == ParameterKind.REST) {
+        if (this.paramKind() == ParameterKind.REST) {
             signature = this.typeDescriptor().signature();
             signature = signature.substring(0, signature.length() - 2) + "...";
         } else {
             signature = this.typeDescriptor().signature();
         }
         joiner.add(signature);
-        if (this.name().isPresent()) {
-            joiner.add(this.name().get());
+        if (this.getName().isPresent()) {
+            joiner.add(this.getName().get());
         }
 
         return joiner.toString();
@@ -112,6 +117,11 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
 
     @Override
     public ParameterKind kind() {
+        return this.kind;
+    }
+
+    @Override
+    public ParameterKind paramKind() {
         return this.kind;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterSymbol.java
@@ -6,7 +6,7 @@
  * in compliance with the License.
  * You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,7 +16,6 @@
  */
 package io.ballerina.compiler.api.symbols;
 
-import java.util.List;
 import java.util.Optional;
 
 /**
@@ -24,14 +23,23 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface ParameterSymbol extends Annotatable {
+public interface ParameterSymbol extends Annotatable, Qualifiable {
+
+    /**
+     * Get the parameter name.
+     *
+     * @return {@link Optional} name of the field
+     * @deprecated This method will be removed in a later version. Use getName() instead.
+     */
+    @Deprecated
+    Optional<String> name();
 
     /**
      * Get the parameter name.
      *
      * @return {@link Optional} name of the field
      */
-    Optional<String> name();
+    Optional<String> getName();
 
     /**
      * Get the type descriptor of the field.
@@ -39,13 +47,6 @@ public interface ParameterSymbol extends Annotatable {
      * @return {@link TypeSymbol} of the field
      */
     TypeSymbol typeDescriptor();
-
-    /**
-     * Get the access modifiers.
-     *
-     * @return {@link List} of access modifiers
-     */
-    List<Qualifier> qualifiers();
 
     /**
      * Get a string representation of the signature of the parameter.
@@ -59,5 +60,13 @@ public interface ParameterSymbol extends Annotatable {
      *
      * @return {@link ParameterKind} of the param
      */
+    @Deprecated
     ParameterKind kind();
+
+    /**
+     * Get the kind of the parameter.
+     *
+     * @return {@link ParameterKind} of the param
+     */
+    ParameterKind paramKind();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -163,7 +163,7 @@ public final class FunctionCompletionItemBuilder {
         docAttachment.ifPresent(documentation -> documentation.parameterMap().forEach(docParamsMap::put));
 
         List<ParameterSymbol> defaultParams = functionTypeDesc.parameters().stream()
-                .filter(parameter -> parameter.kind() == ParameterKind.DEFAULTABLE)
+                .filter(parameter -> parameter.paramKind() == ParameterKind.DEFAULTABLE)
                 .collect(Collectors.toList());
 
         MarkupContent docMarkupContent = new MarkupContent();
@@ -183,11 +183,11 @@ public final class FunctionCompletionItemBuilder {
             }
 
             Optional<ParameterSymbol> defaultVal = defaultParams.stream()
-                    .filter(parameter -> parameter.name().get().equals(param.name().get()))
+                    .filter(parameter -> parameter.getName().get().equals(param.getName().get()))
                     .findFirst();
-            String paramDescription = "- " + "`" + paramType + "` " + param.name().get();
-            if (param.name().isPresent() && docParamsMap.containsKey(param.name().get())) {
-                paramDescription += ": " + docParamsMap.get(param.name().get());
+            String paramDescription = "- " + "`" + paramType + "` " + param.getName().get();
+            if (param.getName().isPresent() && docParamsMap.containsKey(param.getName().get())) {
+                paramDescription += ": " + docParamsMap.get(param.getName().get());
             }
             if (defaultVal.isPresent()) {
                 joiner.add(paramDescription + "(Defaultable)");
@@ -269,15 +269,15 @@ public final class FunctionCompletionItemBuilder {
                 continue;
             }
             ParameterSymbol param = parameterDefs.get(i);
-            args.add(CommonUtil.getModifiedTypeName(ctx, param.typeDescriptor()) + (param.name().isEmpty() ? ""
-                    : " " + param.name().get()));
+            args.add(CommonUtil.getModifiedTypeName(ctx, param.typeDescriptor()) + (param.getName().isEmpty() ? ""
+                    : " " + param.getName().get()));
         }
         restParam.ifPresent(param -> {
             // Rest param is represented as an array type symbol
             ArrayTypeSymbol typeSymbol = (ArrayTypeSymbol) param.typeDescriptor();
             args.add(CommonUtil.getModifiedTypeName(ctx, typeSymbol.memberTypeDescriptor())
-                    + (param.name().isEmpty() ? "" : "... "
-                    + param.name().get()));
+                    + (param.getName().isEmpty() ? "" : "... "
+                    + param.getName().get()));
         });
         return (!args.isEmpty()) ? args : new ArrayList<>();
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -298,10 +298,10 @@ public class HoverUtil {
 
             params.addAll(symbol.typeDescriptor().parameters().stream()
                     .map(param -> {
-                        if (param.name().isEmpty()) {
+                        if (param.getName().isEmpty()) {
                             return quotedString(CommonUtil.getModifiedTypeName(ctx, param.typeDescriptor()));
                         }
-                        String paramName = param.name().get();
+                        String paramName = param.getName().get();
                         String desc = paramsMap.get(paramName);
                         return quotedString(CommonUtil.getModifiedTypeName(ctx, param.typeDescriptor())) + " "
                                 + italicString(boldString(paramName)) + " : " + desc;
@@ -311,9 +311,9 @@ public class HoverUtil {
             if (restParam.isPresent()) {
                 String modifiedTypeName = CommonUtil.getModifiedTypeName(ctx, restParam.get().typeDescriptor());
                 StringBuilder restParamBuilder = new StringBuilder(quotedString(modifiedTypeName + "..."));
-                if (restParam.get().name().isPresent()) {
-                    restParamBuilder.append(" ").append(italicString(boldString(restParam.get().name().get())))
-                            .append(" : ").append(paramsMap.get(restParam.get().name().get()));
+                if (restParam.get().getName().isPresent()) {
+                    restParamBuilder.append(" ").append(italicString(boldString(restParam.get().getName().get())))
+                            .append(" : ").append(paramsMap.get(restParam.get().getName().get()));
                 }
                 params.add(restParamBuilder.toString());
             }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -236,8 +236,8 @@ public class SignatureHelpUtil {
         }
 
         public Optional<String> getName() {
-            return (parameterSymbol.name().isPresent() && this.isOptional)
-                    ? Optional.of(parameterSymbol.name().get() + "?") : parameterSymbol.name();
+            return (parameterSymbol.getName().isPresent() && this.isOptional)
+                    ? Optional.of(parameterSymbol.getName().get() + "?") : parameterSymbol.getName();
         }
 
         public String getType() {

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
@@ -51,11 +51,11 @@ public class InvocationArgProcessor {
 
         for (ParameterSymbol parameterSymbol : definition.parameters()) {
             params.add(parameterSymbol);
-            remainingParams.put(parameterSymbol.name().get(), parameterSymbol);
+            remainingParams.put(parameterSymbol.getName().get(), parameterSymbol);
         }
         if (definition.restParam().isPresent()) {
             params.add(definition.restParam().get());
-            remainingParams.put(definition.restParam().get().name().get(), definition.restParam().get());
+            remainingParams.put(definition.restParam().get().getName().get(), definition.restParam().get());
         }
 
         Map<String, Value> argValues = new HashMap<>();
@@ -76,7 +76,7 @@ public class InvocationArgProcessor {
                             "too many arguments in call to '" + functionName + "'."));
                 }
 
-                String parameterName = params.get(i).name().get();
+                String parameterName = params.get(i).getName().get();
                 argValues.put(parameterName, arg.getValue().evaluate().getJdiValue());
                 remainingParams.remove(parameterName);
             } else if (argType == ArgType.NAMED) {
@@ -101,7 +101,7 @@ public class InvocationArgProcessor {
 
                 String restParamName = null;
                 for (Map.Entry<String, ParameterSymbol> entry : remainingParams.entrySet()) {
-                    ParameterKind parameterType = entry.getValue().kind();
+                    ParameterKind parameterType = entry.getValue().paramKind();
                     if (parameterType == ParameterKind.REST) {
                         restParamName = entry.getKey();
                         break;
@@ -119,7 +119,7 @@ public class InvocationArgProcessor {
 
         for (Map.Entry<String, ParameterSymbol> entry : remainingParams.entrySet()) {
             String paramName = entry.getKey();
-            ParameterKind parameterType = entry.getValue().kind();
+            ParameterKind parameterType = entry.getValue().paramKind();
             if (parameterType == ParameterKind.REQUIRED) {
                 throw new EvaluationException(String.format(EvaluationExceptionKind.CUSTOM_ERROR.getString(),
                         "missing required parameter '" + paramName + "'."));

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -476,21 +476,21 @@ public class Generator {
                             .anyMatch(annotationSymbol -> annotationSymbol.name().equals("deprecated"));
                     Type type = new Type(parameterSymbol.typeDescriptor().signature());
                     Type.resolveSymbol(type, parameterSymbol.typeDescriptor());
-                    parameters.add(new DefaultableVariable(parameterSymbol.name().isPresent() ?
-                            parameterSymbol.name().get() : "", "", parameterDeprecated, type, ""));
+                    parameters.add(new DefaultableVariable(parameterSymbol.getName().isPresent() ?
+                            parameterSymbol.getName().get() : "", "", parameterDeprecated, type, ""));
                 });
 
                 if (methodSymbol.typeDescriptor().restParam().isPresent()) {
                     ParameterSymbol restParam = methodSymbol.typeDescriptor().restParam().get();
                     boolean parameterDeprecated = restParam.annotations().stream()
                             .anyMatch(annotationSymbol -> annotationSymbol.name().equals("deprecated"));
-                    Type type = new Type(restParam.name().isPresent() ? restParam.name().get() : "");
+                    Type type = new Type(restParam.getName().isPresent() ? restParam.getName().get() : "");
                     type.isRestParam = true;
                     Type elemType = new Type(restParam.typeDescriptor().signature());
                     Type.resolveSymbol(elemType, restParam.typeDescriptor());
                     type.elementType = elemType;
-                    parameters.add(new DefaultableVariable(restParam.name().isPresent() ?
-                            restParam.name().get() : "", "", parameterDeprecated, type, ""));
+                    parameters.add(new DefaultableVariable(restParam.getName().isPresent() ?
+                            restParam.getName().get() : "", "", parameterDeprecated, type, ""));
                 }
 
                 if (methodSymbol.typeDescriptor().returnTypeDescriptor().isPresent()) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -72,9 +72,9 @@ public class ClassSymbolTest {
 
         MethodSymbol initMethod = symbol.initMethod().get();
         assertEquals(initMethod.name(), "init");
-        assertEquals(
-                initMethod.typeDescriptor().parameters().stream().map(p -> p.name().get()).collect(Collectors.toList()),
-                fieldNames);
+        assertEquals(initMethod.typeDescriptor().parameters().stream()
+                             .map(p -> p.getName().get())
+                             .collect(Collectors.toList()), fieldNames);
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -607,8 +607,8 @@ public class TypedescriptorTest {
     }
 
     private void validateParam(ParameterSymbol param, String name, ParameterKind kind, TypeDescKind typeKind) {
-        assertEquals(param.name().get(), name);
-        assertEquals(param.kind(), kind);
+        assertEquals(param.getName().get(), name);
+        assertEquals(param.paramKind(), kind);
         assertEquals(param.typeDescriptor().typeKind(), typeKind);
     }
 }


### PR DESCRIPTION
## Purpose
Deprecating `name()` and `kind()` in `ParameterSymbol` since with the changes to `name()` in `Symbol` we plan on extending `ParameterSymbol` from `Symbol` as well. When extending from `Symbol`, we'll inherit the `getName()` method and `kind()` method. Therefore, to be compatible with those planned changes, introduced `getName()` and `paramKind()` respectively as alternatives.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
