### PR TITLE
Fix references to type definitions where a `typedesc` is expected

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/SymTag.java
@@ -41,13 +41,13 @@ public class SymTag {
     public static final int OBJECT = 1 << 17 | TYPE_DEF | STRUCT;
     public static final int RECORD = 1 << 18 | TYPE_DEF | STRUCT;
     public static final int ERROR = 1 << 19 | TYPE_DEF;
-    public static final int FINITE_TYPE = 1 << 20 | TYPE | VARIABLE_NAME;
+    public static final int FINITE_TYPE = 1 << 20 | TYPE_DEF;
     public static final int UNION_TYPE = 1 << 21 | TYPE_DEF;
-    public static final int INTERSECTION_TYPE = 1 << 22 | TYPE | VARIABLE_NAME;
+    public static final int INTERSECTION_TYPE = 1 << 22 | TYPE_DEF;
     public static final int TUPLE_TYPE = 1 << 23 | TYPE_DEF;
     public static final int ARRAY_TYPE = 1 << 24 | TYPE_DEF;
     public static final int CONSTANT = 1 << 25 | VARIABLE_NAME | TYPE;
-    public static final int FUNCTION_TYPE = 1 << 26 | TYPE | VARIABLE_NAME;
+    public static final int FUNCTION_TYPE = 1 << 26 | TYPE_DEF;
     public static final int CONSTRUCTOR = 1 << 27 | INVOKABLE;
     public static final int LET = 1 << 28;
     public static final int ENUM = 1 << 29 | TYPE_DEF;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolBIRTest.java
@@ -101,7 +101,7 @@ public class SymbolBIRTest {
         List<String> fooConstants = getSymbolNames(fooPkgSymbol, SymTag.CONSTANT);
         SemanticAPITestUtils.assertList(fooModule.constants(), fooConstants);
 
-        List<String> fooTypeDefs = getSymbolNames(getSymbolNames(fooPkgSymbol, SymTag.TYPE_DEF), "Digit");
+        List<String> fooTypeDefs = getSymbolNames(fooPkgSymbol, SymTag.TYPE_DEF);
         fooTypeDefs.remove("PersonObj");
         fooTypeDefs.remove("Colour");
         SemanticAPITestUtils.assertList(fooModule.typeDefinitions(), fooTypeDefs);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/typedesc/TypedescTests.java
@@ -19,7 +19,6 @@ package org.ballerinalang.test.types.typedesc;
 import org.ballerinalang.core.model.types.TypeTags;
 import org.ballerinalang.core.model.values.BTypeDescValue;
 import org.ballerinalang.core.model.values.BValue;
-import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
 import org.ballerinalang.test.CompileResult;
@@ -27,6 +26,8 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.ballerinalang.test.BAssertUtil.validateError;
 
 /**
  * This class contains typedesc type related test cases.
@@ -44,20 +45,28 @@ public class TypedescTests {
     public void testNegative() {
         final CompileResult compileResult = BCompileUtil.compile("test-src/types/typedesc/typedesc_negative.bal");
         int index = 0;
-        BAssertUtil.validateError(compileResult, index++, "missing identifier", 2, 8);
-        BAssertUtil.validateError(compileResult, index++, "undefined symbol 'i'", 7, 9);
-        BAssertUtil.validateError(compileResult, index++,
-                "invalid operation: type 'byte' does not support indexing", 9, 18);
-        BAssertUtil.validateError(compileResult, index++,
-                "missing key expr in member access expr", 9, 23);
-        BAssertUtil.validateError(compileResult, index++,
-                "invalid operation: type 'int' does not support indexing", 10, 18);
-        BAssertUtil.validateError(compileResult, index++,
-                "missing key expr in member access expr", 10, 22);
-        BAssertUtil.validateError(compileResult, index++,
-                "invalid operation: type 'string' does not support indexing", 10, 24);
-        BAssertUtil.validateError(compileResult, index++,
-                "missing key expr in member access expr", 10, 31);
+        validateError(compileResult, index++, "missing identifier", 2, 8);
+        validateError(compileResult, index++, "undefined symbol 'i'", 7, 9);
+        validateError(compileResult, index++, "invalid operation: type 'byte' does not support indexing", 9, 18);
+        validateError(compileResult, index++, "missing key expr in member access expr", 9, 23);
+        validateError(compileResult, index++, "invalid operation: type 'int' does not support indexing", 10, 18);
+        validateError(compileResult, index++, "missing key expr in member access expr", 10, 22);
+        validateError(compileResult, index++, "invalid operation: type 'string' does not support indexing", 10, 24);
+        validateError(compileResult, index++, "missing key expr in member access expr", 10, 31);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<readonly>', found " +
+                "'typedesc<int[]>'", 21, 28);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<(string[]|boolean[])>', found " +
+                "'typedesc<(int[] & readonly)>'", 22, 38);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<string>', " +
+                "found 'typedesc<(int[] & readonly)>'", 23, 26);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<string[]>', found " +
+                "'typedesc<foo>'", 24, 28);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<string>', found " +
+                "'typedesc<foo|1>'", 25, 26);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<string>', found " +
+                "'typedesc<function (int) returns (string)>'", 26, 26);
+        validateError(compileResult, index++, "incompatible types: expected 'typedesc<function (int) returns (string)" +
+                ">', found 'typedesc<function () returns (string)>'", 27, 51);
         Assert.assertEquals(compileResult.getErrorCount(), index);
     }
 
@@ -191,6 +200,21 @@ public class TypedescTests {
    public void testCustomErrorTypeDescWithoutConstraint() {
        BRunUtil.invoke(result, "testCustomErrorTypeDescWithoutConstraint");
    }
+
+    @Test
+    public void testTypeDefWithIntersectionTypeDescAsTypedesc() {
+        BRunUtil.invoke(result, "testTypeDefWithIntersectionTypeDescAsTypedesc");
+    }
+
+    @Test
+    public void testFiniteTypeAsTypedesc() {
+        BRunUtil.invoke(result, "testFiniteTypeAsTypedesc");
+    }
+
+    @Test
+    public void testTypeDefWithFunctionTypeDescAsTypedesc() {
+        BRunUtil.invoke(result, "testTypeDefWithFunctionTypeDescAsTypedesc");
+    }
 
     @AfterClass
     public void tearDown() {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_negative.bal
@@ -9,3 +9,20 @@ function test1(){
     typedesc a = byte[];
     typedesc b = int[]|string[];
 }
+
+type ImmutableIntArray int[] & readonly;
+type IntArray int[];
+type Foo "foo";
+type FooBar "foo"|1;
+type FunctionTypeOne function (int i) returns string;
+type FunctionTypeTwo function () returns string;
+
+function testTypeDefReferenceAsTypeDescNegative() {
+    typedesc<readonly> a = IntArray;
+    typedesc<string[]|boolean[]> b = ImmutableIntArray;
+    typedesc<string> c = ImmutableIntArray;
+    typedesc<string[]> d = Foo;
+    typedesc<string> e = FooBar;
+    typedesc<string> f = FunctionTypeOne;
+    typedesc<function (int i) returns string> g = FunctionTypeTwo;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/typedesc/typedesc_positive.bal
@@ -195,6 +195,63 @@ function testCustomErrorTypeDescWithoutConstraint() {
 
 }
 
+type ImmutableIntArray int[] & readonly;
+
+function testTypeDefWithIntersectionTypeDescAsTypedesc() {
+    typedesc<anydata> a = ImmutableIntArray;
+    (int|string)[] arr = [1, 2, 3];
+    var b = arr.cloneWithType(a);
+    // https://github.com/ballerina-platform/ballerina-lang/issues/28912
+    //assertEquality(true, (typeof b).toString());
+    //assertEquality(true, b is int[]);
+    //assertEquality(true, (<int[]> checkpanic b).isReadOnly());
+    //assertEquality(<int[]> [1, 2, 3], b);
+
+    var c = arr.fromJsonWithType(ImmutableIntArray);
+    // https://github.com/ballerina-platform/ballerina-lang/issues/28912
+    //assertEquality(true, c is int[]);
+    //assertEquality(true, (<int[]> checkpanic c).isReadOnly());
+    //assertEquality(<int[]> [1, 2, 3], c);
+
+    typedesc<readonly> d = ImmutableIntArray;
+}
+
+type Foo "foo";
+type FooBar "foo"|"bar";
+
+function testFiniteTypeAsTypedesc() {
+    typedesc<string> a = Foo;
+    typedesc<anydata> b = FooBar;
+
+    string foo = "foo";
+    string bar = "bar";
+    string baz = "baz";
+
+    var c = foo.cloneWithType(a);
+    assertEquality(true, c is Foo);
+
+    var d = baz.cloneWithType(a);
+    assertEquality(true, d is error);
+
+    var e = bar.fromJsonWithType(FooBar);
+    assertEquality(false, e is Foo);
+    assertEquality(true, e is FooBar);
+}
+
+type FunctionTypeOne function (int i) returns string;
+type FunctionTypeTwo function () returns string;
+
+function testTypeDefWithFunctionTypeDescAsTypedesc() {
+    typedesc a = FunctionTypeOne;
+    typedesc b = FunctionTypeTwo;
+
+    any c = function () returns string => "hello";
+    typedesc d = typeof c;
+
+    assertEquality(false, a.toString() == b.toString());
+    assertEquality(true, b.toString() == d.toString());
+}
+
 const ASSERTION_ERROR_REASON = "AssertionError";
 
 function assertEquality(any|error expected, any|error actual) {


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28910

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
