### PR TITLE
Improve the synchronization of the compiler context in PackageCompilation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -59,7 +59,7 @@ public class PackageCompilation {
     private final List<Diagnostic> pluginDiagnostics;
 
     private DiagnosticResult diagnosticResult;
-    private boolean compiled;
+    private volatile boolean compiled;
 
     private PackageCompilation(PackageContext rootPackageContext,
                                PackageResolution packageResolution) {
@@ -99,18 +99,12 @@ public class PackageCompilation {
     }
 
     public DiagnosticResult diagnosticResult() {
-        // TODO think about parallel invocations of this method
-        if (!compiled) {
-            compile();
-        }
+        compileIfRequired();
         return diagnosticResult;
     }
 
     public SemanticModel getSemanticModel(ModuleId moduleId) {
-        // TODO think about parallel invocations of this method
-        if (!compiled) {
-            compile();
-        }
+        compileIfRequired();
 
         ModuleContext moduleContext = this.rootPackageContext.moduleContext(moduleId);
         // We check whether the particular module compilation state equal to the typecheck phase here. 
@@ -139,8 +133,16 @@ public class PackageCompilation {
         return rootPackageContext;
     }
 
-    private void compile() {
+    private void compileIfRequired() {
+        if (compiled) {
+            return;
+        }
+
         synchronized (this.compilerContext) {
+            if (compiled) {
+                return;
+            }
+            
             List<Diagnostic> diagnostics = new ArrayList<>();
             for (ModuleContext moduleContext : packageResolution.topologicallySortedModuleList()) {
                 moduleContext.compile(compilerContext);


### PR DESCRIPTION
## Purpose
This is an extension of the fix done for #28341. This checks the `compiled` flag before and after synchronizing to determine whether a compilation is required or not
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
