### PR TITLE
Set default load value for decimal values

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmConstants.java
@@ -205,6 +205,7 @@ public class JvmConstants {
     public static final String PATH = "java/nio/file/Path";
     public static final String PATHS = "java/nio/file/Paths";
     public static final String SYSTEM = "java/lang/System";
+    public static final String BIG_DECIMAL = "java/math/BigDecimal";
 
     // service objects, annotation processing related classes
     public static final String ANNOTATION_UTILS = "io/ballerina/runtime/internal/AnnotationUtils";

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTerminatorGen.java
@@ -97,12 +97,14 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ENV;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_ERROR_REASONS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BAL_EXTENSION;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BERROR;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BIG_DECIMAL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BLANG_EXCEPTION_HELPER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.BLOCKED_ON_EXTERN_FIELD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_FUNCTION_POINTER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.B_OBJECT;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CHANNEL_DETAILS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.CURRENT_MODULE_VAR_NAME;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DECIMAL_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.DEFAULT_STRAND_DISPATCHER;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.ERROR_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.FUNCTION;
@@ -141,6 +143,7 @@ import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_TH
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRAND_VALUE_ANY;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.STRING_VALUE;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.TYPE;
+import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.VALUE_OF_METHOD;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WD_CHANNELS;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_DATA_CHANNEL;
 import static org.wso2.ballerinalang.compiler.bir.codegen.JvmConstants.WORKER_UTILS;
@@ -219,7 +222,6 @@ public class JvmTerminatorGen {
             case TypeTags.ARRAY:
             case TypeTags.ERROR:
             case TypeTags.NIL:
-            case TypeTags.DECIMAL:
             case TypeTags.NEVER:
             case TypeTags.ANY:
             case TypeTags.ANYDATA:
@@ -237,6 +239,15 @@ public class JvmTerminatorGen {
             case TypeTags.READONLY:
             case TypeTags.STREAM:
                 mv.visitInsn(ACONST_NULL);
+                break;
+            case TypeTags.DECIMAL:
+                mv.visitTypeInsn(NEW, DECIMAL_VALUE);
+                mv.visitInsn(DUP);
+                mv.visitInsn(DCONST_0);
+                mv.visitMethodInsn(INVOKESTATIC, BIG_DECIMAL, VALUE_OF_METHOD, String.format("(D)L%s;", BIG_DECIMAL),
+                        false);
+                mv.visitMethodInsn(INVOKESPECIAL, DECIMAL_VALUE, JVM_INIT_METHOD, String.format("(L%s;)V", BIG_DECIMAL),
+                        false);
                 break;
             case JTypeTags.JTYPE:
                 loadDefaultJValue(mv, (JType) bType);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -649,4 +649,13 @@ public class StaticMethods {
         BDecimal c = a.add(b);
         return c;
     }
+
+    public static Object defaultDecimalArgs2(String s, BDecimal d) {
+        if (!d.booleanValue()) {
+            BDecimal a = new DecimalValue(s);
+            return a.multiply(d);
+        } else {
+            return null;
+        }
+    }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/nativeimpl/jvm/tests/StaticMethods.java
@@ -645,12 +645,12 @@ public class StaticMethods {
         return ValueCreator.createMapValue(recordType, mapInitialValueEntries);
     }
 
-    public static BDecimal defaultDecimalArgs(BDecimal a, BDecimal b) {
+    public static BDecimal defaultDecimalArgsAddition(BDecimal a, BDecimal b) {
         BDecimal c = a.add(b);
         return c;
     }
 
-    public static Object defaultDecimalArgs2(String s, BDecimal d) {
+    public static Object defaultDecimalArgs(String s, BDecimal d) {
         if (!d.booleanValue()) {
             BDecimal a = new DecimalValue(s);
             return a.multiply(d);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
@@ -180,17 +180,7 @@ public class StaticMethodTest {
         return new String[]{"testBalEnvSlowAsyncVoidSig", "testBalEnvFastAsyncVoidSig", "testBalEnvSlowAsync",
                 "testBalEnvFastAsync", "testReturnNullString", "testReturnNotNullString", "testStaticResolve",
                 "testStringCast", "testGetCurrentModule", "testGetDefaultValueWithBEnv", "testCreateStudentUsingType",
-                "testCreateStudent"};
-    }
-
-    @Test(description = "Test decimal default values with interop functions")
-    public void testDefaultDecimalArgs() {
-        BRunUtil.invoke(result, "testDefaultDecimalArgs");
-    }
-
-    @Test(description = "Test decimal default values with InterOp functions")
-    public void testDefaultDecimalArgs2() {
-        BRunUtil.invoke(result, "testDefaultDecimalArgs2");
+                "testCreateStudent", "testDefaultDecimalArgs", "testDefaultDecimalArgsAddition"};
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/javainterop/basic/StaticMethodTest.java
@@ -188,6 +188,11 @@ public class StaticMethodTest {
         BRunUtil.invoke(result, "testDefaultDecimalArgs");
     }
 
+    @Test(description = "Test decimal default values with InterOp functions")
+    public void testDefaultDecimalArgs2() {
+        BRunUtil.invoke(result, "testDefaultDecimalArgs2");
+    }
+
     @AfterClass
     public void tearDown() {
         result = null;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -155,6 +155,13 @@ public function testDefaultDecimalArgs() {
     test:assertEquals(val, expected);
 }
 
+public function testDefaultDecimalArgs2() {
+    handle h = java:fromString("8");
+    anydata val = defaultDecimalArgs2(h);
+    anydata expected = ();
+    test:assertEquals(val, expected);
+}
+
 function hashCode(int receiver) returns int = @java:Method {
     name: "hashCode",
     'class: "java.lang.Byte",
@@ -355,5 +362,9 @@ function createStudentUsingType() returns (Student & readonly) = @java:Method {
 } external;
 
 function defaultDecimalArgs(decimal a, decimal b = 10.05) returns (decimal) = @java:Method {
+    'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
+} external;
+
+function defaultDecimalArgs2(handle s, decimal d = -1) returns (anydata) = @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
 } external;

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/static_method_tests.bal
@@ -149,15 +149,15 @@ public function testGetDefaultValueWithBEnv() {
      test:assertEquals(defaultValue, 2021);
 }
 
-public function testDefaultDecimalArgs() {
-    decimal val = defaultDecimalArgs(5);
+public function testDefaultDecimalArgsAddition() {
+    decimal val = defaultDecimalArgsAddition(5);
     decimal expected = 15.05;
     test:assertEquals(val, expected);
 }
 
-public function testDefaultDecimalArgs2() {
+public function testDefaultDecimalArgs() {
     handle h = java:fromString("8");
-    anydata val = defaultDecimalArgs2(h);
+    anydata val = defaultDecimalArgs(h);
     anydata expected = ();
     test:assertEquals(val, expected);
 }
@@ -361,10 +361,10 @@ function createStudentUsingType() returns (Student & readonly) = @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
 } external;
 
-function defaultDecimalArgs(decimal a, decimal b = 10.05) returns (decimal) = @java:Method {
+function defaultDecimalArgsAddition(decimal a, decimal b = 10.05) returns (decimal) = @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
 } external;
 
-function defaultDecimalArgs2(handle s, decimal d = -1) returns (anydata) = @java:Method {
+function defaultDecimalArgs(handle s, decimal d = -1) returns (anydata) = @java:Method {
     'class:"org/ballerinalang/nativeimpl/jvm/tests/StaticMethods"
 } external;


### PR DESCRIPTION
## Purpose
> According to spec, the filler value (which has to be load as default value) for decimal should be '+0.0d'. This PR fixes the spec violation on loading default value for decimal. 

Fixes #29113

## Approach

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
