### PR TITLE
Make pluginDiagnostics package private

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -174,7 +174,7 @@ public class PackageCompilation {
         diagnostics.addAll(diagnosticResult.allDiagnostics);
     }
 
-    public List<Diagnostic> pluginDiagnostics() {
+    List<Diagnostic> pluginDiagnostics() {
         return pluginDiagnostics;
     }
 }


### PR DESCRIPTION
## Purpose
Made pluginDiagnostics() method package private as its only being used by JBallerinaBackend to get the diagnostics popped from compiler extensions.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
