### PR TITLE
Manipulate the coverage numbers to consider partially covered numbers as fully covered

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -27,9 +27,12 @@ import org.ballerinalang.test.runtime.util.TesterinaConstants;
 import org.jacoco.core.analysis.Analyzer;
 import org.jacoco.core.analysis.CoverageBuilder;
 import org.jacoco.core.analysis.IBundleCoverage;
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode;
 import org.jacoco.core.analysis.ILine;
 import org.jacoco.core.analysis.IPackageCoverage;
 import org.jacoco.core.analysis.ISourceFileCoverage;
+import org.jacoco.core.internal.analysis.BundleCoverageImpl;
 import org.jacoco.core.tools.ExecFileLoader;
 import org.jacoco.report.IReportVisitor;
 import org.jacoco.report.xml.XMLFormatter;
@@ -70,7 +73,6 @@ public class CoverageReport {
     public CoverageReport(Module module) throws IOException {
         this.module = module;
         this.target = new Target(module.project().sourceRoot());
-
         this.coverageDir = target.getTestsCachePath().resolve(TesterinaConstants.COVERAGE_DIR);
         this.title = coverageDir.toFile().getName();
         this.classesDirectory = coverageDir.resolve(TesterinaConstants.BIN_DIR);
@@ -89,7 +91,6 @@ public class CoverageReport {
         String version = this.module.packageInstance().packageVersion().toString();
 
         List<Path> filteredPathList;
-
         if (!module.testDocumentIds().isEmpty()) {
             filteredPathList =
                     filterPaths(jarResolver.getJarFilePathsRequiredForTestExecution(this.module.moduleName()));
@@ -97,7 +98,6 @@ public class CoverageReport {
             filteredPathList =
                     filterPaths(jarResolver.getJarFilePathsRequiredForExecution());
         }
-
         if (!filteredPathList.isEmpty()) {
             // For each jar file found, we unzip it for this particular module
             for (Path jarPath : filteredPathList) {
@@ -111,13 +111,12 @@ public class CoverageReport {
                     return null;
                 }
             }
-
             execFileLoader.load(executionDataFile.toFile());
-            final IBundleCoverage bundleCoverage = analyzeStructure();
-
+            final CoverageBuilder coverageBuilder = analyzeStructure();
+            IBundleCoverage bundleCoverage = coverageBuilder.getBundle(title);
             ModuleCoverage moduleCoverage = new ModuleCoverage();
             createReport(bundleCoverage, moduleCoverage);
-
+//            bundleCoverage = getModifiedBundle(coverageBuilder);
             createXMLReport(bundleCoverage);
             CodeCoverageUtils.deleteDirectory(coverageDir.resolve(BIN_DIR).toFile());
             return moduleCoverage;
@@ -127,45 +126,47 @@ public class CoverageReport {
         }
     }
 
-    private IBundleCoverage analyzeStructure() throws IOException {
+    private CoverageBuilder analyzeStructure() throws IOException {
         final CoverageBuilder coverageBuilder = new CoverageBuilder();
         final Analyzer analyzer = new Analyzer(execFileLoader.getExecutionDataStore(), coverageBuilder);
         analyzer.analyzeAll(classesDirectory.toFile());
-        return coverageBuilder.getBundle(title);
+        return coverageBuilder;
+    }
+
+    private IBundleCoverage getModifiedBundle(CoverageBuilder coverageBuilder) {
+        final Collection<ISourceFileCoverage> sourcefiles = coverageBuilder.getSourceFiles();
+        final Collection<ISourceFileCoverage> modifiedSourceFiles = modifySources(sourcefiles);
+        final IBundleCoverage bundleCoverage = new BundleCoverageImpl(title, coverageBuilder.getClasses(),
+                modifiedSourceFiles);
+        return bundleCoverage;
     }
 
     private void createXMLReport(IBundleCoverage bundleCoverage) throws IOException {
-            XMLFormatter xmlFormatter = new XMLFormatter();
-            File reportFile = new File(target.getReportPath().resolve(
-                    this.module.moduleName().toString()).resolve(REPORT_XML_FILE).toString());
-            reportFile.getParentFile().mkdirs();
-
-            try (FileOutputStream fileOutputStream = new FileOutputStream(reportFile)) {
-                IReportVisitor visitor = xmlFormatter.createVisitor(fileOutputStream);
-                visitor.visitInfo(execFileLoader.getSessionInfoStore().getInfos(),
-                        execFileLoader.getExecutionDataStore().getContents());
-
-                visitor.visitBundle(bundleCoverage, null);
-
-                visitor.visitEnd();
-            }
+        final XMLFormatter xmlFormatter = new XMLFormatter();
+        final File reportFile = new File(target.getReportPath().resolve(
+                this.module.moduleName().toString()).resolve(REPORT_XML_FILE).toString());
+        reportFile.getParentFile().mkdirs();
+        try (FileOutputStream fileOutputStream = new FileOutputStream(reportFile)) {
+            IReportVisitor visitor = xmlFormatter.createVisitor(fileOutputStream);
+            visitor.visitInfo(execFileLoader.getSessionInfoStore().getInfos(),
+                    execFileLoader.getExecutionDataStore().getContents());
+            visitor.visitBundle(bundleCoverage, null);
+            visitor.visitEnd();
+        }
     }
 
     private void createReport(final IBundleCoverage bundleCoverage, ModuleCoverage moduleCoverage) {
         boolean containsSourceFiles = true;
-
         for (IPackageCoverage packageCoverage : bundleCoverage.getPackages()) {
             if (TesterinaConstants.DOT.equals(this.module.moduleName())) {
                 containsSourceFiles = packageCoverage.getName().isEmpty();
             }
-
             if (containsSourceFiles) {
                 for (ISourceFileCoverage sourceFileCoverage : packageCoverage.getSourceFiles()) {
                     // Extract the Module name individually for each source file
                     // This is done since some source files come from other modules
                     // sourceFileCoverage : "<orgname>/<moduleName>:<version>
                     String sourceFileModule = decodeIdentifier(sourceFileCoverage.getPackageName().split("/")[1]);
-
                     // Only add the source files that belong to the same module and it is a source bal file
                     if (sourceFileModule.equals(this.module.moduleName().toString())
                             && sourceFileCoverage.getName().contains(BLANG_SRC_FILE_SUFFIX)
@@ -188,7 +189,6 @@ public class CoverageReport {
                             }
                         }
                         moduleCoverage.addSourceFileCoverage(document, coveredLines, missedLines);
-
                     }
                 }
             }
@@ -198,14 +198,197 @@ public class CoverageReport {
 
     private List<Path> filterPaths(Collection<Path> pathCollection) {
         List<Path> filteredPathList = new ArrayList<>();
-
         for (Path path : pathCollection) {
             if (path.toString().contains(this.module.project().sourceRoot().toString()) &&
                     path.toString().contains(target.cachesPath().toString())) {
                 filteredPathList.add(path);
             }
         }
-
         return filteredPathList;
+    }
+
+    public Collection<ISourceFileCoverage> modifySources(Collection<ISourceFileCoverage> sourcefiles) {
+        Collection<ISourceFileCoverage> modifiedSourceFiles = new ArrayList<>();
+        for (ISourceFileCoverage sourcefile : sourcefiles) {
+            List<ILine> modifiedLines = new ArrayList<>();
+            for (int i = sourcefile.getFirstLine(); i <= sourcefile.getLastLine(); i++) {
+                ILine line = sourcefile.getLine(i);
+                ILine modifiedLine = new ILine() {
+                    private final CustomCounterImpl instructions = new CustomCounterImpl(line.getInstructionCounter());
+                    private final CustomCounterImpl branches = new CustomCounterImpl(line.getBranchCounter());
+
+                    @Override
+                    public ICounter getInstructionCounter() {
+                        return instructions;
+                    }
+
+                    @Override
+                    public ICounter getBranchCounter() {
+                        return branches;
+                    }
+
+                    @Override
+                    public int getStatus() {
+                        return branches.getStatus() | instructions.getStatus();
+                    }
+                };
+                modifiedLines.add(modifiedLine);
+            }
+            ISourceFileCoverage modifiedSourceFile = new ISourceFileCoverage() {
+                @Override
+                public String getPackageName() {
+                    return sourcefile.getPackageName();
+                }
+
+                @Override
+                public int getFirstLine() {
+                    return sourcefile.getFirstLine();
+                }
+
+                @Override
+                public int getLastLine() {
+                    return sourcefile.getLastLine();
+                }
+
+                //Return the modified lines instead of lines stored in the original source file
+                @Override
+                public ILine getLine(int nr) {
+                    if (modifiedLines.size() == 0 || nr < getFirstLine() || nr > getLastLine()) {
+                        return sourcefile.getLine(nr);
+                    }
+                    ILine reqLine = modifiedLines.get(nr - getFirstLine());
+                    return reqLine == null ? sourcefile.getLine(nr) : reqLine;
+                }
+
+                @Override
+                public ElementType getElementType() {
+                    return sourcefile.getElementType();
+                }
+
+                @Override
+                public String getName() {
+                    return sourcefile.getName();
+                }
+
+                @Override
+                public ICounter getInstructionCounter() {
+                    return sourcefile.getInstructionCounter();
+                }
+
+                @Override
+                public ICounter getBranchCounter() {
+                    return sourcefile.getBranchCounter();
+                }
+
+                @Override
+                public ICounter getLineCounter() {
+                    return sourcefile.getLineCounter();
+                }
+
+                @Override
+                public ICounter getComplexityCounter() {
+                    return sourcefile.getComplexityCounter();
+                }
+
+                @Override
+                public ICounter getMethodCounter() {
+                    return sourcefile.getMethodCounter();
+                }
+
+                @Override
+                public ICounter getClassCounter() {
+                    return sourcefile.getClassCounter();
+                }
+
+                @Override
+                public ICounter getCounter(CounterEntity entity) {
+                    return sourcefile.getCounter(entity);
+                }
+
+                @Override
+                public boolean containsCode() {
+                    return sourcefile.containsCode();
+                }
+
+                @Override
+                public ICoverageNode getPlainCopy() {
+                    return sourcefile.getPlainCopy();
+                }
+            };
+            modifiedSourceFiles.add(modifiedSourceFile);
+        }
+        return modifiedSourceFiles;
+    }
+
+    private class CustomCounterImpl implements ICounter {
+        private int covered;
+        private int missed;
+
+        public CustomCounterImpl(ICounter prevCounter) {
+            this.covered = prevCounter.getCoveredCount();
+            this.missed = prevCounter.getMissedCount();
+            modifyCoverageNumbers();
+        }
+
+        //Modify the covered and missed numbers in cases the counter status is calculated as PARTLY_COVERED
+        //It converts the counter status to FULLY_COVERED
+        public void modifyCoverageNumbers() {
+            if (getStatus() == PARTLY_COVERED) {
+                covered = covered + missed;
+                missed = 0;
+            }
+        }
+
+        @Override
+        public double getValue(CounterValue value) {
+            switch (value) {
+                case TOTALCOUNT:
+                    return getTotalCount();
+                case MISSEDCOUNT:
+                    return getMissedCount();
+                case COVEREDCOUNT:
+                    return getCoveredCount();
+                case MISSEDRATIO:
+                    return getMissedRatio();
+                case COVEREDRATIO:
+                    return getCoveredRatio();
+                default:
+                    throw new AssertionError(value);
+            }
+        }
+
+        @Override
+        public int getTotalCount() {
+            return covered + missed;
+        }
+
+        @Override
+        public int getCoveredCount() {
+            return covered;
+        }
+
+        @Override
+        public int getMissedCount() {
+            return missed;
+        }
+
+        @Override
+        public double getCoveredRatio() {
+            return (double) covered / (missed + covered);
+        }
+
+        @Override
+        public double getMissedRatio() {
+            return (double) missed / (missed + covered);
+        }
+
+        @Override
+        public int getStatus() {
+            int status = covered > 0 ? FULLY_COVERED : EMPTY;
+            if (missed > 0) {
+                status |= NOT_COVERED;
+            }
+            return status;
+        }
     }
 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -132,11 +132,8 @@ public class CoverageReport {
     }
 
     private IBundleCoverage getPartialCoverageModifiedBundle(CoverageBuilder coverageBuilder) {
-        final Collection<ISourceFileCoverage> sourcefiles = coverageBuilder.getSourceFiles();
-        final Collection<ISourceFileCoverage> modifiedSourceFiles = modifySourceFiles(sourcefiles);
-        final IBundleCoverage bundleCoverage = new BundleCoverageImpl(title, coverageBuilder.getClasses(),
-                modifiedSourceFiles);
-        return bundleCoverage;
+        return new BundleCoverageImpl(title, coverageBuilder.getClasses(),
+                modifySourceFiles(coverageBuilder.getSourceFiles()));
     }
 
     private void createXMLReport(IBundleCoverage bundleCoverage) throws IOException {
@@ -204,10 +201,10 @@ public class CoverageReport {
         return filteredPathList;
     }
 
-    public Collection<ISourceFileCoverage> modifySourceFiles(Collection<ISourceFileCoverage> sourcefiles) {
+    private Collection<ISourceFileCoverage> modifySourceFiles(Collection<ISourceFileCoverage> sourcefiles) {
         Collection<ISourceFileCoverage> modifiedSourceFiles = new ArrayList<>();
         for (ISourceFileCoverage sourcefile : sourcefiles) {
-            if (sourcefile.getName().contains(BLANG_SRC_FILE_SUFFIX)) {
+            if (sourcefile.getName().endsWith(BLANG_SRC_FILE_SUFFIX)) {
                 List<ILine> modifiedLines = new ArrayList<>();
                 for (int i = sourcefile.getFirstLine(); i <= sourcefile.getLastLine(); i++) {
                     ILine line = sourcefile.getLine(i);

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -216,13 +216,7 @@ public class CoverageReport {
         Collection<ISourceFileCoverage> modifiedSourceFiles = new ArrayList<>();
         for (ISourceFileCoverage sourcefile : sourcefiles) {
             if (sourcefile.getName().endsWith(BLANG_SRC_FILE_SUFFIX)) {
-                List<ILine> modifiedLines = new ArrayList<>();
-                for (int i = sourcefile.getFirstLine(); i <= sourcefile.getLastLine(); i++) {
-                    ILine line = sourcefile.getLine(i);
-                    ILine modifiedLine = new PartialCoverageModifiedLine(line.getInstructionCounter(),
-                            line.getBranchCounter());
-                    modifiedLines.add(modifiedLine);
-                }
+                List<ILine> modifiedLines = modifyLines(sourcefile);
                 ISourceFileCoverage modifiedSourceFile = new PartialCoverageModifiedSourceFile(sourcefile,
                         modifiedLines);
                 modifiedSourceFiles.add(modifiedSourceFile);
@@ -231,5 +225,15 @@ public class CoverageReport {
             }
         }
         return modifiedSourceFiles;
+    }
+
+    private List<ILine> modifyLines(ISourceFileCoverage sourcefile) {
+        List<ILine> modifiedLines = new ArrayList<>();
+        for (int i = sourcefile.getFirstLine(); i <= sourcefile.getLastLine(); i++) {
+            ILine line = sourcefile.getLine(i);
+            ILine modifiedLine = new PartialCoverageModifiedLine(line.getInstructionCounter(), line.getBranchCounter());
+            modifiedLines.add(modifiedLine);
+        }
+        return modifiedLines;
     }
 }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -71,6 +71,7 @@ public class CoverageReport {
     public CoverageReport(Module module) throws IOException {
         this.module = module;
         this.target = new Target(module.project().sourceRoot());
+
         this.coverageDir = target.getTestsCachePath().resolve(TesterinaConstants.COVERAGE_DIR);
         this.title = coverageDir.toFile().getName();
         this.classesDirectory = coverageDir.resolve(TesterinaConstants.BIN_DIR);
@@ -89,6 +90,7 @@ public class CoverageReport {
         String version = this.module.packageInstance().packageVersion().toString();
 
         List<Path> filteredPathList;
+
         if (!module.testDocumentIds().isEmpty()) {
             filteredPathList =
                     filterPaths(jarResolver.getJarFilePathsRequiredForTestExecution(this.module.moduleName()));
@@ -96,6 +98,7 @@ public class CoverageReport {
             filteredPathList =
                     filterPaths(jarResolver.getJarFilePathsRequiredForExecution());
         }
+
         if (!filteredPathList.isEmpty()) {
             // For each jar file found, we unzip it for this particular module
             for (Path jarPath : filteredPathList) {
@@ -109,6 +112,7 @@ public class CoverageReport {
                     return null;
                 }
             }
+
             execFileLoader.load(executionDataFile.toFile());
             final CoverageBuilder coverageBuilder = analyzeStructure();
             ModuleCoverage moduleCoverage = new ModuleCoverage();
@@ -135,31 +139,37 @@ public class CoverageReport {
     }
 
     private void createXMLReport(IBundleCoverage bundleCoverage) throws IOException {
-        final XMLFormatter xmlFormatter = new XMLFormatter();
-        final File reportFile = new File(target.getReportPath().resolve(
+        XMLFormatter xmlFormatter = new XMLFormatter();
+        File reportFile = new File(target.getReportPath().resolve(
                 this.module.moduleName().toString()).resolve(REPORT_XML_FILE).toString());
         reportFile.getParentFile().mkdirs();
+
         try (FileOutputStream fileOutputStream = new FileOutputStream(reportFile)) {
             IReportVisitor visitor = xmlFormatter.createVisitor(fileOutputStream);
             visitor.visitInfo(execFileLoader.getSessionInfoStore().getInfos(),
                     execFileLoader.getExecutionDataStore().getContents());
+
             visitor.visitBundle(bundleCoverage, null);
+
             visitor.visitEnd();
         }
     }
 
     private void createReport(final IBundleCoverage bundleCoverage, ModuleCoverage moduleCoverage) {
         boolean containsSourceFiles = true;
+
         for (IPackageCoverage packageCoverage : bundleCoverage.getPackages()) {
             if (TesterinaConstants.DOT.equals(this.module.moduleName())) {
                 containsSourceFiles = packageCoverage.getName().isEmpty();
             }
+
             if (containsSourceFiles) {
                 for (ISourceFileCoverage sourceFileCoverage : packageCoverage.getSourceFiles()) {
                     // Extract the Module name individually for each source file
                     // This is done since some source files come from other modules
                     // sourceFileCoverage : "<orgname>/<moduleName>:<version>
                     String sourceFileModule = decodeIdentifier(sourceFileCoverage.getPackageName().split("/")[1]);
+
                     // Only add the source files that belong to the same module and it is a source bal file
                     if (sourceFileModule.equals(this.module.moduleName().toString())
                             && sourceFileCoverage.getName().contains(BLANG_SRC_FILE_SUFFIX)
@@ -182,6 +192,7 @@ public class CoverageReport {
                             }
                         }
                         moduleCoverage.addSourceFileCoverage(document, coveredLines, missedLines);
+
                     }
                 }
             }
@@ -190,12 +201,14 @@ public class CoverageReport {
 
     private List<Path> filterPaths(Collection<Path> pathCollection) {
         List<Path> filteredPathList = new ArrayList<>();
+
         for (Path path : pathCollection) {
             if (path.toString().contains(this.module.project().sourceRoot().toString()) &&
                     path.toString().contains(target.cachesPath().toString())) {
                 filteredPathList.add(path);
             }
         }
+
         return filteredPathList;
     }
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -112,10 +112,8 @@ public class CoverageReport {
             execFileLoader.load(executionDataFile.toFile());
             final CoverageBuilder coverageBuilder = analyzeStructure();
             ModuleCoverage moduleCoverage = new ModuleCoverage();
-            IBundleCoverage bundleCoverage = coverageBuilder.getBundle(title);
-            createReport(bundleCoverage, moduleCoverage);
-            IBundleCoverage modifiedBundleCoverage = getPartialCoverageModifiedBundle(coverageBuilder);
-            createXMLReport(modifiedBundleCoverage);
+            createReport(coverageBuilder.getBundle(title), moduleCoverage);
+            createXMLReport(getPartialCoverageModifiedBundle(coverageBuilder));
             CodeCoverageUtils.deleteDirectory(coverageDir.resolve(BIN_DIR).toFile());
             return moduleCoverage;
         } else {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -46,6 +46,10 @@ public class PartialCoverageModifiedCounter implements ICounter {
         }
     }
 
+    /**
+     * As implemented in
+     * org.jacoco.core.internal.analysis.CounterImpl#getValue(org.jacoco.core.analysis.ICounter.CounterValue)
+     */
     @Override
     public double getValue(CounterValue value) {
         switch (value) {
@@ -89,6 +93,9 @@ public class PartialCoverageModifiedCounter implements ICounter {
         return (double) missed / (missed + covered);
     }
 
+    /**
+     * As implemented in org.jacoco.core.internal.analysis.CounterImpl#getStatus()
+     */
     @Override
     public int getStatus() {
         int status = covered > 0 ? FULLY_COVERED : EMPTY;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -1,10 +1,27 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.runtime.entity;
 
 import org.jacoco.core.analysis.ICounter;
 
 /**
  * Represents a counter that eliminates partially covered counter status and coverts it to fully covered status.
- *
+ * @since 2.0.0
  */
 public class PartialCoverageModifiedCounter implements ICounter {
 
@@ -21,7 +38,7 @@ public class PartialCoverageModifiedCounter implements ICounter {
      * Modify the covered and missed numbers in cases the counter status is calculated as PARTLY_COVERED.
      * It converts the counter status to FULLY_COVERED.
      */
-    public void modifyCoverageNumbers() {
+    private void modifyCoverageNumbers() {
         if (getStatus() == PARTLY_COVERED) {
             covered = covered + missed;
             missed = 0;
@@ -42,7 +59,7 @@ public class PartialCoverageModifiedCounter implements ICounter {
             case COVEREDRATIO:
                 return getCoveredRatio();
             default:
-                throw new AssertionError(value);
+                throw new RuntimeException("No such CounterValue object");
         }
     }
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -1,0 +1,76 @@
+package org.ballerinalang.test.runtime.entity;
+
+import org.jacoco.core.analysis.ICounter;
+
+public class ModifiedCounterImpl implements ICounter {
+
+    private int covered;
+    private int missed;
+
+    public ModifiedCounterImpl(ICounter prevCounter) {
+        this.covered = prevCounter.getCoveredCount();
+        this.missed = prevCounter.getMissedCount();
+        modifyCoverageNumbers();
+    }
+
+    //Modify the covered and missed numbers in cases the counter status is calculated as PARTLY_COVERED
+    //It converts the counter status to FULLY_COVERED
+    public void modifyCoverageNumbers() {
+        if (getStatus() == PARTLY_COVERED) {
+            covered = covered + missed;
+            missed = 0;
+        }
+    }
+
+    @Override
+    public double getValue(CounterValue value) {
+        switch (value) {
+            case TOTALCOUNT:
+                return getTotalCount();
+            case MISSEDCOUNT:
+                return getMissedCount();
+            case COVEREDCOUNT:
+                return getCoveredCount();
+            case MISSEDRATIO:
+                return getMissedRatio();
+            case COVEREDRATIO:
+                return getCoveredRatio();
+            default:
+                throw new AssertionError(value);
+        }
+    }
+
+    @Override
+    public int getTotalCount() {
+        return covered + missed;
+    }
+
+    @Override
+    public int getCoveredCount() {
+        return covered;
+    }
+
+    @Override
+    public int getMissedCount() {
+        return missed;
+    }
+
+    @Override
+    public double getCoveredRatio() {
+        return (double) covered / (missed + covered);
+    }
+
+    @Override
+    public double getMissedRatio() {
+        return (double) missed / (missed + covered);
+    }
+
+    @Override
+    public int getStatus() {
+        int status = covered > 0 ? FULLY_COVERED : EMPTY;
+        if (missed > 0) {
+            status |= NOT_COVERED;
+        }
+        return status;
+    }
+}

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -47,7 +47,7 @@ public class PartialCoverageModifiedCounter implements ICounter {
     }
 
     /**
-     * As implemented in
+     * As implemented in Jacoco API.
      * org.jacoco.core.internal.analysis.CounterImpl#getValue(org.jacoco.core.analysis.ICounter.CounterValue)
      */
     @Override
@@ -94,7 +94,7 @@ public class PartialCoverageModifiedCounter implements ICounter {
     }
 
     /**
-     * As implemented in org.jacoco.core.internal.analysis.CounterImpl#getStatus()
+     * As implemented in org.jacoco.core.internal.analysis.CounterImpl#getStatus().
      */
     @Override
     public int getStatus() {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -21,6 +21,7 @@ import org.jacoco.core.analysis.ICounter;
 
 /**
  * Represents a counter that eliminates partially covered counter status and coverts it to fully covered status.
+ *
  * @since 2.0.0
  */
 public class PartialCoverageModifiedCounter implements ICounter {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedCounter.java
@@ -2,19 +2,25 @@ package org.ballerinalang.test.runtime.entity;
 
 import org.jacoco.core.analysis.ICounter;
 
-public class ModifiedCounterImpl implements ICounter {
+/**
+ * Represents a counter that eliminates partially covered counter status and coverts it to fully covered status.
+ *
+ */
+public class PartialCoverageModifiedCounter implements ICounter {
 
     private int covered;
     private int missed;
 
-    public ModifiedCounterImpl(ICounter prevCounter) {
+    public PartialCoverageModifiedCounter(ICounter prevCounter) {
         this.covered = prevCounter.getCoveredCount();
         this.missed = prevCounter.getMissedCount();
         modifyCoverageNumbers();
     }
 
-    //Modify the covered and missed numbers in cases the counter status is calculated as PARTLY_COVERED
-    //It converts the counter status to FULLY_COVERED
+    /**
+     * Modify the covered and missed numbers in cases the counter status is calculated as PARTLY_COVERED.
+     * It converts the counter status to FULLY_COVERED.
+     */
     public void modifyCoverageNumbers() {
         if (getStatus() == PARTLY_COVERED) {
             covered = covered + missed;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -46,7 +46,7 @@ public class PartialCoverageModifiedLine implements ILine {
     }
 
     /**
-     * As implemented in org.jacoco.core.internal.analysis.LineImpl#getStatus()
+     * As implemented in org.jacoco.core.internal.analysis.LineImpl#getStatus().
      */
     @Override
     public int getStatus() {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.runtime.entity;
 
 import org.jacoco.core.analysis.ICounter;
@@ -5,7 +22,7 @@ import org.jacoco.core.analysis.ILine;
 
 /**
  * Represents a line modified to consider partially covered coverage info as fully covered.
- *
+ * @since 2.0.0
  */
 public class PartialCoverageModifiedLine implements ILine {
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -1,0 +1,30 @@
+package org.ballerinalang.test.runtime.entity;
+
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ILine;
+
+public class ModifiedLineImpl implements ILine {
+
+    private final ModifiedCounterImpl instructions;
+    private final ModifiedCounterImpl branches;
+
+    public ModifiedLineImpl(ICounter instructions, ICounter branches) {
+        this.instructions = new ModifiedCounterImpl(instructions);
+        this.branches = new ModifiedCounterImpl(branches);
+    }
+
+    @Override
+    public ICounter getInstructionCounter() {
+        return instructions;
+    }
+
+    @Override
+    public ICounter getBranchCounter() {
+        return branches;
+    }
+
+    @Override
+    public int getStatus() {
+        return branches.getStatus() | instructions.getStatus();
+    }
+}

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -22,6 +22,7 @@ import org.jacoco.core.analysis.ILine;
 
 /**
  * Represents a line modified to consider partially covered coverage info as fully covered.
+ *
  * @since 2.0.0
  */
 public class PartialCoverageModifiedLine implements ILine {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -3,14 +3,18 @@ package org.ballerinalang.test.runtime.entity;
 import org.jacoco.core.analysis.ICounter;
 import org.jacoco.core.analysis.ILine;
 
-public class ModifiedLineImpl implements ILine {
+/**
+ * Represents a line modified to consider partially covered coverage info as fully covered.
+ *
+ */
+public class PartialCoverageModifiedLine implements ILine {
 
-    private final ModifiedCounterImpl instructions;
-    private final ModifiedCounterImpl branches;
+    private final PartialCoverageModifiedCounter instructions;
+    private final PartialCoverageModifiedCounter branches;
 
-    public ModifiedLineImpl(ICounter instructions, ICounter branches) {
-        this.instructions = new ModifiedCounterImpl(instructions);
-        this.branches = new ModifiedCounterImpl(branches);
+    public PartialCoverageModifiedLine(ICounter instructions, ICounter branches) {
+        this.instructions = new PartialCoverageModifiedCounter(instructions);
+        this.branches = new PartialCoverageModifiedCounter(branches);
     }
 
     @Override

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedLine.java
@@ -45,6 +45,9 @@ public class PartialCoverageModifiedLine implements ILine {
         return branches;
     }
 
+    /**
+     * As implemented in org.jacoco.core.internal.analysis.LineImpl#getStatus()
+     */
     @Override
     public int getStatus() {
         return branches.getStatus() | instructions.getStatus();

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
@@ -7,12 +7,16 @@ import org.jacoco.core.analysis.ISourceFileCoverage;
 
 import java.util.List;
 
-public class ModifiedSourceFileCoverageImpl implements ISourceFileCoverage {
+/**
+ * Represents a source file containing lines modified to consider partially covered coverage info as fully covered.
+ *
+ */
+public class PartialCoverageModifiedSourceFile implements ISourceFileCoverage {
 
     private final ISourceFileCoverage oldSourceFile;
     private final List<ILine> modifiedLines;
 
-    public ModifiedSourceFileCoverageImpl(ISourceFileCoverage oldSourcefile, List<ILine> modifiedLines) {
+    public PartialCoverageModifiedSourceFile(ISourceFileCoverage oldSourcefile, List<ILine> modifiedLines) {
         this.oldSourceFile = oldSourcefile;
         this.modifiedLines = modifiedLines;
     }
@@ -27,7 +31,9 @@ public class ModifiedSourceFileCoverageImpl implements ISourceFileCoverage {
         return oldSourceFile.getLastLine();
     }
 
-    //Return the modified lines instead of lines stored in the original source file
+    /**
+     * Returns the modified lines instead of lines stored in the original source file.
+     */
     @Override
     public ILine getLine(int nr) {
         if (modifiedLines.size() == 0 || nr < getFirstLine() || nr > getLastLine()) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.ballerinalang.test.runtime.entity;
 
 import org.jacoco.core.analysis.ICounter;
@@ -9,7 +26,7 @@ import java.util.List;
 
 /**
  * Represents a source file containing lines modified to consider partially covered coverage info as fully covered.
- *
+ * @since 2.0.0
  */
 public class PartialCoverageModifiedSourceFile implements ISourceFileCoverage {
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
@@ -26,6 +26,7 @@ import java.util.List;
 
 /**
  * Represents a source file containing lines modified to consider partially covered coverage info as fully covered.
+ *
  * @since 2.0.0
  */
 public class PartialCoverageModifiedSourceFile implements ISourceFileCoverage {
@@ -52,12 +53,12 @@ public class PartialCoverageModifiedSourceFile implements ISourceFileCoverage {
      * Returns the modified lines instead of lines stored in the original source file.
      */
     @Override
-    public ILine getLine(int nr) {
-        if (modifiedLines.size() == 0 || nr < getFirstLine() || nr > getLastLine()) {
-            return oldSourceFile.getLine(nr);
+    public ILine getLine(int lineNumber) {
+        if (modifiedLines.size() == 0 || lineNumber < getFirstLine() || lineNumber > getLastLine()) {
+            return oldSourceFile.getLine(lineNumber);
         }
-        ILine reqLine = modifiedLines.get(nr - getFirstLine());
-        return reqLine == null ? oldSourceFile.getLine(nr) : reqLine;
+        ILine reqLine = modifiedLines.get(lineNumber - getFirstLine());
+        return reqLine == null ? oldSourceFile.getLine(lineNumber) : reqLine;
     }
 
     @Override

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/PartialCoverageModifiedSourceFile.java
@@ -1,0 +1,99 @@
+package org.ballerinalang.test.runtime.entity;
+
+import org.jacoco.core.analysis.ICounter;
+import org.jacoco.core.analysis.ICoverageNode;
+import org.jacoco.core.analysis.ILine;
+import org.jacoco.core.analysis.ISourceFileCoverage;
+
+import java.util.List;
+
+public class ModifiedSourceFileCoverageImpl implements ISourceFileCoverage {
+
+    private final ISourceFileCoverage oldSourceFile;
+    private final List<ILine> modifiedLines;
+
+    public ModifiedSourceFileCoverageImpl(ISourceFileCoverage oldSourcefile, List<ILine> modifiedLines) {
+        this.oldSourceFile = oldSourcefile;
+        this.modifiedLines = modifiedLines;
+    }
+
+    @Override
+    public int getFirstLine() {
+        return oldSourceFile.getFirstLine();
+    }
+
+    @Override
+    public int getLastLine() {
+        return oldSourceFile.getLastLine();
+    }
+
+    //Return the modified lines instead of lines stored in the original source file
+    @Override
+    public ILine getLine(int nr) {
+        if (modifiedLines.size() == 0 || nr < getFirstLine() || nr > getLastLine()) {
+            return oldSourceFile.getLine(nr);
+        }
+        ILine reqLine = modifiedLines.get(nr - getFirstLine());
+        return reqLine == null ? oldSourceFile.getLine(nr) : reqLine;
+    }
+
+    @Override
+    public String getPackageName() {
+        return oldSourceFile.getPackageName();
+    }
+
+    @Override
+    public ElementType getElementType() {
+        return oldSourceFile.getElementType();
+    }
+
+    @Override
+    public String getName() {
+        return oldSourceFile.getName();
+    }
+
+    @Override
+    public ICounter getInstructionCounter() {
+        return oldSourceFile.getInstructionCounter();
+    }
+
+    @Override
+    public ICounter getBranchCounter() {
+        return oldSourceFile.getBranchCounter();
+    }
+
+    @Override
+    public ICounter getLineCounter() {
+        return oldSourceFile.getLineCounter();
+    }
+
+    @Override
+    public ICounter getComplexityCounter() {
+        return oldSourceFile.getComplexityCounter();
+    }
+
+    @Override
+    public ICounter getMethodCounter() {
+        return oldSourceFile.getMethodCounter();
+    }
+
+    @Override
+    public ICounter getClassCounter() {
+        return oldSourceFile.getClassCounter();
+    }
+
+    @Override
+    public ICounter getCounter(CounterEntity entity) {
+        return oldSourceFile.getCounter(entity);
+    }
+
+    @Override
+    public boolean containsCode() {
+        return oldSourceFile.containsCode();
+    }
+
+    @Override
+    public ICoverageNode getPlainCopy() {
+        return oldSourceFile.getPlainCopy();
+    }
+}


### PR DESCRIPTION
## Purpose
Jacoc and codecov considers partially covered lines as missed when calculating the final coverage percentage. This results in a low coverage percentage for `.bal` files. Manipulating the coverage numbers in the report generated by Jacoco to calculate partially covered lines as fully covered fixes this. 

Fixes #28642 

## Approach
For instruction and branch counters of partially covered lines:
     ```covered = covered + missed```
    ```missed = 0```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
