### PR TITLE
Update Github Actions to Generate the Code Coverage Report

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,5 @@
+codecov:
+  require_ci_to_pass: no
+
 fixes:
   - "ballerina/lang$0046*/*/::langlib/lang.*/src/main/ballerina/"

--- a/.github/workflows/CI_publish_snapshots.yml
+++ b/.github/workflows/CI_publish_snapshots.yml
@@ -28,10 +28,13 @@ jobs:
                     packageUser: ${{ secrets.BALLERINA_BOT_USERNAME }}
                     packagePAT: ${{ secrets.BALLERINA_BOT_TOKEN }}
                 run: |
-                    ./gradlew clean build createCodeCoverageReport -x createJavadoc --scan publish --continue --rerun-tasks
+                    ./gradlew clean build -x createJavadoc --scan publish --continue --rerun-tasks
+                    ./gradlew createCodeCoverageReport
                     
             -   name: Generate Codecov Report
                 uses: codecov/codecov-action@v1
+                with:
+                    files: ./.jacoco/reports/jacoco/report.xml
 
             -   name: Trigger Standard Library Module Builds
                 run: |


### PR DESCRIPTION
## Purpose
> Update github workflow actions to create the codecov reports after build task.
> Ignore the Codecov CI Pass
> Add the path for the jacoco xml report