### PR TITLE
Include coverage data from native libraries in the XML coverage report

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -240,7 +240,7 @@ public class RunTestsTask implements Task {
 
         try {
             if (hasTests) {
-                generateCoverage(project, jarResolver, target);
+                generateCoverage(project, jarResolver, jBallerinaBackend, target);
                 generateHtmlReport(project, this.out, testReport, target);
             }
         } catch (IOException e) {
@@ -257,7 +257,8 @@ public class RunTestsTask implements Task {
         cleanTempCache(project, cachesRoot);
     }
 
-    private void generateCoverage(Project project, JarResolver jarResolver, Target target) throws IOException {
+    private void generateCoverage(Project project, JarResolver jarResolver, JBallerinaBackend jBallerinaBackend,
+                                  Target target) throws IOException {
         // Generate code coverage
         if (!coverage) {
             return;
@@ -265,7 +266,8 @@ public class RunTestsTask implements Task {
         for (ModuleId moduleId : project.currentPackage().moduleIds()) {
             Module module = project.currentPackage().module(moduleId);
             CoverageReport coverageReport = new CoverageReport(module);
-            testReport.addCoverage(module.moduleName().toString(), coverageReport.generateReport(jarResolver));
+            testReport.addCoverage(module.moduleName().toString(), coverageReport.generateReport(jarResolver,
+                    jBallerinaBackend));
         }
     }
 

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -24,7 +24,6 @@ import io.ballerina.projects.JarResolver;
 import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Module;
 import io.ballerina.projects.ModuleId;
-import io.ballerina.projects.PackageDependencyScope;
 import io.ballerina.projects.PlatformLibrary;
 import io.ballerina.projects.PlatformLibraryScope;
 import io.ballerina.projects.ResolvedPackageDependency;
@@ -51,7 +50,6 @@ import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.List;
 
 import static io.ballerina.runtime.api.utils.IdentifierUtils.decodeIdentifier;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -89,14 +89,13 @@ public class CoverageReport {
         String packageName = this.module.packageInstance().packageName().toString();
         String version = this.module.packageInstance().packageVersion().toString();
 
-        List<Path> filteredPathList;
+        Collection<Path> filteredPathList;
 
         if (!module.testDocumentIds().isEmpty()) {
             filteredPathList =
                     filterPaths(jarResolver.getJarFilePathsRequiredForTestExecution(this.module.moduleName()));
         } else {
-            filteredPathList =
-                    filterPaths(jarResolver.getJarFilePathsRequiredForExecution());
+            filteredPathList = filterPaths(jarResolver.getJarFilePathsRequiredForExecution());
         }
 
         if (!filteredPathList.isEmpty()) {
@@ -204,7 +203,8 @@ public class CoverageReport {
 
         for (Path path : pathCollection) {
             if (path.toString().contains(this.module.project().sourceRoot().toString()) &&
-                    path.toString().contains(target.cachesPath().toString())) {
+                    (path.toString().contains(target.cachesPath().toString()) ||
+                            path.toString().contains("build/libs"))) {
                 filteredPathList.add(path);
             }
         }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -142,8 +142,9 @@ public class CodeCoverageUtils {
     }
 
     private static String resolveClassDir(Path classPath, String version) {
-        // Typical class path is .jar/<moduleName>/<version>/class
-        // This function extracts the <moduleName> to create a unique directory
+        // Typical class path is .jar/<moduleName>/<version>/class for .bal files
+        // This function extracts the <moduleName> to create a unique directory for .bal files
+        // For .java files, the parent directory of the class file is returned
         version = version.replace(".", "_");
         Path resolvedPath = classPath;
         String pathVersion;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -111,7 +111,9 @@ public class CodeCoverageUtils {
         //Next we walk through extractedJarPath and copy only the class files
         List<Path> pathList;
         try (Stream<Path> walk = Files.walk(extractedJarPath, 5)) {
-            pathList = walk.map(path -> path).filter(f -> f.toString().endsWith(".class")).collect(Collectors.toList());
+            pathList =
+                    walk.map(path -> path).filter(f -> (f.toString().endsWith(".class") && !f.toString().endsWith(
+                            "module-info.class"))).collect(Collectors.toList());
         } catch (IOException e) {
             return;
         }

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -110,7 +110,7 @@ public class CodeCoverageUtils {
 
         //Next we walk through extractedJarPath and copy only the class files
         List<Path> pathList;
-        try (Stream<Path> walk = Files.walk(extractedJarPath, 5)) {
+        try (Stream<Path> walk = Files.walk(extractedJarPath)) {
             pathList =
                     walk.map(path -> path).filter(f -> f.toString().endsWith(".class")).collect(Collectors.toList());
         } catch (IOException e) {
@@ -146,12 +146,16 @@ public class CodeCoverageUtils {
         // For .java files, the parent directory of the class file is returned
         version = version.replace(".", "_");
         Path resolvedPath = classPath;
-        String pathVersion;
-        do {
-            resolvedPath = resolvedPath.getParent();
-            pathVersion = resolvedPath.getFileName().toString();
-        } while (!pathVersion.equals(version));
-        return resolvedPath.getParent().getFileName().toString();
+        if (!resolvedPath.toString().contains(version)) {
+            return resolvedPath.getParent().getFileName().toString();
+        } else {
+            String pathVersion;
+            do {
+                resolvedPath = resolvedPath.getParent();
+                pathVersion = resolvedPath.getFileName().toString();
+            } while (!pathVersion.equals(version));
+            return resolvedPath.getParent().getFileName().toString();
+        }
     }
 
     private static boolean isRequiredFile(String path, String orgName, String moduleName, String version) {

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -112,8 +112,7 @@ public class CodeCoverageUtils {
         List<Path> pathList;
         try (Stream<Path> walk = Files.walk(extractedJarPath, 5)) {
             pathList =
-                    walk.map(path -> path).filter(f -> (f.toString().endsWith(".class") && !f.toString().endsWith(
-                            "module-info.class"))).collect(Collectors.toList());
+                    walk.map(path -> path).filter(f -> f.toString().endsWith(".class")).collect(Collectors.toList());
         } catch (IOException e) {
             return;
         }
@@ -164,6 +163,8 @@ public class CodeCoverageUtils {
             return false;
         } else if (path.contains(
                 orgName + "/" + moduleName + "/" + version.replace(".", "_") + "/" + moduleName + ".class")) {
+            return false;
+        } else if (path.contains("module-info.class")) {
             return false;
         }
         return true;

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/util/CodeCoverageUtils.java
@@ -111,8 +111,7 @@ public class CodeCoverageUtils {
         //Next we walk through extractedJarPath and copy only the class files
         List<Path> pathList;
         try (Stream<Path> walk = Files.walk(extractedJarPath)) {
-            pathList =
-                    walk.map(path -> path).filter(f -> f.toString().endsWith(".class")).collect(Collectors.toList());
+            pathList = walk.map(path -> path).filter(f -> f.toString().endsWith(".class")).collect(Collectors.toList());
         } catch (IOException e) {
             return;
         }


### PR DESCRIPTION
## Purpose
XML coverage report currently includes coverage data from ballerina sources only. This fix adds data from Java source files to the report.

Fixes #28851

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
