### PR TITLE
Fix NodeTransformer returns incorrect string value

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -5155,7 +5155,12 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                 type == SyntaxKind.TEMPLATE_STRING || type == SyntaxKind.IDENTIFIER_TOKEN) {
             String text = textValue;
             if (type == SyntaxKind.STRING_LITERAL) {
-                text = text.substring(1, text.length() - 1);
+                if (text.length() > 1 && text.charAt(text.length() - 1) == '"') {
+                    text = text.substring(1, text.length() - 1);
+                } else {
+                    // Missing end quote case
+                    text = text.substring(1);
+                }
             }
             String originalText = text; // to log the errors
             Matcher matcher = IdentifierUtils.UNICODE_PATTERN.matcher(text);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
@@ -226,7 +226,7 @@ public class StringTest {
         ByteArrayUtils.assertJBytesWithBBytes(bytes, bByteArray.getBytes());
     }
 
-    @Test(groups = { "disableOnOldParser" })
+    @Test
     public void testMultilineStringLiterals() {
         CompileResult multilineLiterals = BCompileUtil.compile("test-src/types/string/string_negative.bal");
         int indx = 0;
@@ -237,6 +237,11 @@ public class StringTest {
         validateError(multilineLiterals, indx++, "operator '!' not defined for 'string'", 19, 10);
         validateError(multilineLiterals, indx++, "missing double quote", 19, 11);
         validateError(multilineLiterals, indx++, "missing semicolon token", 20, 1);
+        validateError(multilineLiterals, indx++, "missing plus token", 20, 28);
+        validateError(multilineLiterals, indx++, "undefined symbol 'Bob'", 20, 28);
+        validateError(multilineLiterals, indx++, "missing double quote", 20, 32);
+        validateError(multilineLiterals, indx++, "missing plus token", 20, 32);
+        validateError(multilineLiterals, indx++, "missing semicolon token", 21, 1);
         Assert.assertEquals(multilineLiterals.getErrorCount(), indx);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTest.java
@@ -242,6 +242,9 @@ public class StringTest {
         validateError(multilineLiterals, indx++, "missing double quote", 20, 32);
         validateError(multilineLiterals, indx++, "missing plus token", 20, 32);
         validateError(multilineLiterals, indx++, "missing semicolon token", 21, 1);
+        validateError(multilineLiterals, indx++, "missing double quote", 21, 22);
+        validateError(multilineLiterals, indx++, "missing plus token", 21, 22);
+        validateError(multilineLiterals, indx++, "missing semicolon token", 22, 1);
         Assert.assertEquals(multilineLiterals.getErrorCount(), indx);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string_negative.bal
@@ -17,4 +17,5 @@
 function testMultilineStrings() {
     string s1 = "Hello
     World!";
+    string name = "Alice " Bob "
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string_negative.bal
@@ -18,4 +18,5 @@ function testMultilineStrings() {
     string s1 = "Hello
     World!";
     string name = "Alice " Bob "
+    string name2 = """
 }


### PR DESCRIPTION
## Purpose
Fix NodeTransformer returns incorrect string value for string literals with the missing end quote

Fixes #28739

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
