### PR TITLE
Update type cast code action to use diagnostic properties to determine destination type to be cast

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  * @since 2.0.0
  */
 public class TypeCastTest extends AbstractCodeActionTest {
+
     @Override
     public String getResourceDir() {
         return "type-cast";
@@ -46,6 +47,8 @@ public class TypeCastTest extends AbstractCodeActionTest {
         return new Object[][]{
                 {"typeCast1.json", "typeCast.bal"},
                 {"typeCast2.json", "typeCast.bal"},
+                {"typeCast3.json", "typeCast.bal"},
+                {"typeCast4.json", "typeCast.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast3.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast3.json
@@ -1,0 +1,24 @@
+{
+    "line": 4,
+    "character": 14,
+    "expected": [
+        {
+            "title": "Add type cast to assignment",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 4,
+                            "character": 14
+                        },
+                        "end": {
+                            "line": 4,
+                            "character": 14
+                        }
+                    },
+                    "newText": "<string> "
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast4.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast4.json
@@ -1,0 +1,24 @@
+{
+    "line": 12,
+    "character": 15,
+    "expected": [
+        {
+            "title": "Add type cast to assignment",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 12,
+                            "character": 15
+                        },
+                        "end": {
+                            "line": 12,
+                            "character": 15
+                        }
+                    },
+                    "newText": "<int> "
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/typeCast.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/typeCast.bal
@@ -1,8 +1,32 @@
 public function main(string... args) {
     int a = true;
     int b = foo();
+    Student st = new ("Student 1");
+    st.name = 10;
+    
+    Car car = {
+        registrationNo: "AB1234",
+        model: "Tesla",
+        year: 2020
+    };
+    
+    car.year = "2020";
 }
 
 function foo() returns float {
     return 1.1;
 }
+
+class Student {
+    string name;
+    
+    public function init(string name) {
+        self.name = name;
+    }
+}
+
+type Car record {
+    string registrationNo;
+    string model;
+    int year;
+};


### PR DESCRIPTION
## Purpose
$subject

Fixes #28932

## Approach
`TypeCastCodeAction` now uses diagnostic properties to determine the type to be cast.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
