### PR TITLE
Fix type inclusions for class symbols and add BIR tests 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -616,6 +616,9 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangConstRef constRef) {
+        if (constRef.symbol != null && setEnclosingNode(constRef.symbol.owner, constRef.pkgAlias.pos)) {
+            return;
+        }
         this.symbolAtCursor = constRef.symbol;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -785,6 +785,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                 this.unresolvedTypes.add(classDefinition);
                 return;
             }
+            objectType.typeInclusions.add(referencedType);
         }
 
         classDefinition.setPrecedence(this.typePrecedence++);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
@@ -51,3 +51,32 @@ public type Error FileNotFoundError|EofError;
 public enum Colour {
    RED, GREEN, BLUE
 }
+
+public type Pet object {
+    string name;
+
+    public function getName() returns string;
+
+    public function kind() returns string;
+};
+
+public class Dog {
+    *Pet;
+
+    public function init(string name) {
+        self.name = name;
+    }
+
+    public function getName() returns string => self.name;
+
+    public function kind() returns string => "Dog";
+}
+
+public type Student record {|
+    *Person;
+    string school;
+|};
+
+public type Cat object {
+    *Pet;
+};


### PR DESCRIPTION
## Purpose
This PR fixes an issue with type inclusions for class symbols and adds BIR tests for type inclusions.

Fix #27035
Fix #29204 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
