### PR TITLE
Get basepath from service declaration symbol for observability

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmObservabilityGen.java
@@ -177,7 +177,7 @@ class JvmObservabilityGen {
                 if (serviceName == null) {
                     List<String> attachPoint = this.svcAttachPoints.get(typeDef.name);
                     if (attachPoint != null) {
-                        serviceName = String.join("/", attachPoint);
+                        serviceName = "/" + String.join("/", attachPoint);
                     } else {
                         serviceName = pkg.packageID.orgName.value + "_" + pkg.packageID.name.value + "_svc_" +
                                 defaultServiceIndex++;

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
@@ -40,17 +40,17 @@ import java.util.stream.Collectors;
 @Test(groups = "tracing-test")
 public class ConcurrencyTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "05_concurrency.bal";
-    private static final String SERVICE_NAME = "testServiceFive";
+    private static final String BASE_PATH = "/";
     private static final String BASE_URL = "http://localhost:9095";
 
     @DataProvider(name = "async-call-data-provider")
     public Object[][] getAsyncCallData() {
         return new Object[][] {
-                {"resourceOne", FILE_NAME + ":23:5", FILE_NAME + ":24:33", FILE_NAME + ":30:20",
+                {"resourceOne", FILE_NAME + ":22:5", FILE_NAME + ":23:33", FILE_NAME + ":29:20",
                         MOCK_CLIENT_OBJECT_NAME, "calculateSum", null, null},
-                {"resourceTwo", FILE_NAME + ":34:5", FILE_NAME + ":35:33", FILE_NAME + ":41:20",
+                {"resourceTwo", FILE_NAME + ":33:5", FILE_NAME + ":34:33", FILE_NAME + ":40:20",
                         null, null, null, "calculateSumWithObservability"},
-                {"resourceThree", FILE_NAME + ":45:5", FILE_NAME + ":47:33", FILE_NAME + ":53:20",
+                {"resourceThree", FILE_NAME + ":44:5", FILE_NAME + ":46:33", FILE_NAME + ":52:20",
                         null, null, OBSERVABLE_ADDER_OBJECT_NAME, "getSum"}
         };
     }
@@ -59,13 +59,13 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
     public void testAsyncCall(String resourceName, String resourceFunctionPosition, String asyncCallPosition,
                               String callerRespondPosition, String asyncCallConnectorName, String asyncCallActionName,
                               String asyncCallObjectName, String asyncCallFunctionName) throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -86,12 +86,12 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
@@ -153,14 +153,14 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
 
     @DataProvider(name = "workers-data-provider")
     public Object[][] getWorkersData() {
-        final String w1Position = FILE_NAME + ":104:15";
-        final String w2Position = FILE_NAME + ":111:15";
+        final String w1Position = FILE_NAME + ":103:15";
+        final String w2Position = FILE_NAME + ":110:15";
         return new Object[][] {
-                {"resourceFour", FILE_NAME + ":57:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":59:20"},
-                {"resourceFive", FILE_NAME + ":63:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":65:20"},
-                {"resourceSix", FILE_NAME + ":69:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":71:20"},
-                {"resourceSeven", FILE_NAME + ":75:5", "w3", FILE_NAME + ":78:35", "w4", FILE_NAME + ":86:35",
-                        FILE_NAME + ":99:20"}
+                {"resourceFour", FILE_NAME + ":56:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":58:20"},
+                {"resourceFive", FILE_NAME + ":62:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":64:20"},
+                {"resourceSix", FILE_NAME + ":68:5", "w1", w1Position, "w2", w2Position, FILE_NAME + ":70:20"},
+                {"resourceSeven", FILE_NAME + ":74:5", "w3", FILE_NAME + ":77:35", "w4", FILE_NAME + ":85:35",
+                        FILE_NAME + ":98:20"}
         };
     }
 
@@ -168,13 +168,12 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
     public void testWorkers(String resourceName, String resourceFunctionPosition,
                                        String workerAName, String workerAPosition, String workerBName,
                                        String workerBPosition, String callerRespondPosition) throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
-                "", Collections.emptyMap());
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + resourceName, "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -196,12 +195,12 @@ public class ConcurrencyTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
@@ -39,7 +39,8 @@ import java.util.stream.Collectors;
 @Test(groups = "tracing-test")
 public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "04_observability_annotation.bal";
-    private static final String SERVICE_NAME = "testServiceFour";
+    private static final String SERVICE_NAME = "testSvcFour";
+    private static final String BASE_PATH = "testServiceFour";
     private static final String BASE_URL = "http://localhost:9094";
 
     @Test
@@ -49,7 +50,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         final String span2Position = FILE_NAME + ":24:19";
         final String span3Position = FILE_NAME + ":29:20";
 
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
@@ -76,7 +77,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", "/" + BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
@@ -134,7 +135,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
         final String span2Position = FILE_NAME + ":35:19";
         final String span3Position = FILE_NAME + ":40:20";
 
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
@@ -161,7 +162,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", "/" + BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -41,16 +41,16 @@ import java.util.stream.Collectors;
 @Test(groups = "tracing-test")
 public class RemoteCallTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "03_remote_call.bal";
-    private static final String SERVICE_NAME = "testServiceThree";
+    private static final String SERVICE_NAME = "test/serviceThree";
     private static final String BASE_URL = "http://localhost:9093";
 
     @Test
     public void testNestedRemoteCalls() throws Exception {
         final String resourceName = "resourceOne";
-        final String resourceFunctionPosition = FILE_NAME + ":22:5";
-        final String span2Position = FILE_NAME + ":23:9";
+        final String resourceFunctionPosition = FILE_NAME + ":21:5";
+        final String span2Position = FILE_NAME + ":22:9";
         final String span3Position = MOCK_CLIENT_FILE_NAME + ":32:9";
-        final String span4Position = FILE_NAME + ":24:20";
+        final String span4Position = FILE_NAME + ":23:20";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
                 "", Collections.emptyMap());
@@ -156,14 +156,14 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @DataProvider(name = "remote-error-return-data-provider")
     public Object[][] getRemoteErrorReturnData() {
         return new Object[][]{
-                {"resourceTwo", FILE_NAME + ":28:5", FILE_NAME + ":29:15", "Test Error\n" +
+                {"resourceTwo", FILE_NAME + ":27:5", FILE_NAME + ":28:15", "Test Error\n" +
                         "    at intg_tests.tracing_tests.utils.0_0_1.MockClient:callWithErrorReturn" +
-                        "(mock_client_endpoint.bal:46)\n" +
-                        "       intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceTwo(03_remote_call.bal:29)"},
-                {"resourceThree", FILE_NAME + ":34:5", FILE_NAME + ":35:20", "Test Error\n" +
+                        "(mock_client_endpoint.bal:45)\n" +
+                        "       intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceTwo(03_remote_call.bal:28)"},
+                {"resourceThree", FILE_NAME + ":33:5", FILE_NAME + ":34:20", "Test Error\n" +
                         "    at intg_tests.tracing_tests.utils.0_0_1.MockClient:callWithErrorReturn" +
-                        "(mock_client_endpoint.bal:46)\n" +
-                        "       intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceThree(03_remote_call.bal:35)"}
+                        "(mock_client_endpoint.bal:45)\n" +
+                        "       intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceThree(03_remote_call.bal:34)"}
         };
     }
 
@@ -245,9 +245,9 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @Test
     public void testIgnoredErrorReturnInRemoteCall() throws Exception {
         final String resourceName = "resourceFour";
-        final String resourceFunctionPosition = FILE_NAME + ":40:5";
-        final String span2Position = FILE_NAME + ":41:19";
-        final String span3Position = FILE_NAME + ":42:20";
+        final String resourceFunctionPosition = FILE_NAME + ":39:5";
+        final String span2Position = FILE_NAME + ":40:19";
+        final String span3Position = FILE_NAME + ":41:20";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
                 "", Collections.emptyMap());
@@ -343,9 +343,9 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @Test
     public void testTrappedPanic() throws Exception {
         final String resourceName = "resourceFive";
-        final String resourceFunctionPosition = FILE_NAME + ":46:5";
-        final String span2Position = FILE_NAME + ":47:24";
-        final String span3Position = FILE_NAME + ":49:24";
+        final String resourceFunctionPosition = FILE_NAME + ":45:5";
+        final String span2Position = FILE_NAME + ":46:24";
+        final String span3Position = FILE_NAME + ":48:24";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
                 "", Collections.emptyMap());

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 @Test(groups = "tracing-test")
 public class RemoteCallTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "03_remote_call.bal";
-    private static final String SERVICE_NAME = "test/serviceThree";
+    private static final String BASE_PATH = "/test/serviceThree";
     private static final String BASE_URL = "http://localhost:9093";
 
     @Test
@@ -52,13 +52,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         final String span3Position = MOCK_CLIENT_FILE_NAME + ":32:9";
         final String span4Position = FILE_NAME + ":23:20";
 
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -79,13 +79,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
@@ -170,13 +170,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
     @Test(dataProvider = "remote-error-return-data-provider")
     public void testRemoteFunctionErrorReturn(String resourceName, String resourceFunctionPosition,
                                               String remoteCallPosition, String errorMessage) throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 500);
         Assert.assertEquals(httpResponse.getData(), "Test Error");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -200,10 +200,10 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
@@ -249,13 +249,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         final String span2Position = FILE_NAME + ":40:19";
         final String span3Position = FILE_NAME + ":41:20";
 
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Invocation Successful");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -276,13 +276,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
             ));
@@ -347,13 +347,13 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
         final String span2Position = FILE_NAME + ":46:24";
         final String span3Position = FILE_NAME + ":48:24";
 
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Successfully trapped panic: Test Error");
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -374,12 +374,12 @@ public class RemoteCallTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post")

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
@@ -47,8 +47,8 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
     @DataProvider(name = "success-response-data-provider")
     public Object[][] getSuccessResponseData() {
         return new Object[][] {
-                {"resourceOne", "15", FILE_NAME + ":23:5", FILE_NAME + ":29:20", "Sum of numbers: 120"},
-                {"resourceTwo", "16", FILE_NAME + ":33:5", FILE_NAME + ":39:20", "Sum of numbers: 136"}
+                {"resourceOne", "15", FILE_NAME + ":22:5", FILE_NAME + ":28:20", "Sum of numbers: 120"},
+                {"resourceTwo", "16", FILE_NAME + ":32:5", FILE_NAME + ":38:20", "Sum of numbers: 136"}
         };
     }
 
@@ -118,22 +118,22 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
     @DataProvider(name = "error-response-data-provider")
     public Object[][] getErrorResponseData() {
         return new Object[][] {
-                {"resourceThree", FILE_NAME + ":43:5", "Test Error 1", "Test Error 1\n" +
+                {"resourceThree", FILE_NAME + ":42:5", "Test Error 1", "Test Error 1\n" +
                         "    at intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceThree" +
-                        "(02_resource_function.bal:54)"},
-                {"resourceFour", FILE_NAME + ":59:5", "Test Error 2", "Test Error 2\n" +
+                        "(02_resource_function.bal:53)"},
+                {"resourceFour", FILE_NAME + ":58:5", "Test Error 2", "Test Error 2\n" +
                         "    at intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceFour" +
-                        "(02_resource_function.bal:70),"},
-                {"resourceFive", FILE_NAME + ":76:5", "Test Error. Sum: 91", "Test Error. Sum: 91\n" +
+                        "(02_resource_function.bal:69),"},
+                {"resourceFive", FILE_NAME + ":75:5", "Test Error. Sum: 91", "Test Error. Sum: 91\n" +
                         "    at intg_tests.tracing_tests.0_0_1:panicAfterCalculatingSum(commons.bal:36)\n" +
                         "       intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceFive" +
-                        "(02_resource_function.bal:77)"},
-                {"resourceSix", FILE_NAME + ":82:5", "Test Error. Sum: 153", "Test Error. Sum: 153\n" +
+                        "(02_resource_function.bal:76)"},
+                {"resourceSix", FILE_NAME + ":81:5", "Test Error. Sum: 153", "Test Error. Sum: 153\n" +
                         "    at intg_tests.tracing_tests.0_0_1:panicAfterCalculatingSum(commons.bal:36)\n" +
                         "       intg_tests.tracing_tests.0_0_1.$anonType$_0:panicAfterCalculatingSum$lambda0$" +
-                        "(02_resource_function.bal:83)\n" +
+                        "(02_resource_function.bal:82)\n" +
                         "       intg_tests.tracing_tests.0_0_1.$anonType$_0:$post$resourceSix" +
-                        "(02_resource_function.bal:84)"}
+                        "(02_resource_function.bal:83)"}
         };
     }
 
@@ -190,9 +190,9 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
     @DataProvider(name = "simple-remote-call-data-provider")
     public Object[][] getSimpleRemoteCallData() {
         return new Object[][] {
-                {"resourceSeven", FILE_NAME + ":89:5", FILE_NAME + ":91:30", FILE_NAME + ":98:20",
+                {"resourceSeven", FILE_NAME + ":88:5", FILE_NAME + ":90:30", FILE_NAME + ":97:20",
                         "Sum of numbers: 12"},
-                {"resourceEight", FILE_NAME + ":102:5", FILE_NAME + ":103:24", FILE_NAME + ":105:24",
+                {"resourceEight", FILE_NAME + ":101:5", FILE_NAME + ":102:24", FILE_NAME + ":104:24",
                         "Successfully executed"}
         };
     }

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 @Test(groups = "tracing-test")
 public class ResourceFunctionTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "02_resource_function.bal";
-    private static final String SERVICE_NAME = "testServiceTwo";
+    private static final String BASE_PATH = "/testServiceTwo";
     private static final String BASE_URL = "http://localhost:9092";
 
     @DataProvider(name = "success-response-data-provider")
@@ -55,13 +55,13 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
     @Test(dataProvider = "success-response-data-provider")
     public void testSimpleResourceCall(String resourceName, String requestPayload, String resourceFunctionPosition,
                                        String callerResponsePosition, String expectedResponsePayload) throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 requestPayload, Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), expectedResponsePayload);
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -82,12 +82,12 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("src.resource.accessor", "post"),
                     new AbstractMap.SimpleEntry<>("src.resource.path", "/" + resourceName)
@@ -141,13 +141,13 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
     public void testResourceSingleSpanErrorResponse(String resourceName, String resourceFunctionPosition,
                                                     String expectedResponsePayload, String errorMessage)
             throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 "15", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 500);
         Assert.assertEquals(httpResponse.getData(), expectedResponsePayload);
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -171,11 +171,11 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("error", "true"),
@@ -201,13 +201,13 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
     public void testResourceWithRemoteCall(String resourceName, String resourceFunctionPosition,
                                            String remoteCallPosition, String callerRespondPosition,
                                            String expectedPayload) throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + "/" + SERVICE_NAME + "/" + resourceName,
+        HttpResponse httpResponse = HttpClientRequest.doPost(BASE_URL + BASE_PATH + "/" + resourceName,
                 "", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), expectedPayload);
         Thread.sleep(1000);
 
-        List<BMockSpan> spans = this.getFinishedSpans(SERVICE_NAME, DEFAULT_MODULE_ID, resourceFunctionPosition);
+        List<BMockSpan> spans = this.getFinishedSpans(BASE_PATH, DEFAULT_MODULE_ID, resourceFunctionPosition);
         Assert.assertEquals(spans.stream()
                         .map(span -> span.getTags().get("src.position"))
                         .collect(Collectors.toSet()),
@@ -228,10 +228,10 @@ public class ResourceFunctionTestCase extends TracingBaseTestCase {
                     new AbstractMap.SimpleEntry<>("src.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("src.position", resourceFunctionPosition),
                     new AbstractMap.SimpleEntry<>("src.service.resource", "true"),
-                    new AbstractMap.SimpleEntry<>("http.url", "/" + SERVICE_NAME + "/" + resourceName),
+                    new AbstractMap.SimpleEntry<>("http.url", BASE_PATH + "/" + resourceName),
                     new AbstractMap.SimpleEntry<>("http.method", "POST"),
                     new AbstractMap.SimpleEntry<>("protocol", "http"),
-                    new AbstractMap.SimpleEntry<>("src.object.name", SERVICE_NAME),
+                    new AbstractMap.SimpleEntry<>("src.object.name", BASE_PATH),
                     new AbstractMap.SimpleEntry<>("listener.name", SERVER_CONNECTOR_NAME),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.module", DEFAULT_MODULE_ID),
                     new AbstractMap.SimpleEntry<>("entrypoint.function.position", resourceFunctionPosition),

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
@@ -17,7 +17,6 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-@display { label: "testServiceTwo" }
 service /testServiceTwo on new testobserve:Listener(9092) {
     # Resource function for testing whether no return functions are instrumented properly.
     resource function post resourceOne(testobserve:Caller caller, string body) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
@@ -16,8 +16,7 @@
 
 import ballerina/testobserve;
 
-@display { label: "testServiceThree" }
-service /testServiceThree on new testobserve:Listener(9093) {
+service /test/serviceThree on new testobserve:Listener(9093) {
     # Resource function for testing remote call which calls another remote call
     resource function post resourceOne(testobserve:Caller caller) {
         testClient->callAnotherRemoteFunction();

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-@display { label: "testServiceFour" }
+@display { label: "testSvcFour" }
 service /testServiceFour on new testobserve:Listener(9094) {
     # Resource function for testing function call with observable annotation
     resource function post resourceOne(testobserve:Caller caller) {

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
@@ -17,8 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-@display { label: "testServiceFive" }
-service /testServiceFive on new testobserve:Listener(9095) {
+service / on new testobserve:Listener(9095) {
     # Resource function for testing async remote call wait
     resource function post resourceOne(testobserve:Caller caller) {
         future<int> futureSum = start testClient->calculateSum(6, 17);

--- a/tests/observability-test-utils/src/main/java/org/ballerina/testobserve/listenerendpoint/Utils.java
+++ b/tests/observability-test-utils/src/main/java/org/ballerina/testobserve/listenerendpoint/Utils.java
@@ -54,7 +54,10 @@ public class Utils {
 
     public static String normalizeResourcePath(String resourcePath) {
         if (!resourcePath.startsWith("/")) {
-            resourcePath = "/"  + resourcePath;
+            resourcePath = "/" + resourcePath;
+        }
+        if (resourcePath.endsWith("/")) {
+            resourcePath = resourcePath.substring(0, resourcePath.length() - 1);
         }
         return resourcePath;
     }


### PR DESCRIPTION
## Purpose
> Get service base path from the service declaration symbol for distributed tracing.
Fixes https://github.com/ballerina-platform/ballerina-lang/issues/29158

## Approach
> Use the base path as the service name when the user hasn't provided a service name with the `@display` annotation.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
