### PR TITLE
Improve parameter symbol implementation

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -317,7 +317,7 @@ public class SymbolFactory {
             annotSymbols.add(createAnnotationSymbol((BAnnotationSymbol) annot));
         }
 
-        return new BallerinaParameterSymbol(name, typeDescriptor, qualifiers, annotSymbols, kind);
+        return new BallerinaParameterSymbol(name, typeDescriptor, qualifiers, annotSymbols, kind, symbol, this.context);
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -134,6 +134,15 @@ public class SymbolFactory {
             if (symbol.owner instanceof BObjectTypeSymbol) {
                 return createObjectFieldSymbol((BVarSymbol) symbol);
             }
+            if (Symbols.isFlagOn(symbol.flags, Flags.REQUIRED_PARAM)) {
+                return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.REQUIRED);
+            }
+            if (Symbols.isFlagOn(symbol.flags, Flags.DEFAULTABLE_PARAM)) {
+                return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.DEFAULTABLE);
+            }
+            if (Symbols.isFlagOn(symbol.flags, Flags.REST_PARAM)) {
+                return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.REST);
+            }
 
             // return the variable symbol
             return createVariableSymbol((BVarSymbol) symbol, name);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -21,49 +21,37 @@ import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.StringJoiner;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 
 /**
  * Represents a parameter with a name and type.
  *
  * @since 2.0.0
  */
-public class BallerinaParameterSymbol implements ParameterSymbol {
+public class BallerinaParameterSymbol extends BallerinaSymbol implements ParameterSymbol {
 
     // add the metadata field
-    private List<Qualifier> qualifiers;
-    private List<AnnotationSymbol> annots;
-    private String parameterName;
-    private TypeSymbol typeDescriptor;
-    private ParameterKind kind;
+    private final List<Qualifier> qualifiers;
+    private final List<AnnotationSymbol> annots;
+    private final TypeSymbol typeDescriptor;
+    private final ParameterKind paramKind;
 
     public BallerinaParameterSymbol(String parameterName, TypeSymbol typeDescriptor, List<Qualifier> qualifiers,
-                                    List<AnnotationSymbol> annots, ParameterKind kind) {
+                                    List<AnnotationSymbol> annots, ParameterKind paramKind, BVarSymbol symbol,
+                                    CompilerContext context) {
+        super(parameterName, PARAMETER, symbol, context);
         // TODO: Add the metadata
-        this.parameterName = parameterName;
         this.typeDescriptor = typeDescriptor;
         this.qualifiers = Collections.unmodifiableList(qualifiers);
         this.annots = Collections.unmodifiableList(annots);
-        this.kind = kind;
-    }
-
-    /**
-     * Get the parameter name.
-     *
-     * @return {@link Optional} name of the field
-     */
-    @Override
-    public Optional<String> name() {
-        return Optional.ofNullable(parameterName);
-    }
-
-    @Override
-    public Optional<String> getName() {
-        return Optional.ofNullable(this.parameterName);
+        this.paramKind = paramKind;
     }
 
     /**
@@ -116,12 +104,7 @@ public class BallerinaParameterSymbol implements ParameterSymbol {
     }
 
     @Override
-    public ParameterKind kind() {
-        return this.kind;
-    }
-
-    @Override
     public ParameterKind paramKind() {
-        return this.kind;
+        return this.paramKind;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterSymbol.java
@@ -23,16 +23,7 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public interface ParameterSymbol extends Annotatable, Qualifiable {
-
-    /**
-     * Get the parameter name.
-     *
-     * @return {@link Optional} name of the field
-     * @deprecated This method will be removed in a later version. Use getName() instead.
-     */
-    @Deprecated
-    Optional<String> name();
+public interface ParameterSymbol extends Symbol, Annotatable, Qualifiable {
 
     /**
      * Get the parameter name.
@@ -54,14 +45,6 @@ public interface ParameterSymbol extends Annotatable, Qualifiable {
      * @return {@link String} signature
      */
     String signature();
-
-    /**
-     * Get the kind of the parameter.
-     *
-     * @return {@link ParameterKind} of the param
-     */
-    @Deprecated
-    ParameterKind kind();
 
     /**
      * Get the kind of the parameter.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/SymbolKind.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/SymbolKind.java
@@ -38,5 +38,6 @@ public enum SymbolKind {
     RECORD_FIELD,
     OBJECT_FIELD,
     CLASS_FIELD,
-    ENUM
+    ENUM,
+    PARAMETER
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
@@ -152,5 +152,17 @@ public enum Flag {
     /**
      * Indicates flagged parameter is a included record parameter.
      */
-    INCLUDED;
+    INCLUDED,
+    /**
+     * Indicates flagged node is a required parameter.
+     */
+    REQUIRED_PARAM,
+    /**
+     * Indicates flagged node is a defaultable parameter.
+     */
+    DEFAULTABLE_PARAM,
+    /**
+     * Indicates flagged node is a rest parameter.
+     */
+    REST_PARAM
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -2967,6 +2967,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         if (requiredParameter.paramName().isPresent()) {
             simpleVar.name.pos = getPosition(requiredParameter.paramName().get());
         }
+        simpleVar.flagSet.add(Flag.REQUIRED_PARAM);
         simpleVar.pos = trimLeft(simpleVar.pos, getPosition(requiredParameter.typeName()));
         return simpleVar;
     }
@@ -2991,7 +2992,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                                                         defaultableParameter.annotations());
 
         simpleVar.setInitialExpression(createExpression(defaultableParameter.expression()));
-
+        simpleVar.flagSet.add(Flag.DEFAULTABLE_PARAM);
         simpleVar.pos = getPosition(defaultableParameter);
         return simpleVar;
     }
@@ -3007,6 +3008,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         bLSimpleVar.typeNode = bLArrayType;
         bLArrayType.pos = getPosition(restParameter.typeName());
 
+        bLSimpleVar.flagSet.add(Flag.REST_PARAM);
         bLSimpleVar.pos = getPosition(restParameter);
         return bLSimpleVar;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -73,6 +73,9 @@ public class Flags {
 
     public static final long ENUM = OBJECT_CTOR << 1;                           //  33
     public static final long INCLUDED = ENUM << 1;                              //  34
+    public static final long REQUIRED_PARAM = INCLUDED << 1;                    //  35
+    public static final long DEFAULTABLE_PARAM = REQUIRED_PARAM << 1;           //  36
+    public static final long REST_PARAM = DEFAULTABLE_PARAM << 1;               //  37
 
 
     public static long asMask(Set<Flag> flagSet) {
@@ -175,6 +178,15 @@ public class Flags {
                 case INCLUDED:
                     mask |= INCLUDED;
                     break;
+                case REQUIRED_PARAM:
+                    mask |= REQUIRED_PARAM;
+                    break;
+                case DEFAULTABLE_PARAM:
+                    mask |= DEFAULTABLE_PARAM;
+                    break;
+                case REST_PARAM:
+                    mask |= REST_PARAM;
+                    break;
             }
         }
         return mask;
@@ -274,6 +286,15 @@ public class Flags {
                     break;
                 case INCLUDED:
                     flagVal = INCLUDED;
+                    break;
+                case REQUIRED_PARAM:
+                    flagVal = REQUIRED_PARAM;
+                    break;
+                case DEFAULTABLE_PARAM:
+                    flagVal = DEFAULTABLE_PARAM;
+                    break;
+                case REST_PARAM:
+                    flagVal = REST_PARAM;
                     break;
                 default:
                     continue;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
@@ -16,10 +16,10 @@
 package org.ballerinalang.langserver.codeaction.providers.changetype;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
 import io.ballerina.compiler.syntax.tree.ExpressionNode;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
@@ -28,7 +28,6 @@ import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
-import io.ballerina.projects.Document;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import org.ballerinalang.annotation.JavaSPIService;
 import org.ballerinalang.langserver.codeaction.CodeActionUtil;
@@ -85,14 +84,14 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
 
         // Get parameter symbol
         SemanticModel semanticModel = context.currentSemanticModel().orElseThrow();
-        Document srcFile = context.currentDocument().orElseThrow();
-        Optional<Symbol> optParamSymbol = semanticModel.symbol(srcFile,
-                                                               initializer.get().lineRange().startLine());
-        if (optParamSymbol.isEmpty() || optParamSymbol.get().kind() != SymbolKind.VARIABLE) {
+        Optional<Symbol> optParamSymbol = semanticModel.symbol(initializer.get());
+        if (optParamSymbol.isEmpty() || optParamSymbol.get().kind() != SymbolKind.PARAMETER) {
             return Collections.emptyList();
         }
-        VariableSymbol paramSymbol = (VariableSymbol) optParamSymbol.get();
+        ParameterSymbol paramSymbol = (ParameterSymbol) optParamSymbol.get();
 
+        // TODO: Check whether the following code segment is required. Since we know the symbol is a param symbol, it
+        //  follows that the var decl is within a function/method.
         // Find parent function definition
         NonTerminalNode funcDefNode = localVarNode.parent();
         while (funcDefNode != null && funcDefNode.kind() != SyntaxKind.FUNCTION_DEFINITION) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ParameterCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ParameterCompletionItemBuilder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ParameterCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ParameterCompletionItemBuilder.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.langserver.completions.builder;
+
+import org.ballerinalang.langserver.completions.util.ItemResolverConstants;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+
+/**
+ * This is used for building parameter completions.
+ *
+ * @since 2.0.0
+ */
+public final class ParameterCompletionItemBuilder {
+    private ParameterCompletionItemBuilder() {
+    }
+
+    /**
+     * Creates and returns a parameter completion item.
+     *
+     * @param label label
+     * @param type  parameter type
+     * @return {@link CompletionItem}
+     */
+    public static CompletionItem build(String label, String type) {
+        CompletionItem item = new CompletionItem();
+        item.setLabel(label);
+        String[] delimiterSeparatedTokens = label.split("\\.");
+        item.setInsertText(delimiterSeparatedTokens[delimiterSeparatedTokens.length - 1]);
+        item.setDetail((type.equals("")) ? ItemResolverConstants.NONE : type);
+        item.setKind(CompletionItemKind.Variable);
+        return item;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -168,10 +168,10 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                         typeName);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
             } else if (symbol.kind() == PARAMETER) {
-                ParameterSymbol varSymbol = (ParameterSymbol) symbol;
-                TypeSymbol typeDesc = (varSymbol).typeDescriptor();
-                String typeName = typeDesc == null ? "" : CommonUtil.getModifiedTypeName(ctx, typeDesc);
-                CompletionItem variableCItem = ParameterCompletionItemBuilder.build(varSymbol.getName().get(),
+                ParameterSymbol paramSymbol = (ParameterSymbol) symbol;
+                TypeSymbol typeDesc = paramSymbol.typeDescriptor();
+                String typeName = CommonUtil.getModifiedTypeName(ctx, typeDesc);
+                CompletionItem variableCItem = ParameterCompletionItemBuilder.build(paramSymbol.getName().get(),
                                                                                     typeName);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
             } else if (symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -22,6 +22,7 @@ import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
@@ -53,6 +54,7 @@ import org.ballerinalang.langserver.completions.SymbolCompletionItem;
 import org.ballerinalang.langserver.completions.builder.ConstantCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.builder.FieldCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.builder.FunctionCompletionItemBuilder;
+import org.ballerinalang.langserver.completions.builder.ParameterCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.builder.TypeCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.builder.VariableCompletionItemBuilder;
 import org.ballerinalang.langserver.completions.builder.WorkerCompletionItemBuilder;
@@ -79,6 +81,7 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.OBJECT_FIELD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 import static io.ballerina.compiler.api.symbols.SymbolKind.RECORD_FIELD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.XMLNS;
 
@@ -163,6 +166,13 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
                 String typeName = typeDesc == null ? "" : CommonUtil.getModifiedTypeName(ctx, typeDesc);
                 CompletionItem variableCItem = VariableCompletionItemBuilder.build(varSymbol, varSymbol.getName().get(),
                         typeName);
+                completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
+            } else if (symbol.kind() == PARAMETER) {
+                ParameterSymbol varSymbol = (ParameterSymbol) symbol;
+                TypeSymbol typeDesc = (varSymbol).typeDescriptor();
+                String typeName = typeDesc == null ? "" : CommonUtil.getModifiedTypeName(ctx, typeDesc);
+                CompletionItem variableCItem = ParameterCompletionItemBuilder.build(varSymbol.getName().get(),
+                                                                                    typeName);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, variableCItem));
             } else if (symbol.kind() == SymbolKind.TYPE_DEFINITION || symbol.kind() == SymbolKind.CLASS) {
                 // Here skip all the package symbols since the package is added separately
@@ -400,8 +410,8 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
 
         // Avoid the error symbol suggestion since it is covered by the lang.error lang-lib 
         List<Symbol> filteredList = visibleSymbols.stream()
-                .filter(symbol -> (symbol instanceof VariableSymbol || symbol.kind() == FUNCTION)
-                        && !symbol.getName().orElse("").equals(Names.ERROR.getValue()))
+                .filter(symbol -> (symbol instanceof VariableSymbol || symbol.kind() == PARAMETER ||
+                        symbol.kind() == FUNCTION) && !symbol.getName().orElse("").equals(Names.ERROR.getValue()))
                 .collect(Collectors.toList());
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         // TODO: anon function expressions, 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -176,7 +176,8 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
         List<LSCompletionItem> completionItems = new ArrayList<>();
         // TODO: Can we get this filter to a common place
         List<Symbol> filteredList = visibleSymbols.stream()
-                .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION || symbol instanceof VariableSymbol)
+                .filter(symbol -> symbol.kind() == SymbolKind.FUNCTION || symbol instanceof VariableSymbol ||
+                        symbol.kind() == SymbolKind.PARAMETER)
                 .collect(Collectors.toList());
         completionItems.addAll(this.getCompletionItemList(filteredList, context));
         completionItems.addAll(this.getTypeguardDestructedItems(visibleSymbols, context));

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -40,8 +40,8 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 import static io.ballerina.compiler.api.symbols.SymbolKind.RECORD_FIELD;
-import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
@@ -87,7 +87,7 @@ public class AnnotationsTest {
                 {65, 6, CLASS, of("v1", "v2", "v2")},
                 {66, 15, CLASS_FIELD, of("v5")},
                 {71, 20, METHOD, of("v3")},
-                {71, 69, VARIABLE, of("v4")},
+                {71, 69, PARAMETER, of("v4")},
                 {81, 16, FUNCTION, of("v3")},
                 {86, 11, ANNOTATION, of("v1")},
                 {98, 18, CLASS_FIELD, of("v5")},

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ParameterSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ParameterSymbolTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.impl.BallerinaModuleID;
+import io.ballerina.compiler.api.symbols.ParameterKind;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.SymbolKind;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static io.ballerina.compiler.api.symbols.ParameterKind.DEFAULTABLE;
+import static io.ballerina.compiler.api.symbols.ParameterKind.REQUIRED;
+import static io.ballerina.compiler.api.symbols.ParameterKind.REST;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for parameter symbols.
+ *
+ * @since 2.0.0
+ */
+public class ParameterSymbolTest {
+
+    private Project project;
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        project = BCompileUtil.loadProject("test-src/param_symbols_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "ParamPos")
+    public void testSymbolAtCursor(int line, int col, String paramName, TypeDescKind typeKind, ParameterKind paramKind,
+                                   String signature) {
+        Symbol symbol = getSymbol(line, col);
+        assertEquals(symbol.kind(), SymbolKind.PARAMETER);
+
+        ParameterSymbol param = (ParameterSymbol) symbol;
+        assertEquals(param.getName().get(), paramName);
+        assertEquals(param.typeDescriptor().typeKind(), typeKind);
+        assertEquals(param.paramKind(), paramKind);
+        assertEquals(param.signature(), signature);
+    }
+
+    @DataProvider(name = "ParamPos")
+    public Object[][] getParamPos() {
+        return new Object[][]{
+                {16, 31, "x", STRING, REQUIRED, "string x"},
+                {16, 38, "y", INT, REQUIRED, "int y"},
+                {16, 47, "f", FLOAT, DEFAULTABLE, "float f"},
+                {16, 68, "rest", ARRAY, REST, "string... rest"},
+                {25, 31, "name", STRING, REQUIRED, "string name"},
+                {25, 41, "age", INT, DEFAULTABLE, "int age"},
+                {25, 61, "other", ARRAY, REST, "anydata... other"},
+                {33, 32, "name", STRING, REQUIRED, "string name"},
+                {33, 42, "age", INT, DEFAULTABLE, "int age"},
+                {33, 62, "other", ARRAY, REST, "anydata... other"},
+                {39, 35, "name", STRING, REQUIRED, "string name"},
+                {40, 20, "name", STRING, REQUIRED, "string name"},
+                {43, 31, "age", INT, DEFAULTABLE, "int age"},
+                {44, 19, "age", INT, DEFAULTABLE, "int age"},
+                {47, 39, "misc", ARRAY, REST, "anydata... misc"},
+                {48, 20, "misc", ARRAY, REST, "anydata... misc"},
+                {53, 30, "p", TYPE_REFERENCE, REQUIRED, "Person p"},
+                {53, 44, "misc", ARRAY, REST, "anydata... misc"},
+        };
+    }
+
+    @Test
+    public void testVisibleSymbols() {
+        BallerinaModuleID moduleID =
+                new BallerinaModuleID(project.currentPackage().getCompilation().defaultModuleBLangPackage().packageID);
+        Map<String, Symbol> symbols = SemanticAPITestUtils.getSymbolsInFile(model, srcFile, 17, 20,
+                                                                            moduleID);
+        Map<String, Symbol> params = symbols.entrySet().stream()
+                .filter(entry -> entry.getValue().kind() == SymbolKind.PARAMETER)
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        assertParam((ParameterSymbol) params.get("x"), "x", REQUIRED, STRING);
+        assertParam((ParameterSymbol) params.get("y"), "y", REQUIRED, INT);
+        assertParam((ParameterSymbol) params.get("f"), "f", DEFAULTABLE, FLOAT);
+        assertParam((ParameterSymbol) params.get("rest"), "rest", REST, ARRAY);
+    }
+
+    private Symbol getSymbol(int line, int col) {
+        return model.symbol(srcFile, from(line, col))
+                .orElseThrow(() -> new AssertionError("Expected a symbol at: (" + line + ", " + col + ")"));
+    }
+
+    private void assertParam(ParameterSymbol param, String name, ParameterKind kind, TypeDescKind typeKind) {
+        assertEquals(param.getName().get(), name);
+        assertEquals(param.paramKind(), kind);
+        assertEquals(param.typeDescriptor().typeKind(), typeKind);
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolEquivalenceTest.java
@@ -19,6 +19,7 @@
 package io.ballerina.semantic.api.test;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -55,7 +56,6 @@ public class SymbolEquivalenceTest {
     private SemanticModel typesModel;
     private Document srcFile;
     private Document typesSrcFile;
-    private final String typesFileName = "typedesc_test.bal";
 
     @BeforeClass
     public void setup() {
@@ -122,8 +122,17 @@ public class SymbolEquivalenceTest {
     public void testTypedescriptors(List<LinePosition> positions) {
         List<TypeSymbol> types = positions.stream()
                 .map(pos -> typesModel.symbol(typesSrcFile, pos).get())
-                .map(s -> s.kind() == RECORD_FIELD ?
-                        ((RecordFieldSymbol) s).typeDescriptor() : ((VariableSymbol) s).typeDescriptor())
+                .map(s -> {
+                    switch (s.kind()) {
+                        case RECORD_FIELD:
+                            return ((RecordFieldSymbol) s).typeDescriptor();
+                        case PARAMETER:
+                            return ((ParameterSymbol) s).typeDescriptor();
+                        case VARIABLE:
+                            return ((VariableSymbol) s).typeDescriptor();
+                    }
+                    throw new AssertionError("Unexpected symbol kind: " + s.kind());
+                })
                 .collect(Collectors.toList());
         assertTypeSymbols(types);
     }
@@ -143,7 +152,7 @@ public class SymbolEquivalenceTest {
         List<TypeSymbol> types = positions.stream()
                 .map(pos -> typesModel.symbol(typesSrcFile, pos).get())
                 .map(s -> s.kind() == RECORD_FIELD ?
-                        ((RecordFieldSymbol) s).typeDescriptor() : ((VariableSymbol) s).typeDescriptor())
+                        ((RecordFieldSymbol) s).typeDescriptor() : ((ParameterSymbol) s).typeDescriptor())
                 .collect(Collectors.toList());
 
         for (int i = 0; i < types.size(); i++) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByFunctionTest.java
@@ -18,6 +18,7 @@
 package io.ballerina.semantic.api.test.symbolbynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.DefaultableParameterNode;
@@ -32,8 +33,11 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
+import static io.ballerina.compiler.api.symbols.ParameterKind.DEFAULTABLE;
+import static io.ballerina.compiler.api.symbols.ParameterKind.REQUIRED;
+import static io.ballerina.compiler.api.symbols.ParameterKind.REST;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
-import static io.ballerina.compiler.api.symbols.SymbolKind.VARIABLE;
+import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -65,20 +69,29 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
 
             @Override
             public void visit(RequiredParameterNode requiredParameterNode) {
-                assertSymbol(requiredParameterNode, model, VARIABLE, "a");
-                assertSymbol(requiredParameterNode.paramName().get(), model, VARIABLE, "a");
+                Symbol symbol = assertSymbol(requiredParameterNode, model, PARAMETER, "a");
+                assertEquals(((ParameterSymbol) symbol).paramKind(), REQUIRED);
+
+                symbol = assertSymbol(requiredParameterNode.paramName().get(), model, PARAMETER, "a");
+                assertEquals(((ParameterSymbol) symbol).paramKind(), REQUIRED);
             }
 
             @Override
             public void visit(DefaultableParameterNode defaultableParameterNode) {
-                assertSymbol(defaultableParameterNode, model, VARIABLE, "b");
-                assertSymbol(defaultableParameterNode.paramName().get(), model, VARIABLE, "b");
+                Symbol symbol = assertSymbol(defaultableParameterNode, model, PARAMETER, "b");
+                assertEquals(((ParameterSymbol) symbol).paramKind(), DEFAULTABLE);
+
+                symbol = assertSymbol(defaultableParameterNode.paramName().get(), model, PARAMETER, "b");
+                assertEquals(((ParameterSymbol) symbol).paramKind(), DEFAULTABLE);
             }
 
             @Override
             public void visit(RestParameterNode restParameterNode) {
-                assertSymbol(restParameterNode, model, VARIABLE, "c");
-                assertSymbol(restParameterNode.paramName().get(), model, VARIABLE, "c");
+                Symbol symbol = assertSymbol(restParameterNode, model, PARAMETER, "c");
+                assertEquals(((ParameterSymbol) symbol).paramKind(), REST);
+
+                symbol = assertSymbol(restParameterNode.paramName().get(), model, PARAMETER, "c");
+                assertEquals(((ParameterSymbol) symbol).paramKind(), REST);
             }
 
             @Override
@@ -100,10 +113,11 @@ public class SymbolByFunctionTest extends SymbolByNodeTest {
         assertEquals(getAssertCount(), 13);
     }
 
-    private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
+    private Symbol assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {
         Optional<Symbol> symbol = model.symbol(node);
         assertEquals(symbol.get().kind(), kind);
         assertEquals(symbol.get().getName().get(), name);
         incrementAssertCount();
+        return symbol.get();
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/param_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/param_symbols_test.bal
@@ -1,0 +1,55 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function funcWithParams(string x, int y, float f = 12.34, string... rest) {
+    int sum = x + y;
+}
+
+type Person object {
+    string name;
+    int age;
+    anydata[] misc;
+
+    public function set(string name, int age = 0, anydata... other);
+};
+
+class Person {
+    string name;
+    int age;
+    anydata[] misc;
+
+    public function init(string name, int age = 0, anydata... other) {
+        self.name = name;
+        self.age = age;
+        self.misc = other;
+    }
+
+    public function setName(string name) {
+        self.name = name;
+    }
+
+    public function setAge(int age = 0) {
+        self.age = age;
+    }
+
+    public function setMisc(anydata... misc) {
+        self.misc = misc;
+    }
+}
+
+function foo() {
+    var fn = function (Person p, anydata... misc) {};
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/param_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/param_symbols_test.bal
@@ -18,7 +18,7 @@ function funcWithParams(string x, int y, float f = 12.34, string... rest) {
     int sum = x + y;
 }
 
-type Person object {
+type PersonObj object {
     string name;
     int age;
     anydata[] misc;

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -28,6 +28,7 @@
             <class name="io.ballerina.semantic.api.test.ExpressionTypeTest" />
             <class name="io.ballerina.semantic.api.test.FieldSymbolTest" />
             <class name="io.ballerina.semantic.api.test.LangLibFunctionTest" />
+            <class name="io.ballerina.semantic.api.test.ParameterSymbolTest" />
             <class name="io.ballerina.semantic.api.test.SymbolAtCursorTest" />
             <class name="io.ballerina.semantic.api.test.SymbolBIRTest" />
             <class name="io.ballerina.semantic.api.test.SymbolEquivalenceTest" />


### PR DESCRIPTION
## Purpose
This PR makes `ParameterSymbol` a proper symbol by extending from `Symbol`. This also resolves a bug we had where if the parameters were looked up directly, the returned symbols were var symbols.

## Remarks
I introduced separate flags for the different types of params since the other solution of introducing a separate internal symbol for the params turned out to be a bigger task than expected.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
