### PR TITLE
Restrict type() to return types of expressions and expression components

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -93,8 +93,9 @@ public interface SemanticModel {
     List<Location> references(Document sourceDocument, LinePosition position);
 
     /**
-     * Retrieves the type of the expression in the specified text range. If it's not a valid expression, returns an
-     * empty {@link Optional} value!.
+     * Retrieves the type of the expression (or part of an expression e.g., specific field of a mapping constructor) in
+     * the specified text range. If it's not a valid expression nor a part of an expression, returns an empty {@link
+     * Optional} value.
      *
      * @param range the text range of the expression
      * @return the type of the expression
@@ -102,8 +103,8 @@ public interface SemanticModel {
     Optional<TypeSymbol> type(LineRange range);
 
     /**
-     * Given a syntax tree node, returns the type of that node, if it is an expression node. For any other node, this
-     * will return empty.
+     * Given a syntax tree node, returns the type of that node, if it is an expression node or a node which makes up the
+     * expression (e.g., specific field of a mapping constructor). For any other node, this will return empty.
      *
      * @param node The expression node of which the type is needed
      * @return The type if it's a valid expression node, if not, returns empty

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -46,6 +46,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangRecordLiteral;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
@@ -205,7 +206,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         NodeFinder nodeFinder = new NodeFinder();
         BLangNode node = nodeFinder.lookup(compilationUnit, range);
 
-        if (node instanceof BLangExpression) {
+        if (node instanceof BLangExpression || node instanceof BLangRecordLiteral.BLangRecordKeyValueField) {
             return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -45,6 +45,7 @@ import org.wso2.ballerinalang.compiler.tree.BLangCompilationUnit;
 import org.wso2.ballerinalang.compiler.tree.BLangNode;
 import org.wso2.ballerinalang.compiler.tree.BLangPackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 import org.wso2.ballerinalang.util.Flags;
@@ -204,11 +205,11 @@ public class BallerinaSemanticModel implements SemanticModel {
         NodeFinder nodeFinder = new NodeFinder();
         BLangNode node = nodeFinder.lookup(compilationUnit, range);
 
-        if (node == null) {
-            return Optional.empty();
+        if (node instanceof BLangExpression) {
+            return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
         }
 
-        return Optional.ofNullable(typesFactory.getTypeDescriptor(node.type));
+        return Optional.empty();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/desugar/ConstantPropagation.java
@@ -237,7 +237,8 @@ public class ConstantPropagation extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangObjectConstructorExpression objectConstructorExpression) {
-        result = rewrite(objectConstructorExpression.typeInit);
+        objectConstructorExpression.typeInit = rewrite(objectConstructorExpression.typeInit);
+        result = objectConstructorExpression;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -1435,6 +1435,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
 
 //        attachAnnotations(function, annCount, false);
         bLFunction.pos = pos;
+        bLFunction.internal = true;
 
         bLFunction.addFlag(Flag.LAMBDA);
         bLFunction.addFlag(Flag.ANONYMOUS);
@@ -4065,6 +4066,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             case XML_ELEMENT:
             case XML_EMPTY_ELEMENT:
                 expr = createExpression(expressionNode.content().get(0));
+                break;
             default:
                 expr = createXMLLiteral(expressionNode);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -4052,6 +4052,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     }
 
     public BLangNode createXmlTemplateLiteral(TemplateExpressionNode expressionNode) {
+        BLangNode expr;
         SyntaxKind contentKind;
         if (expressionNode.content().isEmpty()) {
             contentKind = SyntaxKind.XML_TEXT;
@@ -4063,10 +4064,12 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             case XML_PI:
             case XML_ELEMENT:
             case XML_EMPTY_ELEMENT:
-                return createExpression(expressionNode.content().get(0));
+                expr = createExpression(expressionNode.content().get(0));
             default:
-                return createXMLLiteral(expressionNode);
+                expr = createXMLLiteral(expressionNode);
         }
+        expr.pos = getPosition(expressionNode);
+        return expr;
     }
 
     private BLangMatchPattern transformMatchPattern(Node matchPattern) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/visitors/FunctionCallExpressionTypeFinder.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.compiler.syntax.tree.AssignmentStatementNode;
 import io.ballerina.compiler.syntax.tree.FunctionCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.LetExpressionNode;
@@ -108,8 +109,11 @@ public class FunctionCallExpressionTypeFinder extends NodeVisitor {
 
     @Override
     public void visit(LetVariableDeclarationNode letVariableDeclarationNode) {
-        TypeSymbol typeSymbol = semanticModel.type(letVariableDeclarationNode).orElse(null);
-        checkAndSetTypeResult(typeSymbol);
+        Optional<Symbol> symbol = semanticModel.symbol(letVariableDeclarationNode);
+        if (symbol.isEmpty()) {
+            return;
+        }
+        checkAndSetTypeResult(((VariableSymbol) symbol.get()).typeDescriptor());
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -53,6 +53,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_ELEMENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -110,8 +111,8 @@ public class ExpressionTypeTest {
         TypeSymbol type = getExprType(24, 12, 24, 45);
 
         assertEquals(type.typeKind(), TYPE_REFERENCE);
-        assertEquals(type.name(), "Element");
-        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), XML);
+        assertEquals(type.getName().get(), "Element");
+        assertEquals(((TypeReferenceTypeSymbol) type).typeDescriptor().typeKind(), XML_ELEMENT);
     }
 
     @Test
@@ -351,6 +352,6 @@ public class ExpressionTypeTest {
     private Optional<TypeSymbol> getOptionalType(int sLine, int sCol, int eLine, int eCol) {
         LinePosition start = LinePosition.from(sLine, sCol);
         LinePosition end = LinePosition.from(eLine, eCol);
-        return model.type("expressions_test.bal", LineRange.from("expressions_test.bal", start, end));
+        return model.type(LineRange.from("expressions_test.bal", start, end));
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -52,7 +52,6 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TUPLE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
-import static io.ballerina.compiler.api.symbols.TypeDescKind.XML;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.XML_ELEMENT;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByAnonFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByAnonFunctionTest.java
@@ -19,6 +19,7 @@
 package io.ballerina.semantic.api.test.typebynode;
 
 import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.syntax.tree.ExplicitAnonymousFunctionExpressionNode;
@@ -59,7 +60,11 @@ public class TypeByAnonFunctionTest extends TypeByNodeTest {
             @Override
             public void visit(ImplicitAnonymousFunctionExpressionNode implicitAnonymousFunctionExpressionNode) {
                 assertType(implicitAnonymousFunctionExpressionNode, model, FUNCTION);
-                assertType(implicitAnonymousFunctionExpressionNode.params(), model, STRING);
+                FunctionTypeSymbol type =
+                        (FunctionTypeSymbol) model.type(implicitAnonymousFunctionExpressionNode).get();
+                assertEquals(type.parameters().size(), 1);
+                assertEquals(type.parameters().get(0).getName().get(), "s");
+                assertEquals(type.parameters().get(0).typeDescriptor().typeKind(), STRING);
             }
 
             @Override
@@ -70,7 +75,7 @@ public class TypeByAnonFunctionTest extends TypeByNodeTest {
     }
 
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 4);
+        assertEquals(getAssertCount(), 3);
     }
 
     private void assertType(Node node, SemanticModel model, TypeDescKind typeKind) {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByReferenceTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typebynode/TypeByReferenceTest.java
@@ -64,18 +64,8 @@ public class TypeByReferenceTest extends TypeByNodeTest {
 
             @Override
             public void visit(BuiltinSimpleNameReferenceNode builtinSimpleNameReferenceNode) {
-                TypeDescKind typeKind;
-                switch (builtinSimpleNameReferenceNode.kind()) {
-                    case FLOAT_TYPE_DESC:
-                        typeKind = FLOAT;
-                        break;
-                    case INT_TYPE_DESC:
-                        typeKind = INT;
-                        break;
-                    default:
-                        throw new IllegalStateException();
-                }
-                assertType(builtinSimpleNameReferenceNode, model, typeKind);
+                assertTrue(model.type(builtinSimpleNameReferenceNode).isEmpty());
+                incrementAssertCount();
             }
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -111,6 +111,7 @@ function testFunctionCall() {
 
     PersonObj p = new("Pubudu");
     string s = p.getName();
+    boolean b = true;
 }
 
 // utils

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_constructor_expr_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/type-by-node/type_by_constructor_expr_test.bal
@@ -27,7 +27,7 @@ function test() {
     object {
         string name;
         function getName() returns string;
-    } person = object {
+    } personObj = object {
         string name = "Anon";
 
         function getName() returns string => self.name;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLTextToStringConversionNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLTextToStringConversionNegativeTest.java
@@ -43,7 +43,7 @@ public class XMLTextToStringConversionNegativeTest {
         int i = 0;
         Assert.assertEquals(negativeResult.getErrorCount(), 20);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 22, 22);
+                "expected 'string', found 'xml:Text'", 22, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
                 "expected 'string', found 'xml:Text'", 23, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
@@ -51,18 +51,18 @@ public class XMLTextToStringConversionNegativeTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
                 "expected 'string', found 'xml:Text'", 28, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 29, 42);
+                "expected 'string', found 'xml:Text'", 29, 37);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 31, 31);
+                "expected 'string', found 'xml:Text'", 31, 26);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 32, 13);
+                "expected 'string', found 'xml:Text'", 32, 8);
 
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 40, 46);
+                "expected 'string', found 'xml:Text'", 40, 41);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 41, 36);
+                "expected 'string', found 'xml:Text'", 41, 31);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
-                "expected 'string', found 'xml:Text'", 42, 26);
+                "expected 'string', found 'xml:Text'", 42, 21);
 
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: " +
                 "expected 'string', found 'xml:Text'", 48, 9);


### PR DESCRIPTION
## Purpose
Currently `type()` returns the type of any node which has the `type` field set. Instead of doing that, this restricts the `type()` method to only return the types of expression nodes or nodes that make up an expression (e.g., specific fields of a mapping constructor).

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
