### PR TITLE
Skip adding observe imports to BALA projects in ObservabilityDesugar

### DIFF
--- a/.github/workflows/CI_ubuntu_windows.yml
+++ b/.github/workflows/CI_ubuntu_windows.yml
@@ -75,4 +75,4 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle
 
       - name: Build with Gradle
-        run: ./gradlew.bat build --continue -x :jballerina-unit-test:test -x :jballerina-integration-test:test -x :jballerina-debugger-integration-test:test -x :ballerina-shell:shell-cli:test -x createJavadoc --stacktrace -scan --console=plain --no-daemon --no-parallel
+        run: ./gradlew.bat build --continue -x :jballerina-unit-test:test -x :jballerina-integration-test:test -x :jballerina-debugger-integration-test:test -x :ballerina-cli:test -x :ballerina-shell:shell-cli:test -x createJavadoc --stacktrace -scan --console=plain --no-daemon --no-parallel

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleContext.java
@@ -349,6 +349,7 @@ class ModuleContext {
         CompilerPhaseRunner compilerPhaseRunner = CompilerPhaseRunner.getInstance(compilerContext);
 
         BLangPackage pkgNode = (BLangPackage) TreeBuilder.createPackageNode();
+        pkgNode.projectKind = moduleContext.project().kind();
         packageCache.put(moduleCompilationId, pkgNode);
 
         // Parse source files

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/BLangPackage.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.tree;
 
+import io.ballerina.projects.ProjectKind;
 import io.ballerina.tools.diagnostics.Diagnostic;
 import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import org.ballerinalang.compiler.CompilerPhase;
@@ -81,6 +82,7 @@ public class BLangPackage extends BLangNode implements PackageNode {
     public BPackageSymbol symbol;
     public Set<Flag> flagSet;
     public byte[] jarBinaryContent;
+    public ProjectKind projectKind = null;
 
     private int errorCount;
     private int warnCount;


### PR DESCRIPTION
## Purpose
> Skip injecting observe imports to bala projects in ObservabilityDesugar
> Fixes #29142 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
