### PR TITLE
Implement a mechanism for cancelling stale compilation invocations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilationState.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleCompilationState.java
@@ -288,6 +288,28 @@ enum ModuleCompilationState {
                                           CompilerBackend compilerBackend) {
             // Do nothing
         }
+    },
+    CANCELLED_COMPILATION {
+        @Override
+        void parse(ModuleContext moduleContext) {
+            // Do nothing
+        }
+
+        @Override
+        void resolveDependencies(ModuleContext moduleContext) {
+            // Do nothing
+        }
+
+        @Override
+        void compile(ModuleContext moduleContext, CompilerContext compilerContext) {
+            // Do nothing
+        }
+
+        @Override
+        void generatePlatformSpecificCode(ModuleContext moduleContext, CompilerContext compilerContext,
+                                          CompilerBackend compilerBackend) {
+            // Do nothing
+        }
     };
 
     abstract void parse(ModuleContext moduleContext);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/PackageCompilation.java
@@ -113,16 +113,9 @@ public class PackageCompilation {
         // We check whether the particular module compilation state equal to the typecheck phase here. 
         // If the states do not match, then this is a illegal state exception.
         if (moduleContext.compilationState() != ModuleCompilationState.COMPILED) {
-            if (moduleContext == null) {
-                System.err.println("ModuleContext was null");
-            } else if (moduleContext.compilationState() == null) {
-                System.err.println("Compilation state was null");
-            }
             throw new IllegalStateException("Semantic model cannot be retrieved when the module is in " +
-                                                    "compilation state '" + moduleContext.compilationState().name() +
-                                                    "'. " +
-                                                    "This is an internal error which will be fixed in a later release" +
-                                                    ".");
+                    "compilation state '" + moduleContext.compilationState().name() + "'. " +
+                    "This is an internal error which will be fixed in a later release.");
         }
 
         return new BallerinaSemanticModel(moduleContext.bLangPackage(), this.compilerContext);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilationRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilationRequest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Represents an instance of a compilation invocation. This is used for uniquely identifying and chronologically
+ * ordering the compilation invocations.
+ *
+ * @since 2.0.0
+ */
+public interface CompilationRequest {
+
+    /**
+     * Returns the UUID associated with this instance.
+     *
+     * @return The UUID of this request
+     */
+    UUID getId();
+
+    /**
+     * Returns the timestamp of the instance this request was created. This is the property used for ordering the
+     * compilation requests.
+     *
+     * @return The {@link Instant} this was created
+     */
+    Instant getTimestamp();
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilationRequestManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilationRequestManager.java
@@ -66,7 +66,7 @@ public class CompilationRequestManager {
      *
      * @param request The request to be checked if it was cancelled
      */
-    public synchronized void throwIfCancelled(CompilationRequest request) {
+    public synchronized void throwIfCancelled(CompilationRequest request) throws StaleCompilationRequestException {
         if (!this.currentCompileRequest.equals(request)) {
             throw new StaleCompilationRequestException(currentCompileRequest, request);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilationRequestManager.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/CompilationRequestManager.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler;
+
+import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.compiler.util.StaleCompilationRequestException;
+
+/**
+ * This class is responsible for collecting compilation requests that are coming in from various sources and ensuring
+ * that the latest request is maintained.
+ *
+ * @since 2.0.0
+ */
+public class CompilationRequestManager {
+
+    private static final CompilerContext.Key<CompilationRequestManager> COMPILATION_REQUEST_MANAGER_KEY =
+            new CompilerContext.Key<>();
+
+    private CompilationRequest currentCompileRequest;
+
+    private CompilationRequestManager(CompilerContext context) {
+        context.put(COMPILATION_REQUEST_MANAGER_KEY, this);
+    }
+
+    public static synchronized CompilationRequestManager getInstance(CompilerContext context) {
+        CompilationRequestManager compilationRequestManager = context.get(COMPILATION_REQUEST_MANAGER_KEY);
+        if (compilationRequestManager == null) {
+            compilationRequestManager = new CompilationRequestManager(context);
+        }
+        return compilationRequestManager;
+    }
+
+    /**
+     * This method accepts a {@link CompilationRequest} instance and compares it against the currently held compilation
+     * request. If this new request is more recent than the currently held request, it will discard the current request
+     * and set this new request as the current request. The provided request must not be null.
+     *
+     * @param request A request to perform a compilation
+     */
+    public synchronized void submit(CompilationRequest request) {
+        if (currentCompileRequest == null || currentCompileRequest.getTimestamp().isBefore(request.getTimestamp())) {
+            currentCompileRequest = request;
+        }
+    }
+
+    /**
+     * Given a compilation request, this method will check if it is still valid. If there is a more recent request, this
+     * will throw a {@link StaleCompilationRequestException} to signal to the one initiating this compilation that it
+     * should abort this compilation.
+     *
+     * @param request The request to be checked if it was cancelled
+     */
+    public synchronized void throwIfCancelled(CompilationRequest request) {
+        if (!this.currentCompileRequest.equals(request)) {
+            throw new StaleCompilationRequestException(currentCompileRequest, request);
+        }
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/ModuleCompilationRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/ModuleCompilationRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler;
+
+import io.ballerina.projects.ModuleId;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Represents a module compilation request
+ *
+ * @since 2.0.0
+ */
+public final class ModuleCompilationRequest implements CompilationRequest {
+
+    private final UUID id;
+    private final Instant timestamp;
+    private final ModuleId moduleId;
+
+    public ModuleCompilationRequest(ModuleId moduleId) {
+        this.id = UUID.randomUUID();
+        this.timestamp = Instant.now();
+        this.moduleId = moduleId;
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return this.timestamp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof ModuleCompilationRequest)) {
+            return false;
+        }
+
+        ModuleCompilationRequest that = (ModuleCompilationRequest) obj;
+        return Objects.equals(this.id, that.id) && Objects.equals(this.timestamp, that.timestamp)
+                && Objects.equals(this.moduleId, that.moduleId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id, this.timestamp, this.moduleId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("ModuleCompilationRequest{%s, %s, %s}", this.moduleId, this.id, this.timestamp);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/ModuleCompilationRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/ModuleCompilationRequest.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Represents a module compilation request
+ * Represents a module compilation request.
  *
  * @since 2.0.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCompilationRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCompilationRequest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler;
+
+import io.ballerina.projects.PackageId;
+
+import java.time.Instant;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * Represents a package compilation request
+ *
+ * @since 2.0.0
+ */
+public final class PackageCompilationRequest implements CompilationRequest {
+
+    private final UUID id;
+    private final Instant timestamp;
+    private final PackageId packageId;
+
+    public PackageCompilationRequest(PackageId packageId) {
+        this.id = UUID.randomUUID();
+        this.timestamp = Instant.now();
+        this.packageId = packageId;
+    }
+
+    @Override
+    public UUID getId() {
+        return this.id;
+    }
+
+    @Override
+    public Instant getTimestamp() {
+        return this.timestamp;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+
+        if (!(obj instanceof PackageCompilationRequest)) {
+            return false;
+        }
+
+        PackageCompilationRequest that = (PackageCompilationRequest) obj;
+        return Objects.equals(this.id, that.id) && Objects.equals(this.timestamp, that.timestamp)
+                && Objects.equals(this.packageId, that.packageId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.id, this.timestamp, this.packageId);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PackageCompilationRequest{%s, %s, %s}", this.packageId, this.id, this.timestamp);
+    }
+}

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCompilationRequest.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/PackageCompilationRequest.java
@@ -25,7 +25,7 @@ import java.util.Objects;
 import java.util.UUID;
 
 /**
- * Represents a package compilation request
+ * Represents a package compilation request.
  *
  * @since 2.0.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/StaleCompilationRequestException.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/StaleCompilationRequestException.java
@@ -18,7 +18,6 @@
 
 package org.wso2.ballerinalang.compiler.util;
 
-import org.ballerinalang.compiler.BLangCompilerException;
 import org.wso2.ballerinalang.compiler.CompilationRequest;
 
 /**
@@ -26,7 +25,7 @@ import org.wso2.ballerinalang.compiler.CompilationRequest;
  *
  * @since 2.0.0
  */
-public class StaleCompilationRequestException extends BLangCompilerException {
+public class StaleCompilationRequestException extends Exception {
 
     public StaleCompilationRequestException(CompilationRequest staleRequest, CompilationRequest newRequest) {
         super(String.format("%s was cancelled by %s", staleRequest.toString(), newRequest.toString()));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/StaleCompilationRequestException.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/StaleCompilationRequestException.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.ballerinalang.compiler.util;
+
+import org.ballerinalang.compiler.BLangCompilerException;
+import org.wso2.ballerinalang.compiler.CompilationRequest;
+
+/**
+ * An exception indicating that the compilation request is stale. i.e., there's a more recent compilation request.
+ *
+ * @since 2.0.0
+ */
+public class StaleCompilationRequestException extends BLangCompilerException {
+
+    public StaleCompilationRequestException(CompilationRequest staleRequest, CompilationRequest newRequest) {
+        super(String.format("%s was cancelled by %s", staleRequest.toString(), newRequest.toString()));
+    }
+}


### PR DESCRIPTION
## Purpose
This PR implements a mechanism for canceling stale compilation invocations when multiple compilation requests are made.

## Approach
- Introduced a `CompilationRequest` entity which represents and uniquely identifies a compilation invocation.
- Add a per-compiler-context compilation request manager for accepting compilation requests from multiple sources.
- When invoking a compilation, a compilation request is submitted to the request manager. 
- By the time that particular invocation reaches the point where it's about to begin the compilation, it will check with the request manager whether the compilation request is still valid. 
- If it has become stale, the request manager will throw an exception. 
- The one attempting to invoke the compilation will then handle this exception and set the compilation state of that module context to `CANCELLED_COMPILATION`. This particular module context will not recover from this state.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
