### PR TITLE
Add debug termination tests

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTerminationListener.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTerminationListener.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.ballerinalang.debugger.test.utils;
+
+import org.ballerinalang.debugger.test.utils.client.TestDAPClientConnector;
+
+import java.util.TimerTask;
+
+/**
+ * Timer Task implementation to capture debug termination from terminated events.
+ */
+public class DebugTerminationListener extends TimerTask {
+
+    TestDAPClientConnector connector;
+    private boolean terminationFound;
+
+    public DebugTerminationListener(TestDAPClientConnector connector) {
+        this.connector = connector;
+        this.terminationFound = false;
+    }
+
+    public boolean isTerminationFound() {
+        return terminationFound;
+    }
+
+    @Override
+    public void run() {
+        // If the debuggee program execution is already finished, update terminationFound to true and
+        // cancel the timer task immediately.
+        if (!connector.getServerEventHolder().getTerminatedEvents().isEmpty() ||
+            !connector.getServerEventHolder().getExitedEvents().isEmpty()) {
+            terminationFound = true;
+            this.cancel();
+        }
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
+++ b/tests/jballerina-debugger-integration-test/src/main/java/org/ballerinalang/debugger/test/utils/DebugTestRunner.java
@@ -84,6 +84,7 @@ public class DebugTestRunner {
     private BMainInstance balClient = null;
     private Process debuggeeProcess;
     private DebugHitListener listener;
+    private DebugTerminationListener terminationListener;
     private AssertionMode assertionMode;
     private SoftAssert softAsserter;
 
@@ -349,6 +350,25 @@ public class DebugTestRunner {
             throw new BallerinaTestException("Timeout expired waiting for the debug hit");
         }
         return new ImmutablePair<>(listener.getDebugHitpoint(), listener.getDebugHitContext());
+    }
+
+    /**
+     * Waits for debug termination within a given time.
+     *
+     * @param timeoutMillis timeout.
+     * @return boolean true if debug termination is found.
+     */
+    public boolean waitForDebugTermination(long timeoutMillis) {
+        terminationListener = new DebugTerminationListener(debugClientConnector);
+        Timer timer = new Timer(true);
+        timer.scheduleAtFixedRate(terminationListener, 0, 1000);
+        try {
+            Thread.sleep(timeoutMillis);
+        } catch (InterruptedException ignored) {
+        }
+        timer.cancel();
+
+        return terminationListener.isTerminationFound();
     }
 
     /**

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugTerminationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugTerminationTest.java
@@ -30,6 +30,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+/**
+ * Test class for debug termination scenarios.
+ */
 public class DebugTerminationTest extends BaseTestCase {
 
     DebugTestRunner debugTestRunner;

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugTerminationTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/DebugTerminationTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.debugger.test.adapter;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.ballerinalang.debugger.test.BaseTestCase;
+import org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint;
+import org.ballerinalang.debugger.test.utils.DebugTestRunner;
+import org.ballerinalang.debugger.test.utils.DebugUtils;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class DebugTerminationTest extends BaseTestCase {
+
+    DebugTestRunner debugTestRunner;
+    private boolean isTerminationFound;
+
+    @BeforeClass
+    public void setup() {
+        String testProjectName = "debug-termination-tests";
+        String testModuleFileName = "main.bal";
+        debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
+    }
+
+    @Test(description = "Debug termination test for STEP_OVER action in the last line of main() method")
+    public void testDebugTerminationStepOver() throws BallerinaTestException {
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 19));
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_OVER);
+        isTerminationFound = debugTestRunner.waitForDebugTermination(10000);
+        Assert.assertTrue(isTerminationFound);
+    }
+
+    @Test(description = "Debug termination test for STEP_IN action in the last line of main() method")
+    public void testDebugTerminationStepIn() throws BallerinaTestException {
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 19));
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_IN);
+        isTerminationFound = debugTestRunner.waitForDebugTermination(10000);
+        Assert.assertTrue(isTerminationFound);
+    }
+
+    @Test(description = "Debug termination test for STEP_OUT action in the last line of main() method")
+    public void testDebugTerminationStepOut() throws BallerinaTestException {
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 19));
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_OUT);
+        isTerminationFound = debugTestRunner.waitForDebugTermination(10000);
+        Assert.assertTrue(isTerminationFound);
+    }
+
+    @Test(description = "Debug termination test for CONTINUE action in the last line of main() method")
+    public void testDebugTerminationContinue() throws BallerinaTestException {
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 19));
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        isTerminationFound = debugTestRunner.waitForDebugTermination(10000);
+        Assert.assertTrue(isTerminationFound);
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanUp() {
+        debugTestRunner.terminateDebugSession();
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/debug-termination-tests/Ballerina.toml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/debug-termination-tests/Ballerina.toml
@@ -1,0 +1,4 @@
+[package]
+org = "debug_test_resources"
+name = "debug_termination_tests"
+version = "0.1.0"

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/debug-termination-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/debug-termination-tests/main.bal
@@ -1,0 +1,19 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public function main() {
+    int x = 5;
+}

--- a/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
@@ -46,6 +46,7 @@ under the License.
             <class name="org.ballerinalang.debugger.test.adapter.ControlFlowDebugTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.CallStackDebugTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.LanguageConstructDebugTest"/>
+            <class name="org.ballerinalang.debugger.test.adapter.DebugTerminationTest"/>
 
             <!--Debug Variables Tests-->
             <class name="org.ballerinalang.debugger.test.adapter.variables.VariableVisibilityTest"/>


### PR DESCRIPTION
## Purpose
This PR will add debug termination tests for the following debug actions when the debug navigator is in the last line of `main()` method.

- [x] STEP_OVER
- [x] STEP_IN
- [x] STEP_OUT
- [x] CONTINUE

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28468

