### PR TITLE
Add array and map initialization data to bir

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRInstructionWriter.java
@@ -350,6 +350,20 @@ public class BIRInstructionWriter extends BIRVisitor {
     public void visit(NewStructure birNewStructure) {
         birNewStructure.rhsOp.accept(this);
         birNewStructure.lhsOp.accept(this);
+        buf.writeInt(birNewStructure.initialValues.size());
+        for (BIRNode.BIRMappingConstructorEntry initialValue : birNewStructure.initialValues) {
+            buf.writeBoolean(initialValue.isKeyValuePair());
+            if (initialValue.isKeyValuePair()) {
+                BIRNode.BIRMappingConstructorKeyValueEntry keyValueEntry =
+                        (BIRNode.BIRMappingConstructorKeyValueEntry) initialValue;
+                keyValueEntry.keyOp.accept(this);
+                keyValueEntry.valueOp.accept(this);
+            } else {
+                BIRNode.BIRMappingConstructorSpreadFieldEntry spreadEntry =
+                        (BIRNode.BIRMappingConstructorSpreadFieldEntry) initialValue;
+                spreadEntry.exprOp.accept(this);
+            }
+        }
     }
 
     public void visit(BIRNonTerminator.NewInstance newInstance) {
@@ -368,6 +382,10 @@ public class BIRInstructionWriter extends BIRVisitor {
         writeType(birNewArray.type);
         birNewArray.lhsOp.accept(this);
         birNewArray.sizeOp.accept(this);
+        buf.writeInt(birNewArray.values.size());
+        for (BIROperand value : birNewArray.values) {
+            value.accept(this);
+        }
     }
 
     public void visit(BIRNonTerminator.FieldAccess birFieldAccess) {

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -1202,6 +1202,37 @@ types:
         type: operand
       - id: lhs_operand
         type: operand
+      - id: init_values_count
+        type: s4
+      - id: init_values
+        type: mapping_constructor
+        repeat: expr
+        repeat-expr: init_values_count
+  mapping_constructor:
+    seq:
+      - id: mapping_constructor_kind
+        type: u1
+        enum: mapping_constructor_body_kind
+      - id: mapping_constructor_body
+        type:
+          switch-on: mapping_constructor_kind
+          cases:
+            'mapping_constructor_body_kind::mapping_constructor_spread_field_kind': mapping_constructor_spread_field_body
+            'mapping_constructor_body_kind::mapping_constructor_key_value_kind': mapping_constructor_key_value_body
+    enums:
+      mapping_constructor_body_kind:
+        0: mapping_constructor_spread_field_kind
+        1: mapping_constructor_key_value_kind
+  mapping_constructor_key_value_body:
+    seq:
+      - id: key_operand
+        type: operand
+      - id: value_operand
+        type: operand
+  mapping_constructor_spread_field_body:
+    seq:
+      - id: expr_operand
+        type: operand
   instruction_type_cast:
     seq:
       - id: lhs_operand
@@ -1220,6 +1251,12 @@ types:
         type: operand
       - id: size_operand
         type: operand
+      - id: init_values_count
+        type: s4
+      - id: init_values
+        type: operand
+        repeat: expr
+        repeat-expr: init_values_count
   instruction_branch:
     seq:
       - id: branch_operand

--- a/docs/bir-spec/src/test/resources/test-src/values.bal
+++ b/docs/bir-spec/src/test/resources/test-src/values.bal
@@ -348,6 +348,7 @@ function testToString() returns string[] {
     () varNil = ();
     Address addr = {country : "Sri Lanka", city: "Colombo", street: "Palm Grove"};
     Person p = {name : "Gima", address: addr, age: 12};
+    var s = {...p};
     boolean varBool = true;
     decimal varDecimal = 345.2425341;
     map<any|error> varMap = {};


### PR DESCRIPTION
## Purpose
Adds array and map initialization data.
Eg `int[] i = [1,2,3];`
now `1,2,3` will appear in the new array initialization.

Related to https://github.com/ballerina-platform/nballerina/issues/85

## Remarks
Needs to be backported to SLP2 for in to be fixed.
