### PR TITLE
Fix incorrect type symbol returning issue in resource function signatures

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -5837,7 +5837,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         Location pos = getPosition(recordTypeDescriptorNode);
         // Generate a name for the anonymous object
         String genName = anonymousModelHelper.getNextAnonymousTypeKey(this.packageID);
-        IdentifierNode anonTypeGenName = createIdentifier(pos, genName, null);
+        IdentifierNode anonTypeGenName = createIdentifier(symTable.builtinPos, genName, null);
         typeDef.setName(anonTypeGenName);
         typeDef.flagSet.add(Flag.PUBLIC);
         typeDef.flagSet.add(Flag.ANONYMOUS);

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_service_decl_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_service_decl_test.bal
@@ -24,6 +24,9 @@ service HelloWorld /foo/bar on new Listener() {
 
     resource function get greet/[int x]/hello/[float y]/[string... rest] () returns json => { output: self.greeting };
 
+    resource function delete pets () returns record{|Error body;|} {
+    }
+
     remote function sayHello() return string => self.greeting;
 
     function createError() returns @tainted error? => ();
@@ -46,3 +49,8 @@ public class Listener {
     public function attach(service object {} s, string[]? name = ()) returns error? {
     }
 }
+
+type Error record {
+    int id;
+    string code;
+};


### PR DESCRIPTION
## Purpose
This fixes an issue that was there where when you look up a field of a record type symbol which is in a resource function's return signature it returned a type def symbol.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
