### PR TITLE
Update field access completion sorting order to prioritize record/object fields

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -56,13 +56,19 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
 
     @Override
     public void sort(BallerinaCompletionContext context, T node, List<LSCompletionItem> completionItems) {
-        // First we do the default sorting
-        super.sort(context, node, completionItems);
+        // We assign higher priority to record/object fields while assigning other completion items default priorities
+        completionItems.forEach(completionItem -> {
+            int rank;
+            switch (completionItem.getType()) {
+                case OBJECT_FIELD:
+                case RECORD_FIELD:
+                    rank = 1;
+                    break;
+                default:
+                    rank = SortingUtil.toRank(completionItem, 1);
+            }
 
-        // Then we rank object/record fields at top
-        completionItems.stream()
-                .filter(item -> item.getType() == LSCompletionItem.CompletionItemType.OBJECT_FIELD ||
-                        item.getType() == LSCompletionItem.CompletionItemType.RECORD_FIELD)
-                .forEach(item -> item.getCompletionItem().setSortText(SortingUtil.genSortText(1)));
+            completionItem.getCompletionItem().setSortText(SortingUtil.genSortText(rank));
+        });
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/FieldAccessContext.java
@@ -22,6 +22,7 @@ import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
 import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
 import org.ballerinalang.langserver.completions.providers.AbstractCompletionProvider;
 import org.ballerinalang.langserver.completions.util.FieldAccessCompletionResolver;
+import org.ballerinalang.langserver.completions.util.SortingUtil;
 
 import java.util.List;
 
@@ -51,5 +52,17 @@ public abstract class FieldAccessContext<T extends Node> extends AbstractComplet
         List<Symbol> symbolList = resolver.getVisibleEntries(expr);
 
         return this.getCompletionItemList(symbolList, ctx);
+    }
+
+    @Override
+    public void sort(BallerinaCompletionContext context, T node, List<LSCompletionItem> completionItems) {
+        // First we do the default sorting
+        super.sort(context, node, completionItems);
+
+        // Then we rank object/record fields at top
+        completionItems.stream()
+                .filter(item -> item.getType() == LSCompletionItem.CompletionItemType.OBJECT_FIELD ||
+                        item.getType() == LSCompletionItem.CompletionItemType.RECORD_FIELD)
+                .forEach(item -> item.getCompletionItem().setSortText(SortingUtil.genSortText(1)));
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
@@ -255,84 +255,112 @@ public class SortingUtil {
         return Optional.empty();
     }
 
+    /**
+     * Sets the sorting text to provided completion items using the default sorting.
+     *
+     * @param context Completion context
+     * @param completionItems Completion items to be set sorting texts
+     */
     public static void toDefaultSorting(BallerinaCompletionContext context, List<LSCompletionItem> completionItems) {
         for (LSCompletionItem item : completionItems) {
-            int rank;
-            CompletionItemKind completionItemKind = item.getCompletionItem().getKind();
-            if (completionItemKind == null) {
-                // TODO: Added for failsafe
-                rank = 17;
-            } else {
-                switch (item.getType()) {
-                    case SYMBOL:
-                        switch (completionItemKind) {
-                            case Constant:
-                                rank = 1;
-                                break;
-                            case Variable:
-                                rank = 2;
-                                break;
-                            case Function:
-                                rank = 3;
-                                break;
-                            case Method:
-                                rank = 4;
-                                break;
-                            case Constructor:
-                                rank = 5;
-                                break;
-                            case EnumMember:
-                                rank = 8;
-                                break;
-                            case Enum:
-                                rank = 9;
-                                break;
-                            case Class:
-                                rank = 10;
-                                break;
-                            case Interface:
-                                rank = 11;
-                                break;
-                            case Struct:
-                                rank = 12;
-                                break;
-                            case TypeParameter:
-                                rank = 13;
-                                break;
-                            case Module:
-                                rank = 14;
-                                break;
-                            default:
-                                rank = 17;
-                        }
-                        break;
-                    case SNIPPET:
-                        switch (completionItemKind) {
-                            case TypeParameter:
-                                rank = 13;
-                                break;
-                            case Snippet:
-                                rank = 15;
-                                break;
-                            case Keyword:
-                                rank = 16;
-                                break;
-                            default:
-                                rank = 17;
-                        }
-                        break;
-                    case OBJECT_FIELD:
-                        rank = 6;
-                        break;
-                    case RECORD_FIELD:
-                        rank = 7;
-                        break;
-                    default:
-                        rank = 17;
-                        break;
-                }
-            }
+            int rank = SortingUtil.toRank(item);
             item.getCompletionItem().setSortText(SortingUtil.genSortText(rank));
         }
+    }
+
+    /**
+     * Calculates the rank of a given completion item with rank offset 0.
+     *
+     * @param completionItem Completion item
+     * @return rank
+     * @see #toRank(LSCompletionItem, int)
+     */
+    public static int toRank(LSCompletionItem completionItem) {
+        return toRank(completionItem, 0);
+    }
+
+    /**
+     * Calculates the rank of a given completion item.
+     *
+     * @param completionItem Completion item
+     * @param rankOffset     Number to offset the rank by
+     * @return Rank
+     */
+    public static int toRank(LSCompletionItem completionItem, int rankOffset) {
+        int rank = -1;
+        CompletionItemKind completionItemKind = completionItem.getCompletionItem().getKind();
+        switch (completionItem.getType()) {
+            case SYMBOL:
+                if (completionItemKind != null) {
+                    switch (completionItemKind) {
+                        case Constant:
+                            rank = 1;
+                            break;
+                        case Variable:
+                            rank = 2;
+                            break;
+                        case Function:
+                            rank = 3;
+                            break;
+                        case Method:
+                            rank = 4;
+                            break;
+                        case Constructor:
+                            rank = 5;
+                            break;
+                        case EnumMember:
+                            rank = 8;
+                            break;
+                        case Enum:
+                            rank = 9;
+                            break;
+                        case Class:
+                            rank = 10;
+                            break;
+                        case Interface:
+                            rank = 11;
+                            break;
+                        case Struct:
+                            rank = 12;
+                            break;
+                        case TypeParameter:
+                            rank = 13;
+                            break;
+                        case Module:
+                            rank = 14;
+                            break;
+                    }
+                }
+                break;
+            case SNIPPET:
+                if (completionItemKind != null) {
+                    switch (completionItemKind) {
+                        case TypeParameter:
+                            rank = 13;
+                            break;
+                        case Snippet:
+                            rank = 15;
+                            break;
+                        case Keyword:
+                            rank = 16;
+                            break;
+                    }
+                }
+                break;
+            case OBJECT_FIELD:
+                rank = 6;
+                break;
+            case RECORD_FIELD:
+                rank = 7;
+                break;
+        }
+
+        if (rank == -1) {
+            rank = 17;
+        } else {
+            rank = rankOffset + rank;
+        }
+
+        return rank;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
@@ -322,10 +322,15 @@ public class SortingUtil {
                         }
                         break;
                     case OBJECT_FIELD:
-                        rank = 6;
-                        break;
                     case RECORD_FIELD:
-                        rank = 7;
+                        switch (completionItemKind) {
+                            case Interface:
+                            case Struct:
+                                rank = 1;
+                                break;
+                            default:
+                                rank = 7;
+                        }
                         break;
                     default:
                         rank = 17;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/SortingUtil.java
@@ -322,15 +322,10 @@ public class SortingUtil {
                         }
                         break;
                     case OBJECT_FIELD:
+                        rank = 6;
+                        break;
                     case RECORD_FIELD:
-                        switch (completionItemKind) {
-                            case Interface:
-                            case Struct:
-                                rank = 1;
-                                break;
-                            default:
-                                rank = 7;
-                        }
+                        rank = 7;
                         break;
                     default:
                         rank = 17;

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
@@ -9,7 +9,7 @@
       "label": "testField",
       "kind": "Field",
       "detail": "module1:TestRecord1",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testField",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "testOptional",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config1.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config10.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config10.json
@@ -15,7 +15,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -33,7 +33,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -47,7 +47,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -61,7 +61,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -75,7 +75,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -89,7 +89,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -103,7 +103,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -121,7 +121,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -135,7 +135,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config11.json
@@ -9,7 +9,7 @@
       "label": "city",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "city",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "state",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "state",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config11.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config11.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config12.json
@@ -9,7 +9,7 @@
       "label": "url",
       "kind": "Field",
       "detail": "string",
-      "sortText": "F",
+      "sortText": "A",
       "insertText": "url",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config12.json
@@ -23,7 +23,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -37,7 +37,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -55,7 +55,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config13.json
@@ -9,7 +9,7 @@
       "label": "foo",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "foo",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config13.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config13.json
@@ -23,7 +23,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -41,7 +41,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -59,7 +59,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -77,7 +77,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -91,7 +91,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -105,7 +105,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -123,7 +123,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -141,7 +141,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -159,7 +159,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -173,7 +173,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -187,7 +187,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -201,7 +201,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -219,7 +219,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -233,7 +233,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -251,7 +251,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -269,7 +269,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -283,7 +283,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -297,7 +297,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -311,7 +311,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -325,7 +325,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -339,7 +339,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -357,7 +357,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -371,7 +371,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config14.json
@@ -47,7 +47,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "getModel()",
       "insertTextFormat": "Snippet"
     },
@@ -61,7 +61,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -75,7 +75,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -93,7 +93,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config14.json
@@ -1,0 +1,101 @@
+{
+  "position": {
+    "line": 16,
+    "character": 10
+  },
+  "source": "expression_context/source/field_access_ctx_source14.bal",
+  "items": [
+    {
+      "label": "brandName",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "A",
+      "insertText": "brandName",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "modelName",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "A",
+      "insertText": "modelName",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "manufacturedYear",
+      "kind": "Field",
+      "detail": "int",
+      "sortText": "A",
+      "insertText": "manufacturedYear",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "owner",
+      "kind": "Field",
+      "detail": "string",
+      "sortText": "A",
+      "insertText": "owner",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "getModel()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `string`   \n  \n"
+        }
+      },
+      "sortText": "C",
+      "insertText": "getModel()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "toBalString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
+        }
+      },
+      "sortText": "C",
+      "insertText": "toBalString()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(typedesc<any> t)(any|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
+        }
+      },
+      "sortText": "C",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    },
+    {
+      "label": "toString()(string)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
+        }
+      },
+      "sortText": "C",
+      "insertText": "toString()",
+      "insertTextFormat": "Snippet"
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
@@ -9,7 +9,7 @@
       "label": "testField",
       "kind": "Field",
       "detail": "module1:TestRecord1",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testField",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "testOptional",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config2.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
@@ -9,7 +9,7 @@
       "label": "rec1Field1",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "rec1Field1",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "rec1Field2",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "rec1Field2",
       "insertTextFormat": "Snippet"
     },
@@ -25,7 +25,7 @@
       "label": "optionalInt",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "optionalInt",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config3.json
@@ -39,7 +39,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -57,7 +57,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -75,7 +75,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -93,7 +93,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -107,7 +107,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -121,7 +121,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -139,7 +139,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -157,7 +157,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -175,7 +175,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -189,7 +189,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -203,7 +203,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -217,7 +217,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -235,7 +235,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -249,7 +249,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -267,7 +267,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -285,7 +285,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -299,7 +299,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -313,7 +313,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -327,7 +327,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -341,7 +341,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -355,7 +355,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -373,7 +373,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -387,7 +387,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config4.json
@@ -15,7 +15,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nApplies a function to each item in an xml sequence.\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each item in `x`  \n  \n**Returns** `()`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -33,7 +33,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns number of xml items in `x`.\n  \n  \n  \n**Returns** `int`   \n- number of XML items in `x`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -47,7 +47,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nSelects the items from an xml sequence for which a function returns true.\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each item to test whether it should be selected  \n  \n**Returns** `xml<>`   \n- new xml sequence containing items in `x` for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -65,7 +65,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns an iterator over the xml items of `x`\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| xml:Element|xml:Comment|xml:ProcessingInstruction|xml:Text value; |}? ;}`   \n- iterator object  \nEach item is represented by an xml singleton.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -79,7 +79,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nStrips the insignificant parts of the an xml value.\nComment items, processing instruction items are considered insignificant.\nAfter removal of comments and processing instructions, the text is grouped into\nthe biggest possible chunks (i.e. only elements cause division into multiple chunks)\nand a chunk is considered insignificant if the entire chunk is whitespace.\n  \n  \n  \n**Returns** `xml<>`   \n- `x` with insignificant parts removed  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "strip()",
       "insertTextFormat": "Snippet"
     },
@@ -93,7 +93,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns a subsequence of an xml value.\n  \n**Params**  \n- `int` startIndex: start index, inclusive  \n- `int` endIndex: end index, exclusive(Defaultable)  \n  \n**Returns** `xml<>`   \n- a subsequence of `x` consisting of items with index >= startIndex and < endIndex  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "slice(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -111,7 +111,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns the children of elements in an xml value.\nWhen `x` is of type Element, it is equivalent to `getChildren`.  \n  \n  \n**Returns** `xml<>`   \n- xml sequence containing the children of each element x concatenated in order  \nThis is equivalent to `elements(x).map(getChildren)`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "children()",
       "insertTextFormat": "Snippet"
     },
@@ -125,7 +125,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nReturns the item of `x` with index `i`.\nThis differs from `x[i]` in that it panics if\n`x` does not have an item with index `i`.\n  \n**Params**  \n- `int` i: the index  \n  \n**Returns** `xml<>`   \n- the item with index `i` in `x`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -143,7 +143,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nSelects elements from an xml value.\nIf `nm` is `()`, selects all elements;\notherwise, selects only elements whose expanded name is `nm`.\n  \n**Params**  \n- `string?` nm: the expanded name of the elements to be selected, or `()` for all elements(Defaultable)  \n  \n**Returns** `xml<Element>`   \n- an xml sequence consisting of all the element items in `x` whose expanded name is `nm`,  \n or, if `nm` is `()`, all element items in `x`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "elements(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -161,7 +161,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nSelects element children of an xml value  \n**Params**  \n- `string?` nm: the expanded name of the elements to be selected, or `()` for all elements(Defaultable)  \n  \n**Returns** `xml<Element>`   \n- an xml sequence consisting of child elements of elements in `x`; if `nm`  \n is `()`, returns a sequence of all such elements;  \n otherwise, include only elements whose expanded name is `nm`  \nThis is equivalent to `children(x).elements(nm)`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "elementChildren(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -179,7 +179,7 @@
           "value": "**Package:** _ballerina/lang.xml:0.8.0_  \n  \nApplies a function to each item in an xml sequence, and returns an xml sequence of the results.\nEach item is represented as a singleton value.\n  \n**Params**  \n- `function ()` func: a function to apply to each child or `item`  \n  \n**Returns** `xml<xml<>>`   \n- new xml value containing result of applying `func` to each child or `item`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -197,7 +197,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \n  type descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \n  an error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \n  structural values in the result will be mutable, except for error values  \n  (which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \n  to supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -215,7 +215,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -229,7 +229,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -243,7 +243,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -257,7 +257,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -271,7 +271,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -285,7 +285,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -303,7 +303,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -317,7 +317,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
@@ -9,7 +9,7 @@
       "label": "testField",
       "kind": "Field",
       "detail": "module1:TestRecord1",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testField",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "testOptional",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testOptional",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config5.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config6.json
@@ -23,7 +23,7 @@
           "value": "**Package:** _._  \n  \n  \n  \n  \n**Returns** `int`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "testMethod()",
       "insertTextFormat": "Snippet"
     },
@@ -37,7 +37,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -51,7 +51,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -69,7 +69,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config6.json
@@ -9,7 +9,7 @@
       "label": "testClassField",
       "kind": "Field",
       "detail": "int",
-      "sortText": "F",
+      "sortText": "A",
       "insertText": "testClassField",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
@@ -9,7 +9,7 @@
       "label": "testField",
       "kind": "Field",
       "detail": "int",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testField",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "testField2",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "testField2",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config7.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config8.json
@@ -9,7 +9,7 @@
       "label": "city",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "city",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "state",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "state",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config8.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config8.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config9.json
@@ -9,7 +9,7 @@
       "label": "city",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "city",
       "insertTextFormat": "Snippet"
     },
@@ -17,7 +17,7 @@
       "label": "state",
       "kind": "Field",
       "detail": "string",
-      "sortText": "G",
+      "sortText": "A",
       "insertText": "state",
       "insertTextFormat": "Snippet"
     },

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config9.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/config/field_access_ctx_config9.json
@@ -31,7 +31,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nCombines the members of a map using a combining function.\nThe combining function takes the combined value so far and a member of the map,\nand returns a new combined value.\n  \n**Params**  \n- `function ()` func: combining function  \n- `any|error` initial: initial value for the first argument of combining parameter `func`  \n  \n**Returns** `any|error`   \n- result of combining the members of `m` using `func`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "reduce(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -49,7 +49,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nTests whether m has a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `boolean`   \n- true if m has a member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "hasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -67,7 +67,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function to each member of a map.\nThe parameter `func` is applied to each member of `m`.\n  \n**Params**  \n- `function ()` func: a function to apply to each member"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "forEach(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -85,7 +85,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the keys of map `m`.\n  \n  \n  \n**Returns** `string[]`   \n- a new list of all keys  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "keys()",
       "insertTextFormat": "Snippet"
     },
@@ -99,7 +99,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns number of members of a map.\n  \n  \n  \n**Returns** `int`   \n- number of members in `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "length()",
       "insertTextFormat": "Snippet"
     },
@@ -113,7 +113,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- the member of `m` that had key `k`  \nThis removed the member of `m` with key `k` and returns it.  \nIt panics if there is no such member.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "remove(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -131,7 +131,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nSelects the members from a map for which a function returns true.\n  \n**Params**  \n- `function ()` func: a predicate to apply to each element to test whether it should be included  \n  \n**Returns** `map<any|error>`   \n- new map containing members for which `func` evaluates to true  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "filter(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -149,7 +149,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves a member of a map with a given key, if the map has member with the key.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error?`   \n- the member of `m` that had key `k`, or `()` if `m` does not have a key `k`  \nIf `m` has a member with key `k`, it removes and returns it;  \notherwise it returns `()`.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeIfHasKey(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -167,7 +167,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns an iterator over a map.\nThe iterator will iterate over the members of the map not the keys.\nThe `entries` function can be used to iterate over the keys and members together.\nThe `keys` function can be used to iterator over just the keys.\n  \n  \n  \n**Returns** `object {public isolated function next() returns record {| any|error value; |}? ;}`   \n- a new iterator object that will iterate over the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "iterator()",
       "insertTextFormat": "Snippet"
     },
@@ -181,7 +181,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a map containing [key, member] pair as the value for each key.\n  \n  \n  \n**Returns** `map<[string, any|error]>`   \n- a new map of [key, member] pairs  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "entries()",
       "insertTextFormat": "Snippet"
     },
@@ -195,7 +195,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nRemoves all members of a map.\nThis panics if any member cannot be removed.\n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "removeAll()",
       "insertTextFormat": "Snippet"
     },
@@ -209,7 +209,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns the member of map `m` with key `k`.\nThis for use in a case where it is known that the map has a specific key,\nand accordingly panics if `m` does not have a member with key `k`.\n  \n**Params**  \n- `string` k: the key  \n  \n**Returns** `any|error`   \n- member with key `k`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "get(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -227,7 +227,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nReturns a list of all the members of a map.\n  \n  \n  \n**Returns** `(any|error)[]`   \n- an array whose members are the members of `m`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toArray()",
       "insertTextFormat": "Snippet"
     },
@@ -241,7 +241,7 @@
           "value": "**Package:** _ballerina/lang.map:1.1.0_  \n  \nApplies a function each member of a map and returns a map of the result.\nThe resulting map will have the same keys as the argument map.\n  \n**Params**  \n- `function ()` func: a function to apply to each member  \n  \n**Returns** `map<any|error>`   \n- new map containing result of applying parameter `func` to each member  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "map(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -259,7 +259,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConstructs a value with a specified type by cloning another value.  \n**Params**  \n- `typedesc<anydata>` t: the type for the cloned to be constructed  \n  \n**Returns** `anydata|error`   \n- a new value that belongs to `t`, or an error if this cannot be done  \n  \nWhen `v` is a structural value, the inherent type of the value to be constructed  \ncomes from `t`. When `t` is a union, it must be possible to determine which  \nmember of the union to use for the inherent type by following the same rules  \nthat are used by list constructor expressions and mapping constructor expressions  \nwith the contextually expected type. If not, then an error is returned.  \nThe `constructFrom` operation is recursively applied to each member of `v` using  \nthe type descriptor that the inherent type requires for that member.  \n  \nLike the Clone abstract operation, this does a deep copy, but differs in  \nthe following respects:  \n- the inherent type of any structural values constructed comes from the specified  \ntype descriptor rather than the value being constructed  \n- the read-only bit of values and fields comes from the specified type descriptor  \n- the graph structure of `v` is not preserved; the result will always be a tree;  \nan error will be returned if `v` has cycles  \n- immutable structural values are copied rather being returned as is; all  \nstructural values in the result will be mutable, except for error values  \n(which are always immutable)  \n- numeric values can be converted using the NumericConvert abstract operation  \n- if a record type descriptor specifies default values, these will be used  \nto supply any missing members  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneWithType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -277,7 +277,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- immutable clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "cloneReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -291,7 +291,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toBalString()",
       "insertTextFormat": "Snippet"
     },
@@ -305,7 +305,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value of type `anydata` to `json`.\nThis does a deep copy of `v` converting values that do\nnot belong to json into values that do.\nA value of type `xml` is converted into a string as if\nby the `toString` function.\nA value of type `table` is converted into a list of\nmappings one for each row.\nThe inherent type of arrays in the return value will be\n`json[]` and of mappings will be `map<json>`.\nA new copy is made of all structural values, including\nimmutable values.\n  \n  \n  \n**Returns** `json`   \n- representation of `v` as value of type json  \nThis panics if `v` has cycles.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJson()",
       "insertTextFormat": "Snippet"
     },
@@ -319,7 +319,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nTests whether `v` is read-only, i.e. immutable\nReturns true if read-only, false otherwise.\n  \n  \n  \n**Returns** `boolean`   \n- true if read-only, false otherwise  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "isReadOnly()",
       "insertTextFormat": "Snippet"
     },
@@ -333,7 +333,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "clone()",
       "insertTextFormat": "Snippet"
     },
@@ -347,7 +347,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `any|error`   \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "ensureType(${1})",
       "insertTextFormat": "Snippet",
       "command": {
@@ -365,7 +365,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toString()",
       "insertTextFormat": "Snippet"
     },
@@ -379,7 +379,7 @@
           "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns the string that represents `v` in JSON format.\n`v` is first converted to `json` as if by the `toJson` function.\n  \n  \n  \n**Returns** `string`   \n- string representation of json  \n  \n"
         }
       },
-      "sortText": "C",
+      "sortText": "D",
       "insertText": "toJsonString()",
       "insertTextFormat": "Snippet"
     }

--- a/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/source/field_access_ctx_source14.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/new/expression_context/source/field_access_ctx_source14.bal
@@ -1,0 +1,18 @@
+import ballerina/module1;
+
+class Car {
+    
+    string brandName;
+    string modelName;
+    int manufacturedYear;
+    string owner;
+    
+    function getModel() returns string {
+        return '${self.brandName} ${self.modelName} - ${self.manufacturedYear}';
+    }
+}
+
+function testObjectFieldAccess() {
+    Car myCar = new;
+    myCar.
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #20313

## Approach
If a completion item is a `record field` or an `object field` while the node at cursor is a `field access`, we now show the record/object fields at the top of the list. Overridden the `sort()` method in `FieldAccessContext` to achieve this.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
