### PR TITLE
Fix record intersection check

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -3717,8 +3717,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         // It'll be only possible iff, the target type has been assigned to the source
         // variable at some point. To do that, a value of target type should be assignable
         // to the type of the source variable.
-        if (!types.isAssignable(typeTestExpr.typeNode.type, typeTestExpr.expr.type) &&
-                !indirectIntersectionExists(typeTestExpr.expr, typeTestExpr.typeNode.type)) {
+        if (!intersectionExists(typeTestExpr.expr, typeTestExpr.typeNode.type)) {
             dlog.error(typeTestExpr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPE_CHECK, typeTestExpr.expr.type,
                        typeTestExpr.typeNode.type);
         }
@@ -3733,35 +3732,15 @@ public class CodeAnalyzer extends BLangNodeVisitor {
         }
     }
 
-    private boolean indirectIntersectionExists(BLangExpression expression, BType testType) {
+    private boolean intersectionExists(BLangExpression expression, BType testType) {
         BType expressionType = expression.type;
-        SymbolEnv symbolEnv = symTable.pkgEnvMap.get(env.enclPkg.symbol);
-        Types.IntersectionContext intersectionContext =
-                Types.IntersectionContext.compilerInternalIntersectionTestContext();
 
-        switch (expressionType.tag) {
-            case TypeTags.UNION:
-                if (types.getTypeForUnionTypeMembersAssignableToType((BUnionType) expressionType, testType,
-                        symbolEnv, intersectionContext) !=
-                        symTable.semanticError) {
-                    return true;
-                }
-                break;
-            case TypeTags.FINITE:
-                if (types.getTypeForFiniteTypeValuesAssignableToType((BFiniteType) expressionType, testType) !=
-                        symTable.semanticError) {
-                    return true;
-                }
-        }
+        BType intersectionType = types.getTypeIntersection(
+                Types.IntersectionContext.compilerInternalNonGenerativeIntersectionContext(),
+                expressionType, testType, env);
 
-        switch (testType.tag) {
-            case TypeTags.UNION:
-                return types.getTypeForUnionTypeMembersAssignableToType((BUnionType) testType, expressionType,
-                        symbolEnv, intersectionContext) !=
-                        symTable.semanticError;
-            case TypeTags.FINITE:
-                return types.getTypeForFiniteTypeValuesAssignableToType((BFiniteType) testType, expressionType) !=
-                        symTable.semanticError;
+        if (intersectionType != null && intersectionType != symTable.semanticError) {
+            return true;
         }
 
         // any and readonly has a intersection

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/CodeAnalyzer.java
@@ -3739,7 +3739,7 @@ public class CodeAnalyzer extends BLangNodeVisitor {
                 Types.IntersectionContext.compilerInternalNonGenerativeIntersectionContext(),
                 expressionType, testType, env);
 
-        if (intersectionType != null && intersectionType != symTable.semanticError) {
+        if (intersectionType != symTable.semanticError) {
             return true;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3630,7 +3630,8 @@ public class Types {
                 return intersectionType;
             }
         } else if (type.tag == TypeTags.RECORD && lhsType.tag == TypeTags.RECORD) {
-            BType intersectionType = createRecordIntersection(intersectionContext, lhsType, type, env);
+            BType intersectionType = createRecordIntersection(intersectionContext, (BRecordType) lhsType,
+                                                              (BRecordType) type, env);
             if (intersectionType != symTable.semanticError) {
                 return intersectionType;
             }
@@ -3746,17 +3747,22 @@ public class Types {
     }
 
     private BType createRecordIntersection(IntersectionContext diagnosticContext,
-                                           BType recordTypeOne, BType recordTypeTwo, SymbolEnv env) {
+                                           BRecordType recordTypeOne, BRecordType recordTypeTwo, SymbolEnv env) {
 
         BRecordType newType = createAnonymousRecord(env);
 
-        if (!populateRecordFields(diagnosticContext.switchLeft(), newType, recordTypeOne, env, null) ||
-                !populateRecordFields(diagnosticContext.switchRight(), newType, recordTypeTwo, env, null)) {
+        BType restFieldTypeOne = recordTypeOne.restFieldType;
+        BType restFieldTypeTwo = recordTypeTwo.restFieldType;
+
+        BType constraintOne = restFieldTypeOne == null || restFieldTypeOne == symTable.noType ? null : restFieldTypeOne;
+        BType constraintTwo = restFieldTypeTwo == null || restFieldTypeTwo == symTable.noType ? null : restFieldTypeTwo;
+
+        if (!populateRecordFields(diagnosticContext.switchLeft(), newType, recordTypeOne, env, constraintTwo) ||
+                !populateRecordFields(diagnosticContext.switchRight(), newType, recordTypeTwo, env, constraintOne)) {
             return symTable.semanticError;
         }
 
-        newType.restFieldType = getTypeIntersection(diagnosticContext, ((BRecordType) recordTypeOne).restFieldType,
-                                                       ((BRecordType) recordTypeTwo).restFieldType, env);
+        newType.restFieldType = getTypeIntersection(diagnosticContext, restFieldTypeOne, restFieldTypeTwo, env);
 
         if (newType.restFieldType == symTable.semanticError) {
             return symTable.semanticError;
@@ -3919,16 +3925,15 @@ public class Types {
 
     private BType validateRecordField(IntersectionContext intersectionContext,
                                       BRecordType newType, BField origField, BType constraint, SymbolEnv env) {
-        BType fieldType = validateOverlappingFields(newType, origField);
-        if (fieldType == symTable.semanticError) {
-            return fieldType;
+        if (hasField(newType, origField)) {
+            return validateOverlappingFields(newType, origField);
         }
 
         if (constraint == null) {
-            return fieldType;
+            return origField.type;
         }
 
-        fieldType = getTypeIntersection(intersectionContext, fieldType, constraint, env);
+        BType fieldType = getTypeIntersection(intersectionContext, origField.type, constraint, env);
         if (fieldType != symTable.semanticError) {
             return fieldType;
         }
@@ -3940,12 +3945,16 @@ public class Types {
         return symTable.semanticError;
     }
 
+    private boolean hasField(BRecordType recordType, BField origField) {
+        return recordType.fields.containsKey(origField.name.value);
+    }
+
     private BType validateOverlappingFields(BRecordType newType, BField origField) {
-        BField overlappingField = newType.fields.get(origField.name.value);
-        if (overlappingField == null) {
+        if (!hasField(newType, origField)) {
             return origField.type;
         }
 
+        BField overlappingField = newType.fields.get(origField.name.value);
         if (isAssignable(overlappingField.type, origField.type)) {
             return overlappingField.type;
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3751,18 +3751,15 @@ public class Types {
 
         BRecordType newType = createAnonymousRecord(env);
 
-        BType restFieldTypeOne = recordTypeOne.restFieldType;
-        BType restFieldTypeTwo = recordTypeTwo.restFieldType;
-
-        BType constraintOne = restFieldTypeOne == symTable.noType ? null : restFieldTypeOne;
-        BType constraintTwo = restFieldTypeTwo == symTable.noType ? null : restFieldTypeTwo;
-
-        if (!populateRecordFields(diagnosticContext.switchLeft(), newType, recordTypeOne, env, constraintTwo) ||
-                !populateRecordFields(diagnosticContext.switchRight(), newType, recordTypeTwo, env, constraintOne)) {
+        if (!populateRecordFields(diagnosticContext.switchLeft(), newType, recordTypeOne, env,
+                                  getConstraint(recordTypeTwo)) ||
+                !populateRecordFields(diagnosticContext.switchRight(), newType, recordTypeTwo, env,
+                                      getConstraint(recordTypeOne))) {
             return symTable.semanticError;
         }
 
-        newType.restFieldType = getTypeIntersection(diagnosticContext, restFieldTypeOne, restFieldTypeTwo, env);
+        newType.restFieldType = getTypeIntersection(diagnosticContext, recordTypeOne.restFieldType,
+                                                    recordTypeTwo.restFieldType, env);
 
         if (newType.restFieldType == symTable.semanticError) {
             return symTable.semanticError;
@@ -3778,6 +3775,14 @@ public class Types {
         }
 
         return newType;
+    }
+
+    private BType getConstraint(BRecordType recordType) {
+        if (recordType.sealed) {
+            return symTable.neverType;
+        }
+
+        return recordType.restFieldType;
     }
 
     private BRecordType createAnonymousRecord(SymbolEnv env) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -3754,8 +3754,8 @@ public class Types {
         BType restFieldTypeOne = recordTypeOne.restFieldType;
         BType restFieldTypeTwo = recordTypeTwo.restFieldType;
 
-        BType constraintOne = restFieldTypeOne == null || restFieldTypeOne == symTable.noType ? null : restFieldTypeOne;
-        BType constraintTwo = restFieldTypeTwo == null || restFieldTypeTwo == symTable.noType ? null : restFieldTypeTwo;
+        BType constraintOne = restFieldTypeOne == symTable.noType ? null : restFieldTypeOne;
+        BType constraintTwo = restFieldTypeTwo == symTable.noType ? null : restFieldTypeTwo;
 
         if (!populateRecordFields(diagnosticContext.switchLeft(), newType, recordTypeOne, env, constraintTwo) ||
                 !populateRecordFields(diagnosticContext.switchRight(), newType, recordTypeTwo, env, constraintOne)) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -145,6 +145,9 @@ public class TypeTestExprTest {
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: '(Baz|int)' will not be matched to 'Bar'",
                 280, 17);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: '(Baz|int)' will not be matched to 'Qux'",
+                281, 18);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
@@ -730,7 +733,7 @@ public class TypeTestExprTest {
     }
 
     @Test
-    public void testRecordWithObjects() {
-        BRunUtil.invoke(result, "testRecordWithObjects");
+    public void testRecordIntersections() {
+        BRunUtil.invoke(result, "testRecordIntersections");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -51,7 +51,6 @@ public class TypeTestExprTest {
     public void testTypeTestExprNegative() {
         CompileResult negativeResult =
                 BCompileUtil.compile("test-src/expressions/binaryoperations/type-test-expr-negative.bal");
-        Assert.assertEquals(negativeResult.getErrorCount(), 42);
         int i = 0;
         BAssertUtil.validateError(negativeResult, i++,
                 "unnecessary condition: expression will always evaluate to 'true'", 19, 9);
@@ -140,9 +139,13 @@ public class TypeTestExprTest {
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: 'xml<xml<never>>' will not be matched to 'string'",
                 274, 9);
-        BAssertUtil.validateError(negativeResult, i,
+        BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: 'xml' will not be matched to 'string'",
                 275, 9);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: '(Baz|int)' will not be matched to 'Bar'",
+                280, 17);
+        Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
     @Test
@@ -724,5 +727,10 @@ public class TypeTestExprTest {
     @Test
     public void testMapAsRecord() {
         BRunUtil.invoke(result, "testMapAsRecord");
+    }
+
+    @Test
+    public void testRecordWithObjects() {
+        BRunUtil.invoke(result, "testRecordWithObjects");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -143,11 +143,23 @@ public class TypeTestExprTest {
                 "incompatible types: 'xml' will not be matched to 'string'",
                 275, 9);
         BAssertUtil.validateError(negativeResult, i++,
-                "incompatible types: '(Baz|int)' will not be matched to 'Bar'",
-                280, 17);
+                "incompatible types: '(Baz|int)' will not be matched to 'Bar'", 280, 17);
         BAssertUtil.validateError(negativeResult, i++,
-                "incompatible types: '(Baz|int)' will not be matched to 'Qux'",
-                281, 18);
+                "incompatible types: '(Baz|int)' will not be matched to 'Qux'", 281, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Bar' will not be matched to 'Baz'", 284, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Bar' will not be matched to 'Quux'", 285, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Qux' will not be matched to 'Baz'", 288, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Qux' will not be matched to 'Quux'", 289, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Quux' will not be matched to 'Bar'", 292, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Quux' will not be matched to 'Qux'", 293, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'Quux' will not be matched to 'record {| int i; boolean b; |}'", 294, 18);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -160,6 +160,9 @@ public class TypeTestExprTest {
                 "incompatible types: 'Quux' will not be matched to 'Qux'", 293, 18);
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: 'Quux' will not be matched to 'record {| int i; boolean b; |}'", 294, 18);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'ClosedRecordWithIntField' will not be matched to " +
+                        "'record {| int i; string s; |}'", 297, 19);
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -43,7 +43,7 @@ public class TypeGuardTest {
         result = BCompileUtil.compile("test-src/statements/ifelse/type-guard.bal");
     }
 
-    @Test(groups = { "brokenOnNewParser" })
+    @Test
     public void testTypeGuardNegative() {
         CompileResult negativeResult = BCompileUtil.compile("test-src/statements/ifelse/type-guard-negative.bal");
         int i = 0;
@@ -56,8 +56,8 @@ public class TypeGuardTest {
         BAssertUtil.validateError(negativeResult, i++,
                                   "incompatible types: '(float|boolean)' will not be matched to 'string'", 53, 16);
         BAssertUtil.validateError(negativeResult, i++, "unreachable code", 84, 5);
-        BAssertUtil.validateError(negativeResult, i++,
-                                  "incompatible types: '(string|int)' will not be matched to 'float'", 91, 23);
+//        BAssertUtil.validateError(negativeResult, i++,
+//                                  "incompatible types: '(string|int)' will not be matched to 'float'", 91, 23);
         BAssertUtil.validateError(negativeResult, i++,
                                   "incompatible types: '(int|boolean)' will not be matched to 'float'", 99, 63);
         BAssertUtil.validateError(negativeResult, i++,
@@ -76,8 +76,10 @@ public class TypeGuardTest {
                                   "incompatible types: '(Person|Student)' will not be matched to 'float'", 147, 40);
         BAssertUtil.validateError(negativeResult, i++,
                                   "incompatible types: '(Person|Student)' will not be matched to 'boolean'", 147, 56);
+//        BAssertUtil.validateError(negativeResult, i++,
+//                                  "incompatible types: 'any' will not be matched to 'error'", 157, 18);
         BAssertUtil.validateError(negativeResult, i++,
-                                  "incompatible types: 'any' will not be matched to 'error'", 157, 18);
+                "incompatible types: '(Baz|int)' will not be matched to 'Bar'", 167, 15);
 
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -80,6 +80,8 @@ public class TypeGuardTest {
 //                                  "incompatible types: 'any' will not be matched to 'error'", 157, 18);
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: '(Baz|int)' will not be matched to 'Bar'", 167, 15);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: '(Baz|int)' will not be matched to 'Qux'", 173, 15);
 
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -86,7 +86,7 @@ public class TypeGuardTest {
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
 
-    @Test(groups = { "brokenOnNewParser" })
+    @Test
     public void testTypeGuardSemanticsNegative() {
         CompileResult negativeResult = BCompileUtil.compile(
                 "test-src/statements/ifelse/type-guard-semantics-negative.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -519,7 +519,8 @@ public class TypeGuardTest {
                 {"testTypeNarrowingForIntersectingDirectUnion_1"},
                 {"testTypeNarrowingForIntersectingDirectUnion_2"},
                 {"testTypeNarrowingForIntersectingAssignableUnion_1"},
-                {"testTypeNarrowingForIntersectingAssignableUnion_2"}
+                {"testTypeNarrowingForIntersectingAssignableUnion_2"},
+                {"testTypeNarrowingForIntersectingUnionWithRecords"}
         };
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
@@ -274,3 +274,23 @@ function testXMLNeverType() {
     _ = g is string;
     _ = e is string;
 }
+
+function testRecordNegative() {
+    Baz|int val = 11;
+    boolean b = val is Bar;
+}
+
+type Baz record {
+};
+
+type Foo record {
+    readonly Class code = new;
+};
+
+type Bar record {
+    readonly Class code = new;
+};
+
+readonly class Class {
+
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
@@ -292,6 +292,9 @@ function testRecordNegative() {
     boolean b7 = val4 is Bar;
     boolean b8 = val4 is Qux;
     boolean b9 = val4 is record {|int i; boolean b;|};
+
+    ClosedRecordWithIntField val5 = {i: 100};
+    boolean b10 = val5 is record {| int i; string s; |};
 }
 
 type Baz record {
@@ -315,4 +318,8 @@ readonly class Class {
 
 type Quux record {|
     int...;
+|};
+
+type ClosedRecordWithIntField record {|
+    int i;
 |};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
@@ -279,6 +279,19 @@ function testRecordNegative() {
     Baz|int val = 11;
     boolean b = val is Bar;
     boolean b2 = val is Qux;
+
+    Bar val2 = {};
+    boolean b3 = val2 is Baz;
+    boolean b4 = val2 is Quux;
+
+    Qux val3 = {code: new};
+    boolean b5 = val3 is Baz;
+    boolean b6 = val3 is Quux;
+
+    Quux val4 = {"i": 1, "j": 2};
+    boolean b7 = val4 is Bar;
+    boolean b8 = val4 is Qux;
+    boolean b9 = val4 is record {|int i; boolean b;|};
 }
 
 type Baz record {
@@ -299,3 +312,7 @@ type Qux record {
 readonly class Class {
 
 }
+
+type Quux record {|
+    int...;
+|};

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
@@ -278,6 +278,7 @@ function testXMLNeverType() {
 function testRecordNegative() {
     Baz|int val = 11;
     boolean b = val is Bar;
+    boolean b2 = val is Qux;
 }
 
 type Baz record {
@@ -289,6 +290,10 @@ type Foo record {
 
 type Bar record {
     readonly Class code = new;
+};
+
+type Qux record {
+    readonly Class code;
 };
 
 readonly class Class {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -1100,7 +1100,7 @@ function testXMLTextType(){
     assertEquality(<any> t is string, false);
 }
 
-function testRecordWithObjects() {
+function testRecordIntersections() {
     Baz|int val = 11;
     assertFalse(val is Bar);
 
@@ -1109,6 +1109,12 @@ function testRecordWithObjects() {
 
     Baz|int val3 = <Bar> {code: new};
     assertTrue(val3 is Bar);
+
+    Bar val4 = {code: new};
+    assertFalse(val4 is Foo);
+
+    Bar val5 = <Foo> {code: new, index: 0};
+    assertTrue(val5 is Foo);
 }
 
 type Baz record {|
@@ -1122,6 +1128,11 @@ type Bar record {
 readonly class Class {
 
 }
+
+type Foo record {|
+    readonly Class code;
+    int index;
+|};
 
 function assertTrue(anydata actual) {
     assertEquality(true, actual);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -1100,6 +1100,29 @@ function testXMLTextType(){
     assertEquality(<any> t is string, false);
 }
 
+function testRecordWithObjects() {
+    Baz|int val = 11;
+    assertFalse(val is Bar);
+
+    Baz|int val2 = {};
+    assertFalse(val2 is Bar);
+
+    Baz|int val3 = <Bar> {code: new};
+    assertTrue(val3 is Bar);
+}
+
+type Baz record {|
+    anydata|object {}...;
+|};
+
+type Bar record {
+    readonly Class code = new;
+};
+
+readonly class Class {
+
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -1115,6 +1115,23 @@ function testRecordIntersections() {
 
     Bar val5 = <Foo> {code: new, index: 0};
     assertTrue(val5 is Foo);
+
+    OpenRecordWithIntField val6 = {i: 1, "s": "hello"};
+    assertFalse(val6 is record {| int i; string s; |});
+
+    record {| int i; string s; |} v = {i: 2, s: "world"};
+    OpenRecordWithIntField val7 = v;
+    assertTrue(val7 is record {| int i; string s; |});
+
+    ClosedRecordWithIntField val8 = {i: 10};
+    assertFalse(val8 is record {| byte i; |});
+    assertTrue(<any> val8 is record {});
+    assertTrue(<any> val8 is record {| int...; |});
+
+    int|ClosedRecordWithIntField val9 = <record {| byte i; |}> {i: 10};
+    assertTrue(val9 is record {| byte i; |});
+    assertTrue(val9 is record {});
+    assertTrue(val9 is record {| int...; |});
 }
 
 type Baz record {|
@@ -1132,6 +1149,14 @@ readonly class Class {
 type Foo record {|
     readonly Class code;
     int index;
+|};
+
+type OpenRecordWithIntField record {
+    int i;
+};
+
+type ClosedRecordWithIntField record {|
+    int i;
 |};
 
 function assertTrue(anydata actual) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-negative.bal
@@ -167,6 +167,12 @@ function testTypeGuardWithRecordNegative() {
     } else if val is Bar {
         var v = val.code;
     }
+
+    if val is Foo {
+
+    } else if val is Qux {
+        var v = val.code;
+    }
 }
 
 type Baz record {
@@ -178,6 +184,10 @@ type Foo record {
 
 type Bar record {
     readonly Class code = new;
+};
+
+type Qux record {
+    readonly Class code;
 };
 
 readonly class Class {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-negative.bal
@@ -158,3 +158,28 @@ function testTypeGuardsWithErrorInmatch() returns string {
         var p => {return "Internal server error";}
     }
 }
+
+function testTypeGuardWithRecordNegative() {
+    Foo|Baz|int val = 10;
+
+    if val is Foo {
+
+    } else if val is Bar {
+        var v = val.code;
+    }
+}
+
+type Baz record {
+};
+
+type Foo record {
+    readonly Class code = new;
+};
+
+type Bar record {
+    readonly Class code = new;
+};
+
+readonly class Class {
+
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
@@ -363,7 +363,7 @@ type Detail record {
 };
 
 function errorReturningFunc(int? i) returns error<Detail> {
-    return ErrorD("hello", message = "hello", code = i, f = 1.0);
+    return error ErrorD("hello", message = "hello", code = i);
 }
 
 function testInvalidAccessOfOutOfScopeVar() {


### PR DESCRIPTION
## Purpose
$title. 

This PR also changes the intersection check for the type test "will not match" error to use the generic intersection logic and enables some disabled tests.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/29175

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
