### PR TITLE
Add apache commons-text dependency to lang module

### DIFF
--- a/compiler/ballerina-lang/build.gradle
+++ b/compiler/ballerina-lang/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.ow2.asm:asm-util'
     implementation 'org.ow2.asm:asm-tree'
     implementation 'commons-io:commons-io'
+    implementation 'org.apache.commons:commons-text:1.9'
     implementation 'com.github.zafarkhaja:java-semver'
     testCompile 'org.testng:testng'
 }

--- a/compiler/ballerina-lang/src/main/java/module-info.java
+++ b/compiler/ballerina-lang/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module io.ballerina.lang {
     requires io.ballerina.toml;
     requires io.ballerina.central.client;
     requires java.semver;
+    requires org.apache.commons.lang3;
     exports io.ballerina.compiler.api;
     exports io.ballerina.compiler.api.symbols;
     exports org.wso2.ballerinalang.compiler.util;

--- a/langlib/lang.test/src/main/ballerina/Ballerina.toml
+++ b/langlib/lang.test/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "lang.test"
 version = "1.0.0"
 
 [[platform.java11.dependency]]
-path = "../libs/ballerina-lang-test-2.0.0-alpha5.jar"
+path = "../libs/ballerina-lang-test-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "io"
 version = "0.5.0"

--- a/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
+++ b/misc/testerina/modules/testerina-core/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "test"
 version = "0.0.0"
 
 [[platform.java11.dependency]]
-path = "../libs/testerina-core-2.0.0-alpha5.jar"
+path = "../libs/testerina-core-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "mock"
 version = "0.0.0"

--- a/observelib/observe-internal/src/main/ballerina/Ballerina.toml
+++ b/observelib/observe-internal/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "observe"
 version = "0.9.0"
 
 [[platform.java11.dependency]]
-path = "../libs/ballerina-observability-internal-2.0.0-alpha5.jar"
+path = "../libs/ballerina-observability-internal-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "observability-internal"
 version = "0.9.0"

--- a/observelib/observe/src/main/ballerina/Ballerina.toml
+++ b/observelib/observe/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "observe"
 version = "0.9.0"
 
 [[platform.java11.dependency]]
-path = "../libs/ballerina-observability-2.0.0-alpha5.jar"
+path = "../libs/ballerina-observability-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "observability"
 version = "0.9.0"

--- a/stdlib/io/src/main/ballerina/Ballerina.toml
+++ b/stdlib/io/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "io"
 version = "0.5.0"
 
 [[platform.java11.dependency]]
-path = "../libs/ballerina-io-2.0.0-alpha5.jar"
+path = "../libs/ballerina-io-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "io"
 version = "0.5.0"

--- a/stdlib/runtime-api/src/main/ballerina/Ballerina.toml
+++ b/stdlib/runtime-api/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "runtime"
 version = "0.5.0"
 
 [[platform.java11.dependency]]
-path = "../libs/ballerina-runtime-api-2.0.0-alpha5.jar"
+path = "../libs/ballerina-runtime-api-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "runtime"
 version = "0.5.0"

--- a/tests/observability-test-utils/src/main/ballerina/Ballerina.toml
+++ b/tests/observability-test-utils/src/main/ballerina/Ballerina.toml
@@ -4,7 +4,7 @@ name = "testobserve"
 version = "0.0.0"
 
 [[platform.java11.dependency]]
-path = "../libs/observability-test-utils-2.0.0-alpha5.jar"
+path = "../libs/observability-test-utils-2.0.0-alpha6-SNAPSHOT.jar"
 groupId = "ballerina"
 artifactId = "observability"
 version = "0.0.0"


### PR DESCRIPTION
## Purpose
Include module dependency on apache commons-text, distribution class path already have this dependency[1]
And commit updated toml files. Without this IDEA keeps complaining saying it can't find `org.apache.commons.lang3.StringEscapeUtils` in imports.

[1] - https://github.com/ballerina-platform/ballerina-lang/blob/747a3eb46fbf56fbea35cc505c13ed7932a0ef2b/distribution/zip/jballerina-tools/build.gradle#L82
Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
