### PR TITLE
Fix error message for invalid org in ballerina-toml-schema.json

### DIFF
--- a/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
+++ b/compiler/ballerina-lang/src/main/resources/ballerina-toml-schema.json
@@ -20,7 +20,7 @@
           "type": "string",
           "pattern": "^[a-zA-Z0-9_]*$",
           "message" : {
-            "pattern" : "invalid 'org' under [package]: 'org' can only contain alphanumerics, underscores and periods and the maximum length is 256 characters"
+            "pattern" : "invalid 'org' under [package]: 'org' can only contain alphanumerics, underscores and the maximum length is 256 characters"
           }
         },
         "version": {

--- a/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
+++ b/compiler/ballerina-lang/src/test/java/io/ballerina/projects/BallerinaTomlTests.java
@@ -208,7 +208,7 @@ public class BallerinaTomlTests {
         Assert.assertEquals(firstDiagnostic.location().textRange().toString(), "(17,33)");
 
         Assert.assertEquals(iterator.next().message(), "invalid 'org' under [package]: 'org' can only contain "
-                + "alphanumerics, underscores and periods and the maximum length is 256 characters");
+                + "alphanumerics, underscores and the maximum length is 256 characters");
         Assert.assertEquals(iterator.next().message(), "invalid 'version' under [package]: "
                 + "'version' should be compatible with semver");
     }


### PR DESCRIPTION
## Purpose
> org name should be a valid identifier according to the spec.
```
org-name := identifier
pkg-name := identifier (. identifier)*
```
So changing the error message accordingly in the `ballerina-toml-schema.json`.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
