### PR TITLE
Add map having the local variables used in lamdas to table

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/methodgen/MethodGen.java
@@ -526,15 +526,11 @@ public class MethodGen {
                 continue;
             }
             BType bType = optionalTypeDef.type;
-            if ((bType.flags & Flags.OBJECT_CTOR) == Flags.OBJECT_CTOR) {
-                // Annotations for object ctors are populated at object init site.
-                continue;
-            }
-
-            if (bType.tag != TypeTags.FINITE) {
+            // Annotations for object constructors are populated at object init site.
+            boolean constructorsPopulated = (bType.flags & Flags.OBJECT_CTOR) == Flags.OBJECT_CTOR;
+            if (!constructorsPopulated && bType.tag != TypeTags.FINITE) {
                 loadAnnots(mv, typePkgName, optionalTypeDef, jvmTypeGen, localVarOffset);
             }
-
         }
     }
 
@@ -927,7 +923,7 @@ public class MethodGen {
             BIRVariableDcl localVar = func.localVars.get(i);
             Label startLabel = methodStartLabel;
             Label endLabel = methodEndLabel;
-            if (!isLocalOrArg(localVar)) {
+            if (!isValidArg(localVar)) {
                 continue;
             }
             // local vars have visible range information
@@ -948,9 +944,12 @@ public class MethodGen {
         }
     }
 
-    private boolean isLocalOrArg(BIRVariableDcl localVar) {
+    private boolean isValidArg(BIRVariableDcl localVar) {
+        boolean localArg = localVar.kind == VarKind.LOCAL || localVar.kind == VarKind.ARG;
         boolean synArg = localVar.type.tag == TypeTags.BOOLEAN && localVar.name.value.startsWith("%syn");
-        return !synArg && (localVar.kind == VarKind.LOCAL || localVar.kind == VarKind.ARG);
+        boolean lambdaMapArg = localVar.metaVarName != null && localVar.metaVarName.startsWith("$map$block$") &&
+                localVar.kind == VarKind.SYNTHETIC;
+        return (localArg && !synArg) || lambdaMapArg;
     }
 
     private boolean isCompilerAddedVars(String metaVarName) {


### PR DESCRIPTION
## Purpose
> At ballerina desugar level a map is introduced to hold the variables passed to a lambda. These variables as well as the map holding them are not in the LocalVariableTable. This prevents the debugger from showing them. This PR adds the map to the LocalVariableTable so that the variables in it are accessible to the debugger.

Related issues: https://github.com/ballerina-platform/ballerina-lang/issues/27739 and https://github.com/ballerina-platform/ballerina-lang/issues/27738


## Approach
> Add the map to the LocalVariableTable so that the variables in it are accessible to the debugger.

## Samples
> N/A

## Remarks
> N/A

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
