### PR TITLE
Add annotations to BIR type-defs

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -426,6 +426,9 @@ public class BIRPackageSymbolEnter {
 
         byte[] docBytes = readDocBytes(dataInStream);
 
+        // Skip annotation attachments for now
+        dataInStream.skip(dataInStream.readLong());
+
         BType type = readBType(dataInStream);
         if (type.tag == TypeTags.INVOKABLE) {
             setInvokableTypeSymbol((BInvokableType) type);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -419,6 +419,7 @@ public class BIRGen extends BLangNodeVisitor {
         typeDef.index = this.env.enclPkg.typeDefs.size() - 1;
 
         typeDef.setMarkdownDocAttachment(astTypeDefinition.symbol.markdownDocumentation);
+        populateBIRAnnotAttachments(astTypeDefinition.annAttachments, typeDef.annotAttachments, this.env);
 
         if (astTypeDefinition.typeNode.getKind() == NodeKind.RECORD_TYPE ||
                 astTypeDefinition.typeNode.getKind() == NodeKind.OBJECT_TYPE) {
@@ -496,6 +497,8 @@ public class BIRGen extends BLangNodeVisitor {
         for (BLangType typeRef : classDefinition.typeRefs) {
             typeDef.referencedTypes.add(typeRef.type);
         }
+
+        populateBIRAnnotAttachments(classDefinition.annAttachments, typeDef.annotAttachments, this.env);
 
         for (BAttachedFunction func : ((BObjectTypeSymbol) classDefinition.symbol).referencedFunctions) {
             BInvokableSymbol funcSymbol = func.symbol;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -451,6 +451,8 @@ public abstract class BIRNode {
 
         public SymbolOrigin origin;
 
+        public List<BIRAnnotationAttachment> annotAttachments;
+
         /**
          * this is not serialized. it's used to keep the index of the def in the list.
          * otherwise the writer has to *find* it in the list.
@@ -469,6 +471,7 @@ public abstract class BIRNode {
             this.attachedFuncs = attachedFuncs;
             this.referencedTypes = new ArrayList<>();
             this.origin = origin;
+            this.annotAttachments = new ArrayList<>();
         }
 
         @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -177,6 +177,7 @@ public class BIRBinaryWriter {
         buf.writeByte(typeDef.origin.value());
         // write documentation
         typeWriter.writeMarkdownDocAttachment(buf, typeDef.markdownDocAttachment);
+        writeAnnotAttachments(buf, typeDef.annotAttachments);
         writeType(buf, typeDef.type);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
@@ -87,7 +87,7 @@ public class BObjectType extends BStructureType implements ObjectType {
                 sb.append("isolated ");
             }
 
-            sb.append(isClass? CLASS : OBJECT).append(SPACE).append(LEFT_CURL);
+            sb.append(isClass ? CLASS : OBJECT).append(SPACE).append(LEFT_CURL);
             for (BField field : fields.values()) {
                 var flags = field.symbol.flags;
                 if (Symbols.isFlagOn(flags, Flags.PUBLIC)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
@@ -35,7 +35,6 @@ import org.wso2.ballerinalang.util.Flags;
 public class BObjectType extends BStructureType implements ObjectType {
 
     private static final String OBJECT = "object";
-    private static final String CLASS = "class";
     private static final String SPACE = " ";
     private static final String PUBLIC = "public";
     private static final String PRIVATE = "private";
@@ -74,11 +73,6 @@ public class BObjectType extends BStructureType implements ObjectType {
 
     @Override
     public String toString() {
-        boolean isClass = false;
-        if (this.tsymbol != null) {
-            isClass = (this.tsymbol.flags & Flags.CLASS) == Flags.CLASS;
-        }
-
         if (shouldPrintShape()) {
             StringBuilder sb = new StringBuilder();
 
@@ -87,7 +81,7 @@ public class BObjectType extends BStructureType implements ObjectType {
                 sb.append("isolated ");
             }
 
-            sb.append(isClass ? CLASS : OBJECT).append(SPACE).append(LEFT_CURL);
+            sb.append(OBJECT).append(SPACE).append(LEFT_CURL);
             for (BField field : fields.values()) {
                 var flags = field.symbol.flags;
                 if (Symbols.isFlagOn(flags, Flags.PUBLIC)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
@@ -35,6 +35,7 @@ import org.wso2.ballerinalang.util.Flags;
 public class BObjectType extends BStructureType implements ObjectType {
 
     private static final String OBJECT = "object";
+    private static final String CLASS = "class";
     private static final String SPACE = " ";
     private static final String PUBLIC = "public";
     private static final String PRIVATE = "private";
@@ -73,6 +74,10 @@ public class BObjectType extends BStructureType implements ObjectType {
 
     @Override
     public String toString() {
+        boolean isClass = false;
+        if (this.tsymbol != null) {
+            isClass = (this.tsymbol.flags & Flags.CLASS) == Flags.CLASS;
+        }
 
         if (shouldPrintShape()) {
             StringBuilder sb = new StringBuilder();
@@ -82,7 +87,7 @@ public class BObjectType extends BStructureType implements ObjectType {
                 sb.append("isolated ");
             }
 
-            sb.append(OBJECT).append(SPACE).append(LEFT_CURL);
+            sb.append(isClass? CLASS : OBJECT).append(SPACE).append(LEFT_CURL);
             for (BField field : fields.values()) {
                 var flags = field.symbol.flags;
                 if (Symbols.isFlagOn(flags, Flags.PUBLIC)) {

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -479,6 +479,8 @@ types:
         type: s1
       - id: doc
         type: markdown
+      - id: annotation_attachments_content
+        type: annotation_attachments_content
       - id: type_cp_index
         type: s4
   type_definition_body:


### PR DESCRIPTION
## Purpose
Add annotations to BIR type-defs, BIR functions already have this. This change do change the BIR.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
