### PR TITLE
Fix invalid iteration type for `xml` in `from` clause

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/QueryDesugar.java
@@ -265,7 +265,9 @@ public class QueryDesugar extends BLangNodeVisitor {
             onConflictExpr = null;
         } else {
             BLangVariableReference result;
-            if (TypeTags.isXMLTypeTag(queryExpr.type.tag)) {
+            if (TypeTags.isXMLTypeTag(queryExpr.type.tag) || (queryExpr.type.tag == TypeTags.UNION &&
+                    ((BUnionType) queryExpr.type).getMemberTypes().stream()
+                            .allMatch(memType -> TypeTags.isXMLTypeTag(memType.tag)))) {
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_XML_FUNCTION, Lists.of(streamRef), pos);
             } else if (TypeTags.isStringTypeTag(queryExpr.type.tag)) {
                 result = getStreamFunctionVariableRef(queryBlock, QUERY_TO_STRING_FUNCTION, Lists.of(streamRef), pos);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -1880,7 +1880,11 @@ public class Types {
                 varType = inferRecordFieldType(recordType);
                 break;
             case TypeTags.XML:
-                varType = BUnionType.create(null, symTable.xmlType, symTable.stringType);
+                BXMLType xmlType = (BXMLType) collectionType;
+                varType = xmlType.constraint;
+                break;
+            case TypeTags.XML_TEXT:
+                varType = symTable.xmlTextType;
                 break;
             case TypeTags.TABLE:
                 BTableType tableType = (BTableType) collectionType;

--- a/langlib/lang.query/src/main/ballerina/types.bal
+++ b/langlib/lang.query/src/main/ballerina/types.bal
@@ -141,10 +141,10 @@ class _InitFunction {
             return lang_map:iterator(collection);
         } else if (collection is map<Type>) {
             return lang_map:iterator(collection);
-        } else if (collection is string) {
-            return lang_string:iterator(collection);
         } else if (collection is xml) {
             return lang_xml:iterator(collection);
+        } else if (collection is string) {
+            return lang_string:iterator(collection);
         } else if (collection is table<map<Type>>) {
             return lang_table:iterator(collection);
         } else if (collection is _Iterable) {
@@ -261,10 +261,10 @@ class _NestedFromFunction {
             return lang_map:iterator(collection);
         } else if (collection is map<Type>) {
             return lang_map:iterator(collection);
-        } else if (collection is string) {
-            return lang_string:iterator(collection);
         } else if (collection is xml) {
             return lang_xml:iterator(collection);
+        } else if (collection is string) {
+            return lang_string:iterator(collection);
         } else if (collection is table<map<Type>>) {
             return lang_table:iterator(collection);
         } else if (collection is _Iterable) {

--- a/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
+++ b/tests/ballerina-test-utils/src/main/java/org/ballerinalang/test/BRunUtil.java
@@ -1177,6 +1177,10 @@ public class BRunUtil {
                 bvmObjectType.setFields(objectFields);
                 return bvmObjectType;
             case io.ballerina.runtime.api.TypeTags.XML_TAG:
+            case io.ballerina.runtime.api.TypeTags.XML_ELEMENT_TAG:
+            case io.ballerina.runtime.api.TypeTags.XML_COMMENT_TAG:
+            case io.ballerina.runtime.api.TypeTags.XML_PI_TAG:
+            case io.ballerina.runtime.api.TypeTags.XML_TEXT_TAG:
                 return BTypes.typeXML;
             case io.ballerina.runtime.api.TypeTags.TYPEDESC_TAG:
                 TypedescType typedescType = (TypedescType) jvmType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryActionTest.java
@@ -18,6 +18,7 @@
 
 package org.ballerinalang.test.query;
 
+import org.ballerinalang.core.model.values.BFloat;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BMap;
 import org.ballerinalang.core.model.values.BValue;
@@ -126,6 +127,13 @@ public class QueryActionTest {
 
         Assert.assertEquals(employee.get("firstName").stringValue(), "Alex");
         Assert.assertEquals(employee.get("deptAccess").stringValue(), "Human Resource");
+    }
+
+    @Test(description = "Test query expression iterating over xml<xml:Element> in from clause in query action")
+    public void testQueryExpressionIteratingOverXMLInFromInQueryAction() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLInFromInQueryAction");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(((BFloat) returnValues[0]).floatValue(), 149.93);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryNegativeTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryNegativeTests.java
@@ -35,7 +35,7 @@ public class QueryNegativeTests {
     @Test
     public void testFromClauseWithInvalidType() {
         CompileResult compileResult = BCompileUtil.compile("test-src/query/query-negative.bal");
-        Assert.assertEquals(compileResult.getErrorCount(), 24);
+        Assert.assertEquals(compileResult.getErrorCount(), 23);
         int index = 0;
 
         validateError(compileResult, index++, "incompatible types: expected 'Person', found 'Teacher'",
@@ -59,15 +59,14 @@ public class QueryNegativeTests {
                 "'(string|float)'", 222, 10);
         validateError(compileResult, index++, "incompatible types: expected 'Address', found 'map<string>'", 241, 13);
         validateError(compileResult, index++, "incompatible types: expected 'FullName[]', found 'error?'", 266, 13);
-        validateError(compileResult, index++, "incompatible types: expected 'xml', found '(xml|string)'", 283, 24);
-        validateError(compileResult, index++, "incompatible types: expected 'string', found 'int'", 297, 24);
+        validateError(compileResult, index++, "incompatible types: expected 'string', found 'int'", 278, 24);
         validateError(compileResult, index++, "a type compatible with mapping constructor expressions " +
-                "not found in type 'string'", 311, 24);
-        validateError(compileResult, index++, "ambiguous type '[xml, xml]'", 333, 24);
-        validateError(compileResult, index++, "ambiguous type '[string, string]'", 346, 24);
-        validateError(compileResult, index++, "redeclared symbol 'fname'", 370, 36);
-        validateError(compileResult, index++, "redeclared symbol 'age'", 383, 21);
-        validateError(compileResult, index, "redeclared symbol 'age'", 400, 44);
+                "not found in type 'string'", 292, 24);
+        validateError(compileResult, index++, "ambiguous type '[xml, xml]'", 314, 24);
+        validateError(compileResult, index++, "ambiguous type '[string, string]'", 327, 24);
+        validateError(compileResult, index++, "redeclared symbol 'fname'", 351, 36);
+        validateError(compileResult, index++, "redeclared symbol 'age'", 364, 21);
+        validateError(compileResult, index, "redeclared symbol 'age'", 381, 44);
     }
 
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/XMLQueryExpressionTest.java
@@ -200,6 +200,56 @@ public class XMLQueryExpressionTest {
         Assert.assertEquals(returnValues[0].stringValue(), "<doc> <entry>Value</entry> </doc>");
     }
 
+    @Test(description = "Test query expression iterating over xml in from clause")
+    public void testQueryExpressionIteratingOverXMLInFrom() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLInFrom");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<foo>Hello<bar>World</bar></foo>");
+    }
+
+    @Test(description = "Test query expression iterating over xml:Text in from clause")
+    public void testQueryExpressionIteratingOverXMLTextInFrom() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLTextInFrom");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "hello text");
+    }
+
+    @Test(description = "Test query expression iterating over xml<xml:Element> in from clause")
+    public void testQueryExpressionIteratingOverXMLElementInFrom() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLElementInFrom");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<foo>Hello<bar>World</bar></foo>");
+    }
+
+    @Test(description = "Test query expression iterating over xml<xml:ProcessingInstruction> in from clause")
+    public void testQueryExpressionIteratingOverXMLPIInFrom() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLPIInFrom");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<?xml-stylesheet type=\"text/xsl\" href=\"style.xsl\"?>");
+    }
+
+    @Test(description = "Test query expression iterating over xml<xml:Element> in from clause with other clauses")
+    public void testQueryExpressionIteratingOverXMLWithOtherClauses() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLWithOtherClauses");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<author>Dan Brown</author><author>Enid Blyton</author>");
+    }
+
+    @Test(description = "Test query expression iterating over xml<xml:Comment> in from clause with xml or nil result")
+    public void testQueryExpressionIteratingOverXMLInFromWithXMLOrNilResult() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLInFromWithXMLOrNilResult");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<!-- this is a comment text -->");
+    }
+
+    @Test(description = "Test query expression iterating over xml<xml:Element> in from clause in inner queries")
+    public void testQueryExpressionIteratingOverXMLInFromInInnerQueries() {
+        BValue[] returnValues = BRunUtil.invoke(result, "testQueryExpressionIteratingOverXMLInFromInInnerQueries");
+        Assert.assertNotNull(returnValues);
+        Assert.assertEquals(returnValues[0].stringValue(), "<author>Enid Blyton</author>" +
+                "<author>Sir Arthur Conan Doyle</author><author>Dan Brown</author>");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/inner-queries.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/inner-queries.bal
@@ -271,7 +271,7 @@ function testMultipleJoinClausesWithInnerQueries5() returns boolean {
 
     float total = 0;
     var res =
-        from var price in (from var book in bookstore/<book> select <xml> book)/**/<price>
+        from var price in (from var book in bookstore/<book> select book)/**/<price>
         do {
             var p = (<xml> price)/*;
             if (p is 'xml:Text) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/order-by-clause.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/order-by-clause.bal
@@ -421,7 +421,7 @@ function testQueryExprWithOrderByClauseReturnXML() returns xml {
     xml authors = from var book in bookStore/<book>/<author>
                   order by book.toString()
                   limit 2
-                  select <xml> book;
+                  select book;
 
     return  authors;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-action.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-action.bal
@@ -163,3 +163,37 @@ function testSimpleSelectQueryWithMultipleFromClauses() returns  Employee[] {
             };
     return  employeeList;
 }
+
+function testQueryExpressionIteratingOverXMLInFromInQueryAction() returns float {
+    xml<xml:Element> bookstore = xml `<bookstore>
+                                          <book category="cooking">
+                                              <title lang="en">Everyday Italian</title>
+                                              <price>30.00</price>
+                                          </book>
+                                          <book category="children">
+                                              <title lang="en">Harry Potter</title>
+                                              <price>29.99</price>
+                                          </book>
+                                          <book category="web">
+                                              <title lang="en">XQuery Kick Start</title>
+                                              <price>49.99</price>
+                                          </book>
+                                          <book category="web" cover="paperback">
+                                              <title lang="en">Learning XML</title>
+                                              <price>39.95</price>
+                                          </book>
+                                      </bookstore>`;
+
+    float total = 0;
+    var res = from xml:Element price in bookstore/<book>/**/<price>
+              do {
+                  var p = price/*;
+                  if (p is xml:Text) {
+                      var i = float:fromString(p.toString());
+                      if (i is float) {
+                          total += i;
+                      }
+                  }
+              };
+    return total;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/query-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/query-negative.bal
@@ -266,25 +266,6 @@ function testReassignValueInLet() returns FullName[]{
     return  outputNameList;
 }
 
-function testQueryExprForXML() returns xml {
-    xml book1 = xml `<book>
-                           <name>Sherlock Holmes</name>
-                           <author>Sir Arthur Conan Doyle</author>
-                     </book>`;
-
-    xml book2 = xml `<book>
-                           <name>The Da Vinci Code</name>
-                           <author>Dan Brown</author>
-                    </book>`;
-
-    xml book = book1 + book2;
-
-    xml books = from var x in book/<name>
-                select x;
-
-    return  books;
-}
-
 function testQueryExprForString() returns string {
     Person p1 = {firstName: "Alex", lastName: "George", age: 23};
     Person p2 = {firstName: "Ranjan", lastName: "Fonseka", age: 30};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/query/xml-query-expression.bal
@@ -28,7 +28,7 @@ function testSimpleQueryExprForXML() returns xml {
     xml book = book1 + book2;
 
     xml books = from var x in book/<name>
-                select <xml> x;
+                select x;
 
     return  books;
 }
@@ -39,7 +39,7 @@ function testSimpleQueryExprForXML2() returns xml {
     xml compositeXml = theXml + bitOfText;
 
     xml finalOutput = from var elem in compositeXml
-                      select <xml> elem;
+                      select elem;
 
     return  finalOutput;
 }
@@ -77,7 +77,7 @@ function testSimpleQueryExprForXML3() returns xml {
                     </bookstore>`;
 
     xml finalOutput = from var price in bookstore/**/<price>
-                      select <xml> price;
+                      select price;
 
     return  finalOutput;
 }
@@ -100,7 +100,7 @@ function testQueryExprWithLimitForXML() returns xml {
 
     xml authors = from var book in bookStore/<book>/<author>
                   limit 2
-                  select <xml> book;
+                  select book;
 
     return  authors;
 }
@@ -127,7 +127,7 @@ function testQueryExprWithWhereLetClausesForXML() returns xml {
     xml authors = from var x in bookStore/<book>/<author>
                   let string authorDetails = "<author>Enid Blyton</author>"
                   where x.toString() == authorDetails
-                  select <xml> x;
+                  select x;
 
     return  authors;
 }
@@ -159,7 +159,7 @@ function testQueryExprWithMultipleFromClausesForXML() returns xml {
 
     xml authors = from var x in bookStore/<book>/<author>
                   from var y in authorList/<author>/<name>
-                  select <xml> y;
+                  select y;
 
     return  authors;
 }
@@ -178,7 +178,7 @@ function testSimpleQueryExprForXMLOrNilResult() returns xml? {
     xml book = book1 + book2;
 
     xml? books = from var x in book/<name>
-                select <xml> x;
+                select x;
 
     return  books;
 }
@@ -189,7 +189,7 @@ function testSimpleQueryExprForXMLOrNilResult2() returns xml? {
     xml compositeXml = theXml + bitOfText;
 
     xml? finalOutput = from var elem in compositeXml
-                      select <xml> elem;
+                      select elem;
 
     return  finalOutput;
 }
@@ -227,7 +227,7 @@ function testSimpleQueryExprForXMLOrNilResult3() returns xml? {
                     </bookstore>`;
 
     xml? finalOutput = from var price in bookstore/**/<price>
-                      select <xml> price;
+                      select price;
 
     return  finalOutput;
 }
@@ -250,7 +250,7 @@ function testQueryExprWithLimitForXMLOrNilResult() returns xml? {
 
     xml? authors = from var book in bookStore/<book>/<author>
                   limit 2
-                  select <xml> book;
+                  select book;
 
     return  authors;
 }
@@ -277,7 +277,7 @@ function testQueryExprWithWhereLetClausesForXMLOrNilResult() returns xml? {
     xml? authors = from var x in bookStore/<book>/<author>
                   let string authorDetails = "<author>Enid Blyton</author>"
                   where x.toString() == authorDetails
-                  select <xml> x;
+                  select x;
 
     return  authors;
 }
@@ -309,7 +309,7 @@ function testQueryExprWithMultipleFromClausesForXMLOrNilResult() returns xml? {
 
     xml? authors = from var x in bookStore/<book>/<author>
                   from var y in authorList/<author>/<name>
-                  select <xml> y;
+                  select y;
 
     return  authors;
 }
@@ -328,7 +328,7 @@ function testSimpleQueryExprWithVarForXML() returns xml {
     xml book = book1 + book2;
 
     var books = from var x in book/<name>
-                select <xml> x;
+                select x;
 
     return  books;
 }
@@ -347,7 +347,7 @@ function testSimpleQueryExprWithListForXML() returns xml[] {
     xml book = book1 + book2;
 
     xml[] books = from var x in book/<name>
-                select <xml> x;
+                select x;
 
     return  books;
 }
@@ -366,7 +366,7 @@ function testSimpleQueryExprWithUnionTypeForXML() returns error|xml {
     xml book = book1 + book2;
 
     error|xml books = from var x in book/<name>
-                select <xml> x;
+                select x;
 
     return  books;
 }
@@ -385,7 +385,7 @@ function testSimpleQueryExprWithUnionTypeForXML2() returns xml[]|error {
     xml book = book1 + book2;
 
     xml[]|error books = from var x in book/<name>
-                select <xml> x;
+                select x;
 
     return  books;
 }
@@ -427,5 +427,79 @@ public function testSimpleQueryExprWithNestedXMLElements() returns xml {
          let var value = <xml> x/<'field>[3].name
          select xml `<entry>${<string> checkpanic value}</entry>`} </doc>`;
 
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLInFrom() returns xml {
+    xml x = xml `<foo>Hello<bar>World</bar></foo>`;
+    xml res = from xml y in x select y;
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLTextInFrom() returns xml {
+    xml:Text x = xml `hello text`;
+    xml res = from xml y in x select y;
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLElementInFrom() returns xml {
+    xml<xml:Element> x = xml `<foo>Hello<bar>World</bar></foo>`;
+    xml<xml:Element> res = from xml:Element y in x select y;
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLPIInFrom() returns xml {
+    xml<xml:ProcessingInstruction> x = xml `<?xml-stylesheet type="text/xsl" href="style.xsl"?>`;
+    xml res = from var y in x select y;
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLWithOtherClauses() returns xml {
+    xml<xml:Element> bookStore = xml `<bookStore>
+                                        <book>
+                                            <name>The Enchanted Wood</name>
+                                            <author>Enid Blyton</author>
+                                        </book>
+                                        <book>
+                                            <name>Sherlock Holmes</name>
+                                            <author>Sir Arthur Conan Doyle</author>
+                                        </book>
+                                        <book>
+                                            <name>The Da Vinci Code</name>
+                                            <author>Dan Brown</author>
+                                        </book>
+                                    </bookStore>`;
+
+    xml res = from xml<xml:Element> book in bookStore/<book>/<author>
+              order by book.toString()
+              limit 2
+              select book;
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLInFromWithXMLOrNilResult() returns xml? {
+    xml<xml:Comment> x = xml `<!-- this is a comment text -->`;
+    xml? res = from var y in x select y;
+    return res;
+}
+
+function testQueryExpressionIteratingOverXMLInFromInInnerQueries() returns xml? {
+    xml<xml:Element> bookStore = xml `<bookStore>
+                                        <book>
+                                            <name>The Enchanted Wood</name>
+                                            <author>Enid Blyton</author>
+                                        </book>
+                                        <book>
+                                            <name>Sherlock Holmes</name>
+                                            <author>Sir Arthur Conan Doyle</author>
+                                        </book>
+                                        <book>
+                                            <name>The Da Vinci Code</name>
+                                            <author>Dan Brown</author>
+                                        </book>
+                                    </bookStore>`;
+
+    xml res = from var book in (from xml:Element e in bookStore/<book>/<author> select e)
+              select book;
     return res;
 }


### PR DESCRIPTION
## Purpose
$title since iterating over `xml` now returns `xml` and iterating over `xml<T>` returns `T`.

Fixes #28436

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
