### PR TITLE
[LS] Fix create variable and check error code action duplicate imports being added

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleInsideCodeAction.java
@@ -90,7 +90,7 @@ public class ErrorHandleInsideCodeAction extends CreateVariableCodeAction {
 
         edits.add(createVarTextEdits.edits.get(0));
         // Add all the import text edits excluding duplicates
-        createVarTextEdits.imports.stream().filter(edits::contains).forEach(edits::add);
+        createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
         return Collections.singletonList(AbstractCodeActionProvider.createQuickFixCodeAction(commandTitle, edits, uri));
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/codeaction/providers/createvar/ErrorHandleOutsideCodeAction.java
@@ -110,7 +110,7 @@ public class ErrorHandleOutsideCodeAction extends CreateVariableCodeAction {
         textEdit.setNewText(typeWithoutError + textEdit.getNewText().substring(typeWithError.length()));
         edits.add(textEdit);
         // Add all the import text edits excluding duplicates
-        createVarTextEdits.imports.stream().filter(edits::contains).forEach(edits::add);
+        createVarTextEdits.imports.stream().filter(edit -> !edits.contains(edit)).forEach(edits::add);
         return edits;
     }
 }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/CreateVariableTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
  * @since 2.0.0
  */
 public class CreateVariableTest extends AbstractCodeActionTest {
+
     @Override
     public String getResourceDir() {
         return "create-variable";

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/projectVariableAssignmentRequiredCodeAction2.json
@@ -43,19 +43,6 @@
             }
           },
           "newText": "module2:Country|error countryWithError = "
-        },
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import lstest/testproject.module2;\n"
         }
       ]
     },
@@ -87,19 +74,6 @@
             }
           },
           "newText": "module2:Country countryWithError = "
-        },
-        {
-          "range": {
-            "start": {
-              "line": 0,
-              "character": 0
-            },
-            "end": {
-              "line": 0,
-              "character": 0
-            }
-          },
-          "newText": "import lstest/testproject.module2;\n"
         },
         {
           "range": {


### PR DESCRIPTION
## Purpose
$subject
In #29082 the suggested fix for `create variable and check error` code action is wrong due to an invalid checking of a condition while filtering the text edits. It is fixed in this PR 

## Approach
See description

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
