### PR TITLE
Remove printing DOT when testing single bal file

### DIFF
--- a/cli/ballerina-cli/spotbugs-exclude.xml
+++ b/cli/ballerina-cli/spotbugs-exclude.xml
@@ -37,6 +37,10 @@
         <Class name="io.ballerina.cli.task.RunTestsTask"/>
         <Bug pattern="RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE"/>
     </Match>
+    <Match>
+        <Class name="io.ballerina.cli.task.RunTestsTask"/>
+        <Bug pattern="NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE"/>
+    </Match>
 
     <Match>
         <Package name="io.ballerina.cli.launcher.util" />

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/task/RunTestsTask.java
@@ -199,6 +199,9 @@ public class RunTestsTask implements Task {
             if (isSingleTestExecution || isRerunTestExecution) {
                 suite.setTests(TesterinaUtils.getSingleExecutionTests(suite, singleExecTests));
             }
+            if (project.kind() == ProjectKind.SINGLE_FILE_PROJECT) {
+                suite.setSourceFileName(project.sourceRoot().getFileName().toString());
+            }
             suite.setReportRequired(report || coverage);
             String resolvedModuleName =
                     module.isDefaultModule() ? moduleName.toString() : module.moduleName().moduleNamePart();

--- a/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
+++ b/misc/testerina/modules/testerina-runtime/src/main/java/org/ballerinalang/test/runtime/Main.java
@@ -86,7 +86,8 @@ public class Main {
                         TestSuite testSuite = entry.getValue();
 
                         out.println("\n\t" + (moduleName.equals(testSuite.getPackageName()) ?
-                                moduleName : testSuite.getPackageName() + TesterinaConstants.DOT + moduleName));
+                                (moduleName.equals(TesterinaConstants.DOT) ? testSuite.getSourceFileName() : moduleName)
+                                : testSuite.getPackageName() + TesterinaConstants.DOT + moduleName));
 
                         testSuite.setModuleName(moduleName);
                         List<String> testExecutionDependencies = testSuite.getTestExecutionDependencies();


### PR DESCRIPTION
## Purpose
Removes printing just `.` when testing single bal files

Output for single bal files now looks like this.

```
Compiling source
	main_test.bal

Running Tests

	main_test.bal

		[pass] test1
		[pass] test2
		[pass] test3

		3 passing
		0 failing
		0 skipped
```

Fixes #29266

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
