### PR TITLE
Disallow modeling vars of nilable function types as invokable symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -389,6 +389,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     EXPRESSION_DOES_NOT_SUPPORT_FIELD_ACCESS("BCE2648", "expression.does.not.support.field.access"),
     CANNOT_USE_TYPE_INCLUSION_WITH_MORE_THAN_ONE_OPEN_RECORD_WITH_DIFFERENT_REST_DESCRIPTOR_TYPES("BCE2649",
             "cannot.use.type.inclusion.with.more.than.one.open.record.with.different.rest.descriptor.types"),
+    METHOD_CALL_NOT_ALLOWED_FOR_FIELD("BCE2650", "method.call.expr.not.allowed"),
 
     // Error codes related to iteration.
     ITERABLE_NOT_SUPPORTED_COLLECTION("BCE2800", "iterable.not.supported.collection"),

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/util/diagnostic/DiagnosticErrorCode.java
@@ -389,7 +389,7 @@ public enum DiagnosticErrorCode implements DiagnosticCode {
     EXPRESSION_DOES_NOT_SUPPORT_FIELD_ACCESS("BCE2648", "expression.does.not.support.field.access"),
     CANNOT_USE_TYPE_INCLUSION_WITH_MORE_THAN_ONE_OPEN_RECORD_WITH_DIFFERENT_REST_DESCRIPTOR_TYPES("BCE2649",
             "cannot.use.type.inclusion.with.more.than.one.open.record.with.different.rest.descriptor.types"),
-    METHOD_CALL_NOT_ALLOWED_FOR_FIELD("BCE2650", "method.call.expr.not.allowed"),
+    INVALID_METHOD_CALL_EXPR_ON_FIELD("BCE2650", "invalid.method.call.expr.on.field"),
 
     // Error codes related to iteration.
     ITERABLE_NOT_SUPPORTED_COLLECTION("BCE2800", "iterable.not.supported.collection"),

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3742,9 +3742,8 @@ public class SymbolEnter extends BLangNodeVisitor {
 
     public BVarSymbol createVarSymbol(long flags, BType varType, Name varName, SymbolEnv env,
                                       Location location, boolean isInternal) {
-        BType safeType = types.getSafeType(varType, true, false);
         BVarSymbol varSymbol;
-        if (safeType.tag == TypeTags.INVOKABLE) {
+        if (varType.tag == TypeTags.INVOKABLE) {
             varSymbol = new BInvokableSymbol(SymTag.VARIABLE, flags, varName, env.enclPkg.symbol.pkgID, varType,
                                              env.scope.owner, location, isInternal ? VIRTUAL : getOrigin(varName));
             varSymbol.kind = SymbolKind.FUNCTION;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2981,8 +2981,8 @@ public class TypeChecker extends BLangNodeVisitor {
         }
 
         if (fieldSymbol.kind != SymbolKind.FUNCTION) {
-            checkIfLangLibMethodExists(iExpr, type, iExpr.pos, DiagnosticErrorCode.METHOD_CALL_NOT_ALLOWED_FOR_FIELD,
-                                       invocationIdentifier, fieldSymbol.type);
+            checkIfLangLibMethodExists(iExpr, type, iExpr.pos, DiagnosticErrorCode.INVALID_METHOD_CALL_EXPR_ON_FIELD,
+                                       fieldSymbol.type);
             return false;
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -2971,23 +2971,37 @@ public class TypeChecker extends BLangNodeVisitor {
         if (type == symTable.semanticError) {
             return false;
         }
-        BSymbol funcSymbol = symResolver.resolveStructField(iExpr.pos, env, names.fromIdNode(invocationIdentifier),
-                type.tsymbol);
-        if (funcSymbol == symTable.notFoundSymbol || funcSymbol.kind != SymbolKind.FUNCTION) {
-            BSymbol langLibMethodSymbol = getLangLibMethod(iExpr, type);
-            if (langLibMethodSymbol == symTable.notFoundSymbol) {
-                dlog.error(iExpr.name.pos, DiagnosticErrorCode.UNDEFINED_FIELD_IN_RECORD, invocationIdentifier, type);
-                resultType = symTable.semanticError;
-            } else {
-                checkInvalidImmutableValueUpdate(iExpr, type, langLibMethodSymbol);
-            }
+        BSymbol fieldSymbol = symResolver.resolveStructField(iExpr.pos, env, names.fromIdNode(invocationIdentifier),
+                                                             type.tsymbol);
+
+        if (fieldSymbol == symTable.notFoundSymbol) {
+            checkIfLangLibMethodExists(iExpr, type, iExpr.name.pos, DiagnosticErrorCode.UNDEFINED_FIELD_IN_RECORD,
+                                       invocationIdentifier, type);
             return false;
         }
-        iExpr.symbol = funcSymbol;
-        iExpr.type = ((BInvokableSymbol) funcSymbol).retType;
+
+        if (fieldSymbol.kind != SymbolKind.FUNCTION) {
+            checkIfLangLibMethodExists(iExpr, type, iExpr.pos, DiagnosticErrorCode.METHOD_CALL_NOT_ALLOWED_FOR_FIELD,
+                                       invocationIdentifier, fieldSymbol.type);
+            return false;
+        }
+
+        iExpr.symbol = fieldSymbol;
+        iExpr.type = ((BInvokableSymbol) fieldSymbol).retType;
         checkInvocationParamAndReturnType(iExpr);
         iExpr.functionPointerInvocation = true;
         return true;
+    }
+
+    private void checkIfLangLibMethodExists(BLangInvocation iExpr, BType varRefType, Location pos,
+                                            DiagnosticErrorCode errCode, Object... diagMsgArgs) {
+        BSymbol langLibMethodSymbol = getLangLibMethod(iExpr, varRefType);
+        if (langLibMethodSymbol == symTable.notFoundSymbol) {
+            dlog.error(pos, errCode, diagMsgArgs);
+            resultType = symTable.semanticError;
+        } else {
+            checkInvalidImmutableValueUpdate(iExpr, varRefType, langLibMethodSymbol);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1690,3 +1690,6 @@ error.invalid.readonly.field.type=\
 error.continue.not.allowed=continue not allowed here
 
 error.break.not.allowed=break not allowed here
+
+error.method.call.expr.not.allowed=\
+  method call expression not allowed on field ''{0}'': expected a function type, but found ''{1}''

--- a/compiler/ballerina-lang/src/main/resources/compiler.properties
+++ b/compiler/ballerina-lang/src/main/resources/compiler.properties
@@ -1691,5 +1691,5 @@ error.continue.not.allowed=continue not allowed here
 
 error.break.not.allowed=break not allowed here
 
-error.method.call.expr.not.allowed=\
-  method call expression not allowed on field ''{0}'': expected a function type, but found ''{1}''
+error.invalid.method.call.expr.on.field=\
+  invalid method call expression: expected a function type, but found ''{0}''

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/SymbolAtCursorTest.java
@@ -95,6 +95,7 @@ public class SymbolAtCursorTest {
                 {76, 25, "RSA"},
                 {82, 8, "rsa"},
                 {83, 15, "RSA"},
+                {89, 14, "fn"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol_at_cursor_basic_test.bal
@@ -83,3 +83,9 @@ function testExprs()  {
     RSA rsa = "RSA";
     string s = RSA;
 }
+
+type Function function ();
+
+function testNilableFunctionType() {
+    Function? fn = ();
+}

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
@@ -244,17 +244,13 @@ public class ClosedRecordTest {
     @Test(description = "Test invocation of nil-able function pointer fields in a closed record")
     public void testNilableFunctionPtrInvocation() {
         CompileResult result = BCompileUtil.compile("test-src/record/negative/closed_record_nil-able_fn_ptr.bal");
-        String errMsg1 = "function invocation on type 'function (string,string) returns (string)?' is not supported";
-        String errMsg2 = "incompatible types: expected 'string?', found 'other'";
+        String errMsg =
+                "method call expression not allowed on field 'getName': expected a function type, but found 'function" +
+                        " (string,string) returns (string)?'";
         int indx = 0;
-        BAssertUtil.validateError(result, indx++, errMsg1, 28, 17);
-        BAssertUtil.validateError(result, indx++, errMsg2, 28, 17);
-        BAssertUtil.validateError(result, indx++, errMsg1, 33, 17);
-        BAssertUtil.validateError(result, indx++, errMsg2, 33, 17);
-        BAssertUtil.validateError(result, indx++, errMsg1, 47, 17);
-        BAssertUtil.validateError(result, indx++, errMsg2, 47, 17);
-        BAssertUtil.validateError(result, indx++, errMsg1, 52, 17);
-        BAssertUtil.validateError(result, indx, errMsg2, 52, 17);
+        BAssertUtil.validateError(result, indx++, errMsg, 28, 17);
+        BAssertUtil.validateError(result, indx++, errMsg, 33, 17);
+        Assert.assertEquals(result.getErrorCount(), indx);
     }
 
     @Test(description = "Test closed record mismatch fields")

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/ClosedRecordTest.java
@@ -245,7 +245,7 @@ public class ClosedRecordTest {
     public void testNilableFunctionPtrInvocation() {
         CompileResult result = BCompileUtil.compile("test-src/record/negative/closed_record_nil-able_fn_ptr.bal");
         String errMsg =
-                "method call expression not allowed on field 'getName': expected a function type, but found 'function" +
+                "invalid method call expression: expected a function type, but found 'function" +
                         " (string,string) returns (string)?'";
         int indx = 0;
         BAssertUtil.validateError(result, indx++, errMsg, 28, 17);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordNegativeTest.java
@@ -80,24 +80,15 @@ public class OpenRecordNegativeTest {
     @Test(description = "Test function invocation on a nil-able function pointer")
     public void testNilableFuncPtrInvocation() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/negative/open_record_nil-able_fn_ptr.bal");
+        String errMsg =
+                "method call expression not allowed on field 'getName': expected a function type, but found 'function" +
+                        " (string,string) returns (string)?'";
         int indx = 0;
 
-        validateError(compileResult, indx++,
-                      "function invocation on type 'function (string,string) returns (string)?' is not supported",
-                      28, 17);
-        validateError(compileResult, indx++, "incompatible types: expected 'string?', found 'other'", 28, 17);
-        validateError(compileResult, indx++,
-                      "function invocation on type 'function (string,string) returns (string)?' is not supported",
-                      33, 17);
-        validateError(compileResult, indx++, "incompatible types: expected 'string?', found 'other'", 33, 17);
-        validateError(compileResult, indx++,
-                      "function invocation on type 'function (string,string) returns (string)?' is not supported",
-                      47, 17);
-        validateError(compileResult, indx++, "incompatible types: expected 'string?', found 'other'", 47, 17);
-        validateError(compileResult, indx++,
-                      "function invocation on type 'function (string,string) returns (string)?' is not supported",
-                      53, 17);
-        validateError(compileResult, indx++, "incompatible types: expected 'string?', found 'other'", 53, 17);
+        validateError(compileResult, indx++, errMsg, 28, 17);
+        validateError(compileResult, indx++, errMsg, 33, 17);
+        validateError(compileResult, indx++, errMsg, 47, 17);
+        validateError(compileResult, indx++, errMsg, 53, 17);
         assertEquals(compileResult.getErrorCount(), indx);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/record/OpenRecordNegativeTest.java
@@ -81,7 +81,7 @@ public class OpenRecordNegativeTest {
     public void testNilableFuncPtrInvocation() {
         CompileResult compileResult = BCompileUtil.compile("test-src/record/negative/open_record_nil-able_fn_ptr.bal");
         String errMsg =
-                "method call expression not allowed on field 'getName': expected a function type, but found 'function" +
+                "invalid method call expression: expected a function type, but found 'function" +
                         " (string,string) returns (string)?'";
         int indx = 0;
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/negative/closed_record_nil-able_fn_ptr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/negative/closed_record_nil-able_fn_ptr.bal
@@ -32,22 +32,3 @@ function testNilableFuncPtrInvocation2() {
     Person bob = {fname:"bob", lname:"white"};
     string? x = bob.getName(bob.fname, bob.lname);
 }
-
-type PersonB record {|
-    string fname = "";
-    string lname = "";
-    (function (string, string) returns string)? getName = ();
-|};
-
-function testNilableFuncPtrInvocationInObj() {
-    PersonB bob = {fname:"Bob", lname:"White"};
-    bob.getName = function (string fname, string lname) returns string {
-        return fname + " " + lname;
-    };
-    string? x = bob.getName(bob.fname, bob.lname);
-}
-
-function testNilableFuncPtrInvocationInObj2() {
-    PersonB bob = {fname:"Bob", lname:"White"};
-    string? x = bob.getName(bob.fname, bob.lname);
-}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/record/negative/open_record_nil-able_fn_ptr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/record/negative/open_record_nil-able_fn_ptr.bal
@@ -39,7 +39,7 @@ type PersonB record {
     (function (string, string) returns string)? getName = ();
 };
 
-function testNilableFuncPtrInvocationOnObj() returns string? {
+function testNilableFuncPtrInvocation3() returns string? {
     PersonB bob = {fname:"Bob", lname:"White"};
     bob.getName = function (string fname, string lname) returns string {
         return fname + " " + lname;
@@ -48,7 +48,7 @@ function testNilableFuncPtrInvocationOnObj() returns string? {
     return x;
 }
 
-function testNilableFuncPtrInvocationOnObj2() returns string? {
+function testNilableFuncPtrInvocation4() returns string? {
     PersonB bob = {fname:"Bob", lname:"White"};
     string? x = bob.getName(bob.fname, bob.lname);
     return x;


### PR DESCRIPTION
## Purpose
Due to code remaining from nil-lifting days, a variable of type `T?` where `T` is a function type is modeled as an invokable symbol. This PR removes this behaviour and models such vars as regular var symbols. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
