### PR TITLE
Overload NonTerminalNode.findNode() to include start offset and improve related create function code action usage

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -69,6 +69,7 @@ import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
 import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.TableConstructorExpressionNode;
 import io.ballerina.compiler.syntax.tree.TemplateExpressionNode;
 import io.ballerina.compiler.syntax.tree.Token;
@@ -460,6 +461,11 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
     @Override
     public Optional<Location> transform(PositionalArgumentNode positionalArgumentNode) {
         return Optional.of(positionalArgumentNode.location());
+    }
+
+    @Override
+    public Optional<Location> transform(SpecificFieldNode specificFieldNode) {
+        return Optional.of(specificFieldNode.location());
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/ChangeParameterTypeCodeAction.java
@@ -66,7 +66,8 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
         }
 
         // Skip, non-local var declarations
-        if (positionDetails.matchedNode().kind() != SyntaxKind.LOCAL_VAR_DECL) {
+        VariableDeclarationNode localVarNode = getVariableDeclarationNode(positionDetails.matchedNode());
+        if (localVarNode == null) {
             return Collections.emptyList();
         }
 
@@ -77,7 +78,6 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
         }
 
         // Skip, variable declarations with non-initializers
-        VariableDeclarationNode localVarNode = (VariableDeclarationNode) positionDetails.matchedNode();
         Optional<ExpressionNode> initializer = localVarNode.initializer();
         if (initializer.isEmpty()) {
             return Collections.emptyList();
@@ -121,6 +121,14 @@ public class ChangeParameterTypeCodeAction extends AbstractCodeActionProvider {
             actions.add(createQuickFixCodeAction(commandTitle, edits, context.fileUri()));
         }
         return actions;
+    }
+
+    private VariableDeclarationNode getVariableDeclarationNode(NonTerminalNode node) {
+        while (node != null && node.kind() != SyntaxKind.LOCAL_VAR_DECL) {
+            node = node.parent();
+        }
+
+        return node != null ? (VariableDeclarationNode) node : null;
     }
 
     private Optional<Range> getParameterTypeRange(NonTerminalNode parameterNode) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -18,6 +18,8 @@ package org.ballerinalang.langserver.codeaction.providers.changetype;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.compiler.syntax.tree.SyntaxTree;
@@ -64,9 +66,11 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
             return Collections.emptyList();
         }
 
-        if (positionDetails.matchedNode().kind() != SyntaxKind.RETURN_STATEMENT) {
+        ReturnStatementNode returnStatementNode = getReturnStatement(positionDetails.matchedNode());
+        if (returnStatementNode == null) {
             return Collections.emptyList();
         }
+
         Matcher matcher = CommandConstants.INCOMPATIBLE_TYPE_PATTERN.matcher(diagnostic.message());
         if (matcher.find() && matcher.groupCount() > 1) {
             String foundType = matcher.group(2);
@@ -106,6 +110,14 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
         return Collections.emptyList();
     }
 
+    private ReturnStatementNode getReturnStatement(NonTerminalNode node) {
+        while (node != null && node.kind() != SyntaxKind.RETURN_STATEMENT) {
+            node = node.parent();
+        }
+
+        return node != null ? (ReturnStatementNode) node : null;
+    }
+    
     private FunctionDefinitionNode getFunctionNode(DiagBasedPositionDetails positionDetails) {
         Node parent = positionDetails.matchedNode();
         while (parent.kind() != SyntaxKind.FUNCTION_DEFINITION) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -21,7 +21,6 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
-import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.LetExpressionNode;
@@ -32,6 +31,7 @@ import io.ballerina.compiler.syntax.tree.NodeVisitor;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
 import io.ballerina.compiler.syntax.tree.SpecificFieldNode;
 import io.ballerina.compiler.syntax.tree.VariableDeclarationNode;
+import org.ballerinalang.langserver.common.utils.SymbolUtil;
 
 import java.util.Optional;
 
@@ -66,21 +66,17 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     @Override
     public void visit(ModuleVariableDeclarationNode moduleVariableDeclarationNode) {
         Symbol symbol = semanticModel.symbol(moduleVariableDeclarationNode).orElse(null);
-        if (symbol instanceof VariableSymbol) {
-            TypeSymbol typeSymbol = ((VariableSymbol) symbol).typeDescriptor();
-            checkAndSetTypeResult(typeSymbol);
-        }
+        TypeSymbol typeDescriptor = SymbolUtil.getTypeDescriptor(symbol).orElse(null);
+        checkAndSetTypeResult(typeDescriptor);
     }
 
     @Override
     public void visit(AssignmentStatementNode assignmentStatementNode) {
         Symbol symbol = semanticModel.symbol(assignmentStatementNode).orElse(null);
-        if (symbol instanceof VariableSymbol) {
-            TypeSymbol typeSymbol = ((VariableSymbol) symbol).typeDescriptor();
-            checkAndSetTypeResult(typeSymbol);
-            if (resultFound) {
-                return;
-            }
+        TypeSymbol typeDescriptor = SymbolUtil.getTypeDescriptor(symbol).orElse(null);
+        checkAndSetTypeResult(typeDescriptor);
+        if (resultFound) {
+            return;
         }
 
         assignmentStatementNode.varRef().accept(this);
@@ -90,11 +86,8 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
     @Override
     public void visit(VariableDeclarationNode variableDeclarationNode) {
         Symbol symbol = semanticModel.symbol(variableDeclarationNode).orElse(null);
-        if (symbol instanceof VariableSymbol) {
-            TypeSymbol typeSymbol = ((VariableSymbol) symbol).typeDescriptor();
-            checkAndSetTypeResult(typeSymbol);
-        }
-    }
+        TypeSymbol typeDescriptor = SymbolUtil.getTypeDescriptor(symbol).orElse(null);
+        checkAndSetTypeResult(typeDescriptor);    }
 
     @Override
     public void visit(SpecificFieldNode specificFieldNode) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -853,7 +853,7 @@ public class CommonUtil {
         Position rangeEnd = range.getEnd();
         int start = textDocument.textPositionFrom(LinePosition.from(rangeStart.getLine(), rangeStart.getCharacter()));
         int end = textDocument.textPositionFrom(LinePosition.from(rangeEnd.getLine(), rangeEnd.getCharacter()));
-        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, end - start));
+        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, end - start), true);
     }
 
     /**
@@ -872,7 +872,7 @@ public class CommonUtil {
         LineRange symbolRange = symbol.getLocation().get().lineRange();
         int start = textDocument.textPositionFrom(symbolRange.startLine());
         int len = symbolRange.endLine().offset() - symbolRange.startLine().offset();
-        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, len));
+        return ((ModulePartNode) syntaxTree.rootNode()).findNode(TextRange.from(start, len), true);
     }
 
     public static boolean isWithinLineRange(Position pos, LineRange lineRange) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateFunctionTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  * @since 2.0.0
  */
 public class CreateFunctionTest extends AbstractCodeActionTest {
+
     @Override
     public String getResourceDir() {
         return "create-function";
@@ -46,7 +47,11 @@ public class CreateFunctionTest extends AbstractCodeActionTest {
         return new Object[][]{
                 {"undefinedFunctionCodeAction.json", "createUndefinedFunction.bal"},
                 {"undefinedFunctionCodeAction2.json", "createUndefinedFunction2.bal"},
-                {"undefinedFunctionCodeAction3.json", "createUndefinedFunction2.bal"}
+                {"undefinedFunctionCodeAction3.json", "createUndefinedFunction2.bal"},
+                {"undefinedFunctionCodeActionInRecord.json", "createUndefinedFunctionInRecord.bal"},
+                {"undefinedFunctionCodeActionInRecord2.json", "createUndefinedFunctionInRecord.bal"},
+                {"undefinedFunctionCodeActionInLet.json", "createUndefinedFunctionInLet.bal"},
+                {"undefinedFunctionCodeActionInLet2.json", "createUndefinedFunctionInLet.bal"}
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/command/CreateFunctionCommandExecTest.java
@@ -61,18 +61,22 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
                 {"createUndefinedFunction10.json", "createUndefinedFunction5.bal"},
                 {"createUndefinedFunction11.json", "createUndefinedFunction5.bal"},
                 {"createUndefinedFunction12.json", "createUndefinedFunction5.bal"},
-                // TODO Need to fix records support
+                // TODO Need to fix anonymous records support
                 // {"createUndefinedFunction13.json", "createUndefinedFunction5.bal"},
+
+                {"createUndefinedFunctionInRecord.json", "createUndefinedFunctionInRecord.bal"},
+                {"createUndefinedFunctionInRecord2.json", "createUndefinedFunctionInRecord.bal"},
 
                 {"projectCreateUndefinedFunction1.json", "testproject/main.bal"},
                 {"projectCreateUndefinedFunction2.json", "testproject/main.bal"},
                 {"projectCreateUndefinedFunction3.json", "testproject/main.bal"},
-                // TODO Determining types within records not supported yet
-                // {"projectCreateUndefinedFunction4.json", "testproject/main.bal"},
-                // TODO Assignment to module declaration not supported yet
-                // {"projectCreateUndefinedFunction5.json", "testproject/school.bal"},
-                // TODO Assignment let expressions not supported yet
-                // {"projectCreateUndefinedFunction6.json", "testproject/school.bal"},
+                {"projectCreateUndefinedFunction4.json", "testproject/main.bal"},
+                {"projectCreateUndefinedFunction5.json", "testproject/school.bal"},
+                // Let Expression
+                {"projectCreateUndefinedFunctionInLet.json", "testproject/school.bal"},
+                {"projectCreateUndefinedFunctionInLet2.json", "testproject/school.bal"},
+                {"projectCreateUndefinedFunctionInLet3.json", "testproject/school.bal"},
+                // Module Alias
                 {"projectCreateUndefinedFunctionWithModAlias.json", "testproject/modAlias.bal"},
                 {"projectCreateUndefinedFunctionWithModAlias2.json", "testproject/modAlias.bal"},
                 {"projectCreateUndefinedFunctionWithLangLib.json", "testproject/langlib.bal"},
@@ -81,8 +85,8 @@ public class CreateFunctionCommandExecTest extends AbstractCommandExecutionTest 
 
     @Override
     protected List<Object> getArgs(JsonObject argsObject) {
-        return Collections.singletonList(CommandArgument.from(CommandConstants.ARG_KEY_NODE_POS,
-                argsObject.getAsJsonObject("node.position")));
+        return Collections.singletonList(CommandArgument.from(CommandConstants.ARG_KEY_NODE_RANGE,
+                argsObject.getAsJsonObject("node.range")));
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeAction.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeAction.json
@@ -9,10 +9,16 @@
         "command": "CREATE_FUNC",
         "arguments": [
           {
-            "key": "node.position",
+            "key": "node.range",
             "value": {
-              "line": 3,
-              "character": 3
+              "start": {
+                "line": 3,
+                "character": 3
+              },
+              "end": {
+                "line": 3,
+                "character": 23
+              }
             }
           }
         ]

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeAction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeAction3.json
@@ -9,10 +9,16 @@
         "command": "CREATE_FUNC",
         "arguments": [
           {
-            "key": "node.position",
+            "key": "node.range",
             "value": {
-              "line": 4,
-              "character": 7
+              "start": {
+                "line": 4,
+                "character": 7
+              },
+              "end": {
+                "line": 4,
+                "character": 28
+              }
             }
           }
         ]

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInLet.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInLet.json
@@ -1,23 +1,23 @@
 {
-  "line": 3,
-  "character": 11,
+  "line": 13,
+  "character": 37,
   "expected": [
     {
-      "title": "Create function 'addTwoIntegers2(...)'",
+      "title": "Create function 'getYear(...)'",
       "command": {
-        "title": "Create function 'addTwoIntegers2(...)'",
+        "title": "Create function 'getYear(...)'",
         "command": "CREATE_FUNC",
         "arguments": [
           {
             "key": "node.range",
             "value": {
               "start": {
-                "line": 3,
-                "character": 11
+                "line": 13,
+                "character": 37
               },
               "end": {
-                "line": 3,
-                "character": 32
+                "line": 13,
+                "character": 48
               }
             }
           }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInLet2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInLet2.json
@@ -1,23 +1,23 @@
 {
-  "line": 3,
-  "character": 11,
+  "line": 15,
+  "character": 31,
   "expected": [
     {
-      "title": "Create function 'addTwoIntegers2(...)'",
+      "title": "Create function 'getTestRecord(...)'",
       "command": {
-        "title": "Create function 'addTwoIntegers2(...)'",
+        "title": "Create function 'getTestRecord(...)'",
         "command": "CREATE_FUNC",
         "arguments": [
           {
             "key": "node.range",
             "value": {
               "start": {
-                "line": 3,
-                "character": 11
+                "line": 15,
+                "character": 31
               },
               "end": {
-                "line": 3,
-                "character": 32
+                "line": 15,
+                "character": 47
               }
             }
           }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInRecord.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInRecord.json
@@ -1,23 +1,23 @@
 {
-  "line": 3,
-  "character": 11,
+  "line": 18,
+  "character": 22,
   "expected": [
     {
-      "title": "Create function 'addTwoIntegers2(...)'",
+      "title": "Create function 'getManufacturer(...)'",
       "command": {
-        "title": "Create function 'addTwoIntegers2(...)'",
+        "title": "Create function 'getManufacturer(...)'",
         "command": "CREATE_FUNC",
         "arguments": [
           {
             "key": "node.range",
             "value": {
               "start": {
-                "line": 3,
-                "character": 11
+                "line": 18,
+                "character": 22
               },
               "end": {
-                "line": 3,
-                "character": 32
+                "line": 18,
+                "character": 39
               }
             }
           }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInRecord2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/config/undefinedFunctionCodeActionInRecord2.json
@@ -1,23 +1,23 @@
 {
-  "line": 3,
-  "character": 11,
+  "line": 22,
+  "character": 20,
   "expected": [
     {
-      "title": "Create function 'addTwoIntegers2(...)'",
+      "title": "Create function 'createListener(...)'",
       "command": {
-        "title": "Create function 'addTwoIntegers2(...)'",
+        "title": "Create function 'createListener(...)'",
         "command": "CREATE_FUNC",
         "arguments": [
           {
             "key": "node.range",
             "value": {
               "start": {
-                "line": 3,
-                "character": 11
+                "line": 22,
+                "character": 20
               },
               "end": {
-                "line": 3,
-                "character": 32
+                "line": 22,
+                "character": 41
               }
             }
           }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInLet.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInLet.bal
@@ -1,0 +1,20 @@
+import ballerina/module1;
+
+type Car record {
+    string licenceNo;
+    string model;
+    module1:TestRecord1 rec1;
+};
+
+function testCreateFunction() {
+    string licenceNo = "1234";
+    module1:TestClass1 tc = new();
+    
+    Car myCar = {
+        licenceNo: let string year = getYear(tc) in licenceNo.concat("-", year),
+        model: "Toyota",
+        rec1: let int x = 3 in getTestRecord(x)
+    };
+    
+    
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInRecord.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-function/source/createUndefinedFunctionInRecord.bal
@@ -1,0 +1,25 @@
+import ballerina/module1;
+
+type Manufacturer record {
+    string name;
+};
+
+type Car record {
+    string licenceNo;
+    Manufacturer manufacturer;
+};
+
+type MyListener record {
+    module1:Listener myListener;
+};
+
+function testCreateFunction() {
+    Car myCar = {
+        licenceNo: "1234",
+        manufacturer: getManufacturer()
+    };
+    
+    MyListener ml = {
+        myListener: createListener(myCar)
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction1.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 4,
-      "character": 3
+    "node.range": {
+      "start": {
+        "line": 4,
+        "character": 3
+      },
+      "end": {
+        "line": 4,
+        "character": 29
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction10.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction10.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 20,
-            "character": 29
+        "node.range": {
+            "start": {
+                "line": 20,
+                "character": 29
+            },
+            "end": {
+                "line": 20,
+                "character": 50
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction11.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction11.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 23,
-            "character": 4
+        "node.range": {
+            "start": {
+                "line": 23,
+                "character": 4
+            },
+            "end": {
+                "line": 23,
+                "character": 29
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction12.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction12.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 25,
-            "character": 4
+        "node.range": {
+            "start": {
+                "line": 25,
+                "character": 4
+            },
+            "end": {
+                "line": 25,
+                "character": 28
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction13.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction13.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 32,
-            "character": 17
+        "node.range": {
+            "start": {
+                "line": 32,
+                "character": 17
+            },
+            "end": {
+                "line": 32,
+                "character": 44
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction2.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 5,
-      "character": 11
+    "node.range": {
+      "start": {
+        "line": 5,
+        "character": 11
+      },
+      "end": {
+        "line": 5,
+        "character": 32
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction3.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 6,
-      "character": 7
+    "node.range": {
+      "start": {
+        "line": 6,
+        "character": 7
+      },
+      "end": {
+        "line": 6,
+        "character": 39
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction4.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 5,
-      "character": 34
+    "node.range": {
+      "start": {
+        "line": 5,
+        "character": 34
+      },
+      "end": {
+        "line": 5,
+        "character": 51
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction5.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction5.json
@@ -1,7 +1,15 @@
 {
   "arguments": {
-    "node.line": 5,
-    "node.column": 25
+    "node.range": {
+      "start": {
+        "line": 5,
+        "character": 14
+      },
+      "end": {
+        "line": 5,
+        "character": 38
+      }
+    }
   },
   "expected": {
     "result": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction6.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction6.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 4,
-      "character": 49
+    "node.range": {
+      "start": {
+        "line": 4,
+        "character": 44
+      },
+      "end": {
+        "line": 4,
+        "character": 65
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction7.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction7.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 12,
-      "character": 21
+    "node.range": {
+      "start": {
+        "line": 12,
+        "character": 21
+      },
+      "end": {
+        "line": 12,
+        "character": 57
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction8.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction8.json
@@ -1,8 +1,14 @@
 {
   "arguments": {
-    "node.position": {
-      "line": 16,
-      "character": 28
+    "node.range": {
+      "start": {
+        "line": 16,
+        "character": 28
+      },
+      "end": {
+        "line": 16,
+        "character": 56
+      }
     }
   },
   "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction9.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunction9.json
@@ -1,34 +1,40 @@
 {
-    "arguments": {
-        "node.position": {
-            "line": 17,
-            "character": 17
-        }
-    },
-    "expected": {
-        "result": {
-            "edit": {
-                "documentChanges": [
-                    {
-                        "edits": [
-                            {
-                                "range": {
-                                    "start": {
-                                        "line": 34,
-                                        "character": 0
-                                    },
-                                    "end": {
-                                        "line": 34,
-                                        "character": 0
-                                    }
-                                },
-                                "newText": "\n\nfunction addAndGetResultOfTwoIntegers(int a, int b) returns int {\n    \n    return 0;\n}\n"
-                            }
-                        ]
-                    }
-                ]
-            }
-        },
-        "jsonrpc": "2.0"
+  "arguments": {
+    "node.range": {
+      "start": {
+        "line": 17,
+        "character": 17
+      },
+      "end": {
+        "line": 17,
+        "character": 51
+      }
     }
+  },
+  "expected": {
+    "result": {
+      "edit": {
+        "documentChanges": [
+          {
+            "edits": [
+              {
+                "range": {
+                  "start": {
+                    "line": 34,
+                    "character": 0
+                  },
+                  "end": {
+                    "line": 34,
+                    "character": 0
+                  }
+                },
+                "newText": "\n\nfunction addAndGetResultOfTwoIntegers(int a, int b) returns int {\n    \n    return 0;\n}\n"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "jsonrpc": "2.0"
+  }
 }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord.json
@@ -2,12 +2,12 @@
     "arguments": {
         "node.range": {
             "start": {
-                "line": 9,
-                "character": 4
+                "line": 18,
+                "character": 22
             },
             "end": {
-                "line": 9,
-                "character": 23
+                "line": 18,
+                "character": 39
             }
         }
     },
@@ -20,15 +20,15 @@
                             {
                                 "range": {
                                     "start": {
-                                        "line": 17,
+                                        "line": 25,
                                         "character": 0
                                     },
                                     "end": {
-                                        "line": 17,
+                                        "line": 25,
                                         "character": 0
                                     }
                                 },
-                                "newText": "\n\nfunction addStudent(module1:Student a) {\n    \n}\n"
+                                "newText": "\n\nfunction getManufacturer() returns Manufacturer {\n    \n    return {};\n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/createUndefinedFunctionInRecord2.json
@@ -2,12 +2,12 @@
     "arguments": {
         "node.range": {
             "start": {
-                "line": 9,
-                "character": 4
+                "line": 22,
+                "character": 20
             },
             "end": {
-                "line": 9,
-                "character": 23
+                "line": 22,
+                "character": 41
             }
         }
     },
@@ -20,15 +20,15 @@
                             {
                                 "range": {
                                     "start": {
-                                        "line": 17,
+                                        "line": 25,
                                         "character": 0
                                     },
                                     "end": {
-                                        "line": 17,
+                                        "line": 25,
                                         "character": 0
                                     }
                                 },
-                                "newText": "\n\nfunction addStudent(module1:Student a) {\n    \n}\n"
+                                "newText": "\n\nfunction createListener(Car a) returns module1:Listener {\n    \n    return new();\n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction1.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 8,
-            "character": 30
+        "node.range": {
+            "start": {
+                "line": 8,
+                "character": 30
+            },
+            "end": {
+                "line": 8,
+                "character": 54
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction3.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 10,
-            "character": 32
+        "node.range": {
+            "start": {
+                "line": 10,
+                "character": 32
+            },
+            "end": {
+                "line": 10,
+                "character": 55
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction4.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction4.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 14,
-            "character": 13
+        "node.range": {
+            "start": {
+                "line": 14,
+                "character": 13
+            },
+            "end": {
+                "line": 14,
+                "character": 28
+            }
         }
     },
     "expected": {
@@ -22,7 +28,7 @@
                                         "character": 0
                                     }
                                 },
-                                "newText": "\nfunction getAge(module1:Student a) returns int {\n    \n    return 0;\n}\n"
+                                "newText": "\n\nfunction getAge(module1:Student a) returns int {\n    \n    return 0;\n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction5.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunction5.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 4,
-            "character": 16
+        "node.range": {
+            "start": {
+                "line": 4,
+                "character": 16
+            },
+            "end": {
+                "line": 4,
+                "character": 27
+            }
         }
     },
     "expected": {
@@ -14,15 +20,15 @@
                             {
                                 "range": {
                                     "start": {
-                                        "line": 7,
+                                        "line": 11,
                                         "character": 0
                                     },
                                     "end": {
-                                        "line": 7,
+                                        "line": 11,
                                         "character": 0
                                     }
                                 },
-                                "newText": "\nfunction getSchool() returns School {\n    \n    return new();\n}\n"
+                                "newText": "\n\nfunction getSchool() returns School {\n    \n    return {};\n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet.json
@@ -2,12 +2,12 @@
     "arguments": {
         "node.range": {
             "start": {
-                "line": 9,
-                "character": 4
+                "line": 7,
+                "character": 59
             },
             "end": {
-                "line": 9,
-                "character": 23
+                "line": 7,
+                "character": 80
             }
         }
     },
@@ -20,15 +20,15 @@
                             {
                                 "range": {
                                     "start": {
-                                        "line": 17,
+                                        "line": 11,
                                         "character": 0
                                     },
                                     "end": {
-                                        "line": 17,
+                                        "line": 11,
                                         "character": 0
                                     }
                                 },
-                                "newText": "\n\nfunction addStudent(module1:Student a) {\n    \n}\n"
+                                "newText": "\n\nfunction createSchool([Grade] a) returns School {\n    \n    return {};\n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet2.json
@@ -2,12 +2,12 @@
     "arguments": {
         "node.range": {
             "start": {
-                "line": 9,
-                "character": 4
+                "line": 8,
+                "character": 38
             },
             "end": {
-                "line": 9,
-                "character": 23
+                "line": 8,
+                "character": 46
             }
         }
     },
@@ -20,15 +20,15 @@
                             {
                                 "range": {
                                     "start": {
-                                        "line": 17,
+                                        "line": 11,
                                         "character": 0
                                     },
                                     "end": {
-                                        "line": 17,
+                                        "line": 11,
                                         "character": 0
                                     }
                                 },
-                                "newText": "\n\nfunction addStudent(module1:Student a) {\n    \n}\n"
+                                "newText": "\n\nfunction getStr() returns string {\n    \n    return \"\";\n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet3.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionInLet3.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 4,
-            "character": 44
+        "node.range": {
+            "start": {
+                "line": 9,
+                "character": 22
+            },
+            "end": {
+                "line": 9,
+                "character": 35
+            }
         }
     },
     "expected": {
@@ -14,15 +20,15 @@
                             {
                                 "range": {
                                     "start": {
-                                        "line": 7,
+                                        "line": 11,
                                         "character": 0
                                     },
                                     "end": {
-                                        "line": 7,
+                                        "line": 11,
                                         "character": 0
                                     }
                                 },
-                                "newText": "\nfunction createSchool([Grade] grades) returns School {\n    return {};\n}\n"
+                                "newText": "\n\nfunction getSchool(int a) {\n    \n}\n"
                             }
                         ]
                     }

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithLangLib.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithLangLib.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 8,
-            "character": 25
+        "node.range": {
+            "start": {
+                "line": 8,
+                "character": 25
+            },
+            "end": {
+                "line": 8,
+                "character": 45
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 3,
-            "character": 27
+        "node.range": {
+            "start": {
+                "line": 3,
+                "character": 27
+            },
+            "end": {
+                "line": 3,
+                "character": 53
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias2.json
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/config/projectCreateUndefinedFunctionWithModAlias2.json
@@ -1,8 +1,14 @@
 {
     "arguments": {
-        "node.position": {
-            "line": 4,
-            "character": 16
+        "node.range": {
+            "start": {
+                "line": 4,
+                "character": 16
+            },
+            "end": {
+                "line": 4,
+                "character": 45
+            }
         }
     },
     "expected": {

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/createUndefinedFunctionInRecord.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/createUndefinedFunctionInRecord.bal
@@ -1,0 +1,25 @@
+import ballerina/module1;
+
+type Manufacturer record {
+    string name;
+};
+
+type Car record {
+    string licenceNo;
+    Manufacturer manufacturer;
+};
+
+type MyListener record {
+    module1:Listener myListener;
+};
+
+function testCreateFunction() {
+    Car myCar = {
+        licenceNo: "1234",
+        manufacturer: getManufacturer()
+    };
+    
+    MyListener ml = {
+        myListener: createListener(myCar)
+    };
+}

--- a/language-server/modules/langserver-core/src/test/resources/command/create-function/source/testproject/school.bal
+++ b/language-server/modules/langserver-core/src/test/resources/command/create-function/source/testproject/school.bal
@@ -1,7 +1,11 @@
 type Grade record {
     string name;
 }
-
+    
 School school = getSchool();
 
-School school2 = let Grade grade = {name:"Grade 1"} in createSchool([grade]);
+function myFunc() {
+    School school2 = let Grade grade = {name:"Grade 1"} in createSchool([grade]);
+    School school3 = let string str = getStr() in "Name:".concat(" ", str);
+    let int id = 1 in getSchool(id);
+}

--- a/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
+++ b/misc/ballerinalang-data-mapper/src/main/java/org/ballerinalang/datamapper/AIDataMapperCodeActionUtil.java
@@ -30,6 +30,8 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.NonTerminalNode;
+import io.ballerina.compiler.syntax.tree.SyntaxKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.projects.ProjectKind;
@@ -169,21 +171,33 @@ class AIDataMapperCodeActionUtil {
                         foundErrorRight = true;
                     }
 
+                    NonTerminalNode matchedNode = null;
+                    if (positionDetails.matchedNode().kind() == SyntaxKind.FUNCTION_CALL) {
+                        matchedNode = positionDetails.matchedNode();
+                        if (matchedNode.parent().kind() == SyntaxKind.CHECK_EXPRESSION) {
+                            matchedNode = matchedNode.parent();
+                        }
+                    }
 
-                    String functionCall = positionDetails.matchedNode().toString();
+                    if (matchedNode == null) {
+                        throw new IllegalStateException("Unexpected node at cursor:" +
+                                positionDetails.matchedNode().kind());
+                    }
+
+                    String functionCall = matchedNode.toString();
                     if (foundErrorRight && !foundErrorLeft) {
-                        symbolAtCursorName = functionCall.split("[=;]")[1].trim();
+                        symbolAtCursorName = functionCall.trim();
                         generatedFunctionName =
                                 String.format("map%sTo%s(check %s)", foundTypeRight, foundTypeLeft, symbolAtCursorName);
                         fEdits.add(new TextEdit(newTextRange, generatedFunctionName));
                     } else if (foundErrorLeft && foundErrorRight) {
                         // get the information about the line positions
-                        newTextRange = CommonUtil.toRange(positionDetails.matchedNode().lineRange());
+                        newTextRange = CommonUtil.toRange(matchedNode.lineRange());
                         generatedFunctionName =
                                 String.format("map%sTo%s(%s)", foundTypeRight, foundTypeLeft, functionCall);
                         fEdits.add(new TextEdit(newTextRange, generatedFunctionName));
                     } else {
-                        symbolAtCursorName = functionCall.split("[=;]")[1].trim();
+                        symbolAtCursorName = functionCall.trim();
                         generatedFunctionName =
                                 String.format("map%sTo%s(%s)", foundTypeRight, foundTypeLeft, symbolAtCursorName);
                         fEdits.add(new TextEdit(newTextRange, generatedFunctionName));


### PR DESCRIPTION
## Purpose
1. Overload NonTerminalNode.findNode() method to expose a new API to include start offset when searching for a child node.
2. Update 'Create Function Code Action' to support undefined methods within records and let expressions
3. Fix failing tests after updating `CommonUtil.findNode()` method to include start offset when searching for a node

## Approach
See decription + #28921 discussion

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
