### PR TITLE
[LS] Fix 'fix return type' code action inserting invalid type names

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -190,11 +190,11 @@ public class CodeActionUtil {
      * Returns a list of possible types for this type descriptor.
      *
      * @param typeDescriptor {@link TypeSymbol}
-     * @param edits          a list of {@link TextEdit}
+     * @param importEdits    a list of import {@link TextEdit}
      * @param context        {@link CodeActionContext}
      * @return a list of possible type list
      */
-    public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, List<TextEdit> edits,
+    public static List<String> getPossibleTypes(TypeSymbol typeDescriptor, List<TextEdit> importEdits,
                                                 CodeActionContext context) {
         if (typeDescriptor.getName().isPresent() && typeDescriptor.getName().get().startsWith("$")) {
             typeDescriptor = CommonUtil.getRawType(typeDescriptor);
@@ -299,7 +299,7 @@ public class CodeActionUtil {
             // Handle ambiguous array element types eg. record[], json[], map[]
             ArrayTypeSymbol arrayTypeSymbol = (ArrayTypeSymbol) typeDescriptor;
             boolean isUnion = arrayTypeSymbol.memberTypeDescriptor().typeKind() == TypeDescKind.UNION;
-            return getPossibleTypes(arrayTypeSymbol.memberTypeDescriptor(), edits, context)
+            return getPossibleTypes(arrayTypeSymbol.memberTypeDescriptor(), importEdits, context)
                     .stream().map(m -> isUnion ? "(" + m + ")[]" : m + "[]")
                     .collect(Collectors.toList());
         } else {
@@ -308,7 +308,7 @@ public class CodeActionUtil {
 
         // Remove brackets of the unions
         types = types.stream().map(v -> v.replaceAll("^\\((.*)\\)$", "$1")).collect(Collectors.toList());
-        edits.addAll(importsAcceptor.getNewImportTextEdits());
+        importEdits.addAll(importsAcceptor.getNewImportTextEdits());
         return types;
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/CodeActionUtil.java
@@ -176,13 +176,13 @@ public class CodeActionUtil {
      * Returns first possible type for this type descriptor.
      *
      * @param typeDescriptor {@link TypeSymbol}
-     * @param edits          a list of {@link TextEdit}
+     * @param importEdits    a list of import {@link TextEdit}
      * @param context        {@link CodeActionContext}
      * @return a list of possible type list
      */
-    public static Optional<String> getPossibleType(TypeSymbol typeDescriptor, List<TextEdit> edits,
+    public static Optional<String> getPossibleType(TypeSymbol typeDescriptor, List<TextEdit> importEdits,
                                                    CodeActionContext context) {
-        List<String> possibleTypes = getPossibleTypes(typeDescriptor, edits, context);
+        List<String> possibleTypes = getPossibleTypes(typeDescriptor, importEdits, context);
         return possibleTypes.isEmpty() ? Optional.empty() : Optional.of(possibleTypes.get(0));
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -95,29 +95,27 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
         }
 
         List<CodeAction> codeActions = new ArrayList<>();
-        if (!RuntimeConstants.MAIN_FUNCTION_NAME.equals(funcDef.functionName().text())) {
-            List<TextEdit> importEdits = new ArrayList<>();
-            // Get all possible return types including ambiguous scenarios
-            List<String> types = CodeActionUtil.getPossibleTypes(foundTypeSymbol.get(), importEdits, context);
+        List<TextEdit> importEdits = new ArrayList<>();
+        // Get all possible return types including ambiguous scenarios
+        List<String> types = CodeActionUtil.getPossibleTypes(foundTypeSymbol.get(), importEdits, context);
 
-            types.forEach(type -> {
-                List<TextEdit> edits = new ArrayList<>();
+        types.forEach(type -> {
+            List<TextEdit> edits = new ArrayList<>();
 
-                String editText;
-                // Process function node
-                if (funcDef.functionSignature().returnTypeDesc().isEmpty()) {
-                    editText = " returns " + type;
-                } else {
-                    editText = type;
-                }
-                edits.add(new TextEdit(new Range(start, end), editText));
-                edits.addAll(importEdits);
+            String editText;
+            // Process function node
+            if (funcDef.functionSignature().returnTypeDesc().isEmpty()) {
+                editText = " returns " + type;
+            } else {
+                editText = type;
+            }
+            edits.add(new TextEdit(new Range(start, end), editText));
+            edits.addAll(importEdits);
 
-                // Add code action
-                String commandTitle = String.format(CommandConstants.CHANGE_RETURN_TYPE_TITLE, type);
-                codeActions.add(createQuickFixCodeAction(commandTitle, edits, context.fileUri()));
-            });
-        }
+            // Add code action
+            String commandTitle = String.format(CommandConstants.CHANGE_RETURN_TYPE_TITLE, type);
+            codeActions.add(createQuickFixCodeAction(commandTitle, edits, context.fileUri()));
+        });
 
         return codeActions;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/changetype/FixReturnTypeCodeAction.java
@@ -15,20 +15,18 @@
  */
 package org.ballerinalang.langserver.codeaction.providers.changetype;
 
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
-import io.ballerina.compiler.syntax.tree.ModulePartNode;
 import io.ballerina.compiler.syntax.tree.Node;
 import io.ballerina.compiler.syntax.tree.NonTerminalNode;
 import io.ballerina.compiler.syntax.tree.ReturnStatementNode;
 import io.ballerina.compiler.syntax.tree.ReturnTypeDescriptorNode;
 import io.ballerina.compiler.syntax.tree.SyntaxKind;
-import io.ballerina.compiler.syntax.tree.SyntaxTree;
-import io.ballerina.projects.Module;
 import io.ballerina.runtime.api.constants.RuntimeConstants;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.text.LinePosition;
 import org.ballerinalang.annotation.JavaSPIService;
-import org.ballerinalang.langserver.codeaction.CodeActionModuleId;
+import org.ballerinalang.langserver.codeaction.CodeActionUtil;
 import org.ballerinalang.langserver.codeaction.providers.AbstractCodeActionProvider;
 import org.ballerinalang.langserver.common.constants.CommandConstants;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
@@ -43,9 +41,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-
-import static org.ballerinalang.langserver.common.utils.CommonKeys.PKG_DELIMITER_KEYWORD;
 
 /**
  * Code Action for incompatible return types.
@@ -71,43 +66,60 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
             return Collections.emptyList();
         }
 
-        Matcher matcher = CommandConstants.INCOMPATIBLE_TYPE_PATTERN.matcher(diagnostic.message());
-        if (matcher.find() && matcher.groupCount() > 1) {
-            String foundType = matcher.group(2);
-            FunctionDefinitionNode funcDef = getFunctionNode(positionDetails);
-            if (!RuntimeConstants.MAIN_FUNCTION_NAME.equals(funcDef.functionName().text())) {
-                // Process full-qualified BType name  eg. ballerina/http:Client and if required; add
-                // auto-import
-                matcher = CommandConstants.FQ_TYPE_PATTERN.matcher(foundType);
-                List<TextEdit> edits = new ArrayList<>();
-                String editText = extractTypeName(matcher, context, foundType, edits);
+        Optional<TypeSymbol> foundTypeSymbol = positionDetails.diagnosticProperty(
+                DiagBasedPositionDetails.DIAG_PROP_INCOMPATIBLE_TYPES_FOUND_SYMBOL_INDEX);
+        if (foundTypeSymbol.isEmpty()) {
+            return Collections.emptyList();
+        }
 
+        FunctionDefinitionNode funcDef = getFunctionNode(positionDetails);
+        if (RuntimeConstants.MAIN_FUNCTION_NAME.equals(funcDef.functionName().text())) {
+            return Collections.emptyList();
+        }
+
+        // Where to insert the edit: Depends on if a return statement alredy available or not
+        Position start;
+        Position end;
+        if (funcDef.functionSignature().returnTypeDesc().isEmpty()) {
+            // eg. function test() {...}
+            Position funcBodyStart = CommonUtil.toPosition(funcDef.functionSignature().lineRange().endLine());
+            start = funcBodyStart;
+            end = funcBodyStart;
+        } else {
+            // eg. function test() returns () {...}
+            ReturnTypeDescriptorNode returnTypeDesc = funcDef.functionSignature().returnTypeDesc().get();
+            LinePosition retStart = returnTypeDesc.type().lineRange().startLine();
+            LinePosition retEnd = returnTypeDesc.type().lineRange().endLine();
+            start = new Position(retStart.line(), retStart.offset());
+            end = new Position(retEnd.line(), retEnd.offset());
+        }
+
+        List<CodeAction> codeActions = new ArrayList<>();
+        if (!RuntimeConstants.MAIN_FUNCTION_NAME.equals(funcDef.functionName().text())) {
+            List<TextEdit> importEdits = new ArrayList<>();
+            // Get all possible return types including ambiguous scenarios
+            List<String> types = CodeActionUtil.getPossibleTypes(foundTypeSymbol.get(), importEdits, context);
+
+            types.forEach(type -> {
+                List<TextEdit> edits = new ArrayList<>();
+
+                String editText;
                 // Process function node
-                Position start;
-                Position end;
                 if (funcDef.functionSignature().returnTypeDesc().isEmpty()) {
-                    // eg. function test() {...}
-                    Position funcBodyStart = CommonUtil.toPosition(funcDef.functionBody().lineRange().startLine());
-                    start = funcBodyStart;
-                    end = funcBodyStart;
-                    editText = " returns (" + editText + ")";
+                    editText = " returns " + type;
                 } else {
-                    // eg. function test() returns () {...}
-                    ReturnTypeDescriptorNode returnTypeDesc = funcDef.functionSignature().returnTypeDesc().get();
-                    LinePosition retStart = returnTypeDesc.type().lineRange().startLine();
-                    LinePosition retEnd = returnTypeDesc.type().lineRange().endLine();
-                    start = new Position(retStart.line(),
-                                         retStart.offset());
-                    end = new Position(retEnd.line(), retEnd.offset());
+                    editText = type;
                 }
                 edits.add(new TextEdit(new Range(start, end), editText));
+                edits.addAll(importEdits);
 
                 // Add code action
-                String commandTitle = CommandConstants.CHANGE_RETURN_TYPE_TITLE + foundType + "'";
-                return Collections.singletonList(createQuickFixCodeAction(commandTitle, edits, context.fileUri()));
-            }
+                String commandTitle = String.format(CommandConstants.CHANGE_RETURN_TYPE_TITLE, type);
+                codeActions.add(createQuickFixCodeAction(commandTitle, edits, context.fileUri()));
+            });
         }
-        return Collections.emptyList();
+
+        return codeActions;
     }
 
     private ReturnStatementNode getReturnStatement(NonTerminalNode node) {
@@ -124,37 +136,5 @@ public class FixReturnTypeCodeAction extends AbstractCodeActionProvider {
             parent = parent.parent();
         }
         return (FunctionDefinitionNode) parent;
-    }
-
-    private static String extractTypeName(Matcher matcher, CodeActionContext context, String foundType,
-                                          List<TextEdit> edits) {
-        Optional<SyntaxTree> syntaxTree = context.currentSyntaxTree();
-        if (matcher.find() && matcher.groupCount() > 2 && syntaxTree.isPresent()) {
-            String orgName = matcher.group(1);
-            String moduleName = matcher.group(2);
-            String typeName = matcher.group(3);
-            String pkgId = orgName + "/" + moduleName;
-
-            Module module = context.workspace().module(context.filePath()).orElseThrow();
-            String currentOrg = module.packageInstance().descriptor().org().value();
-            String currentModule = module.descriptor().name().packageName().value();
-
-            if (currentOrg.equals(pkgId) && currentModule.equals(moduleName)) {
-                // TODO: Check the validity of this check since currentPkgId.toString() returns version as well.
-                foundType = typeName;
-            } else {
-                boolean pkgAlreadyImported = ((ModulePartNode) syntaxTree.get().rootNode()).imports().stream()
-                        .anyMatch(importPkg -> {
-                            CodeActionModuleId importModel = CodeActionModuleId.from(importPkg);
-                            return importModel.orgName().equals(orgName)
-                                    && importModel.moduleName().equals(moduleName);
-                        });
-                if (!pkgAlreadyImported) {
-                    edits.addAll(CommonUtil.getAutoImportTextEdits(orgName, moduleName, context));
-                }
-                foundType = moduleName + PKG_DELIMITER_KEYWORD + typeName;
-            }
-        }
-        return foundType;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -89,7 +89,8 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
         }
 
         edits.add(createVarTextEdits.edits.get(0));
-        edits.addAll(createVarTextEdits.imports);
+        // Add all the import text edits excluding duplicates
+        createVarTextEdits.imports.stream().filter(edits::contains).forEach(edits::add);
         return Collections.singletonList(AbstractCodeActionProvider.createQuickFixCodeAction(commandTitle, edits, uri));
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -109,7 +109,8 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         TextEdit textEdit = createVarTextEdits.edits.get(0);
         textEdit.setNewText(typeWithoutError + textEdit.getNewText().substring(typeWithError.length()));
         edits.add(textEdit);
-        edits.addAll(createVarTextEdits.imports);
+        // Add all the import text edits excluding duplicates
+        createVarTextEdits.imports.stream().filter(edits::contains).forEach(edits::add);
         return edits;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/constants/CommandConstants.java
@@ -100,7 +100,7 @@ public class CommandConstants {
 
     public static final String PULL_MOD_TITLE = "Pull from Ballerina Central";
 
-    public static final String CHANGE_RETURN_TYPE_TITLE = "Change return type to '";
+    public static final String CHANGE_RETURN_TYPE_TITLE = "Change return type to '%s'";
 
     public static final String ADD_TYPE_CAST_TITLE = "Add type cast to assignment";
 

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -86,6 +86,8 @@ public class CreateVariableTest extends AbstractCodeActionTest {
 //                {"variableAssignmentRequiredCodeAction40.json", "createVariable5.bal"},   // disabled due to #26996
                 {"variableAssignmentRequiredCodeAction41.json", "createVariable6.bal"},
                 {"ignoreReturnValueCodeAction.json", "createVariable.bal"},
+                {"projectVariableAssignmentRequiredCodeAction1.json", "testproject/main.bal"},
+                {"projectVariableAssignmentRequiredCodeAction2.json", "testproject/main.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/FixReturnTypeTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  * @since 2.0.0
  */
 public class FixReturnTypeTest extends AbstractCodeActionTest {
+
     @Override
     public String getResourceDir() {
         return "fix-return-type";
@@ -47,6 +48,7 @@ public class FixReturnTypeTest extends AbstractCodeActionTest {
                 {"fixReturnType1.json", "fixReturnType.bal"},
                 {"fixReturnType2.json", "fixReturnType.bal"},
                 {"fixReturnType3.json", "fixReturnType.bal"},
+                {"fixReturnTypeWithImports1.json", "fixReturnTypeWithImports.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction1.json
@@ -1,0 +1,55 @@
+{
+  "line": 3,
+  "character": 4,
+  "expected": [
+    {
+      "title": "Create variable",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 4
+            },
+            "end": {
+              "line": 3,
+              "character": 4
+            }
+          },
+          "newText": "module2:Country country = "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lstest/testproject.module2;\n"
+        }
+      ]
+    },
+    {
+      "title": "Ignore return value",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 4
+            },
+            "end": {
+              "line": 3,
+              "character": 4
+            }
+          },
+          "newText": "_ = "
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
@@ -1,0 +1,164 @@
+{
+  "line": 7,
+  "character": 4,
+  "expected": [
+    {
+      "title": "Create variable and type guard",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lstest/testproject.module2;\n"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 34
+            },
+            "end": {
+              "line": 7,
+              "character": 34
+            }
+          },
+          "newText": "\n    if (countryWithError is module2:Country) {\n\n    }"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "module2:Country|error countryWithError = "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lstest/testproject.module2;\n"
+        }
+      ]
+    },
+    {
+      "title": "Create variable and check error",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lstest/testproject.module2;\n"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "module2:Country countryWithError = "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lstest/testproject.module2;\n"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "check "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 6,
+              "character": 31
+            },
+            "end": {
+              "line": 6,
+              "character": 31
+            }
+          },
+          "newText": " returns error?"
+        }
+      ]
+    },
+    {
+      "title": "Create variable",
+      "edits": [
+        {
+          "range": {
+            "start": {
+              "line": 7,
+              "character": 4
+            },
+            "end": {
+              "line": 7,
+              "character": 4
+            }
+          },
+          "newText": "module2:Country|error countryWithError = "
+        },
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import lstest/testproject.module2;\n"
+        }
+      ]
+    }
+  ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/Ballerina.toml
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/Ballerina.toml
@@ -1,0 +1,7 @@
+[package]
+org = "lstest"
+name = "testproject"
+version = "0.1.0"
+
+[build-options]
+observabilityIncluded = true

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/main.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/main.bal
@@ -1,0 +1,9 @@
+import testproject.module1;
+
+public function testFunction1() {
+    module1:getCountry();
+}
+
+public function testFunction2() {
+    module1:getCountryWithError();
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/modules/module1/module1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/modules/module1/module1.bal
@@ -1,0 +1,9 @@
+import testproject.module2;
+
+public function getCountry() returns module2:Country {
+    return {name: "Sri Lanka"};
+}
+
+public function getCountryWithError() returns module2:Country|error {
+    return {name: "Sri Lanka"};
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/modules/module2/module2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/source/testproject/modules/module2/module2.bal
@@ -1,0 +1,3 @@
+public type Country record {
+    string name;
+};

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnType1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnType1.json
@@ -9,14 +9,14 @@
                     "range": {
                         "start": {
                             "line": 0,
-                            "character": 38
+                            "character": 37
                         },
                         "end": {
                             "line": 0,
-                            "character": 38
+                            "character": 37
                         }
                     },
-                    "newText": " returns (int)"
+                    "newText": " returns int"
                 }
             ]
         }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnType2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnType2.json
@@ -3,7 +3,7 @@
     "character": 10,
     "expected": [
         {
-            "title": "Change return type to '[int,string]'",
+            "title": "Change return type to '[int, string]'",
             "edits": [
                 {
                     "range": {
@@ -16,7 +16,7 @@
                             "character": 49
                         }
                     },
-                    "newText": "[int,string]"
+                    "newText": "[int, string]"
                 }
             ]
         }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithImports1.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/config/fixReturnTypeWithImports1.json
@@ -1,0 +1,24 @@
+{
+    "line": 4,
+    "character": 11,
+    "expected": [
+        {
+            "title": "Change return type to 'module1:TestRecord1'",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 2,
+                            "character": 22
+                        },
+                        "end": {
+                            "line": 2,
+                            "character": 22
+                        }
+                    },
+                    "newText": " returns module1:TestRecord1"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithImports.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/fix-return-type/source/fixReturnTypeWithImports.bal
@@ -1,0 +1,10 @@
+import ballerina/module1;
+
+function withImports() {
+    module1:TestRecord1 rec1 = {};
+    return rec1;
+}
+
+function withAmbiguousTypes() {
+    return {key: "value"};
+}


### PR DESCRIPTION
## Purpose
- $subject and improve code action's support for imports
- Fix duplicate imports being added by `create variable and typeguard/check` code actions which requires importing an external module.

Fixes #28855
Fixes #29100

## Approach
Updated to use `CodeActionUtil.getPossibleTypes()` method to determine return type and handle imports. Updated the `FixReturnTypeCodeAction` to use diagnostic properties to determine expected type.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
