### PR TITLE
[LS] Fix type cast code action to add parentheses for binary expressions

### DIFF
--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/codeaction/TypeCastTest.java
@@ -49,6 +49,8 @@ public class TypeCastTest extends AbstractCodeActionTest {
                 {"typeCast2.json", "typeCast.bal"},
                 {"typeCast3.json", "typeCast.bal"},
                 {"typeCast4.json", "typeCast.bal"},
+                {"typeCast5.json", "typeCast.bal"},
+                {"typeCast6.json", "typeCast.bal"},
         };
     }
 }

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast5.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast5.json
@@ -1,0 +1,37 @@
+{
+    "line": 34,
+    "character": 16,
+    "expected": [
+        {
+            "title": "Add type cast to assignment",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 34,
+                            "character": 16
+                        },
+                        "end": {
+                            "line": 34,
+                            "character": 16
+                        }
+                    },
+                    "newText": "<int> ("
+                },
+                {
+                    "range": {
+                        "start": {
+                            "line": 34,
+                            "character": 31
+                        },
+                        "end": {
+                            "line": 34,
+                            "character": 31
+                        }
+                    },
+                    "newText": ")"
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast6.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/config/typeCast6.json
@@ -1,0 +1,24 @@
+{
+    "line": 39,
+    "character": 22,
+    "expected": [
+        {
+            "title": "Add type cast to assignment",
+            "edits": [
+                {
+                    "range": {
+                        "start": {
+                            "line": 39,
+                            "character": 22
+                        },
+                        "end": {
+                            "line": 39,
+                            "character": 22
+                        }
+                    },
+                    "newText": "<boolean|int> "
+                }
+            ]
+        }
+    ]
+}

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/typeCast.bal
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/type-cast/source/typeCast.bal
@@ -30,3 +30,16 @@ type Car record {
     string model;
     int year;
 };
+
+function testFunction2(int value1, float value2) returns int {
+    int total = value1 + value2;
+    return total;
+}
+
+function useUnion() {
+    boolean|int val = testUnion();
+}
+
+function testUnion() returns int|string {
+    return "test";
+}


### PR DESCRIPTION
## Purpose
$subject

Fixes #29194

Consider:
```
function testFunction2(int value1, float value2) returns int {
    int total = value1 + value2;    
    return total;
}
```

Earlier, it generated:
```
function testFunction2(int value1, float value2) returns int {
    int total = <int> value1 + value2;    
    return total;
}
```

Now it generates:
```
function testFunction2(int value1, float value2) returns int {
    int total = <int> (value1 + value2);    
    return total;
}
```

## Approach
Updated `TypeCastCodeAction` to check if the matched node is a binary expression. If yes, it now adds parentheses around the expression.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
