### PR TITLE
Fix showing NPE for members of enums with missing identifier

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3452,7 +3452,11 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             publicQualifier = true;
         }
         for (Node member : enumDeclarationNode.enumMemberList()) {
-            addToTop(transformEnumMember((EnumMemberNode) member, publicQualifier));
+            EnumMemberNode enumMember = (EnumMemberNode) member;
+            if (enumMember.identifier().isMissing()) {
+                continue;
+            }
+            addToTop(transformEnumMember(enumMember, publicQualifier));
         }
 
         BLangTypeDefinition bLangTypeDefinition = (BLangTypeDefinition) TreeBuilder.createTypeDefinition();
@@ -3467,7 +3471,11 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangUnionTypeNode bLangUnionTypeNode = (BLangUnionTypeNode) TreeBuilder.createUnionTypeNode();
         bLangUnionTypeNode.pos = bLangTypeDefinition.pos;
         for (Node member : enumDeclarationNode.enumMemberList()) {
-            bLangUnionTypeNode.memberTypeNodes.add(createTypeNode(((EnumMemberNode) member).identifier()));
+            Node enumMemberIdentifier = ((EnumMemberNode) member).identifier();
+            if (enumMemberIdentifier.isMissing()) {
+                continue;
+            }
+            bLangUnionTypeNode.memberTypeNodes.add(createTypeNode(enumMemberIdentifier));
         }
         Collections.reverse(bLangUnionTypeNode.memberTypeNodes);
         bLangTypeDefinition.setTypeNode(bLangUnionTypeNode);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3509,7 +3509,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
         if (deepLiteral instanceof BLangLiteral) {
             BLangLiteral literal = (BLangLiteral) deepLiteral;
-            if (literal.originalValue != "") {
+            if (!literal.originalValue.equals("")) {
                 BLangFiniteTypeNode typeNodeAssociated = (BLangFiniteTypeNode) TreeBuilder.createFiniteTypeNode();
                 literal.originalValue = null;
                 typeNodeAssociated.addValue(deepLiteral);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/ParserTestRunner.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/ParserTestRunner.java
@@ -63,9 +63,6 @@ public class ParserTestRunner {
         hashSet.add("explicit-new-with-object-keyword-with-one-args.bal");
         hashSet.add("func_def_source_08.bal");
         hashSet.add("find_node_test_1.bal");
-        hashSet.add("enum_decl_source_08.bal");
-        hashSet.add("enum_decl_source_05.bal");
-        hashSet.add("enum_decl_source_09.bal");
         hashSet.add("minutiae_test_05_with_no_newlines.bal");
         hashSet.add("import_decl_source_13.bal");
         hashSet.add("ambiguity_source_29.bal");

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/enums/EnumTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/enums/EnumTest.java
@@ -68,14 +68,16 @@ public class EnumTest {
     @Test
     public void testNegative() {
         int i = 0;
-        validateError(negativeTest, i++, "incompatible types: expected 'string', found 'int'", 29, 16);
-        validateError(negativeTest, i++, "incompatible types: expected 'string', found 'float'", 30, 13);
-        validateError(negativeTest, i++, "incompatible types: expected 'int', found 'string'", 34, 18);
-        validateError(negativeTest, i++, "incompatible types: expected 'float', found 'string'", 35, 16);
-        validateError(negativeTest, i++, "incompatible types: expected '(SQUARE|CIRCLE)', found 'string'", 39, 15);
+        validateError(negativeTest, i++, "missing identifier", 19, 1);
+        validateError(negativeTest, i++, "missing identifier", 23, 1);
+        validateError(negativeTest, i++, "incompatible types: expected 'string', found 'int'", 37, 16);
+        validateError(negativeTest, i++, "incompatible types: expected 'string', found 'float'", 38, 13);
+        validateError(negativeTest, i++, "incompatible types: expected 'int', found 'string'", 42, 18);
+        validateError(negativeTest, i++, "incompatible types: expected 'float', found 'string'", 43, 16);
+        validateError(negativeTest, i++, "incompatible types: expected '(SQUARE|CIRCLE)', found 'string'", 47, 15);
         validateError(negativeTest, i++, "incompatible types: expected '(Ed Shereen|LANA|EMINEM)', found 'string'",
-                40, 16);
-        validateError(negativeTest, i++, "incompatible types: expected 'Ed Shereen', found 'string'", 41, 12);
+                48, 16);
+        validateError(negativeTest, i++, "incompatible types: expected 'Ed Shereen', found 'string'", 49, 12);
         assertEquals(negativeTest.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/enums/enums-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/enums/enums-negative.bal
@@ -14,6 +14,14 @@
 // specific language governing permissions and limitations
 // under the License.
 
+enum Colour {
+    RED,
+}
+
+enum Colours {
+    BLUE = "Blue",
+}
+
 public enum Shape {
     CIRCLE,
     SQ = "SQUARE"


### PR DESCRIPTION
## Purpose
$title

Fixes #28957 

## Approach
Skip adding missing enum members to top-level-nodes in compilation-unit
Skip adding missing members to union-type members which are created for enums

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
