### PR TITLE
Disable update documentation code action for service fields

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/UpdateDocumentationCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/docs/UpdateDocumentationCodeAction.java
@@ -79,6 +79,12 @@ public class UpdateDocumentationCodeAction extends AbstractCodeActionProvider {
         if (topLevelNode.isEmpty()) {
             return Collections.emptyList();
         }
+
+        // TODO: #27493 Documenting services is not fully supported yet due to a limitation in semantic API
+        if (topLevelNode.get().kind() == SyntaxKind.SERVICE_DECLARATION) {
+            return Collections.emptyList();
+        }
+        
         NonTerminalNode node = topLevelNode.get();
         if (node.kind() == SyntaxKind.MARKDOWN_DOCUMENTATION) {
             // If diagnostic message positions inside docs, get parent() node

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AbstractCommandExecutionTest.java
@@ -66,10 +66,8 @@ public abstract class AbstractCommandExecutionTest {
         TestUtil.openDocument(serviceEndpoint, sourcePath);
         JsonObject configJsonObject = FileUtils.fileContentAsObject(configJsonPath);
         JsonObject expected = configJsonObject.get("expected").getAsJsonObject();
-        List<Object> args = new ArrayList<>();
-        JsonObject arguments = configJsonObject.get("arguments").getAsJsonObject();
-        args.add(CommandArgument.from(CommandConstants.ARG_KEY_DOC_URI, sourcePath.toUri().toString()));
-        args.add(CommandArgument.from(CommandConstants.ARG_KEY_NODE_POS, arguments.getAsJsonObject("node.position")));
+        
+        List<Object> args = getArgs(configJsonObject, sourcePath);
 
         JsonObject responseJson = getCommandResponse(args, command);
         responseJson.get("result").getAsJsonObject().get("edit").getAsJsonObject().getAsJsonArray("documentChanges")
@@ -99,6 +97,25 @@ public abstract class AbstractCommandExecutionTest {
                 {"testGenerationForServicesNegative.json", Paths.get("testgen", "module2", "services.bal")},
         };
     }
+
+    /**
+     * Get args to be sent to LS.
+     *
+     * @param configJson Config json
+     * @param sourcePath Source file path
+     * @return List of args
+     */
+    protected List<Object> getArgs(JsonObject configJson, Path sourcePath) {
+        List<Object> args = new ArrayList<>();
+        args.add(CommandArgument.from(CommandConstants.ARG_KEY_DOC_URI, sourcePath.toUri().toString()));
+
+        JsonObject arguments = configJson.get("arguments").getAsJsonObject();
+        args.addAll(getArgs(arguments));
+
+        return args;
+    }
+    
+    protected abstract List<Object> getArgs(JsonObject argsObject);
 
     /**
      * Get the root directory name where test sources and test config are located.

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/AddDocumentationCommandExecTest.java
@@ -17,14 +17,19 @@
  */
 package org.ballerinalang.langserver.command;
 
+import com.google.gson.JsonObject;
 import org.ballerinalang.langserver.command.executors.AddAllDocumentationExecutor;
 import org.ballerinalang.langserver.command.executors.AddDocumentationExecutor;
+import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Add Documentation command execution tests.
@@ -65,6 +70,13 @@ public class AddDocumentationCommandExecTest extends AbstractCommandExecutionTes
                 {"addAllDocumentation.json", "commonDocumentation.bal"},
                 {"addAllDocumentationWithAnnotations.json", "addAllDocumentationWithAnnotations.bal"}
         };
+    }
+
+    @Override
+    protected List<Object> getArgs(JsonObject argsObject) {
+        List<Object> args = new ArrayList<>();
+        args.add(CommandArgument.from(CommandConstants.ARG_KEY_NODE_POS, argsObject.getAsJsonObject("node.position")));
+        return args;
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -17,13 +17,18 @@
  */
 package org.ballerinalang.langserver.command;
 
+import com.google.gson.JsonObject;
 import org.ballerinalang.langserver.command.executors.CreateFunctionExecutor;
+import org.ballerinalang.langserver.common.constants.CommandConstants;
+import org.ballerinalang.langserver.commons.command.CommandArgument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 
 /**
  * Command Execution Test Cases for create function.
@@ -72,6 +77,12 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"projectCreateUndefinedFunctionWithModAlias2.json", "testproject/modAlias.bal"},
                 {"projectCreateUndefinedFunctionWithLangLib.json", "testproject/langlib.bal"},
         };
+    }
+
+    @Override
+    protected List<Object> getArgs(JsonObject argsObject) {
+        return Collections.singletonList(CommandArgument.from(CommandConstants.ARG_KEY_NODE_POS,
+                argsObject.getAsJsonObject("node.position")));
     }
 
     @Override


### PR DESCRIPTION
## Purpose
$subject + refactoring command execution tests

Fixes #28509

## Approach
Due to a limitation in the semantic API, service declaration node's meta data doesn't include the fields defined in that service. Therefore, has to temporarily disable the `update documentation` code action just for fields within a service.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
