### PR TITLE
Fix bug in code coverage tests filtering

### DIFF
--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/entity/CoverageReport.java
@@ -181,11 +181,15 @@ public class CoverageReport {
         Collection<IClassCoverage> modifiedClasses = new ArrayList<>();
         for (IClassCoverage classCoverage : classesList) {
             if (classCoverage.getSourceFileName() != null) {
-                //Normalize package name and class name for classes generated for bal files
-                IClassCoverage modifiedClassCoverage = new NormalizedCoverageClass(classCoverage,
-                        normalizeFileName(classCoverage.getPackageName()),
-                        normalizeFileName(classCoverage.getName()));
-                modifiedClasses.add(modifiedClassCoverage);
+                if (classCoverage.getSourceFileName().startsWith("tests/")) {
+                    continue;
+                } else {
+                    //Normalize package name and class name for classes generated for bal files
+                    IClassCoverage modifiedClassCoverage = new NormalizedCoverageClass(classCoverage,
+                            normalizeFileName(classCoverage.getPackageName()),
+                            normalizeFileName(classCoverage.getName()));
+                    modifiedClasses.add(modifiedClassCoverage);
+                }
             } else {
                 modifiedClasses.add(classCoverage);
             }
@@ -387,11 +391,15 @@ public class CoverageReport {
             ISourceFileCoverage modifiedSourceFile;
             List<ILine> modifiedLines;
             if (sourcefile.getName().endsWith(BLANG_SRC_FILE_SUFFIX)) {
-                modifiedLines = modifyLines(sourcefile);
-                //Normalize source file package name
-                modifiedSourceFile = new PartialCoverageModifiedSourceFile(sourcefile,
-                        modifiedLines, normalizeFileName(sourcefile.getPackageName()));
-                modifiedSourceFiles.add(modifiedSourceFile);
+                if (sourcefile.getName().startsWith("tests/")) {
+                    continue;
+                } else {
+                    modifiedLines = modifyLines(sourcefile);
+                    //Normalize source file package name
+                    modifiedSourceFile = new PartialCoverageModifiedSourceFile(sourcefile,
+                            modifiedLines, normalizeFileName(sourcefile.getPackageName()));
+                    modifiedSourceFiles.add(modifiedSourceFile);
+                }
             } else {
                 modifiedSourceFiles.add(sourcefile);
             }


### PR DESCRIPTION
## Purpose
Fix bug in code coverage tests filtering for generated '$value$$anonType' classes.

Fixes #<Issue Number>

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
Consider a test source file which has a service defined in it. Then a specific class gets generated for these declarations and it does not get caught by the existing tests filter.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
