### PR TITLE
Skip visiting classses generated for services in NodeFinder

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -195,7 +195,8 @@ class NodeFinder extends BaseVisitor {
         this.enclosingNode = null;
 
         for (TopLevelNode node : nodes) {
-            if (!PositionUtil.withinRange(this.range, node.getPosition()) || isLambdaFunction(node)) {
+            if (!PositionUtil.withinRange(this.range, node.getPosition()) || isLambdaFunction(node)
+                    || isClassForService(node)) {
                 continue;
             }
 
@@ -891,11 +892,6 @@ class NodeFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangClassDefinition classDefinition) {
-        // skip the generated class def for services
-        if (classDefinition.flagSet.contains(Flag.SERVICE)) {
-            return;
-        }
-
         lookupNodes(classDefinition.annAttachments);
         lookupNodes(classDefinition.fields);
         lookupNodes(classDefinition.referencedFields);
@@ -1195,5 +1191,13 @@ class NodeFinder extends BaseVisitor {
 
         BLangFunction func = (BLangFunction) node;
         return func.flagSet.contains(Flag.LAMBDA);
+    }
+
+    private boolean isClassForService(TopLevelNode node) {
+        if (node.getKind() != NodeKind.CLASS_DEFN) {
+            return false;
+        }
+
+        return ((BLangClassDefinition) node).flagSet.contains(Flag.SERVICE);
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -321,6 +321,11 @@ public class ExpressionTypeTest {
         };
     }
 
+    @Test
+    public void testTypeWithinServiceDecl() {
+        assertType(118, 15, 118, 16, RECORD);
+    }
+
     private void assertType(int sLine, int sCol, int eLine, int eCol, TypeDescKind kind) {
         TypeSymbol type = getExprType(sLine, sCol, eLine, eCol);
         assertEquals(type.typeKind(), kind);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -113,6 +113,13 @@ function testFunctionCall() {
     string s = p.getName();
 }
 
+service on new Listener() {
+    resource function get processRequest() returns json {
+        var v = {name: "John Doe"};
+        return v;
+    }
+}
+
 // utils
 
 class PersonObj {
@@ -126,3 +133,21 @@ class PersonObj {
 }
 
 function foo() returns string|error => "foo";
+
+public class Listener {
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+
+    public function detach(service object {} s) returns error? {
+    }
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_symbol_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_symbol_test.bal
@@ -77,7 +77,7 @@ service ProcessingService / on lsn {
 
 public class Listener {
 
-    public function start() returns error? {
+    public function 'start() returns error? {
     }
 
     public function gracefulStop() returns error? {


### PR DESCRIPTION
## Purpose
Fixes an issue with how classes generated for services were skipped in `NodeFinder`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
