### PR TITLE
Fix issue in creating field symbols

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -367,7 +367,7 @@ public class BallerinaSemanticModel implements SemanticModel {
         if ((hasCursorPosPassedSymbolPos(symbol, cursorPos) || isImportedSymbol(symbol))
                 && !isServiceDeclSymbol(symbol)) {
             Symbol compiledSymbol = symbolFactory.getBCompiledSymbol(symbol, name.getValue());
-            if (compiledSymbols.contains(compiledSymbol)) {
+            if (compiledSymbol == null || compiledSymbols.contains(compiledSymbol)) {
                 return;
             }
             compiledSymbols.add(compiledSymbol);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -315,15 +315,18 @@ public class SymbolFactory {
     }
 
     public BallerinaRecordFieldSymbol createRecordFieldSymbol(BVarSymbol symbol) {
-        return new BallerinaRecordFieldSymbol(this.context, getBField(symbol));
+        BField bField = getBField(symbol);
+        return bField != null ? new BallerinaRecordFieldSymbol(this.context, bField) : null;
     }
 
     public BallerinaObjectFieldSymbol createObjectFieldSymbol(BVarSymbol symbol) {
-        return new BallerinaObjectFieldSymbol(this.context, getBField(symbol));
+        BField bField = getBField(symbol);
+        return bField != null ? new BallerinaObjectFieldSymbol(this.context, bField) : null;
     }
 
     public BallerinaClassFieldSymbol createClassFieldSymbol(BVarSymbol symbol) {
-        return new BallerinaClassFieldSymbol(this.context, getBField(symbol));
+        BField bField = getBField(symbol);
+        return bField != null ? new BallerinaClassFieldSymbol(this.context, bField) : null;
     }
 
     public BallerinaWorkerSymbol createWorkerSymbol(BVarSymbol symbol, String name) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3149,9 +3149,6 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         for (BLangSimpleVariable field : classDefinition.fields) {
             defineNode(field, typeDefEnv);
-            if (field.symbol.type == symTable.semanticError) {
-                continue;
-            }
             objType.fields.put(field.name.value, new BField(names.fromIdNode(field.name), field.pos, field.symbol));
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3221,7 +3221,6 @@ public class SymbolEnter extends BLangNodeVisitor {
                                SymbolEnv typeDefEnv) {
         structureType.fields = structureTypeNode.fields.stream()
                 .peek((BLangSimpleVariable field) -> defineNode(field, typeDefEnv))
-                .filter(field -> field.symbol.type != symTable.semanticError) // filter out erroneous fields
                 .map((BLangSimpleVariable field) -> {
                     field.symbol.isDefaultable = field.expr != null;
                     return new BField(names.fromIdNode(field.name), field.pos, field.symbol);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -3149,6 +3149,10 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         for (BLangSimpleVariable field : classDefinition.fields) {
             defineNode(field, typeDefEnv);
+            // Unless skipped, this causes issues in negative cases such as duplicate fields.
+            if (field.symbol.type == symTable.semanticError) {
+                continue;
+            }
             objType.fields.put(field.name.value, new BField(names.fromIdNode(field.name), field.pos, field.symbol));
         }
 
@@ -3221,6 +3225,7 @@ public class SymbolEnter extends BLangNodeVisitor {
                                SymbolEnv typeDefEnv) {
         structureType.fields = structureTypeNode.fields.stream()
                 .peek((BLangSimpleVariable field) -> defineNode(field, typeDefEnv))
+                .filter(field -> field.symbol.type != symTable.semanticError) // filter out erroneous fields
                 .map((BLangSimpleVariable field) -> {
                     field.symbol.isDefaultable = field.expr != null;
                     return new BField(names.fromIdNode(field.name), field.pos, field.symbol);

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/incompletesource/InvalidFieldTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/incompletesource/InvalidFieldTypeTest.java
@@ -20,11 +20,7 @@ package io.ballerina.semantic.api.test.incompletesource;
 
 import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.impl.BallerinaModuleID;
-import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
-import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
-import io.ballerina.compiler.api.symbols.RecordFieldSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
-import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
@@ -39,7 +35,8 @@ import java.util.Map;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
-import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for use of undefined types as field types.
@@ -59,33 +56,16 @@ public class InvalidFieldTypeTest {
     }
 
     @Test(dataProvider = "CursorPosProvider1")
-    public void testSymbolAtCursor(int line, int col, String name) {
-        Symbol field = model.symbol(srcFile, from(line, col)).get();
-        assertEquals(field.getName().get(), name);
-
-        TypeDescKind typeKind;
-        switch (field.kind()) {
-            case CLASS_FIELD:
-                typeKind = ((ClassFieldSymbol) field).typeDescriptor().typeKind();
-                break;
-            case RECORD_FIELD:
-                typeKind = ((RecordFieldSymbol) field).typeDescriptor().typeKind();
-                break;
-            case OBJECT_FIELD:
-                typeKind = ((ObjectFieldSymbol) field).typeDescriptor().typeKind();
-                break;
-            default:
-                throw new IllegalArgumentException("Unexpected symbol kind: " + field.kind());
-        }
-        assertEquals(typeKind, TypeDescKind.COMPILATION_ERROR);
+    public void testSymbolAtCursor(int line, int col) {
+        assertTrue(model.symbol(srcFile, from(line, col)).isEmpty());
     }
 
     @DataProvider(name = "CursorPosProvider1")
     public Object[][] getCursorPos1() {
         return new Object[][]{
-                {17, 16, "c"},
-                {22, 13, "name"},
-                {27, 13, "name"},
+                {17, 16},
+                {22, 13},
+                {27, 13},
         };
     }
 
@@ -94,9 +74,7 @@ public class InvalidFieldTypeTest {
         Map<String, Symbol> symbolsInFile =
                 SemanticAPITestUtils.getSymbolsInFile(model, srcFile, line, col,
                                                       new BallerinaModuleID(PackageID.DEFAULT));
-
-        Symbol field = symbolsInFile.get(name);
-        assertEquals(field.getName().get(), name);
+        assertFalse(symbolsInFile.containsKey(name));
     }
 
     @DataProvider(name = "CursorPosProvider2")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/incompletesource/InvalidFieldTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/incompletesource/InvalidFieldTypeTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.incompletesource;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.impl.BallerinaModuleID;
+import io.ballerina.compiler.api.symbols.ClassFieldSymbol;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.semantic.api.test.util.SemanticAPITestUtils;
+import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for incomplete source files.
+ *
+ * @since 2.0.0
+ */
+public class IncompleteSourceTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/incomplete-sources/undefined_type_in_fields.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test
+    public void testSymbolAtCursor() {
+        ClassFieldSymbol field = (ClassFieldSymbol) model.symbol(srcFile, from(17, 16)).get();
+        assertEquals(field.getName().get(), "c");
+        assertEquals(field.typeDescriptor().typeKind(), TypeDescKind.COMPILATION_ERROR);
+    }
+
+    @Test
+    public void testVisibleSymbols() {
+        Map<String, Symbol> symbolsInFile =
+                SemanticAPITestUtils.getSymbolsInFile(model, srcFile, 18, 5, new BallerinaModuleID(PackageID.DEFAULT));
+
+        assertEquals(symbolsInFile.size(), 2);
+
+        ClassFieldSymbol field = (ClassFieldSymbol) symbolsInFile.get("c");
+        assertEquals(field.getName().get(), "c");
+        assertEquals(field.typeDescriptor().typeKind(), TypeDescKind.COMPILATION_ERROR);
+
+        ClassSymbol clazz = (ClassSymbol) symbolsInFile.get("Foo");
+        assertEquals(clazz.getName().get(), "Foo");
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/incomplete-sources/undefined_type_in_fields.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/incomplete-sources/undefined_type_in_fields.bal
@@ -18,3 +18,13 @@ public class Foo {
     bar:Unknown c = new();
     f
 }
+
+type Person record {|
+    bar:Name name;
+    f
+|};
+
+type PersonObj object {
+    bar:Name name;
+    f
+};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/incomplete-sources/undefined_type_in_fields.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/incomplete-sources/undefined_type_in_fields.bal
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public class Foo {
+    bar:Unknown c = new();
+    f
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -78,6 +78,8 @@
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByTypeExprTest" />
 
             <class name="io.ballerina.semantic.api.test.typedescriptors.TypeReferenceTSymbolTest" />
+
+            <class name="io.ballerina.semantic.api.test.incompletesource.IncompleteSourceTest" />
         </classes>
     </test>
 </suite>

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -79,7 +79,7 @@
 
             <class name="io.ballerina.semantic.api.test.typedescriptors.TypeReferenceTSymbolTest" />
 
-            <class name="io.ballerina.semantic.api.test.incompletesource.IncompleteSourceTest" />
+            <class name="io.ballerina.semantic.api.test.incompletesource.InvalidFieldTypeTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR fixes an issue there was in creating field symbols when the field's type is an undefined type. The issue was if there was an issue when defining the field, the compiler sets the type of the field as `semanticError` and later on, when creating the type, we filtered out those fields. This caused the NPE when creating the relevant field symbols in semantic API because when it tries to look up the field by name, it can't find such a field, hence it returns null.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
