### PR TITLE
Make service names available for distributed tracing

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -311,6 +311,7 @@ public class JvmConstants {
     public static final String REPORT_ERROR_METHOD = "reportError";
     public static final String STOP_OBSERVATION_METHOD = "stopObservation";
     public static final String OBSERVABLE_ANNOTATION = "ballerina/observe/Observable";
+    public static final String DISPLAY_ANNOTATION = "display";
     public static final String RECORD_CHECKPOINT_METHOD = "recordCheckpoint";
 
     // visibility flags

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -184,9 +184,11 @@ class JvmObservabilityGen {
                 rewriteObservableFunctionInvocations(func, pkg);
                 if (isService) {
                     if ((func.flags & Flags.RESOURCE) == Flags.RESOURCE) {
-                        rewriteObservableFunctionBody(func, pkg, typeDef, func.name.value, serviceName, true, false, false, false);
+                        rewriteObservableFunctionBody(func, pkg, typeDef, func.name.value, serviceName,
+                                true, false, false, false);
                     } else if ((func.flags & Flags.REMOTE) == Flags.REMOTE) {
-                        rewriteObservableFunctionBody(func, pkg, typeDef, func.name.value, serviceName, false, true, false, false);
+                        rewriteObservableFunctionBody(func, pkg, typeDef, func.name.value, serviceName,
+                                false, true, false, false);
                     }
                 }
             }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -167,9 +167,10 @@ class JvmObservabilityGen {
                             annotationAttachment.annotValues.get(0)).annotValueEntryMap).get("label")).value.toString();
                     break;
                 }
-            }
-            if (serviceName == null) {
-                serviceName = pkg.packageID.orgName.value + "_" + pkg.packageID.name.value + "_" + defaultServiceIndex++;
+                if (serviceName == null) {
+                    serviceName = pkg.packageID.orgName.value + "_" + pkg.packageID.name.value + "_" +
+                            defaultServiceIndex++;
+                }
             }
             for (int i = 0; i < typeDef.attachedFuncs.size(); i++) {
                 BIRFunction func = typeDef.attachedFuncs.get(i);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -161,9 +161,11 @@ class JvmObservabilityGen {
             if (isService) {
                 for (BIRNode.BIRAnnotationAttachment annotationAttachment : typeDef.annotAttachments) {
                     if (DISPLAY_ANNOTATION.equals(annotationAttachment.annotTagRef.value)) {
-                        serviceName = ((BIRNode.BIRAnnotationLiteralValue) (((BIRNode.BIRAnnotationRecordValue)
-                                annotationAttachment.annotValues.get(0)).annotValueEntryMap)
-                                .get("label")).value.toString();
+                        BIRNode.BIRAnnotationRecordValue annotationRecordValue = (BIRNode.BIRAnnotationRecordValue)
+                                annotationAttachment.annotValues.get(0);
+                        Map<String, BIRNode.BIRAnnotationValue> annotationMap =
+                                annotationRecordValue.annotValueEntryMap;
+                        serviceName = ((BIRNode.BIRAnnotationLiteralValue) annotationMap.get("label")).value.toString();
                         break;
                     }
                 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -147,9 +147,9 @@ class JvmObservabilityGen {
             rewriteAsyncInvocations(func, null, pkg);
             rewriteObservableFunctionInvocations(func, pkg);
             if (ENTRY_POINT_MAIN_METHOD_NAME.equals(func.name.value)) {
-                rewriteObservableFunctionBody(func, pkg, null, func.name.value, "", false, false, true, false);
+                rewriteObservableFunctionBody(func, pkg, null, func.name.value, null, false, false, true, false);
             } else if ((func.flags & Flags.WORKER) == Flags.WORKER) {   // Identifying lambdas generated for workers
-                rewriteObservableFunctionBody(func, pkg, null, func.workerName.value, "", false, false, false, true);
+                rewriteObservableFunctionBody(func, pkg, null, func.workerName.value, null, false, false, false, true);
             }
         }
         for (BIRTypeDefinition typeDef : pkg.typeDefs) {
@@ -160,15 +160,15 @@ class JvmObservabilityGen {
             String serviceName = null;
             if (isService) {
                 for (BIRNode.BIRAnnotationAttachment annotationAttachment : typeDef.annotAttachments) {
-                    if (!DISPLAY_ANNOTATION.equals(annotationAttachment.annotTagRef.value)) {
-                        continue;
+                    if (DISPLAY_ANNOTATION.equals(annotationAttachment.annotTagRef.value)) {
+                        serviceName = ((BIRNode.BIRAnnotationLiteralValue) (((BIRNode.BIRAnnotationRecordValue)
+                                annotationAttachment.annotValues.get(0)).annotValueEntryMap)
+                                .get("label")).value.toString();
+                        break;
                     }
-                    serviceName = ((BIRNode.BIRAnnotationLiteralValue) (((BIRNode.BIRAnnotationRecordValue)
-                            annotationAttachment.annotValues.get(0)).annotValueEntryMap).get("label")).value.toString();
-                    break;
                 }
                 if (serviceName == null) {
-                    serviceName = pkg.packageID.orgName.value + "_" + pkg.packageID.name.value + "_" +
+                    serviceName = pkg.packageID.orgName.value + "_" + pkg.packageID.name.value + "_svc_" +
                             defaultServiceIndex++;
                 }
             }

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -43,14 +43,16 @@ import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_
  * This class wraps opentracing apis and exposes extern functions to use within ballerina.
  */
 public class OpenTracerBallerinaWrapper {
-    static final int ROOT_SPAN_INDICATOR = -2;
     private static final Logger log = LoggerFactory.getLogger(OpenTracerBallerinaWrapper.class);
+
     private static final OpenTracerBallerinaWrapper instance = new OpenTracerBallerinaWrapper();
-    private static final int SYSTEM_TRACE_INDICATOR = -1;
     private final TracersStore tracerStore;
     private final boolean enabled;
     private final Map<Long, ObserverContext> observerContextMap = new HashMap<>();
     private final AtomicLong spanIdCounter = new AtomicLong();
+
+    private static final int SYSTEM_TRACE_INDICATOR = -1;
+    static final int ROOT_SPAN_INDICATOR = -2;
 
     private OpenTracerBallerinaWrapper() {
         enabled = ObserveUtils.isTracingEnabled();

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -35,6 +35,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_MODULE;
+import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_POSITION;
 import static io.ballerina.runtime.observability.ObservabilityConstants.DEFAULT_SERVICE_NAME;
 
 /**
@@ -90,6 +92,10 @@ public class OpenTracerBallerinaWrapper {
             serviceName = prevObserverContext.getServiceName();
             observerContext.setEntrypointFunctionModule(prevObserverContext.getEntrypointFunctionModule());
             observerContext.setEntrypointFunctionPosition(prevObserverContext.getEntrypointFunctionPosition());
+            observerContext.addTag(TAG_KEY_ENTRYPOINT_FUNCTION_MODULE,
+                    prevObserverContext.getEntrypointFunctionModule());
+            observerContext.addTag(TAG_KEY_ENTRYPOINT_FUNCTION_POSITION,
+                    prevObserverContext.getEntrypointFunctionPosition());
         } else {
             serviceName = DEFAULT_SERVICE_NAME;
         }

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -35,24 +35,22 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
+import static io.ballerina.runtime.observability.ObservabilityConstants.DEFAULT_SERVICE_NAME;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_MODULE;
 import static io.ballerina.runtime.observability.ObservabilityConstants.TAG_KEY_ENTRYPOINT_FUNCTION_POSITION;
-import static io.ballerina.runtime.observability.ObservabilityConstants.DEFAULT_SERVICE_NAME;
 
 /**
  * This class wraps opentracing apis and exposes extern functions to use within ballerina.
  */
 public class OpenTracerBallerinaWrapper {
+    static final int ROOT_SPAN_INDICATOR = -2;
     private static final Logger log = LoggerFactory.getLogger(OpenTracerBallerinaWrapper.class);
-
     private static final OpenTracerBallerinaWrapper instance = new OpenTracerBallerinaWrapper();
+    private static final int SYSTEM_TRACE_INDICATOR = -1;
     private final TracersStore tracerStore;
     private final boolean enabled;
     private final Map<Long, ObserverContext> observerContextMap = new HashMap<>();
     private final AtomicLong spanIdCounter = new AtomicLong();
-
-    private static final int SYSTEM_TRACE_INDICATOR = -1;
-    static final int ROOT_SPAN_INDICATOR = -2;
 
     private OpenTracerBallerinaWrapper() {
         enabled = ObserveUtils.isTracingEnabled();

--- a/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
+++ b/observelib/observe/src/main/java/org/ballerinalang/observe/nativeimpl/OpenTracerBallerinaWrapper.java
@@ -90,12 +90,12 @@ public class OpenTracerBallerinaWrapper {
         String serviceName;
         if (prevObserverContext != null) {
             serviceName = prevObserverContext.getServiceName();
-            observerContext.setEntrypointFunctionModule(prevObserverContext.getEntrypointFunctionModule());
-            observerContext.setEntrypointFunctionPosition(prevObserverContext.getEntrypointFunctionPosition());
-            observerContext.addTag(TAG_KEY_ENTRYPOINT_FUNCTION_MODULE,
-                    prevObserverContext.getEntrypointFunctionModule());
-            observerContext.addTag(TAG_KEY_ENTRYPOINT_FUNCTION_POSITION,
-                    prevObserverContext.getEntrypointFunctionPosition());
+            String entrypointFunctionModule = prevObserverContext.getEntrypointFunctionModule();
+            String entrypointFunctionPosition = prevObserverContext.getEntrypointFunctionPosition();
+            observerContext.setEntrypointFunctionModule(entrypointFunctionModule);
+            observerContext.setEntrypointFunctionPosition(entrypointFunctionPosition);
+            observerContext.addTag(TAG_KEY_ENTRYPOINT_FUNCTION_MODULE, entrypointFunctionModule);
+            observerContext.addTag(TAG_KEY_ENTRYPOINT_FUNCTION_POSITION, entrypointFunctionPosition);
         } else {
             serviceName = DEFAULT_SERVICE_NAME;
         }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
@@ -46,11 +46,11 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
     @DataProvider(name = "async-call-data-provider")
     public Object[][] getAsyncCallData() {
         return new Object[][] {
-                {"resourceOne", FILE_NAME + ":22:5", FILE_NAME + ":23:33", FILE_NAME + ":29:20",
+                {"resourceOne", FILE_NAME + ":23:5", FILE_NAME + ":24:33", FILE_NAME + ":30:20",
                         MOCK_CLIENT_OBJECT_NAME, "calculateSum", null, null},
-                {"resourceTwo", FILE_NAME + ":33:5", FILE_NAME + ":34:33", FILE_NAME + ":40:20",
+                {"resourceTwo", FILE_NAME + ":34:5", FILE_NAME + ":35:33", FILE_NAME + ":41:20",
                         null, null, null, "calculateSumWithObservability"},
-                {"resourceThree", FILE_NAME + ":44:5", FILE_NAME + ":46:33", FILE_NAME + ":52:20",
+                {"resourceThree", FILE_NAME + ":45:5", FILE_NAME + ":47:33", FILE_NAME + ":53:20",
                         null, null, OBSERVABLE_ADDER_OBJECT_NAME, "getSum"}
         };
     }
@@ -65,7 +65,7 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -80,7 +80,7 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -89,9 +89,12 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -110,8 +113,8 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", asyncCallPosition),
                     asyncCallActionName == null ? null : new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     asyncCallConnectorName == null
                             ? null
                             : new AbstractMap.SimpleEntry<>("src.object.name", asyncCallConnectorName),
@@ -140,8 +143,8 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", callerRespondPosition),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -150,14 +153,14 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
 
     @DataProvider(name = "workers-data-provider")
     public Object[][] getWorkersData() {
-        final String w1Position = FILE_NAME + ":103:15";
-        final String w2Position = FILE_NAME + ":110:15";
+        final String w1Position = FILE_NAME + ":104:15";
+        final String w2Position = FILE_NAME + ":111:15";
         return new Object[][] {
-                {"resourceFour", FILE_NAME + ":56:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":58:20"},
-                {"resourceFive", FILE_NAME + ":62:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":64:20"},
-                {"resourceSix", FILE_NAME + ":68:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":70:20"},
-                {"resourceSeven", FILE_NAME + ":74:5", "w3", FILE_NAME + ":77:35", "w4", FILE_NAME + ":85:35",
-                        FILE_NAME + ":98:20"}
+                {"resourceFour", FILE_NAME + ":57:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":59:20"},
+                {"resourceFive", FILE_NAME + ":63:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":65:20"},
+                {"resourceSix", FILE_NAME + ":69:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":71:20"},
+                {"resourceSeven", FILE_NAME + ":75:5", "w3", FILE_NAME + ":78:35", "w4", FILE_NAME + ":86:35",
+                        FILE_NAME + ":99:20"}
         };
     }
 
@@ -171,7 +174,7 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -187,7 +190,7 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -196,9 +199,12 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -215,8 +221,9 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", workerAPosition),
                     new AbstractMap.SimpleEntry<>("src.worker", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.function.name", workerAName)
             ));
         });
 
@@ -233,8 +240,9 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", workerBPosition),
                     new AbstractMap.SimpleEntry<>("src.worker", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.function.name", workerBName)
             ));
         });
 
@@ -251,8 +259,8 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", callerRespondPosition),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
@@ -26,6 +26,7 @@ import org.testng.annotations.Test;
 
 import java.util.AbstractMap;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -44,16 +45,18 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
     @Test
     public void testAddCustomSpanToSystemTrace() throws Exception {
         final String resourceName = "resourceOne";
-        final String span1Position = FILE_NAME + ":21:5";
-        final String span3Position = FILE_NAME + ":32:19";
-        final String span5Position = FILE_NAME + ":45:20";
+        final String entrypointPosition = FILE_NAME + ":22:5";
+        final String span1Position = FILE_NAME + ":22:5";
+        final String span3Position = FILE_NAME + ":33:19";
+        final String span5Position = FILE_NAME + ":46:20";
 
-        HttpResponse httpResponse = HttpClientRequest.doGet(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName);
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+                "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Hello! from resource one");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
         Assert.assertEquals(spans.size(), 5);
         Assert.assertEquals(spans.stream()
                         .filter(span -> !Objects.equals(span.getTags().get("custom"), "true"))
@@ -70,18 +73,21 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span1Position),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
-                    new AbstractMap.SimpleEntry<>("http.method", "GET"),
+                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -95,6 +101,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "1")
             ));
@@ -112,8 +120,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.function.name", "calculateSumWithObservability")
             ));
         });
@@ -128,6 +136,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "2")
             ));
@@ -146,8 +156,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span5Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -157,16 +167,18 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
     @Test
     public void testCustomTrace() throws Exception {
         final String resourceName = "resourceTwo";
-        final String span1Position = FILE_NAME + ":55:5";
-        final String span2Position = FILE_NAME + ":74:15";
-        final String span3Position = FILE_NAME + ":63:20";
+        final String entrypointPosition = FILE_NAME + ":56:5";
+        final String span1Position = FILE_NAME + ":56:5";
+        final String span2Position = FILE_NAME + ":75:15";
+        final String span3Position = FILE_NAME + ":64:20";
 
-        HttpResponse httpResponse = HttpClientRequest.doGet(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName);
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+                "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Hello! from resource two");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
         Assert.assertEquals(spans.size(), 5);
         Assert.assertEquals(spans.stream()
                         .filter(span -> !Objects.equals(span.getTags().get("custom"), "true"))
@@ -183,18 +195,21 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span1Position),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
-                    new AbstractMap.SimpleEntry<>("http.method", "GET"),
+                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -210,8 +225,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.function.name", "calculateSumWithObservability")
             ));
         });
@@ -229,8 +244,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -247,6 +262,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "3")
             ));
@@ -262,6 +279,8 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "4")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
@@ -45,8 +45,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
     @Test
     public void testAddCustomSpanToSystemTrace() throws Exception {
         final String resourceName = "resourceOne";
-        final String entrypointPosition = FILE_NAME + ":22:5";
-        final String span1Position = FILE_NAME + ":22:5";
+        final String resourceFunctionPosition = FILE_NAME + ":22:5";
         final String span3Position = FILE_NAME + ":33:19";
         final String span5Position = FILE_NAME + ":46:20";
 
@@ -56,17 +55,17 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Hello! from resource one");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.size(), 5);
         Assert.assertEquals(spans.stream()
                         .filter(span -> !Objects.equals(span.getTags().get("custom"), "true"))
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span3Position, span5Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span3Position, span5Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -77,13 +76,13 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
@@ -102,7 +101,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "1")
             ));
@@ -121,7 +120,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.function.name", "calculateSumWithObservability")
             ));
         });
@@ -137,7 +136,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "2")
             ));
@@ -157,7 +156,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span5Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -167,8 +166,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
     @Test
     public void testCustomTrace() throws Exception {
         final String resourceName = "resourceTwo";
-        final String entrypointPosition = FILE_NAME + ":56:5";
-        final String span1Position = FILE_NAME + ":56:5";
+        final String resourceFunctionPosition = FILE_NAME + ":56:5";
         final String span2Position = FILE_NAME + ":75:15";
         final String span3Position = FILE_NAME + ":64:20";
 
@@ -178,17 +176,17 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Hello! from resource two");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.size(), 5);
         Assert.assertEquals(spans.stream()
                         .filter(span -> !Objects.equals(span.getTags().get("custom"), "true"))
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span2Position, span3Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span2Position, span3Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 2);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -199,13 +197,13 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
@@ -226,7 +224,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.function.name", "calculateSumWithObservability")
             ));
         });
@@ -245,7 +243,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -263,7 +261,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "3")
             ));
@@ -280,7 +278,7 @@ public class CustomTracingTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("resource", resourceName),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("custom", "true"),
                     new AbstractMap.SimpleEntry<>("index", "4")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -226,7 +226,7 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Sum of numbers: 120");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(serviceName, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(serviceName, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -213,15 +213,16 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
         });
     }
 
-    @Test(enabled = false)  // TODO: enable after fixing the anonymous service name issue
+    @Test
     public void testProgrammaticallyStartedService() throws Exception {
-        final String serviceName = "$anonService$_0";
+        final String serviceName = "intg_tests_tracing_tests_0";
+        final String basePath = "testServiceOne";
         final String resourceName = "resourceOne";
         final String resourceFunctionPosition = "01_main_function.bal:45:9";
         final String callerResponsePosition = "01_main_function.bal:51:24";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(
-                "http://localhost:9091/" + serviceName + "/" + resourceName, "15", Collections.emptyMap());
+                "http://localhost:9091/" + basePath + "/" + resourceName, "15", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Sum of numbers: 120");
         Thread.sleep(1000);
@@ -241,18 +242,21 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + serviceName + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", "/" + basePath + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", serviceName),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", serviceName),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -269,8 +273,8 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", callerResponsePosition),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", serviceName),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -215,7 +215,7 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
 
     @Test
     public void testProgrammaticallyStartedService() throws Exception {
-        final String serviceName = "intg_tests_tracing_tests_0";
+        final String serviceName = "intg_tests_tracing_tests_svc_0";
         final String basePath = "testServiceOne";
         final String resourceName = "resourceOne";
         final String resourceFunctionPosition = "01_main_function.bal:45:9";

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
@@ -45,8 +45,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     @Test
     public void testObservableFunction() throws Exception {
         final String resourceName = "resourceOne";
-        final String entrypointPosition = FILE_NAME + ":23:5";
-        final String span1Position = FILE_NAME + ":23:5";
+        final String resourceFunctionPosition = FILE_NAME + ":23:5";
         final String span2Position = FILE_NAME + ":24:19";
         final String span3Position = FILE_NAME + ":29:20";
 
@@ -56,15 +55,15 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span2Position, span3Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span2Position, span3Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -75,13 +74,13 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
@@ -102,7 +101,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.function.name", "calculateSumWithObservability")
             ));
         });
@@ -121,7 +120,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -131,8 +130,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     @Test
     public void testObservableAttachedFunction() throws Exception {
         final String resourceName = "resourceTwo";
-        final String entrypointPosition = FILE_NAME + ":33:5";
-        final String span1Position = FILE_NAME + ":33:5";
+        final String resourceFunctionPosition = FILE_NAME + ":33:5";
         final String span2Position = FILE_NAME + ":35:19";
         final String span3Position = FILE_NAME + ":40:20";
 
@@ -142,15 +140,15 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span2Position, span3Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span2Position, span3Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -161,13 +159,13 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
@@ -188,7 +186,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", OBSERVABLE_ADDER_OBJECT_NAME),
                     new AbstractMap.SimpleEntry<>("src.function.name", "getSum")
             ));
@@ -208,7 +206,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
@@ -45,9 +45,10 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     @Test
     public void testObservableFunction() throws Exception {
         final String resourceName = "resourceOne";
-        final String span1Position = FILE_NAME + ":22:5";
-        final String span2Position = FILE_NAME + ":23:19";
-        final String span3Position = FILE_NAME + ":28:20";
+        final String entrypointPosition = FILE_NAME + ":23:5";
+        final String span1Position = FILE_NAME + ":23:5";
+        final String span2Position = FILE_NAME + ":24:19";
+        final String span3Position = FILE_NAME + ":29:20";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
                 "", Collections.emptyMap());
@@ -55,7 +56,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -70,7 +71,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -79,9 +80,12 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -97,8 +101,8 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.function.name", "calculateSumWithObservability")
             ));
         });
@@ -116,8 +120,8 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -127,9 +131,10 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     @Test
     public void testObservableAttachedFunction() throws Exception {
         final String resourceName = "resourceTwo";
-        final String span1Position = FILE_NAME + ":32:5";
-        final String span2Position = FILE_NAME + ":34:19";
-        final String span3Position = FILE_NAME + ":39:20";
+        final String entrypointPosition = FILE_NAME + ":33:5";
+        final String span1Position = FILE_NAME + ":33:5";
+        final String span2Position = FILE_NAME + ":35:19";
+        final String span3Position = FILE_NAME + ":40:20";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
                 "", Collections.emptyMap());
@@ -137,7 +142,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, resourceName);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -152,7 +157,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         span1.ifPresent(span -> {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
-            Assert.assertEquals(span.getOperationName(), resourceName);
+            Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -161,9 +166,12 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVER_CONNECTOR_NAME)
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
         });
 
@@ -179,8 +187,8 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("span.kind", "client"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", OBSERVABLE_ADDER_OBJECT_NAME),
                     new AbstractMap.SimpleEntry<>("src.function.name", "getSum")
             ));
@@ -199,8 +207,8 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("service", SERVICE_NAME),
-                    new AbstractMap.SimpleEntry<>("resource", resourceName),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -192,7 +192,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
             Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
-//            TODO: Uncomment this assertion once https://github.com/ballerina-platform/ballerina-lang/issues/28686 is fixed
+//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
 //            Assert.assertEquals(span.getTags(), toMap(
 //                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
 //                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -220,7 +220,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTraceId(), traceId);
             Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
             Assert.assertEquals(span.getOperationName(), MOCK_CLIENT_OBJECT_NAME + ":callWithErrorReturn");
-//            TODO: Uncomment this assertion once https://github.com/ballerina-platform/ballerina-lang/issues/28686 is fixed
+//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
 //            Assert.assertEquals(span.getTags(), toMap(
 //                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
 //                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -292,7 +292,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTraceId(), traceId);
             Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
             Assert.assertEquals(span.getOperationName(), MOCK_CLIENT_OBJECT_NAME + ":callWithErrorReturn");
-//            TODO: Uncomment this assertion once https://github.com/ballerina-platform/ballerina-lang/issues/28686 is fixed
+//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
 //            Assert.assertEquals(span.getTags(), toMap(
 //                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
 //                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -387,7 +387,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTraceId(), traceId);
             Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
             Assert.assertEquals(span.getOperationName(), MOCK_CLIENT_OBJECT_NAME + ":callWithPanic");
-//            TODO: Uncomment this assertion once https://github.com/ballerina-platform/ballerina-lang/issues/28686 is fixed
+//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
 //            Assert.assertEquals(span.getTags(), toMap(
 //                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
 //                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -46,8 +47,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @Test
     public void testNestedRemoteCalls() throws Exception {
         final String resourceName = "resourceOne";
-        final String entrypointPosition = FILE_NAME + ":22:5";
-        final String span1Position = FILE_NAME + ":22:5";
+        final String resourceFunctionPosition = FILE_NAME + ":22:5";
         final String span2Position = FILE_NAME + ":23:9";
         final String span3Position = MOCK_CLIENT_FILE_NAME + ":32:9";
         final String span4Position = FILE_NAME + ":24:20";
@@ -58,15 +58,15 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span2Position, span3Position, span4Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span2Position, span3Position, span4Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -77,13 +77,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
@@ -106,7 +106,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
                     new AbstractMap.SimpleEntry<>("src.function.name", "callAnotherRemoteFunction")
             ));
@@ -126,7 +126,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
                     new AbstractMap.SimpleEntry<>("src.function.name", "callWithNoReturn")
             ));
@@ -146,7 +146,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span4Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -192,24 +192,27 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
             Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
-//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
-//            Assert.assertEquals(span.getTags(), toMap(
-//                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
-//                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
-//                    new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-//                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
-//                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
-//                    new AbstractMap.SimpleEntry<>("protocol", "http"),
-//                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
-//                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-//                    new AbstractMap.SimpleEntry<>("error", "true"),
-//                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+            Map<String, Object> tags = span.getTags();
+//            TODO: Remove the bellow line once #ballerina-lang/issues/28686 is fixed
+            tags.keySet().removeIf(key -> key.equals("error.message"));
+            Assert.assertEquals(tags, toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
+                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
+                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
+                    new AbstractMap.SimpleEntry<>("protocol", "http"),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("error", "true"),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+//                    TODO: Uncomment the bellow line once #ballerina-lang/issues/28686 is fixed
 //                    new AbstractMap.SimpleEntry<>("error.message", errorMessage),
-//                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
-//            ));
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
+            ));
         });
 
         Optional<BMockSpan> span2 = spans.stream()
@@ -220,19 +223,22 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTraceId(), traceId);
             Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
             Assert.assertEquals(span.getOperationName(), MOCK_CLIENT_OBJECT_NAME + ":callWithErrorReturn");
-//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
-//            Assert.assertEquals(span.getTags(), toMap(
-//                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
-//                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("src.position", remoteCallPosition),
-//                    new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-//                    new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
-//                    new AbstractMap.SimpleEntry<>("src.function.name", "callWithErrorReturn"),
-//                    new AbstractMap.SimpleEntry<>("error", "true"),
+            Map<String, Object> tags = span.getTags();
+//            TODO: Remove the bellow line once #ballerina-lang/issues/28686 is fixed
+            tags.keySet().removeIf(key -> key.equals("error.message"));
+            Assert.assertEquals(tags, toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
+                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", remoteCallPosition),
+                    new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
+                    new AbstractMap.SimpleEntry<>("src.function.name", "callWithErrorReturn"),
+//                    TODO: Uncomment the bellow line once #ballerina-lang/issues/28686 is fixed
 //                    new AbstractMap.SimpleEntry<>("error.message", errorMessage),
-//            ));
+                    new AbstractMap.SimpleEntry<>("error", "true")
+            ));
         });
     }
 
@@ -240,8 +246,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @Test
     public void testIgnoredErrorReturnInRemoteCall() throws Exception {
         final String resourceName = "resourceFour";
-        final String entrypointPosition = FILE_NAME + ":40:5";
-        final String span1Position = FILE_NAME + ":40:5";
+        final String resourceFunctionPosition = FILE_NAME + ":40:5";
         final String span2Position = FILE_NAME + ":41:19";
         final String span3Position = FILE_NAME + ":42:20";
 
@@ -251,15 +256,15 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span2Position, span3Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span2Position, span3Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -270,13 +275,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
@@ -292,23 +297,27 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTraceId(), traceId);
             Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
             Assert.assertEquals(span.getOperationName(), MOCK_CLIENT_OBJECT_NAME + ":callWithErrorReturn");
-//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
-//            Assert.assertEquals(span.getTags(), toMap(
-//                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
-//                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("src.position", span2Position),
-//                    new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
-//                    new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
-//                    new AbstractMap.SimpleEntry<>("src.function.name", "callWithErrorReturn"),
-//                    new AbstractMap.SimpleEntry<>("error", "true"),
+            Map<String, Object> tags = span.getTags();
+//            TODO: Remove the bellow line once #ballerina-lang/issues/28686 is fixed
+            tags.keySet().removeIf(key -> key.equals("error.message"));
+            Assert.assertEquals(tags, toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
+                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", span2Position),
+                    new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
+                    new AbstractMap.SimpleEntry<>("src.function.name", "callWithErrorReturn"),
+//                    TODO: Uncomment the bellow line once #ballerina-lang/issues/28686 is fixed
 //                    new AbstractMap.SimpleEntry<>("error.message", "Test Error\n" +
 //                            "    at intg_tests.tracing_tests.utils.0_0_1.MockClient:callWithErrorReturn" +
 //                            "(mock_client_endpoint.bal:46)\n" +
 //                            "       intg_tests.tracing_tests.0_0_1.$anonType$_8:$post$resourceFour" +
 //                            "(03_remote_call.bal:41)")
-//            ));
+                    new AbstractMap.SimpleEntry<>("error", "true")
+
+            ));
         });
 
         Optional<BMockSpan> span3 = spans.stream()
@@ -325,7 +334,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));
@@ -335,8 +344,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @Test
     public void testTrappedPanic() throws Exception {
         final String resourceName = "resourceFive";
-        final String entrypointPosition = FILE_NAME + ":46:5";
-        final String span1Position = FILE_NAME + ":46:5";
+        final String resourceFunctionPosition = FILE_NAME + ":46:5";
         final String span2Position = FILE_NAME + ":47:24";
         final String span3Position = FILE_NAME + ":49:24";
 
@@ -346,15 +354,15 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         Assert.assertEquals(httpResponse.getData(), "Successfully trapped panic: Test Error");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, entrypointPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
-                new HashSet<>(Arrays.asList(span1Position, span2Position, span3Position)));
+                new HashSet<>(Arrays.asList(resourceFunctionPosition, span2Position, span3Position)));
         Assert.assertEquals(spans.stream().filter(bMockSpan -> bMockSpan.getParentId() == 0).count(), 1);
 
         Optional<BMockSpan> span1 = spans.stream()
-                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), span1Position))
+                .filter(bMockSpan -> Objects.equals(bMockSpan.getTags().get("src.position"), resourceFunctionPosition))
                 .findFirst();
         Assert.assertTrue(span1.isPresent());
         long traceId = span1.get().getTraceId();
@@ -365,13 +373,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTags(), toMap(
                     new AbstractMap.SimpleEntry<>("span.kind", "server"),
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("src.position", span1Position),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
                     new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName),
@@ -387,23 +395,26 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
             Assert.assertEquals(span.getTraceId(), traceId);
             Assert.assertEquals(span.getParentId(), span1.get().getSpanId());
             Assert.assertEquals(span.getOperationName(), MOCK_CLIENT_OBJECT_NAME + ":callWithPanic");
-//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
-//            Assert.assertEquals(span.getTags(), toMap(
-//                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
-//                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("src.position", span2Position),
-//                    new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
-//                    new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
-//                    new AbstractMap.SimpleEntry<>("src.function.name", "callWithPanic"),
-//                    new AbstractMap.SimpleEntry<>("error", "true"),
+            Map<String, Object> tags = span.getTags();
+//            TODO: Remove the bellow line once #ballerina-lang/issues/28686 is fixed
+            tags.keySet().removeIf(key -> key.equals("error.message"));
+            Assert.assertEquals(tags, toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "client"),
+                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", span2Position),
+                    new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.object.name", MOCK_CLIENT_OBJECT_NAME),
+                    new AbstractMap.SimpleEntry<>("src.function.name", "callWithPanic"),
+//                    TODO: Uncomment the bellow line once #ballerina-lang/issues/28686 is fixed
 //                    new AbstractMap.SimpleEntry<>("error.message", "Test Error\n" +
 //                            "    at intg_tests.tracing_tests.utils.0_0_1.MockClient:callWithPanic" +
 //                            "(mock_client_endpoint.bal:58)\n" +
 //                            "       intg_tests.tracing_tests.0_0_1.$anonType$_7:$post$resourceFive" +
 //                            "(03_remote_call.bal:47)")
-//            ));
+                    new AbstractMap.SimpleEntry<>("error", "true")
+            ));
         });
 
         Optional<BMockSpan> span3 = spans.stream()
@@ -420,7 +431,7 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.position", span3Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", entrypointPosition),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/testobserve/Caller"),
                     new AbstractMap.SimpleEntry<>("src.function.name", "respond")
             ));

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -242,7 +242,6 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         });
     }
 
-    //
     @Test
     public void testIgnoredErrorReturnInRemoteCall() throws Exception {
         final String resourceName = "resourceFour";

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
@@ -30,6 +30,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -162,24 +163,27 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
             Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
-//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
-//            Assert.assertEquals(span.getTags(), toMap(
-//                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
-//                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
-//                    new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-//                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
-//                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
-//                    new AbstractMap.SimpleEntry<>("protocol", "http"),
-//                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
-//                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
-//                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-//                    new AbstractMap.SimpleEntry<>("error", "true"),
-//                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+            Map<String, Object> tags = span.getTags();
+//            TODO: Remove the bellow line once #ballerina-lang/issues/28686 is fixed
+            tags.keySet().removeIf(key -> key.equals("error.message"));
+            Assert.assertEquals(span.getTags(), toMap(
+                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
+                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
+                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.method", "POST"),
+                    new AbstractMap.SimpleEntry<>("protocol", "http"),
+                    new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
+                    new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
+                    new AbstractMap.SimpleEntry<>("error", "true"),
+                    new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
+//                    TODO: Uncomment the bellow line once #ballerina-lang/issues/28686 is fixed
 //                    new AbstractMap.SimpleEntry<>("error.message", errorMessage),
-//                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
-//            ));
+                    new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
+            ));
         });
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
@@ -45,7 +45,7 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
 
     @DataProvider(name = "success-response-data-provider")
     public Object[][] getSuccessResponseData() {
-        return new Object[][]{
+        return new Object[][] {
                 {"resourceOne", "15", FILE_NAME + ":23:5", FILE_NAME + ":29:20", "Sum of numbers: 120"},
                 {"resourceTwo", "16", FILE_NAME + ":33:5", FILE_NAME + ":39:20", "Sum of numbers: 136"}
         };
@@ -116,7 +116,7 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
 
     @DataProvider(name = "error-response-data-provider")
     public Object[][] getErrorResponseData() {
-        return new Object[][]{
+        return new Object[][] {
                 {"resourceThree", FILE_NAME + ":43:5", "Test Error 1", "Test Error 1\n" +
                         "    at intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceThree" +
                         "(02_resource_function.bal:54)"},
@@ -138,7 +138,8 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
 
     @Test(dataProvider = "error-response-data-provider")
     public void testResourceSingleSpanErrorResponse(String resourceName, String resourceFunctionPosition,
-                                                    String expectedResponsePayload, String errorMessage) throws Exception {
+                                                    String expectedResponsePayload, String errorMessage)
+            throws Exception {
         HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
                 "15", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 500);
@@ -161,7 +162,7 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
             Assert.assertTrue(spans.stream().noneMatch(mockSpan -> mockSpan.getTraceId() == traceId
                     && mockSpan.getSpanId() == span.getParentId()));
             Assert.assertEquals(span.getOperationName(), "post /" + resourceName);
-//            TODO: Uncomment this assertion once https://github.com/ballerina-platform/ballerina-lang/issues/28686 is fixed
+//            TODO: Uncomment this assertion once #ballerina-lang/issues/28686 is fixed
 //            Assert.assertEquals(span.getTags(), toMap(
 //                    new AbstractMap.SimpleEntry<>("span.kind", "server"),
 //                    new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
@@ -184,7 +185,7 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
 
     @DataProvider(name = "simple-remote-call-data-provider")
     public Object[][] getSimpleRemoteCallData() {
-        return new Object[][]{
+        return new Object[][] {
                 {"resourceSeven", FILE_NAME + ":89:5", FILE_NAME + ":91:30", FILE_NAME + ":98:20",
                         "Sum of numbers: 12"},
                 {"resourceEight", FILE_NAME + ":102:5", FILE_NAME + ":103:24", FILE_NAME + ":105:24",

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -69,7 +69,6 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
 
     protected List<BMockSpan> getFinishedSpans(String serviceName, String entrypointModule,
                                                String entrypointPosition) throws IOException {
-//    protected List<BMockSpan> getFinishedSpans(String serviceName, String resource) throws IOException {
         return getFinishedSpans(serviceName).stream()
                 .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.module"), entrypointModule))
                 .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.position"), entrypointPosition))

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -67,9 +67,12 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
         super.cleanupServer();
     }
 
-    protected List<BMockSpan> getFinishedSpans(String serviceName, String resource) throws IOException {
+    protected List<BMockSpan> getFinishedSpans(String serviceName, String entrypointModule,
+                                               String entrypointPosition) throws IOException {
+//    protected List<BMockSpan> getFinishedSpans(String serviceName, String resource) throws IOException {
         return getFinishedSpans(serviceName).stream()
-                .filter(span -> Objects.equals(span.getTags().get("resource"), resource))
+                .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.module"), entrypointModule))
+                .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.position"), entrypointPosition))
                 .collect(Collectors.toList());
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -70,8 +70,8 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
     protected List<BMockSpan> getFinishedSpans(String serviceName, String entrypointModule,
                                                String entrypointPosition) throws IOException {
         return getFinishedSpans(serviceName).stream()
-                .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.module"), entrypointModule))
-                .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.position"), entrypointPosition))
+                .filter(span -> Objects.equals(span.getTags().get("entrypoint.function.module"), entrypointModule) &&
+                        Objects.equals(span.getTags().get("entrypoint.function.position"), entrypointPosition))
                 .collect(Collectors.toList());
     }
 

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/01_main_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/01_main_function.bal
@@ -42,7 +42,7 @@ public function main() returns error? {
     }
 
     service object {} testServiceInMain = service object {
-        resource function get resourceOne(testobserve:Caller caller, string body) {
+        resource function post resourceOne(testobserve:Caller caller, string body) {
             int numberCount = checkpanic 'int:fromString(body);
             var sum = 0;
             foreach var i in 1 ... numberCount {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
@@ -17,6 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
+@display { label:"testServiceTwo" }
 service /testServiceTwo on new testobserve:Listener(9092) {
     # Resource function for testing whether no return functions are instrumented properly.
     resource function post resourceOne(testobserve:Caller caller, string body) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-@display { label:"testServiceTwo" }
+@display { label: "testServiceTwo" }
 service /testServiceTwo on new testobserve:Listener(9092) {
     # Resource function for testing whether no return functions are instrumented properly.
     resource function post resourceOne(testobserve:Caller caller, string body) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
@@ -16,7 +16,7 @@
 
 import ballerina/testobserve;
 
-@display { label:"testServiceThree" }
+@display { label: "testServiceThree" }
 service /testServiceThree on new testobserve:Listener(9093) {
     # Resource function for testing remote call which calls another remote call
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
@@ -16,6 +16,7 @@
 
 import ballerina/testobserve;
 
+@display { label:"testServiceThree" }
 service /testServiceThree on new testobserve:Listener(9093) {
     # Resource function for testing remote call which calls another remote call
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-@display { label:"testServiceFour" }
+@display { label: "testServiceFour" }
 service /testServiceFour on new testobserve:Listener(9094) {
     # Resource function for testing function call with observable annotation
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
@@ -17,6 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
+@display { label:"testServiceFour" }
 service /testServiceFour on new testobserve:Listener(9094) {
     # Resource function for testing function call with observable annotation
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
@@ -17,6 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
+@display { label:"testServiceFive" }
 service /testServiceFive on new testobserve:Listener(9095) {
     # Resource function for testing async remote call wait
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-@display { label:"testServiceFive" }
+@display { label: "testServiceFive" }
 service /testServiceFive on new testobserve:Listener(9095) {
     # Resource function for testing async remote call wait
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/06_custom_trace_spans.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/06_custom_trace_spans.bal
@@ -17,6 +17,7 @@
 import ballerina/testobserve;
 import ballerina/observe;
 
+@display { label:"testServiceSix" }
 service /testServiceSix on new testobserve:Listener(9096) {
     resource function post resourceOne(testobserve:Caller caller) {
         var customSpanOneId = checkpanic observe:startSpan("customSpanOne");

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/06_custom_trace_spans.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/06_custom_trace_spans.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import ballerina/observe;
 
-@display { label:"testServiceSix" }
+@display { label: "testServiceSix" }
 service /testServiceSix on new testobserve:Listener(9096) {
     resource function post resourceOne(testobserve:Caller caller) {
         var customSpanOneId = checkpanic observe:startSpan("customSpanOne");

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/commons.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/commons.bal
@@ -20,7 +20,7 @@ import intg_tests/tracing_tests.utils as utils;
 
 utils:MockClient testClient = new();
 
-@display { label:"mockTracer" }
+@display { label: "mockTracer" }
 service /mockTracer on new testobserve:Listener(9090) {
     resource function post getMockTraces(testobserve:Caller caller, string serviceName) {
         json spans = testobserve:getFinishedSpans(serviceName);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/commons.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/commons.bal
@@ -20,6 +20,7 @@ import intg_tests/tracing_tests.utils as utils;
 
 utils:MockClient testClient = new();
 
+@display { label:"mockTracer" }
 service /mockTracer on new testobserve:Listener(9090) {
     resource function post getMockTraces(testobserve:Caller caller, string serviceName) {
         json spans = testobserve:getFinishedSpans(serviceName);

--- a/tests/jballerina-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-integration-test/src/test/resources/testng.xml
@@ -208,11 +208,11 @@
         <classes>
             <class name="org.ballerinalang.test.observability.tracing.TracingBaseTestCase"/>
             <class name="org.ballerinalang.test.observability.tracing.MainFunctionTestCase"/>
-<!--            <class name="org.ballerinalang.test.observability.tracing.ResourceFunctionTestCase"/>-->
-<!--            <class name="org.ballerinalang.test.observability.tracing.RemoteCallTestCase"/>-->
-<!--            <class name="org.ballerinalang.test.observability.tracing.ObservableAnnotationTestCase"/>-->
-<!--            <class name="org.ballerinalang.test.observability.tracing.ConcurrencyTestCase"/>-->
-<!--            <class name="org.ballerinalang.test.observability.tracing.CustomTracingTestCase"/>-->
+            <class name="org.ballerinalang.test.observability.tracing.ResourceFunctionTestCase"/>
+            <class name="org.ballerinalang.test.observability.tracing.RemoteCallTestCase"/>
+            <class name="org.ballerinalang.test.observability.tracing.ObservableAnnotationTestCase"/>
+            <class name="org.ballerinalang.test.observability.tracing.ConcurrencyTestCase"/>
+            <class name="org.ballerinalang.test.observability.tracing.CustomTracingTestCase"/>
             <class name="org.ballerinalang.test.observability.metrics.MetricsTestCase"/>
 <!--            <class name="org.ballerinalang.test.observability.tracing.HttpTracingBaseTest"/>-->
 <!--            <class name="org.ballerinalang.test.observability.tracing.HttpTracingTestCase"/>-->


### PR DESCRIPTION
## Purpose
> $Title

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/27402, https://github.com/ballerina-platform/ballerina-lang/issues/27300

## Approach
> Use `@display` annotation to read service names. In case the user has not provided service names, default service names are generated by using the `org name` and `package name` along with a program level counter.

## Samples
```ballerina
@display { label: "greet" }
service on new http:Listener(8090) {
    resource function get sayHello(http:Caller caller, http:Request req) {
        //User Code
    }
}
```

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
