### PR TITLE
Fix Add as resource bug when service name is blank

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/kubernetes/AbstractInvalidResourceCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/kubernetes/AbstractInvalidResourceCodeAction.java
@@ -96,6 +96,8 @@ public abstract class AbstractInvalidResourceCodeAction extends ProbeBasedDiagno
         String serviceResourcePath;
         if (tomlPath.equals(serviceName)) {
             serviceResourcePath = ".";
+        } else if (serviceName.equals("")) {
+            serviceResourcePath = tomlPath;
         } else if (tomlPath.startsWith(serviceName)) {
             serviceResourcePath = tomlPath.substring(serviceName.length() + 1);
         } else {


### PR DESCRIPTION
## Purpose
This PR fixes the issue where you get invalid code action for adding resource to service when the service name is blank(/). 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
