### PR TITLE
Validate for invalid identifier when renaming

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -436,7 +436,6 @@ public class ReferenceFinder extends BaseVisitor {
     @Override
     public void visit(BLangConstPattern constMatchPattern) {
         find(constMatchPattern.expr);
-        find(constMatchPattern.matchExpr);
     }
 
     @Override
@@ -557,7 +556,6 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangMatchClause matchClause) {
-        find(matchClause.expr);
         find(matchClause.matchGuard);
         find(matchClause.blockStmt);
         find(matchClause.matchPatterns);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/BallerinaTextDocumentService.java
@@ -91,7 +91,6 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/PatternConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/PatternConstants.java
@@ -16,7 +16,7 @@
 package org.ballerinalang.langserver.common.constants;
 
 /**
- * Holds constants related to regex patterns
+ * Holds constants related to regex patterns.
  *
  * @since 2.0.0
  */
@@ -54,7 +54,7 @@ public class PatternConstants {
             IDENTIFIER_ESCAPE_PATTERN + ")+";
     
     /**
-     * Regex to match a valid identifier name as per the ballerina specification
+     * Regex to match a valid identifier name as per the ballerina specification.
      */
     public static final String IDENTIFIER_PATTERN = UNQUOTED_IDENTIFIER_PATTERN + "|" + QUOTED_IDENTIFIER_PATTERN;
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/PatternConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/PatternConstants.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.common.constants;
+
+/**
+ * Holds constants related to regex patterns
+ *
+ * @since 2.0.0
+ */
+public class PatternConstants {
+
+    private PatternConstants() {
+    }
+
+    public static final String UNICODE_PATTERN_WHITESPACE_CHAR_PATTERN = "[\u200E\u200F\u2028\u2029]";
+    public static final String UNICODE_PRIVATE_USE_CHAR =
+            "[\uE000-\uF8FF]|[\\x{F0000}-\\x{FFFFD}]|[\\x{100000}-\\x{10FFFD}]";
+    public static final String UNICODE_NON_IDENTIFIER_CHAR = "(" + UNICODE_PATTERN_WHITESPACE_CHAR_PATTERN + "|" +
+            UNICODE_PRIVATE_USE_CHAR + ")";
+
+    public static final String ASCII_CHAR_PATTERN = "[\u0000-\u007F]";
+    public static final String ASCII_LETTER_PATTERN = "[A-Za-z]";
+    public static final String UNICODE_IDENTIFIER_CHAR_PATTERN = "[^(" + ASCII_CHAR_PATTERN + "|" +
+            UNICODE_NON_IDENTIFIER_CHAR + ")]";
+    public static final String DIGIT_PATTERN = "[0-9]";
+    public static final String NUMERIC_ESCAPE_PATTERN = "^\\\\u[A-Fa-f0-9]+";
+
+    public static final String IDENTIFIER_INITIAL_CHAR_PATTERN = "(" + ASCII_LETTER_PATTERN + "|_|" +
+            UNICODE_IDENTIFIER_CHAR_PATTERN + ")";
+    public static final String IDENTIFIER_SINGLE_ESCAPE_PATTERN = "\\[^(" + ASCII_LETTER_PATTERN +
+            "|\\x09|\\x0A|\\x0D|" + UNICODE_PATTERN_WHITESPACE_CHAR_PATTERN + ")]";
+
+    public static final String IDENTIFIER_ESCAPE_PATTERN = "(" + IDENTIFIER_SINGLE_ESCAPE_PATTERN + "|" +
+            NUMERIC_ESCAPE_PATTERN + ")";
+    public static final String IDENTIFIER_FOLLOWING_CHAR_PATTERN = "(" + IDENTIFIER_INITIAL_CHAR_PATTERN + "|" +
+            DIGIT_PATTERN + ")";
+    public static final String UNQUOTED_IDENTIFIER_PATTERN = "^(" + IDENTIFIER_INITIAL_CHAR_PATTERN + "|" +
+            IDENTIFIER_ESCAPE_PATTERN + ")(" + IDENTIFIER_FOLLOWING_CHAR_PATTERN + "|" +
+            IDENTIFIER_ESCAPE_PATTERN + ")*";
+    public static final String QUOTED_IDENTIFIER_PATTERN = "^'(" + IDENTIFIER_FOLLOWING_CHAR_PATTERN + "|" +
+            IDENTIFIER_ESCAPE_PATTERN + ")+";
+    
+    /**
+     * Regex to match a valid identifier name as per the ballerina specification
+     */
+    public static final String IDENTIFIER_PATTERN = UNQUOTED_IDENTIFIER_PATTERN + "|" + QUOTED_IDENTIFIER_PATTERN;
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -699,7 +699,7 @@ public class CommonUtil {
      * @param identifier Identifier to be checked for validity
      * @return True, if the identifier is valid as per the ballerina specification
      */
-    public static boolean isIdentifierValid(String identifier) {
+    public static boolean isValidIdentifier(String identifier) {
         if (identifier == null || identifier.isEmpty()) {
             return false;
         }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -50,6 +50,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.ballerinalang.langserver.codeaction.CodeActionModuleId;
 import org.ballerinalang.langserver.common.ImportsAcceptor;
+import org.ballerinalang.langserver.common.constants.PatternConstants;
 import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.ballerinalang.langserver.commons.DocumentServiceContext;
@@ -690,6 +691,20 @@ public class CommonUtil {
             newName = generateName(++suffix, names);
         }
         return newName;
+    }
+
+    /**
+     * Checks if the provided identifier is valid as per the ballerina specification
+     *
+     * @param identifier Identifier to be checked for validity
+     * @return True, if the identifier is valid as per the ballerina specification
+     */
+    public static boolean isIdentifierValid(String identifier) {
+        if (identifier == null || identifier.isEmpty()) {
+            return false;
+        }
+
+        return identifier.matches(PatternConstants.IDENTIFIER_PATTERN);
     }
 
     /**

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -694,7 +694,7 @@ public class CommonUtil {
     }
 
     /**
-     * Checks if the provided identifier is valid as per the ballerina specification
+     * Checks if the provided identifier is valid as per the ballerina specification.
      *
      * @param identifier Identifier to be checked for validity
      * @return True, if the identifier is valid as per the ballerina specification

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -15,7 +15,9 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * A utility to handle renaming related operations
+ * A utility to handle renaming related operations.
+ * 
+ * @since 2.0.0
  */
 public class RenameUtil {
 
@@ -23,7 +25,7 @@ public class RenameUtil {
     }
 
     /**
-     * Process a rename request and returns the text edits required to be made to complete the rename
+     * Process a rename request and returns the text edits required to be made to complete the rename.
      *
      * @param context Context
      * @param newName Assigned identifier after renaming

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -1,0 +1,50 @@
+package org.ballerinalang.langserver.util.rename;
+
+import io.ballerina.projects.Module;
+import io.ballerina.tools.diagnostics.Location;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.ReferencesContext;
+import org.ballerinalang.langserver.exception.UserErrorException;
+import org.ballerinalang.langserver.util.references.ReferencesUtil;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * A utility to handle renaming related operations
+ */
+public class RenameUtil {
+
+    private RenameUtil() {
+    }
+
+    /**
+     * Process a rename request and returns the text edits required to be made to complete the rename
+     *
+     * @param context Context
+     * @param newName Assigned identifier after renaming
+     * @return Text edits for that rename operation
+     */
+    public static Map<String, List<TextEdit>> rename(ReferencesContext context, String newName) {
+        if (!CommonUtil.isIdentifierValid(newName)) {
+            throw new UserErrorException("Invalid identifier provided");
+        }
+
+        Map<Module, List<Location>> locationMap = ReferencesUtil.getReferences(context);
+
+        Path projectRoot = context.workspace().projectRoot(context.filePath());
+
+        Map<String, List<TextEdit>> changes = new HashMap<>();
+        locationMap.forEach((module, locations) ->
+                locations.forEach(location -> {
+                    String uri = ReferencesUtil.getUriFromLocation(module, location, projectRoot);
+                    List<TextEdit> textEdits = changes.computeIfAbsent(uri, k -> new ArrayList<>());
+                    textEdits.add(new TextEdit(ReferencesUtil.getRange(location), newName));
+                }));
+        return changes;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.ballerinalang.langserver.util.rename;
 
 import io.ballerina.projects.Module;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/util/rename/RenameUtil.java
@@ -47,7 +47,7 @@ public class RenameUtil {
      * @return Text edits for that rename operation
      */
     public static Map<String, List<TextEdit>> rename(ReferencesContext context, String newName) {
-        if (!CommonUtil.isIdentifierValid(newName)) {
+        if (!CommonUtil.isValidIdentifier(newName)) {
             throw new UserErrorException("Invalid identifier provided");
         }
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/common/utils/CommonUtilTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/common/utils/CommonUtilTest.java
@@ -25,11 +25,11 @@ import org.testng.annotations.Test;
 public class CommonUtilTest {
 
     /**
-     * Tests the correctness of {@link CommonUtil#isIdentifierValid(String)} method.
+     * Tests the correctness of {@link CommonUtil#isValidIdentifier(String)} method.
      */
     @Test(dataProvider = "data-provider")
     public void testIsIdentifierValid(String identifier, boolean valid) {
-        Assert.assertEquals(CommonUtil.isIdentifierValid(identifier), valid);
+        Assert.assertEquals(CommonUtil.isValidIdentifier(identifier), valid);
     }
 
     @DataProvider(name = "data-provider")

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/common/utils/CommonUtilTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/common/utils/CommonUtilTest.java
@@ -20,12 +20,12 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 /**
- * Tests for {@link CommonUtil}s
+ * Tests for {@link CommonUtil}s.
  */
 public class CommonUtilTest {
 
     /**
-     * Tests the correctness of {@link CommonUtil#isIdentifierValid(String)} method
+     * Tests the correctness of {@link CommonUtil#isIdentifierValid(String)} method.
      */
     @Test(dataProvider = "data-provider")
     public void testIsIdentifierValid(String identifier, boolean valid) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/common/utils/CommonUtilTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/common/utils/CommonUtilTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.common.utils;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link CommonUtil}s
+ */
+public class CommonUtilTest {
+
+    /**
+     * Tests the correctness of {@link CommonUtil#isIdentifierValid(String)} method
+     */
+    @Test(dataProvider = "data-provider")
+    public void testIsIdentifierValid(String identifier, boolean valid) {
+        Assert.assertEquals(CommonUtil.isIdentifierValid(identifier), valid);
+    }
+
+    @DataProvider(name = "data-provider")
+    public Object[][] dataProvider() {
+        return new Object[][]{
+                {"6name", false},
+                {"varName", true},
+                {"_varName", true},
+                {"_varName\uD83D\uDE05", true},
+                {"n@me", false},
+                {"a1", true},
+                {"'6name", true},
+                {"name", true},
+                {"_6", true},
+                {"544", false},
+                {"name]", false},
+                {"_{name}", false},
+                {"වාර්", true},
+                {"\uE000", false},
+                {"\uE001", false},
+                {"\uF8FF", false},
+                // In java we cannot specify unicode code points with more than 4 characters. Therefore, using
+                // surrogate pairs
+                {"\uDBBF\uDFFD", false},
+                {"\uDBBF\uDFFD", false},
+                {"\uDBC0\uDC01", false},
+                {"\uDBFF\uDFFD", false},
+                {"汉字", true},
+                {"பெயர்", true},
+        };
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -73,6 +73,7 @@ public class RenameTest {
         return new Object[][]{
                 {"rename_method_param_result.json", "newA"},
                 {"rename_rec_result.json", "NewRecData"},
+                {"rename_with_invalid_identifier.json", "NewRecData]"},
                 {"rename_with_cursor_at_end.json", "myIntVal"},
                 {"rename_with_cursor_at_end2.json", "x"},
                 {"rename_on_fail.json", "myVarName"},

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_invalid_identifier.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_with_invalid_identifier.json
@@ -1,0 +1,13 @@
+{
+  "source": {
+    "file": "renameTest1.bal"
+  },
+  "position": {
+    "line": 29,
+    "character": 8
+  },
+  "result": {
+    "changes": {
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/testng.xml
+++ b/language-server/modules/langserver-core/src/test/resources/testng.xml
@@ -45,6 +45,7 @@ under the License.
             <package name="org.ballerinalang.langserver.diagnostics.*" />
             <package name="org.ballerinalang.langserver.command.*"/>
             <package name="org.ballerinalang.langserver.foldingrange.*" />
+            <package name="org.ballerinalang.langserver.common.utils.*" />
         </packages>
         <classes>
             <class name="org.ballerinalang.langserver.workspace.TestWorkspaceManager" />


### PR DESCRIPTION
## Purpose
$subject

Fixes #28664
Fixes #28817

## Approach
1. LS now validates the `newName` sent by the VSCode side for a valid identifier according to the [spec](https://ballerina.io/ballerina-spec/spec.html#lexical_structure) and shows an error in VSCode UI if the identifier is invalid. See the new behavior in following screen capture:

https://user-images.githubusercontent.com/11285165/108664088-0c2e3b80-74f8-11eb-86e6-0e4c2c1c79bc.mp4

2. Update `ReferenceFinder` to not visit `BLangMatchClause.matchExpr` since it is a cached node pointing to the expression of the match statement

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
