### PR TITLE
Fix CCE in TreeModifier when modifying error message match pattern

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -13808,9 +13808,9 @@ public class BallerinaParser extends AbstractParser {
             case ERROR_KEYWORD:
                 return parseMatchPattern();
             case VAR_KEYWORD:
-                STNode varKeyword = consume();
+                STNode varType = createBuiltinSimpleNameReference(consume());
                 STNode variableName = createCaptureOrWildcardBP(parseVariableName());
-                return STNodeFactory.createTypedBindingPatternNode(varKeyword, variableName);
+                return STNodeFactory.createTypedBindingPatternNode(varType, variableName);
             case CLOSE_PAREN_TOKEN:
                 return null;
             default:

--- a/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_assert_12.json
+++ b/compiler/ballerina-parser/src/test/resources/statements/match-stmt/match_stmt_assert_12.json
@@ -429,11 +429,16 @@
                                       "kind": "TYPED_BINDING_PATTERN",
                                       "children": [
                                         {
-                                          "kind": "VAR_KEYWORD",
-                                          "trailingMinutiae": [
+                                          "kind": "VAR_TYPE_DESC",
+                                          "children": [
                                             {
-                                              "kind": "WHITESPACE_MINUTIAE",
-                                              "value": " "
+                                              "kind": "VAR_KEYWORD",
+                                              "trailingMinutiae": [
+                                                {
+                                                  "kind": "WHITESPACE_MINUTIAE",
+                                                  "value": " "
+                                                }
+                                              ]
                                             }
                                           ]
                                         },

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/ParserTestFormatter.java
@@ -67,7 +67,6 @@ public class ParserTestFormatter extends FormatterTest {
                 "ambiguity_source_11.bal", // parser issue for indexed expressions #26420
                 "annotations_source_04.bal", // could be considered an invalid scenario
                 "receive_action_source_01.bal", // issue #26376
-                "match_stmt_source_12.bal", // issue #28520
                 "doc_source_21.bal", // issue #28172
 
                 "service_decl_source_02.bal", "service_decl_source_05.bal", "service_decl_source_17.bal",


### PR DESCRIPTION
## Purpose
$subject
Wrap `var` as a type desc in error message match pattern.

Fixes #28520

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
