### PR TITLE
Add XML code coverage report generation to testerina

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -31,7 +31,6 @@ import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.jacoco.core.tools.ExecFileLoader;
-import org.jacoco.report.DirectorySourceFileLocator;
 import org.jacoco.report.IReportVisitor;
 import org.jacoco.report.xml.XMLFormatter;
 
@@ -60,7 +59,6 @@ import static org.jacoco.core.analysis.ICounter.PARTLY_COVERED;
  */
 public class CoverageReport {
 
-    private static final int TAB_WIDTH = 4;
     private final String title;
     private final Path coverageDir;
     private Path executionDataFile;
@@ -141,14 +139,16 @@ public class CoverageReport {
             File reportFile = new File(target.getReportPath().resolve(
                     this.module.moduleName().toString()).resolve(REPORT_XML_FILE).toString());
             reportFile.getParentFile().mkdirs();
-            IReportVisitor visitor = xmlFormatter.createVisitor(new FileOutputStream(reportFile));
-            visitor.visitInfo(execFileLoader.getSessionInfoStore().getInfos(),
-                    execFileLoader.getExecutionDataStore().getContents());
 
-            visitor.visitBundle(bundleCoverage,
-                    new DirectorySourceFileLocator(null, "utf-8", TAB_WIDTH));
+            try (FileOutputStream fileOutputStream = new FileOutputStream(reportFile)) {
+                IReportVisitor visitor = xmlFormatter.createVisitor(fileOutputStream);
+                visitor.visitInfo(execFileLoader.getSessionInfoStore().getInfos(),
+                        execFileLoader.getExecutionDataStore().getContents());
 
-            visitor.visitEnd();
+                visitor.visitBundle(bundleCoverage, null);
+
+                visitor.visitEnd();
+            }
     }
 
     private void createReport(final IBundleCoverage bundleCoverage, ModuleCoverage moduleCoverage) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -33,8 +33,6 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 import org.jacoco.core.tools.ExecFileLoader;
 import org.jacoco.report.DirectorySourceFileLocator;
 import org.jacoco.report.IReportVisitor;
-import org.jacoco.report.ISourceFileLocator;
-import org.jacoco.report.MultiSourceFileLocator;
 import org.jacoco.report.xml.XMLFormatter;
 
 import java.io.File;
@@ -43,15 +41,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import static io.ballerina.runtime.api.utils.IdentifierUtils.decodeIdentifier;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.BIN_DIR;
 import static org.ballerinalang.test.runtime.util.TesterinaConstants.BLANG_SRC_FILE_SUFFIX;
+import static org.ballerinalang.test.runtime.util.TesterinaConstants.REPORT_XML_FILE;
 import static org.jacoco.core.analysis.ICounter.FULLY_COVERED;
 import static org.jacoco.core.analysis.ICounter.NOT_COVERED;
 import static org.jacoco.core.analysis.ICounter.PARTLY_COVERED;
@@ -63,19 +60,16 @@ import static org.jacoco.core.analysis.ICounter.PARTLY_COVERED;
  */
 public class CoverageReport {
 
+    private static final int TAB_WIDTH = 4;
     private final String title;
     private final Path coverageDir;
     private Path executionDataFile;
     private Path classesDirectory;
     private ExecFileLoader execFileLoader;
-
-    private int tabwidth = 4;
-
     private Module module;
     private Target target;
 
     public CoverageReport(Module module) throws IOException {
-
         this.module = module;
         this.target = new Target(module.project().sourceRoot());
 
@@ -92,7 +86,6 @@ public class CoverageReport {
      * @throws IOException when file operations are failed
      */
     public ModuleCoverage generateReport(JarResolver jarResolver) throws IOException {
-
         String orgName = this.module.packageInstance().packageOrg().toString();
         String packageName = this.module.packageInstance().packageName().toString();
         String version = this.module.packageInstance().packageVersion().toString();
@@ -134,38 +127,31 @@ public class CoverageReport {
             String msg = "Unable to generate code coverage for the module " + packageName + ". Jar files dont exist.";
             throw new NoSuchFileException(msg);
         }
-
     }
 
     private IBundleCoverage analyzeStructure() throws IOException {
-
         final CoverageBuilder coverageBuilder = new CoverageBuilder();
         final Analyzer analyzer = new Analyzer(execFileLoader.getExecutionDataStore(), coverageBuilder);
         analyzer.analyzeAll(classesDirectory.toFile());
         return coverageBuilder.getBundle(title);
     }
 
-    private void createXMLReport(IBundleCoverage bundleCoverage) {
-
-        try {
+    private void createXMLReport(IBundleCoverage bundleCoverage) throws IOException {
             XMLFormatter xmlFormatter = new XMLFormatter();
             File reportFile = new File(target.getReportPath().resolve(
-                    this.module.moduleName().toString()).resolve("report.xml").toString());
+                    this.module.moduleName().toString()).resolve(REPORT_XML_FILE).toString());
             reportFile.getParentFile().mkdirs();
             IReportVisitor visitor = xmlFormatter.createVisitor(new FileOutputStream(reportFile));
             visitor.visitInfo(execFileLoader.getSessionInfoStore().getInfos(),
                     execFileLoader.getExecutionDataStore().getContents());
 
             visitor.visitBundle(bundleCoverage,
-                    new DirectorySourceFileLocator(null, "utf-8", 4));
+                    new DirectorySourceFileLocator(null, "utf-8", TAB_WIDTH));
 
             visitor.visitEnd();
-        } catch (IOException e) {
-        }
     }
 
     private void createReport(final IBundleCoverage bundleCoverage, ModuleCoverage moduleCoverage) {
-
         boolean containsSourceFiles = true;
 
         for (IPackageCoverage packageCoverage : bundleCoverage.getPackages()) {
@@ -211,7 +197,6 @@ public class CoverageReport {
     }
 
     private List<Path> filterPaths(Collection<Path> pathCollection) {
-
         List<Path> filteredPathList = new ArrayList<>();
 
         for (Path path : pathCollection) {
@@ -223,58 +208,4 @@ public class CoverageReport {
 
         return filteredPathList;
     }
-
-    private void writeReport(final IBundleCoverage bundle) {
-
-        try {
-            final IReportVisitor visitor = createReportVisitor();
-
-            // Not sure what this does. Enable and test
-
-            final ExecFileLoader loader = new ExecFileLoader();
-            File execFile = coverageDir.resolve("ballerina.exec").toFile();
-            loader.load(execFile);
-
-            visitor.visitInfo(loader.getSessionInfoStore().getInfos(), loader.getExecutionDataStore().getContents());
-            visitor.visitBundle(bundle, getSourceLocator());
-            visitor.visitEnd();
-
-        } catch (IOException e) {
-        }
-
-    }
-
-    private IReportVisitor createReportVisitor() throws IOException {
-
-        IReportVisitor visitor = null;
-
-        final XMLFormatter formatter = new XMLFormatter();
-        visitor =
-                formatter.createVisitor(new FileOutputStream(target.getReportPath().resolve("report.xml").toString()));
-
-//        final HTMLFormatter formatter = new HTMLFormatter();
-//        visitor =
-//                formatter.createVisitor(
-//                new FileMultiReportOutput(target.getReportPath().resolve("report.html").toFile()));
-
-        return visitor;
-    }
-
-    private ISourceFileLocator getSourceLocator() throws IOException {
-
-        final MultiSourceFileLocator multi = new MultiSourceFileLocator(tabwidth);
-
-        List<File> sourcefiles = null;
-
-        sourcefiles = Files.walk(Paths.get(coverageDir.resolve(BIN_DIR).toString()))
-                .filter(Files::isRegularFile)
-                .map(Path::toFile)
-                .collect(Collectors.toList());
-
-        for (final File f : sourcefiles) {
-            multi.add(new DirectorySourceFileLocator(f, null, tabwidth));
-        }
-        return multi;
-    }
-
 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
@@ -49,7 +49,7 @@ public class TesterinaConstants {
     public static final String RESULTS_JSON_FILE = "test_results.json";
     public static final String RERUN_TEST_JSON_FILE = "rerun_test.json";
     public static final String RESULTS_HTML_FILE = "index.html";
-    public static final String REPORT_XML_FILE = "report.xml";
+    public static final String REPORT_XML_FILE = "coverage-report.xml";
     public static final String TOOLS_DIR_NAME = "tools";
     public static final String REPORT_DIR_NAME = "report";
     public static final String REPORT_ZIP_NAME = REPORT_DIR_NAME + ".zip";

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/TesterinaConstants.java
@@ -49,6 +49,7 @@ public class TesterinaConstants {
     public static final String RESULTS_JSON_FILE = "test_results.json";
     public static final String RERUN_TEST_JSON_FILE = "rerun_test.json";
     public static final String RESULTS_HTML_FILE = "index.html";
+    public static final String REPORT_XML_FILE = "report.xml";
     public static final String TOOLS_DIR_NAME = "tools";
     public static final String REPORT_DIR_NAME = "report";
     public static final String REPORT_ZIP_NAME = REPORT_DIR_NAME + ".zip";


### PR DESCRIPTION
## Purpose
Generating a XML coverage report using Jacoco API in Testerina

**Fix:** [#28642](https://github.com/ballerina-platform/ballerina-lang/issues/28642)

## Approach
Use Jacoco API 's ```XMLFormatter``` object to generate the XML report. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
