### PR TITLE
Fix NPE in FunctionTypeSymbol

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -25,8 +25,10 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.util.Collections;
 import java.util.List;
@@ -50,6 +52,7 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     private ParameterSymbol restParam;
     private TypeSymbol returnType;
     private final BInvokableTypeSymbol typeSymbol;
+    private String signature;
 
     public BallerinaFunctionTypeSymbol(CompilerContext context, ModuleID moduleID,
                                        BInvokableTypeSymbol invokableSymbol, BType type) {
@@ -102,6 +105,15 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
 
     @Override
     public String signature() {
+        if (this.signature != null) {
+            return this.signature;
+        }
+
+        if (Symbols.isFlagOn(getBType().flags, Flags.ANY_FUNCTION)) {
+            this.signature = "function";
+            return this.signature;
+        }
+
         StringBuilder signature = new StringBuilder("function (");
         StringJoiner joiner = new StringJoiner(", ");
         for (ParameterSymbol requiredParam : this.parameters()) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -60,8 +60,13 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     @Override
     public List<ParameterSymbol> parameters() {
         if (this.requiredParams == null) {
-            SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+            // Becomes null for the function typedesc.
+            if (this.typeSymbol.params == null) {
+                this.requiredParams = Collections.emptyList();
+                return this.requiredParams;
+            }
 
+            SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
             this.requiredParams = this.typeSymbol.params.stream()
                     .filter(symbol -> symbol.kind != SymbolKind.PATH_PARAMETER
                             && symbol.kind != SymbolKind.PATH_REST_PARAMETER)

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -636,6 +636,14 @@ public class TypedescriptorTest {
         };
     }
 
+    @Test
+    public void testFunctionTypedesc() {
+        FunctionSymbol symbol = (FunctionSymbol) getSymbol(216, 13);
+        assertEquals(symbol.typeDescriptor().parameters().size(), 0);
+        assertTrue(symbol.typeDescriptor().restParam().isEmpty());
+        assertTrue(symbol.typeDescriptor().returnTypeDescriptor().isEmpty());
+    }
+
     private Symbol getSymbol(int line, int column) {
         return model.symbol(srcFile, from(line, column)).get();
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -642,6 +642,7 @@ public class TypedescriptorTest {
         assertEquals(symbol.typeDescriptor().parameters().size(), 0);
         assertTrue(symbol.typeDescriptor().restParam().isEmpty());
         assertTrue(symbol.typeDescriptor().returnTypeDescriptor().isEmpty());
+        assertEquals(symbol.typeDescriptor().signature(), "function");
     }
 
     private Symbol getSymbol(int line, int column) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedesc_test.bal
@@ -212,3 +212,7 @@ const NIL = ();
 type Nil NIL;
 
 type Pi PI;
+
+function testFunctionTypedesc() {
+    function f = foo;
+}


### PR DESCRIPTION
## Purpose
Fixes the unhandled case for the any function typedesc in `FunctionTypeSymbol`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
