### PR TITLE
[Debugger] Improve variable visibility test

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationBaseTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/evaluation/ExpressionEvaluationBaseTest.java
@@ -91,7 +91,7 @@ public abstract class ExpressionEvaluationBaseTest extends BaseTestCase {
         String testModuleFileName = "main.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
 
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 182));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 191));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
         Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
         this.context = debugHitInfo.getRight();

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -61,7 +61,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 218));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 224));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 231));
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 240));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 259));
         debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 237));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
     }

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -66,12 +66,13 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
     }
 
-    @Test(description = "Variable visibility test at the beginning of the main() method")
+    @Test(description = "Variable visibility test at the beginning(first line) of the main() method")
     public void initialVariableVisibilityTest() throws BallerinaTestException {
         debugHitInfo = debugTestRunner.waitForDebugHit(25000);
         globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
 
+        // TODO - enable test
         // local variable visibility test at the beginning of the main() method (should be 0).
         // Assert.assertEquals(localVariables.size(), 0);
 
@@ -80,16 +81,18 @@ public class VariableVisibilityTest extends BaseTestCase {
     }
 
     @Test(dependsOnMethods = "initialVariableVisibilityTest",
-        description = "Variable visibility test in the middle of the main() method")
-    public void midVariableVisibilityTest() throws BallerinaTestException {
+        description = "Variable visibility test in the middle of the main() method for a new variable")
+    public void newVariableVisibilityTest() throws BallerinaTestException {
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
 
+        // TODO - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/28064
         // local variable visibility test in the middle of the main() method,
         // all the variables above the debug point should be visible,
         // Assert.assertEquals(localVariables.size(), 30);
 
+        // TODO - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/28064
         // debug point variable should not be visible
         // Assert.assertFalse(localVariables.containsKey("byteVar"));
 
@@ -97,11 +100,12 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_OVER);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
         localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        // TODO - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/28064
         // Assert.assertEquals(localVariables.size(), 31);
         Assert.assertTrue(localVariables.containsKey("byteVar"));
     }
 
-    @Test(dependsOnMethods = "midVariableVisibilityTest",
+    @Test(dependsOnMethods = "newVariableVisibilityTest",
         description = "Variable visibility test in control flows")
     public void controlFlowVariableVisibilityTest() throws BallerinaTestException {
 
@@ -132,6 +136,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         // local variable visibility test inside `foreach` loop.
         debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
         debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        // TODO - Enable test
         // Assert.assertEquals(localVariables.size(), 37);
 
         // local variable visibility test inside `match` statement.
@@ -164,7 +169,9 @@ public class VariableVisibilityTest extends BaseTestCase {
         // debugTestRunner.assertVariable(globalVariables, "nameWithType", "Ballerina", "string");
         debugTestRunner.assertVariable(globalVariables, "nameMap", "map", "map");
         debugTestRunner.assertVariable(globalVariables, "nilWithoutType", "()", "nil");
+        debugTestRunner.assertVariable(globalVariables, "nilWithType", "()", "nil");
         debugTestRunner.assertVariable(globalVariables, "RED", "()", "nil");
+        // TODO - Enable test
         // debugTestRunner.assertVariable(globalVariables, "BLUE", "Blue", "string");
 
         // global variables

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -170,8 +170,8 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(globalVariables, "nameMap", "map", "map");
         debugTestRunner.assertVariable(globalVariables, "nilWithoutType", "()", "nil");
         debugTestRunner.assertVariable(globalVariables, "nilWithType", "()", "nil");
-        debugTestRunner.assertVariable(globalVariables, "RED", "()", "nil");
         // TODO - Enable test
+        // debugTestRunner.assertVariable(globalVariables, "RED", "RED", "string");
         // debugTestRunner.assertVariable(globalVariables, "BLUE", "Blue", "string");
 
         // global variables
@@ -278,7 +278,7 @@ public class VariableVisibilityTest extends BaseTestCase {
     }
 
     @Test(dependsOnMethods = "globalVariableVisibilityTest",
-        description = " Child variable visibility test for local variables at the last line of main() method")
+        description = "Child variable visibility test for local variables at the last line of main() method")
     public void localVariableChildrenVisibilityTest() throws BallerinaTestException {
         // xml child variable visibility test
         Map<String, Variable> xmlChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("xmlVar"));

--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/variables/VariableVisibilityTest.java
@@ -26,6 +26,7 @@ import org.ballerinalang.debugger.test.utils.DebugUtils;
 import org.ballerinalang.test.context.BallerinaTestException;
 import org.eclipse.lsp4j.debug.StoppedEventArguments;
 import org.eclipse.lsp4j.debug.Variable;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -40,6 +41,7 @@ import static org.ballerinalang.debugger.test.utils.DebugTestRunner.VariableScop
  */
 public class VariableVisibilityTest extends BaseTestCase {
 
+    Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo;
     Map<String, Variable> globalVariables = new HashMap<>();
     Map<String, Variable> localVariables = new HashMap<>();
     DebugTestRunner debugTestRunner;
@@ -50,26 +52,121 @@ public class VariableVisibilityTest extends BaseTestCase {
         String testModuleFileName = "main.bal";
         debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
 
-        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 183));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 117));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 184));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 195));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 195));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 202));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 209));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 218));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 224));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 231));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 240));
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(debugTestRunner.testEntryFilePath, 237));
         debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
-        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
-
-        globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
-        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
     }
 
-    @Test
-    public void globalVariableVisibilityTest() {
+    @Test(description = "Variable visibility test at the beginning of the main() method")
+    public void initialVariableVisibilityTest() throws BallerinaTestException {
+        debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
+
+        // local variable visibility test at the beginning of the main() method (should be 0).
+        // Assert.assertEquals(localVariables.size(), 0);
+
+        // global variable visibility test at the beginning of the main() method (should be 14).
+         Assert.assertEquals(globalVariables.size(), 14);
+    }
+
+    @Test(dependsOnMethods = "initialVariableVisibilityTest",
+        description = "Variable visibility test in the middle of the main() method")
+    public void midVariableVisibilityTest() throws BallerinaTestException {
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+
+        // local variable visibility test in the middle of the main() method,
+        // all the variables above the debug point should be visible,
+        // Assert.assertEquals(localVariables.size(), 30);
+
+        // debug point variable should not be visible
+        // Assert.assertFalse(localVariables.containsKey("byteVar"));
+
+        // debug point variable should be visible when we go to the next line (STEP_OVER).
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.STEP_OVER);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        // Assert.assertEquals(localVariables.size(), 31);
+        Assert.assertTrue(localVariables.containsKey("byteVar"));
+    }
+
+    @Test(dependsOnMethods = "midVariableVisibilityTest",
+        description = "Variable visibility test in control flows")
+    public void controlFlowVariableVisibilityTest() throws BallerinaTestException {
+
+        // local variable visibility test inside `if` statement.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        Assert.assertEquals(localVariables.size(), 36);
+
+        // local variable visibility test inside `else` statement.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        Assert.assertEquals(localVariables.size(), 36);
+
+        // local variable visibility test inside `else-if` statement.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        Assert.assertEquals(localVariables.size(), 36);
+
+        // local variable visibility test inside `while` loop.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        Assert.assertEquals(localVariables.size(), 36);
+
+        // local variable visibility test inside `foreach` loop.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        // Assert.assertEquals(localVariables.size(), 37);
+
+        // local variable visibility test inside `match` statement.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), DebugTestRunner.VariableScope.LOCAL);
+        Assert.assertEquals(localVariables.size(), 37);
+    }
+
+    @Test(dependsOnMethods = "controlFlowVariableVisibilityTest",
+        description = "Variable visibility test for global variables")
+    public void globalVariableVisibilityTest() throws BallerinaTestException {
+
+        // global variable visibility test outside main() method.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
+        Assert.assertEquals(globalVariables.size(), 14);
+
+        // global variable visibility at the last line of the main() method.
+        debugTestRunner.resumeProgram(debugHitInfo.getRight(), DebugTestRunner.DebugResumeKind.NEXT_BREAKPOINT);
+        debugHitInfo = debugTestRunner.waitForDebugHit(10000);
+        globalVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.GLOBAL);
+        localVariables = debugTestRunner.fetchVariables(debugHitInfo.getRight(), VariableScope.LOCAL);
+        Assert.assertEquals(globalVariables.size(), 14);
+
         // Todo - Enable after fixing https://github.com/ballerina-platform/ballerina-lang/issues/26139
-        // Asserts the number of globally visible variables (should be 11).
-        // Assert.assertEquals(globalVariables.size(), 11);
         // global constants
         // debugTestRunner.assertVariable(globalVariables, "nameWithoutType", "Ballerina", "string");
         // debugTestRunner.assertVariable(globalVariables, "nameWithType", "Ballerina", "string");
-
         debugTestRunner.assertVariable(globalVariables, "nameMap", "map", "map");
         debugTestRunner.assertVariable(globalVariables, "nilWithoutType", "()", "nil");
-        debugTestRunner.assertVariable(globalVariables, "nilWithType", "()", "nil");
+        debugTestRunner.assertVariable(globalVariables, "RED", "()", "nil");
+        // debugTestRunner.assertVariable(globalVariables, "BLUE", "Blue", "string");
+
         // global variables
         debugTestRunner.assertVariable(globalVariables, "stringValue", "Ballerina", "string");
         debugTestRunner.assertVariable(globalVariables, "decimalValue", "100.0", "decimal");
@@ -77,9 +174,11 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(globalVariables, "floatValue", "2.0", "float");
         debugTestRunner.assertVariable(globalVariables, "jsonVar", "map<json>", "json");
         debugTestRunner.assertVariable(globalVariables, " /:@[`{~⌤_IL", "IL with global var", "string");
+        debugTestRunner.assertVariable(globalVariables, "port", "9090", "int");
     }
 
-    @Test
+    @Test(dependsOnMethods = "globalVariableVisibilityTest",
+        description = "Variable visibility test for local variables at the last line of main() method")
     public void localVariableVisibilityTest() {
         // var variable visibility test
         debugTestRunner.assertVariable(localVariables, "varVariable", "()", "nil");
@@ -88,7 +187,7 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "booleanVar", "true", "boolean");
 
         // int variable visibility test
-        debugTestRunner.assertVariable(localVariables, "intVar", "20", "int");
+        debugTestRunner.assertVariable(localVariables, "intVar", "5", "int");
 
         // float variable visibility test
         debugTestRunner.assertVariable(localVariables, "floatVar", "-10.0", "float");
@@ -171,7 +270,8 @@ public class VariableVisibilityTest extends BaseTestCase {
         debugTestRunner.assertVariable(localVariables, "ĠĿŐΒȂɭ_ /:@[`{~⌤_json", "map<json>", "json");
     }
 
-    @Test
+    @Test(dependsOnMethods = "globalVariableVisibilityTest",
+        description = " Child variable visibility test for local variables at the last line of main() method")
     public void localVariableChildrenVisibilityTest() throws BallerinaTestException {
         // xml child variable visibility test
         Map<String, Variable> xmlChildVariables = debugTestRunner.fetchChildVariables(localVariables.get("xmlVar"));

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/Config.toml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/Config.toml
@@ -1,2 +1,2 @@
 [variable_tests]
-    port = 9090
+port = 9090

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/Config.toml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/Config.toml
@@ -1,0 +1,2 @@
+[variable_tests]
+    port = 9090

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -236,6 +236,25 @@ public function main() {
     intVar = addition(2, 3);
 }
 
+function printSalaryDetails(int baseSalary, int annualIncrement = 20, float bonusRate = 0.02) returns string {
+    return string `[${baseSalary}, ${annualIncrement}, ${bonusRate}]`;
+}
+
+function calculate(int a, int b, int c) returns int {
+    return a + 2 * b + 3 * c;
+}
+
+function printDetails(string name, int age = 18, string... modules) returns string {
+    string detailString = "Name: " + name + ", Age: " + age.toString();
+    string moduleString = "";
+    if (modules.length() == 0) {
+        moduleString = "Module(s): ()";
+    } else {
+        moduleString = "Module(s): " + modules[0];
+    }
+    return  string `[${name}, ${age}, ${moduleString}]`;
+}
+
 function addition(int a, int b) returns int {
     return a + b;
 }

--- a/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/project-based-tests/variable-tests/main.bal
@@ -94,6 +94,12 @@ const map<string> nameMap = {"name":"John"};
 const nilWithoutType = ();
 const () nilWithType = ();
 
+// enums
+enum Color {
+    RED,
+    BLUE = "Blue"
+}
+
 // global variables
 var stringValue = "Ballerina";
 var decimalValue = 100.0d;
@@ -101,6 +107,9 @@ var byteValue = <byte>2;
 var floatValue = 2.0;
 json jsonVar = {name:"John", age:20};
 var '\ \/\:\@\[\`\{\~\u{2324}_IL = "IL with global var";
+
+// configurable variables
+configurable int port = ?;
 
 public function main() {
     //------------------------ basic, simple type variables ------------------------//
@@ -180,23 +189,53 @@ public function main() {
     string '\ \/\:\@\[\`\{\~\u{2324}_var = "IL with special characters in var";
     string 'üňĩćőđę_var = "IL with unicode characters in var";
     json 'ĠĿŐΒȂɭ_\ \/\:\@\[\`\{\~\u{2324}_json = {};
-}
-
-function printSalaryDetails(int baseSalary, int annualIncrement = 20, float bonusRate = 0.02) returns string {
-    return string `[${baseSalary}, ${annualIncrement}, ${bonusRate}]`;
-}
-
-function calculate(int a, int b, int c) returns int {
-    return a + 2 * b + 3 * c;
-}
-
-function printDetails(string name, int age = 18, string... modules) returns string {
-    string detailString = "Name: " + name + ", Age: " + age.toString();
-    string moduleString = "";
-    if (modules.length() == 0) {
-        moduleString = "Module(s): ()";
-    } else {
-        moduleString = "Module(s): " + modules[0];
+    
+    // variable visibility in 'if' statement
+    if (true) {
+        intVar = 1;
     }
-    return  string `[${name}, ${age}, ${moduleString}]`;
+
+    // variable visibility in 'else' statement
+    if (false) {
+        intVar = 2;
+    } else {
+        intVar = 3;
+    }
+
+    // variable visibility in 'else-if' statement
+    if (false) {
+        intVar = 4;
+    } else if (true) {
+        intVar = 5;
+    } else {
+        intVar = 6;
+    }
+
+    // variable visibility in 'while' loop
+    while (true) {
+        if (intVar >= 1) {
+            intVar = 7;
+            break;
+        }
+    }
+
+    // variable visibility in 'foreach' loop
+    foreach string str in nameMap {
+        intVar = intVar + 1;
+    }
+
+    // variable visibility in 'match' statement
+    foreach var str in nameMap {
+        match str {
+            "John" => {
+                intVar = 8;
+            }
+        }
+    }
+    
+    intVar = addition(2, 3);
+}
+
+function addition(int a, int b) returns int {
+    return a + b;
 }


### PR DESCRIPTION
## Purpose
This PR will improve the variable visibility test with the following scenarios:

- [x] The variable count should be zero(0) at the beginning of the main() method.
- [x] All variables should be visible at the last line of the main() method.
- [x] Global variables and their values should be visible at the beginning of the main() method.
- [x] CONSTANTS and their values should be visible outside the main() method.
- [x] Variable and its value should not be visible at the declaration line. It should be visible when we go to the next line (STEP_OVER).
- [x] Variable visibility inside control flows
    - [x] If/Else
    - [x] While
    - [x] Foreach
    - [x] Match
    Here we have to check variable count outside control flows. That is all variables should be visible when the debug navigator within the control flow.
- [x] Variable visibility test
    - [x] Enums
    - [x] Configurable variables
    
Fixes: https://github.com/ballerina-platform/ballerina-lang/issues/28730