### PR TITLE
Fix locations bugs in Toml Parser AST

### DIFF
--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -56,9 +56,7 @@ public class TomlKeyNode extends TomlNode {
 
     @Override
     public String toString() {
-        return "TomlKeyNode{" +
-                "keys=" + name() +
-                '}';
+        return "TomlKeyNode{" + "keys=" + name() + '}';
     }
 
     @Override

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -19,6 +19,9 @@
 package io.ballerina.toml.semantic.ast;
 
 import io.ballerina.toml.semantic.TomlType;
+import io.ballerina.toml.semantic.diagnostics.TomlNodeLocation;
+import io.ballerina.tools.text.LineRange;
+import io.ballerina.tools.text.TextRange;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,8 +35,8 @@ public class TomlKeyNode extends TomlNode {
 
     private final List<TomlKeyEntryNode> keys;
 
-    public TomlKeyNode(List<TomlKeyEntryNode> keys) {
-        super(TomlType.KEY_VALUE, null);
+    public TomlKeyNode(List<TomlKeyEntryNode> keys, TomlNodeLocation location) {
+        super(TomlType.KEY_VALUE,location);
         this.keys = keys;
     }
 

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlKeyNode.java
@@ -20,8 +20,6 @@ package io.ballerina.toml.semantic.ast;
 
 import io.ballerina.toml.semantic.TomlType;
 import io.ballerina.toml.semantic.diagnostics.TomlNodeLocation;
-import io.ballerina.tools.text.LineRange;
-import io.ballerina.tools.text.TextRange;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +34,7 @@ public class TomlKeyNode extends TomlNode {
     private final List<TomlKeyEntryNode> keys;
 
     public TomlKeyNode(List<TomlKeyEntryNode> keys, TomlNodeLocation location) {
-        super(TomlType.KEY_VALUE,location);
+        super(TomlType.KEY_VALUE, location);
         this.keys = keys;
     }
 
@@ -54,6 +52,13 @@ public class TomlKeyNode extends TomlNode {
             }
         }
         return String.join(".", list);
+    }
+
+    @Override
+    public String toString() {
+        return "TomlKeyNode{" +
+                "keys=" + name() +
+                '}';
     }
 
     @Override

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/semantic/ast/TomlTransformer.java
@@ -119,7 +119,8 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
             } else {
                 //create the table
                 TomlKeyEntryNode tomlKeyEntryNode = keys.get(i);
-                parentTable = createDottedKeyParentTable(parentTable, tomlKeyEntryNode);
+                parentTable =
+                        createDottedKeyParentTable(parentTable, tomlKeyEntryNode, transformedKeyValuePair.location());
             }
         }
         if (isDottedKey(keys)) {
@@ -143,11 +144,12 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         }
     }
 
-    private TomlTableNode createDottedKeyParentTable(TomlTableNode parentTable, TomlKeyEntryNode dottedKey) {
+    private TomlTableNode createDottedKeyParentTable(TomlTableNode parentTable, TomlKeyEntryNode dottedKey,
+                                                     TomlNodeLocation location) {
         List<TomlKeyEntryNode> list = new ArrayList<>();
         list.add(dottedKey);
         TomlKeyNode newTableKey = new TomlKeyNode(list, getLocationOfKeyEntryList(list));
-        TomlTableNode newTomlTableNode = new TomlTableNode(newTableKey, null);
+        TomlTableNode newTomlTableNode = new TomlTableNode(newTableKey, location);
         addChildToTableAST(parentTable, newTomlTableNode);
         return newTomlTableNode;
     }
@@ -198,9 +200,9 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
             } else {
                 TomlKeyEntryNode tomlKeyEntryNode = childNode.key().keys().get(i);
                 if (childNode instanceof TomlTableArrayNode) {
-                    parentTable = generateTable(parentTable, tomlKeyEntryNode, false);
+                    parentTable = generateTable(parentTable, tomlKeyEntryNode, false, childNode.location());
                 } else {
-                    parentTable = generateTable(parentTable, tomlKeyEntryNode, true);
+                    parentTable = generateTable(parentTable, tomlKeyEntryNode, true, childNode.location());
                 }
             }
         }
@@ -213,7 +215,7 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         TomlKeyEntryNode lastKeyEntry = getLastKeyEntry(tableChild);
         List<TomlKeyEntryNode> entries = new ArrayList<>();
         entries.add(lastKeyEntry);
-        TomlTableNode newTableNode = new TomlTableNode(new TomlKeyNode(entries,getLocationOfKeyEntryList(entries)),
+        TomlTableNode newTableNode = new TomlTableNode(new TomlKeyNode(entries, getLocationOfKeyEntryList(entries)),
                 tableChild.generated(), tableChild.location(), tableChild.entries());
         if (topLevelNode == null) {
             addChildToTableAST(parentTable, newTableNode);
@@ -237,11 +239,12 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
         }
     }
 
-    private TomlTableNode generateTable(TomlTableNode parentTable, TomlKeyEntryNode parentString, boolean isGenerated) {
+    private TomlTableNode generateTable(TomlTableNode parentTable, TomlKeyEntryNode parentString, boolean isGenerated
+            , TomlNodeLocation location) {
         List<TomlKeyEntryNode> list = new ArrayList<>();
         list.add(parentString);
-        TomlKeyNode newTableKey = new TomlKeyNode(list,getLocationOfKeyEntryList(list));
-        TomlTableNode newTomlTableNode = new TomlTableNode(newTableKey, isGenerated, null);
+        TomlKeyNode newTableKey = new TomlKeyNode(list, getLocationOfKeyEntryList(list));
+        TomlTableNode newTomlTableNode = new TomlTableNode(newTableKey, isGenerated, location);
         addChildToTableAST(parentTable, newTomlTableNode);
         return newTomlTableNode;
     }
@@ -296,7 +299,7 @@ public class TomlTransformer extends NodeTransformer<TomlNode> {
     private TomlTableNode addChildsToTableArray(TableArrayNode tableArrayNode) {
         NodeList<KeyValueNode> children = tableArrayNode.fields();
         TomlNodeLocation position = getPosition(tableArrayNode);
-        TomlKeyNode anonKey = new TomlKeyNode(null, null);
+        TomlKeyNode anonKey = getTomlKeyNode(tableArrayNode.identifier());
         TomlTableNode anonTable = new TomlTableNode(anonKey, position);
         for (KeyValueNode child : children) {
             TomlNode transformedChild = child.apply(this);

--- a/misc/toml-parser/src/test/java/toml/parser/test/ParserTestUtils.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/ParserTestUtils.java
@@ -35,6 +35,7 @@ import io.ballerina.toml.internal.syntax.SyntaxUtils;
 import io.ballerina.toml.syntax.tree.Node;
 import io.ballerina.toml.syntax.tree.SyntaxKind;
 import io.ballerina.toml.syntax.tree.SyntaxTree;
+import io.ballerina.tools.text.LineRange;
 import io.ballerina.tools.text.TextDocument;
 import io.ballerina.tools.text.TextDocuments;
 import org.testng.Assert;
@@ -503,5 +504,14 @@ public class ParserTestUtils {
                 return SyntaxKind.NONE;
         }
         return null;
+    }
+
+    public static void assertLineRange(LineRange lineRange, int startLine, int startOffset, int endLine,
+                                       int endOffset) {
+        Assert.assertEquals(lineRange.startLine().line(), startLine);
+        Assert.assertEquals(lineRange.startLine().offset(), startOffset);
+
+        Assert.assertEquals(lineRange.endLine().line(), endLine);
+        Assert.assertEquals(lineRange.endLine().offset(), endOffset);
     }
 }


### PR DESCRIPTION
## Purpose
This PR fixes various occasions Location field of AST becomes null. 
This includes dotted keys, Table Array nodes generated tables and key lists.

This PR also few NPEs on toString as well caused by null keys in anonymous tables.

Resolves #28762 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
