### PR TITLE
Replace all stdlib imports in parser tests and enable ParserTestRunner

### DIFF
--- a/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/NodeLocationTest.java
+++ b/compiler/ballerina-parser/src/test/java/io/ballerinalang/compiler/parser/test/tree/NodeLocationTest.java
@@ -58,7 +58,7 @@ public class NodeLocationTest extends AbstractSyntaxTreeAPITest {
         ImportDeclarationNode importDeclNode = modulePartNode.imports().get(0);
 
         LinePosition expectedStartPos = LinePosition.from(0, 0);
-        LinePosition expectedEndPos = LinePosition.from(0, 20);
+        LinePosition expectedEndPos = LinePosition.from(0, 18);
         LineRange expectedLineRange = LineRange.from(sourceFileName, expectedStartPos, expectedEndPos);
         assertLineRange(importDeclNode.location().lineRange(), expectedLineRange);
     }
@@ -158,7 +158,7 @@ public class NodeLocationTest extends AbstractSyntaxTreeAPITest {
         ImportDeclarationNode importDeclarationNode = modulePartNode.imports().get(3);
 
         LinePosition expectedStartPos = LinePosition.from(3, 0);
-        LinePosition expectedEndPos = LinePosition.from(3, 29);
+        LinePosition expectedEndPos = LinePosition.from(3, 19);
         LineRange expectedLineRange = LineRange.from(sourceFileName, expectedStartPos, expectedEndPos);
         assertLineRange(importDeclarationNode.location().lineRange(), expectedLineRange);
     }

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_19.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_19.json
@@ -22,7 +22,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "io"
+                  "value": "bar"
                 }
               ]
             },
@@ -136,7 +136,7 @@
                               "children": [
                                 {
                                   "kind": "IDENTIFIER_TOKEN",
-                                  "value": "io",
+                                  "value": "bar",
                                   "leadingMinutiae": [
                                     {
                                       "kind": "WHITESPACE_MINUTIAE",

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_21.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_21.json
@@ -22,7 +22,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "http"
+                  "value": "baz"
                 }
               ]
             },

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_22.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_assert_22.json
@@ -22,7 +22,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "http"
+                  "value": "baz"
                 }
               ]
             },

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_19.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_19.bal
@@ -1,6 +1,6 @@
-import ballerina/io;
+import foobar/bar;
 public function main() {
-   io:println("Hello World!");
+   bar:println("Hello World!");
 }
 
 func

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_21.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_21.bal
@@ -1,3 +1,3 @@
-import ballerina/http;
+import foobar/baz;
 
 public 

--- a/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_22.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/func-definition/func_def_source_22.bal
@@ -1,3 +1,3 @@
-import ballerina/http;
+import foobar/baz;
 
 function 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_03.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_03.json
@@ -15,7 +15,7 @@
       "children": [
         {
           "kind": "IDENTIFIER_TOKEN",
-          "value": "ballerina"
+          "value": "foobar"
         },
         {
           "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_04.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_04.json
@@ -16,7 +16,7 @@
       "children": [
         {
           "kind": "IDENTIFIER_TOKEN",
-          "value": "ballerina"
+          "value": "foobar"
         },
         {
           "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_05.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_05.json
@@ -16,7 +16,7 @@
       "children": [
         {
           "kind": "IDENTIFIER_TOKEN",
-          "value": "ballerina"
+          "value": "foobar"
         },
         {
           "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_06.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_06.json
@@ -16,7 +16,7 @@
       "children": [
         {
           "kind": "IDENTIFIER_TOKEN",
-          "value": "ballerina"
+          "value": "foobar"
         },
         {
           "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_07.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_07.json
@@ -15,7 +15,7 @@
       "children": [
         {
           "kind": "IDENTIFIER_TOKEN",
-          "value": "ballerina"
+          "value": "foobar"
         },
         {
           "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_08.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_08.json
@@ -16,7 +16,7 @@
       "children": [
         {
           "kind": "IDENTIFIER_TOKEN",
-          "value": "ballerina"
+          "value": "foobar"
         },
         {
           "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_22.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_22.json
@@ -22,7 +22,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "io"
+                  "value": "bar"
                 }
               ]
             },
@@ -165,7 +165,7 @@
                         "children": [
                           {
                             "kind": "IDENTIFIER_TOKEN",
-                            "value": "ballerina"
+                            "value": "foobar"
                           }
                         ]
                       }
@@ -188,7 +188,7 @@
                         "children": [
                           {
                             "kind": "IDENTIFIER_TOKEN",
-                            "value": "http"
+                            "value": "baz"
                           }
                         ]
                       }

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_23.json
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_assert_23.json
@@ -22,7 +22,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "io"
+                  "value": "bar"
                 }
               ]
             },
@@ -165,7 +165,7 @@
                         "children": [
                           {
                             "kind": "IDENTIFIER_TOKEN",
-                            "value": "ballerina"
+                            "value": "foobar"
                           }
                         ]
                       }
@@ -188,7 +188,7 @@
                         "children": [
                           {
                             "kind": "IDENTIFIER_TOKEN",
-                            "value": "http"
+                            "value": "baz"
                           }
                         ]
                       }
@@ -417,7 +417,7 @@
                     "children": [
                       {
                         "kind": "IDENTIFIER_TOKEN",
-                        "value": "ballerina"
+                        "value": "foobar"
                       }
                     ]
                   }
@@ -440,7 +440,7 @@
                     "children": [
                       {
                         "kind": "IDENTIFIER_TOKEN",
-                        "value": "io"
+                        "value": "bar"
                       }
                     ]
                   }

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_03.bal
@@ -1,2 +1,2 @@
-import ballerina/foo.bar.baz;
+import foobar/foo.bar.baz;
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_04.bal
@@ -1,2 +1,2 @@
-import ballerina/foo.bar.baz version 2;
+import foobar/foo.bar.baz version 2;
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_05.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_05.bal
@@ -1,2 +1,2 @@
-import ballerina/foo.bar.baz version 2.4;
+import foobar/foo.bar.baz version 2.4;
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_06.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_06.bal
@@ -1,2 +1,2 @@
-import ballerina/foo.bar.baz version 2.4.0;
+import foobar/foo.bar.baz version 2.4.0;
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_07.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_07.bal
@@ -1,2 +1,2 @@
-import ballerina/foo.bar.baz as pkg1;
+import foobar/foo.bar.baz as pkg1;
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_08.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_08.bal
@@ -1,2 +1,2 @@
-import ballerina/foo.bar.baz version 2.4.0 as pkg1;
+import foobar/foo.bar.baz version 2.4.0 as pkg1;
 

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_22.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_22.bal
@@ -1,7 +1,7 @@
-import ballerina/io;
+import foobar/bar;
 
 function foo() {
 
 }
 
-import ballerina/http;
+import foobar/baz;

--- a/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_23.bal
+++ b/compiler/ballerina-parser/src/test/resources/declarations/import-decl/import_decl_source_23.bal
@@ -1,14 +1,14 @@
-import ballerina/io;
+import foobar/bar;
 
 function foo() {
 
 }
 
-import ballerina/http;
+import foobar/baz;
 
 type Person record {
     int a;
     string b = 10;
 }
 
-import ballerina/io;
+import foobar/bar;

--- a/compiler/ballerina-parser/src/test/resources/incremental/module_declarations/module_declarations_new.bal
+++ b/compiler/ballerina-parser/src/test/resources/incremental/module_declarations/module_declarations_new.bal
@@ -1,4 +1,4 @@
-import ballerina/io;
+import foobar/bar;
 
 type Foo record {
     int a;

--- a/compiler/ballerina-parser/src/test/resources/incremental/module_declarations/module_declarations_old.bal
+++ b/compiler/ballerina-parser/src/test/resources/incremental/module_declarations/module_declarations_old.bal
@@ -1,4 +1,4 @@
-import ballerina/io;
+import foobar/bar;
 
 type Foo record {
     int a;

--- a/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_assert_30.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_assert_30.json
@@ -22,7 +22,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "http"
+                  "value": "baz"
                 }
               ]
             },

--- a/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_source_30.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/ambiguity/ambiguity_source_30.bal
@@ -1,3 +1,3 @@
-import ballerina/http;
+import foobar/baz;
 
 public function hello() re

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_01.bal
@@ -1,5 +1,5 @@
 // Override lang.int with custom import
-import ballerina/foo.bar.baz as int;
+import foobar/foo.bar.baz as int;
 
 // Predeclared prefix in annotation and listener decl
 @int:annot

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_02.bal
@@ -1,5 +1,5 @@
 // Override lang.int with custom import
-import ballerina/foo.bar.baz as int:;
+import foobar/foo.bar.baz as int:;
 
 // Predeclared prefix in annotation and listener decl
 @int:%

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_01.json
@@ -31,7 +31,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_02.json
@@ -34,7 +34,7 @@
               "children": [
                 {
                   "kind": "IDENTIFIER_TOKEN",
-                  "value": "ballerina"
+                  "value": "foobar"
                 },
                 {
                   "kind": "SLASH_TOKEN"

--- a/compiler/ballerina-parser/src/test/resources/tree/child_node_list_test_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/child_node_list_test_01.bal
@@ -1,4 +1,4 @@
-import ballerina/io;
+import foobar/bar;
 
 public function add(int x, int y) returns int {
     int a;

--- a/compiler/ballerina-parser/src/test/resources/tree/diagnostics/diagnostics_test_001.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/diagnostics/diagnostics_test_001.bal
@@ -1,7 +1,7 @@
 // No diagnostics in the following line
-import ballerina/io;
+import foobar/bar;
 // Semicolon is missing
-import ballerina/log
+import foobar/qux
 
 public function funcWithDiagnostics() {
     int a = 5;

--- a/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_02.bal
@@ -1,5 +1,5 @@
 
 
 // This is an import declaration node
- import      ballerina/io;
-import ballerina/log;   //This is the second import
+ import      foobar/bar;
+import foobar/qux;   //This is the second import

--- a/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_03.bal
@@ -2,8 +2,8 @@
 
 // This is an import declaration node
 
- import      ballerina/io;
+ import      foobar/bar;
 // This is a comment
 
 
-import ballerina/log;   //This is the second import
+import foobar/qux;   //This is the second import

--- a/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_04.bal
@@ -2,11 +2,11 @@
 
 // This is an import declaration node
 
- import      ballerina/io;
+ import      foobar/bar;
 // This is a comment
 
 
-import ballerina/log;   //This is the second import
+import foobar/qux;   //This is the second import
 
 
 function add() returns int {

--- a/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_04_with_no_newlines.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/minutiae_test_04_with_no_newlines.bal
@@ -1,1 +1,1 @@
-// This is an import declaration node import      ballerina/io;// This is a commentimport ballerina/log;   //This is the second importfunction add() returns int {    int x = a;    int y = b;    int z = a + b;    return z;}
+// This is an import declaration node import      foobar/bar;// This is a commentimport foobar/qux;   //This is the second importfunction add() returns int {    int x = a;    int y = b;    int z = a + b;    return z;}

--- a/compiler/ballerina-parser/src/test/resources/tree/node_list_api/node_list_test_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_list_api/node_list_test_01.bal
@@ -1,4 +1,4 @@
-import ballerina/io;
+import foobar/bar;
 
 public function add(int x, int y) returns int {
     int a;

--- a/compiler/ballerina-parser/src/test/resources/tree/node_location_test_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_location_test_01.bal
@@ -1,6 +1,6 @@
-import ballerina/io;
-import ballerina/http;
-import ballerina/log;
+import foobar/bar;
+import foobar/baz;
+import foobar/qux;
 import sammj/adder;
 
 // adfadsfds

--- a/compiler/ballerina-parser/src/test/resources/tree/node_location_test_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_location_test_02.bal
@@ -1,2 +1,2 @@
-import ballerina/io;
+import foobar/bar;
 

--- a/compiler/ballerina-parser/src/test/resources/tree/node_location_test_03.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_location_test_03.bal
@@ -1,5 +1,5 @@
-import ballerina/io;
-import ballerina/http;
-import ballerina/log;
-import ballerina/stringutils;
+import foobar/bar;
+import foobar/baz;
+import foobar/qux;
+import foobar/quux;
 

--- a/compiler/ballerina-parser/src/test/resources/tree/node_location_test_04.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_location_test_04.bal
@@ -1,6 +1,6 @@
-import ballerina/io;
-import ballerina/http;
-import ballerina/log;
+import foobar/bar;
+import foobar/baz;
+import foobar/qux;
 import sammj/adder;
 
 public function main(string[] args) returns error? {

--- a/compiler/ballerina-parser/src/test/resources/tree/node_location_test_05.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_location_test_05.bal
@@ -1,6 +1,6 @@
-import ballerina/io;
-import ballerina/http;
-import ballerina/log;
+import foobar/bar;
+import foobar/baz;
+import foobar/qux;
 import sammj/adder;
 
 public function main(string[] args) returns error? {

--- a/compiler/ballerina-parser/src/test/resources/tree/node_location_test_06.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/node_location_test_06.bal
@@ -1,2 +1,2 @@
-import ballerina/io;
+import foobar/bar;
 

--- a/compiler/ballerina-parser/src/test/resources/tree/replace_node_test_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/replace_node_test_01.bal
@@ -1,4 +1,4 @@
-import ballerina/io;
+import foobar/bar;
 
 function bar() returns int {
     return a + b + d + (s * 6);

--- a/compiler/ballerina-parser/src/test/resources/tree/separated_node_list_import_decl.bal
+++ b/compiler/ballerina-parser/src/test/resources/tree/separated_node_list_import_decl.bal
@@ -1,6 +1,6 @@
 import smj/foo;
 import smj/foo.bar;
-import ballerina/a.b.c.d.e.f.g.h;
+import foobar/a.b.c.d.e.f.g.h;
 
 public function main() {
 }

--- a/tests/jballerina-unit-test/src/test/resources/testng.xml
+++ b/tests/jballerina-unit-test/src/test/resources/testng.xml
@@ -240,7 +240,7 @@
             </class>
             <class name="org.ballerinalang.test.bala.record.OpenRecordTypeReferenceTest" />
             <class name="org.ballerinalang.test.bala.record.ClosedRecordTypeReferenceTest" />
-<!--            <class name="org.ballerinalang.test.ParserTestRunner"/>-->
+            <class name="org.ballerinalang.test.ParserTestRunner"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
$subject.

Fixes #29374 

## Approach
N/A

## Samples
N/A

## Remarks
```bal
import ballerina/io;
import ballerina/http;
import ballerina/log;
import ballerina/stringutils;
```
are replaced with,
```bal
import foobar/bar;
import foobar/baz;
import foobar/qux;
import foobar/quux;
````
## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples