### PR TITLE
Add stale check for PRs 

### DIFF
--- a/.github/workflows/stale_check.yml
+++ b/.github/workflows/stale_check.yml
@@ -1,0 +1,17 @@
+name: 'Close stale pull requests'
+
+on:
+  schedule:
+    - cron: '30 19 * * *'
+  workflow_dispatch:
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          stale-pr-message: 'This PR has been open for more than 15 days with no activity. This will be closed in 3 days unless the `stale` label is removed or commented.'
+          close-pr-message: 'Closed PR due to inactivity for more than 18 days.'
+          days-before-pr-stale: 15
+          days-before-pr-close: 3

--- a/.github/workflows/stale_check.yml
+++ b/.github/workflows/stale_check.yml
@@ -15,4 +15,3 @@ jobs:
           close-pr-message: 'Closed PR due to inactivity for more than 18 days.'
           days-before-pr-stale: 15
           days-before-pr-close: 3
-          

--- a/.github/workflows/stale_check.yml
+++ b/.github/workflows/stale_check.yml
@@ -15,3 +15,4 @@ jobs:
           close-pr-message: 'Closed PR due to inactivity for more than 18 days.'
           days-before-pr-stale: 15
           days-before-pr-close: 3
+          


### PR DESCRIPTION
## Purpose
Warns and then closes PRs that have had no activity for 18 days. Used https://github.com/actions/stale for this.
