### PR TITLE
Fix a formatting issue in markdown parameter documentation nodes

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1658,11 +1658,34 @@ public class FormattingTreeModifier extends TreeModifier {
     public MarkdownParameterDocumentationLineNode transform(
             MarkdownParameterDocumentationLineNode markdownParameterDocumentationLineNode) {
         Token hashToken = formatToken(markdownParameterDocumentationLineNode.hashToken(), 1, 0);
-        Token plusToken = formatToken(markdownParameterDocumentationLineNode.plusToken(), 1, 0);
-        Token parameterName = formatToken(markdownParameterDocumentationLineNode.parameterName(), 1, 0);
-        Token minusToken = formatToken(markdownParameterDocumentationLineNode.minusToken(), 1, 0);
-        NodeList<Node> documentElements = formatNodeList(markdownParameterDocumentationLineNode.documentElements(),
-                0, 0, env.trailingWS, env.trailingNL);
+
+        Token plusToken = markdownParameterDocumentationLineNode.plusToken();
+        Token parameterName = markdownParameterDocumentationLineNode.parameterName();
+        Token minusToken = markdownParameterDocumentationLineNode.minusToken();
+        NodeList<Node> documentElements = markdownParameterDocumentationLineNode.documentElements();
+
+        // handle a scenario when the plus token is the final token in the documentation line
+        if (parameterName.isMissing() && minusToken.isMissing() && documentElements.isEmpty()) {
+            plusToken = formatToken(plusToken, env.trailingWS, env.trailingNL);
+        } else {
+            plusToken = formatToken(plusToken, 1, 0);
+        }
+
+        // handle a scenario when the parameter name is the final token in the documentation line
+        if (minusToken == null && documentElements.isEmpty()) {
+            parameterName = formatToken(parameterName, env.trailingWS, env.trailingNL);
+        } else {
+            parameterName = formatToken(parameterName, 1, 0);
+        }
+
+        // handle a scenario when the minus token is the final token in the documentation line
+        if (documentElements.isEmpty()) {
+            minusToken = formatToken(minusToken, env.trailingWS, env.trailingNL);
+        } else {
+            minusToken = formatToken(minusToken, 1, 0);
+            documentElements = formatNodeList(markdownParameterDocumentationLineNode.documentElements(),
+                    0, 0, env.trailingWS, env.trailingNL);
+        }
 
         return markdownParameterDocumentationLineNode.modify()
                 .withHashToken(hashToken)

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1664,27 +1664,25 @@ public class FormattingTreeModifier extends TreeModifier {
         Token minusToken = markdownParameterDocumentationLineNode.minusToken();
         NodeList<Node> documentElements = markdownParameterDocumentationLineNode.documentElements();
 
-        // handle a scenario when the plus token is the last token in the documentation line
         if (parameterName == null && minusToken == null && documentElements.isEmpty()) {
+            // handle a scenario when the plus token is the last token in the documentation line
             plusToken = formatToken(plusToken, env.trailingWS, env.trailingNL);
         } else {
             plusToken = formatToken(plusToken, 1, 0);
-        }
-
-        // handle a scenario when the parameter name is the last token in the documentation line
-        if (minusToken == null && documentElements.isEmpty()) {
-            parameterName = formatToken(parameterName, env.trailingWS, env.trailingNL);
-        } else {
-            parameterName = formatToken(parameterName, 1, 0);
-        }
-
-        // handle a scenario when the minus token is the last token in the documentation line
-        if (documentElements.isEmpty()) {
-            minusToken = formatToken(minusToken, env.trailingWS, env.trailingNL);
-        } else {
-            minusToken = formatToken(minusToken, 1, 0);
-            documentElements = formatNodeList(markdownParameterDocumentationLineNode.documentElements(),
-                    0, 0, env.trailingWS, env.trailingNL);
+            if (minusToken == null && documentElements.isEmpty()) {
+                // handle a scenario when the parameter name is the last token in the documentation line
+                parameterName = formatToken(parameterName, env.trailingWS, env.trailingNL);
+            } else {
+                parameterName = formatToken(parameterName, 1, 0);
+                if (documentElements.isEmpty()) {
+                    // handle a scenario when the minus token is the last token in the documentation line
+                    minusToken = formatToken(minusToken, env.trailingWS, env.trailingNL);
+                } else {
+                    minusToken = formatToken(minusToken, 1, 0);
+                    documentElements = formatNodeList(markdownParameterDocumentationLineNode.documentElements(),
+                            0, 0, env.trailingWS, env.trailingNL);
+                }
+            }
         }
 
         return markdownParameterDocumentationLineNode.modify()

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1665,7 +1665,7 @@ public class FormattingTreeModifier extends TreeModifier {
         NodeList<Node> documentElements = markdownParameterDocumentationLineNode.documentElements();
 
         // handle a scenario when the plus token is the last token in the documentation line
-        if (parameterName.isMissing() && minusToken.isMissing() && documentElements.isEmpty()) {
+        if (parameterName == null && minusToken == null && documentElements.isEmpty()) {
             plusToken = formatToken(plusToken, env.trailingWS, env.trailingNL);
         } else {
             plusToken = formatToken(plusToken, 1, 0);

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -1664,21 +1664,21 @@ public class FormattingTreeModifier extends TreeModifier {
         Token minusToken = markdownParameterDocumentationLineNode.minusToken();
         NodeList<Node> documentElements = markdownParameterDocumentationLineNode.documentElements();
 
-        // handle a scenario when the plus token is the final token in the documentation line
+        // handle a scenario when the plus token is the last token in the documentation line
         if (parameterName.isMissing() && minusToken.isMissing() && documentElements.isEmpty()) {
             plusToken = formatToken(plusToken, env.trailingWS, env.trailingNL);
         } else {
             plusToken = formatToken(plusToken, 1, 0);
         }
 
-        // handle a scenario when the parameter name is the final token in the documentation line
+        // handle a scenario when the parameter name is the last token in the documentation line
         if (minusToken == null && documentElements.isEmpty()) {
             parameterName = formatToken(parameterName, env.trailingWS, env.trailingNL);
         } else {
             parameterName = formatToken(parameterName, 1, 0);
         }
 
-        // handle a scenario when the minus token is the final token in the documentation line
+        // handle a scenario when the minus token is the last token in the documentation line
         if (documentElements.isEmpty()) {
             minusToken = formatToken(minusToken, env.trailingWS, env.trailingNL);
         } else {

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/misc/MetadataTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/misc/MetadataTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.formatter.core.misc;
+
+import org.ballerinalang.formatter.core.FormatterTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Test the metadata attached to a construct.
+ *
+ * @since 2.0.0
+ */
+public class MetadataTest extends FormatterTest {
+
+    @Test(dataProvider = "test-file-provider")
+    public void test(String source, String sourcePath) throws IOException {
+        super.test(source, sourcePath);
+    }
+
+    @DataProvider(name = "test-file-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return this.getConfigsList();
+    }
+
+    @Override
+    public String getTestResourceDir() {
+        return Paths.get("misc", "metadata").toString();
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/assert/documentation_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/assert/documentation_1.bal
@@ -1,0 +1,6 @@
+# Adds two parameters
+# + x - one thing to be added
+# + y
+# + return
+function foo(int x, int y) {
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/assert/documentation_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/assert/documentation_1.bal
@@ -1,6 +1,9 @@
 # Adds two parameters
 # + x - one thing to be added
+#
+# + 
 # + y 
+# + z -
 # + return 
-function foo(int x, int y) {
+function foo(int x, int y, int z) {
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/assert/documentation_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/assert/documentation_1.bal
@@ -1,6 +1,6 @@
 # Adds two parameters
 # + x - one thing to be added
-# + y
-# + return
+# + y 
+# + return 
 function foo(int x, int y) {
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/source/documentation_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/source/documentation_1.bal
@@ -1,0 +1,7 @@
+ #   Adds two parameters
+
+#    +  x   -   one thing to be added
+  #   +   y
+#+ return
+function foo(int x, int y) {
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/source/documentation_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/metadata/source/documentation_1.bal
@@ -1,7 +1,10 @@
  #   Adds two parameters
 
 #    +  x   -   one thing to be added
+#
+  #+
   #   +   y
+#   +   z   -
 #+ return
-function foo(int x, int y) {
+function foo(int x, int y, int z) {
 }


### PR DESCRIPTION
## Purpose
Improve the formatting of markdown parameter documentation lines nodes when there are missing mandatory nodes.

Fixes #28172

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
