### PR TITLE
Fix symbol lookup for annotations on a return type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -344,13 +344,16 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangAnnotationAttachment annAttachmentNode) {
+        if (annAttachmentNode.annotationSymbol != null
+                && setEnclosingNode(annAttachmentNode.annotationSymbol.owner, annAttachmentNode.pkgAlias.pos)) {
+            return;
+        }
+
         if (setEnclosingNode(annAttachmentNode.annotationSymbol, annAttachmentNode.annotationName.pos)) {
             return;
         }
 
         lookupNode(annAttachmentNode.expr);
-
-        // TODO: See how we can return module info if the cursor is at the module alias
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -82,20 +82,27 @@ public class AnnotationsTest {
     @DataProvider(name = "PosProvider")
     public Object[][] getPos() {
         return new Object[][]{
-                {46, 6, CONSTANT, of("v1")},
-//                {52, 12, TYPE_DEFINITION, of("v1")}, // TODO: Uncomment after fixing #27461
-                {53, 15, RECORD_FIELD, of("v5")},
-                {65, 6, CLASS, of("v1", "v2", "v2")},
-                {66, 15, CLASS_FIELD, of("v5")},
-                {71, 20, METHOD, of("v3")},
-                {71, 69, PARAMETER, of("v4")},
-                {81, 16, FUNCTION, of("v3")},
-                {86, 11, ANNOTATION, of("v1")},
-                {98, 18, CLASS_FIELD, of("v5")},
-                {103, 22, RESOURCE_METHOD, of("v3")},
-//                {112, 11, WORKER, of("v1")} // TODO: Uncomment after fixing #27461
-                {121, 5, ENUM, of("v1", "v5")},
-                {125, 4, CONSTANT, of("v1")}
+                {30, 6, CONSTANT, of("v1")},
+//                {36, 12, TYPE_DEFINITION, of("v1")}, // TODO: Uncomment after fixing #27461
+                {37, 15, RECORD_FIELD, of("v5")},
+                {49, 6, CLASS, of("v1", "v2", "v2")},
+                {50, 15, CLASS_FIELD, of("v5")},
+                {55, 20, METHOD, of("v3")},
+                {55, 69, PARAMETER, of("v4")},
+                {65, 16, FUNCTION, of("v3")},
+                {70, 11, ANNOTATION, of("v1")},
+                {82, 18, CLASS_FIELD, of("v5")},
+                {87, 22, RESOURCE_METHOD, of("v3")},
+//                {96, 11, WORKER, of("v1")} // TODO: Uncomment after fixing #27461
+                {105, 5, ENUM, of("v1", "v5")},
+                {109, 4, CONSTANT, of("v1")}
         };
+    }
+
+    @Test
+    public void testAnnotOnReturnType() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(57, 85));
+        assertEquals(symbol.get().kind(), ANNOTATION);
+        assertEquals(symbol.get().getName().get(), "v5");
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByAnnotationTest.java
@@ -63,7 +63,7 @@ public class SymbolByAnnotationTest extends SymbolByNodeTest {
 
     @Override
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 4);
+        assertEquals(getAssertCount(), 6);
     }
 
     private void assertSymbol(Node node, SemanticModel model) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/annotations_test.bal
@@ -14,22 +14,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-//
-// WSO2 Inc. licenses this file to you under the Apache License,
-// Version 2.0 (the "License"); you may not use this file except
-// in compliance with the License.
-// You may obtain a copy of the License at
-//
-// http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing,
-// software distributed under the License is distributed on an
-// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-// KIND, either express or implied.  See the License for the
-// specific language governing permissions and limitations
-// under the License.
-
 type Annot record {
     string foo;
     int bar?;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_annotation_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_annotation_test.bal
@@ -19,7 +19,7 @@ type Annot record {
     int bar?;
 };
 
-public const annotation Annot v1 on source type, class, service, annotation, var, const, worker;
+public const annotation Annot v1 on source type, class, service, annotation, var, const, worker, return;
 
 @v1 {
     foo: strValue,
@@ -28,3 +28,5 @@ public const annotation Annot v1 on source type, class, service, annotation, var
 public type T1 record {
     string name;
 };
+
+function greet() returns @v1 { foo: "func" } string => "Hello";


### PR DESCRIPTION
## Purpose
This PR fixes the issue we had with not being able to lookup the symbol of an annotation attached to the return type of a function/method.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
