### PR TITLE
Fix resource file for validation not found issue

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/FileUtils.java
@@ -92,7 +92,7 @@ public class FileUtils {
      * @throws IOException if IO exception occurs
      */
     public static String readFileAsString(String path) throws IOException {
-        InputStream is = ClassLoader.getSystemResourceAsStream(path);
+        InputStream is = FileUtils.class.getClassLoader().getResourceAsStream(path);
         InputStreamReader inputStreamReader = null;
         BufferedReader br = null;
         StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
## Purpose
  - When passed in as the class path in springboot toml validation schema resource is not loading. Hence have to change the class loader and update the search path for resources.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
