### PR TITLE
Fix renaming in failure clause var and renaming after highlighting a symbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -59,6 +59,7 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangLetClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLimitClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnConflictClause;
+import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderKey;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangSelectClause;
@@ -135,6 +136,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCompoundAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangContinue;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangDo;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangErrorDestructure;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangErrorVariableDef;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangExpressionStmt;
@@ -468,6 +470,12 @@ class SymbolFinder extends BaseVisitor {
     }
 
     @Override
+    public void visit(BLangDo doNode) {
+        lookupNode(doNode.body);
+        lookupNode(doNode.onFailClause);
+    }
+
+    @Override
     public void visit(BLangFromClause fromClause) {
         lookupNode(fromClause.collection);
         lookupNode((BLangNode) fromClause.variableDefinitionNode);
@@ -518,6 +526,12 @@ class SymbolFinder extends BaseVisitor {
     @Override
     public void visit(BLangDoClause doClause) {
         lookupNode(doClause.body);
+    }
+
+    @Override
+    public void visit(BLangOnFailClause onFailClause) {
+        lookupNode((BLangNode) onFailClause.variableDefinitionNode);
+        lookupNode(onFailClause.body);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3556,6 +3556,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         var.setName(this.createIdentifier(onFailClauseNode.failErrorName()));
         var.name.pos = getPosition(onFailClauseNode.failErrorName());
         variableDefinitionNode.setVariable(var);
+        variableDefinitionNode.pos = var.name.pos;
 
 
         BLangOnFailClause onFailClause = (BLangOnFailClause) TreeBuilder.createOnFailClauseNode();

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/references/ReferencesUtil.java
@@ -53,16 +53,36 @@ public class ReferencesUtil {
 
         Position position = context.getCursorPosition();
         Optional<Project> project = context.workspace().project(context.filePath());
-        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
-                LinePosition.from(position.getLine(),
-                        position.getCharacter()));
-
-        if (project.isEmpty() || symbolAtCursor.isEmpty()) {
+        if (project.isEmpty()) {
             return moduleLocationMap;
         }
+
+        Optional<Symbol> symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
+                LinePosition.from(position.getLine(), position.getCharacter()));
+
+        if (symbolAtCursor.isEmpty()) {
+            if (position.getCharacter() == 0) {
+                return moduleLocationMap;
+            }
+            
+            // If we did not find the symbol, there are 2 possibilities.
+            //  1. Cursor is at the end (RHS) of the symbol
+            //  2. Semantic API has a limitation
+            // Out of those, 2nd one is ignored assuming semantic API behaves correctly. 1st one is caused due to the
+            // right end column being excluded when searching. To overcome that, here we search for the symbol at 
+            // (col - 1). Ideally this shouldn't be an issue, because if we had cursor at the start col or middle, the
+            // 1st search (above) would have found that.
+            position = new Position(position.getLine(), position.getCharacter() - 1);
+            symbolAtCursor = semanticModel.get().symbol(srcFile.get(),
+                    LinePosition.from(position.getLine(), position.getCharacter()));
+            if (symbolAtCursor.isEmpty()) {
+                return moduleLocationMap;
+            }
+        }
         
+        Symbol symbol = symbolAtCursor.get();
         project.get().currentPackage().modules().forEach(module -> {
-            List<Location> references = module.getCompilation().getSemanticModel().references(symbolAtCursor.get());
+            List<Location> references = module.getCompilation().getSemanticModel().references(symbol);
             moduleLocationMap.put(module, references);
         });
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -73,6 +73,9 @@ public class RenameTest {
         return new Object[][]{
                 {"rename_method_param_result.json", "newA"},
                 {"rename_rec_result.json", "NewRecData"},
+                {"rename_with_cursor_at_end.json", "myIntVal"},
+                {"rename_with_cursor_at_end2.json", "x"},
+                {"rename_on_fail.json", "myVarName"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_on_fail.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_on_fail.json
@@ -1,0 +1,41 @@
+{
+  "source": {
+    "file": "testSource.bal"
+  },
+  "position": {
+    "line": 10,
+    "character": 18
+  },
+  "result": {
+    "changes": {
+      "testSource.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 10,
+              "character": 18
+            },
+            "end": {
+              "line": 10,
+              "character": 25
+            }
+          },
+          "newText": "myVarName"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 11,
+              "character": 17
+            },
+            "end": {
+              "line": 11,
+              "character": 24
+            }
+          },
+          "newText": "myVarName"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_cursor_at_end.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_cursor_at_end.json
@@ -1,0 +1,54 @@
+{
+  "source": {
+    "file": "testSource.bal"
+  },
+  "position": {
+    "line": 1,
+    "character": 13
+  },
+  "result": {
+    "changes": {
+      "testSource.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 1,
+              "character": 8
+            },
+            "end": {
+              "line": 1,
+              "character": 13
+            }
+          },
+          "newText": "myIntVal"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 13
+            },
+            "end": {
+              "line": 2,
+              "character": 18
+            }
+          },
+          "newText": "myIntVal"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 9
+            }
+          },
+          "newText": "myIntVal"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_cursor_at_end2.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_cursor_at_end2.json
@@ -1,0 +1,28 @@
+{
+  "source": {
+    "file": "testSource.bal"
+  },
+  "position": {
+    "line": 3,
+    "character": 9
+  },
+  "result": {
+    "changes": {
+      "testSource.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 8
+            },
+            "end": {
+              "line": 3,
+              "character": 9
+            }
+          },
+          "newText": "x"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/single/testSource.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/single/testSource.bal
@@ -1,0 +1,17 @@
+public function main() {
+    int myVal = 100;
+    myVal += myVal + 12;
+    var y = testFunction();
+}
+
+function testFunction() returns int {
+    var errVar;
+    do {
+        
+    } on fail var varName {
+        errVar = varName;
+    }
+    
+    return 0;
+}
+


### PR DESCRIPTION
## Purpose
$subject

Fixes #28668
Fixes #28669

## Approach
- Updated `ReferenceUtil` to fallback and search for symbol at `cursorCol -1` due to the left index inclusion and right index exclusion.
- The `SymbolFinder` was failing to find the variable at `on fail` clause of a `do` because the position wasn't set in the `VariableDefinitionNode` of the error clause (by the `NodeTransformer`. Fixed that.

## Remarks
The fix suggested here for the cursor at the end of a symbol is not that clean. We just search again for symbol with `cursorCol - 1`. Seems like this is the best solution we can offer to improve usability.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
