### PR TITLE
Update Ballerina Observability Test Ports to avoid port conflicts with other test cases when run in parallel

### DIFF
--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ConcurrencyTestCase.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 public class ConcurrencyTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "05_concurrency.bal";
     private static final String BASE_PATH = "/";
-    private static final String BASE_URL = "http://localhost:9095";
+    private static final String BASE_URL = "http://localhost:19095";
 
     @DataProvider(name = "async-call-data-provider")
     public Object[][] getAsyncCallData() {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/CustomTracingTestCase.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 public class CustomTracingTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "06_custom_trace_spans.bal";
     private static final String SERVICE_NAME = "testServiceSix";
-    private static final String BASE_URL = "http://localhost:9096";
+    private static final String BASE_URL = "http://localhost:19096";
 
     @Test
     public void testAddCustomSpanToSystemTrace() throws Exception {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingBaseTest.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.FileUtils;
 import org.ballerina.testobserve.tracing.extension.BMockSpan;
 import org.ballerinalang.test.BaseTest;
 import org.ballerinalang.test.context.BServerInstance;
+import org.ballerinalang.test.context.Utils;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.testng.annotations.AfterGroups;
 import org.testng.annotations.BeforeGroups;
@@ -99,11 +100,13 @@ public class HttpTracingBaseTest extends BaseTest {     // TODO: Move this test 
             int[] requiredPorts = new int[]{10010, 10011};
             servicesServerInstance = new BServerInstance(balServer);
             servicesServerInstance.startServer(basePath, "backend", null, args, requiredPorts);
+            Utils.waitForPortsToOpen(requiredPorts, 1000 * 60, false, "localhost");
         }
         {
             int[] requiredPorts = new int[]{19090, 19091};
             backendServerInstance = new BServerInstance(balServer);
             backendServerInstance.startServer(basePath, "httptracing", null, args, requiredPorts);
+            Utils.waitForPortsToOpen(requiredPorts, 1000 * 60, false, "localhost");
         }
     }
 

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingBaseTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingBaseTest.java
@@ -101,7 +101,7 @@ public class HttpTracingBaseTest extends BaseTest {     // TODO: Move this test 
             servicesServerInstance.startServer(basePath, "backend", null, args, requiredPorts);
         }
         {
-            int[] requiredPorts = new int[]{9090, 9091};
+            int[] requiredPorts = new int[]{19090, 19091};
             backendServerInstance = new BServerInstance(balServer);
             backendServerInstance.startServer(basePath, "httptracing", null, args, requiredPorts);
         }
@@ -128,13 +128,13 @@ public class HttpTracingBaseTest extends BaseTest {     // TODO: Move this test 
     }
 
     protected List<BMockSpan> getFinishedSpans(String serviceName, String resource) throws IOException {
-        return getFinishedSpans(9090, serviceName).stream()
+        return getFinishedSpans(19090, serviceName).stream()
                 .filter(span -> Objects.equals(span.getTags().get("resource"), resource))
                 .collect(Collectors.toList());
     }
 
     protected List<BMockSpan> getFinishedSpans(String serviceName) throws IOException {
-        return getFinishedSpans(9090, serviceName);
+        return getFinishedSpans(19090, serviceName);
     }
 
     protected List<BMockSpan> getEchoBackendFinishedSpans() throws IOException {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/HttpTracingTestCase.java
@@ -40,7 +40,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
 
     @Test
     public void testChainedResourceFunctions() throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doGet("http://localhost:9091/test-service/resource-1");
+        HttpResponse httpResponse = HttpClientRequest.doGet("http://localhost:19091/test-service/resource-1");
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Hello, World! from resource one");
         Thread.sleep(1000);
@@ -97,7 +97,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
                     new AbstractMap.SimpleEntry<>("src.module", "ballerina-test/httptracing:0.0.1"),
                     new AbstractMap.SimpleEntry<>("src.position", span2Position),
                     new AbstractMap.SimpleEntry<>("src.client.remote", "true"),
-                    new AbstractMap.SimpleEntry<>("http.base_url", "http://localhost:9091/test-service"),
+                    new AbstractMap.SimpleEntry<>("http.base_url", "http://localhost:19091/test-service"),
                     new AbstractMap.SimpleEntry<>("http.url", "/resource-2"),
                     new AbstractMap.SimpleEntry<>("http.method", "GET"),
                     new AbstractMap.SimpleEntry<>("http.status_code_group", "2xx"),
@@ -125,7 +125,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
                     new AbstractMap.SimpleEntry<>("http.status_code_group", "2xx"),
                     new AbstractMap.SimpleEntry<>("http.url", "/test-service/resource-2"),
                     new AbstractMap.SimpleEntry<>("http.method", "GET"),
-                    new AbstractMap.SimpleEntry<>("peer.address", "localhost:9091"),
+                    new AbstractMap.SimpleEntry<>("peer.address", "localhost:19091"),
                     new AbstractMap.SimpleEntry<>("service", "testServiceOne"),
                     new AbstractMap.SimpleEntry<>("resource", "resourceOne"),
                     new AbstractMap.SimpleEntry<>("src.object.name", "ballerina/http/HttpClient"),
@@ -202,7 +202,7 @@ public class HttpTracingTestCase extends HttpTracingBaseTest {  // TODO: Move th
 
     @Test
     public void testHTTPContextPropagation() throws Exception {
-        HttpResponse httpResponse = HttpClientRequest.doGet("http://localhost:9092/test-service/resource-1");
+        HttpResponse httpResponse = HttpClientRequest.doGet("http://localhost:19092/test-service/resource-1");
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Hello, World! from resource one");
         Thread.sleep(1000);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/MainFunctionTestCase.java
@@ -222,7 +222,7 @@ public class MainFunctionTestCase extends TracingBaseTestCase {
         final String callerResponsePosition = "01_main_function.bal:51:24";
 
         HttpResponse httpResponse = HttpClientRequest.doPost(
-                "http://localhost:9091/" + basePath + "/" + resourceName, "15", Collections.emptyMap());
+                "http://localhost:19091/" + basePath + "/" + resourceName, "15", Collections.emptyMap());
         Assert.assertEquals(httpResponse.getResponseCode(), 200);
         Assert.assertEquals(httpResponse.getData(), "Sum of numbers: 120");
         Thread.sleep(1000);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ObservableAnnotationTestCase.java
@@ -41,7 +41,7 @@ public class ObservableAnnotationTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "04_observability_annotation.bal";
     private static final String SERVICE_NAME = "testSvcFour";
     private static final String BASE_PATH = "testServiceFour";
-    private static final String BASE_URL = "http://localhost:9094";
+    private static final String BASE_URL = "http://localhost:19094";
 
     @Test
     public void testObservableFunction() throws Exception {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/RemoteCallTestCase.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 public class RemoteCallTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "03_remote_call.bal";
     private static final String BASE_PATH = "/test/serviceThree";
-    private static final String BASE_URL = "http://localhost:9093";
+    private static final String BASE_URL = "http://localhost:19093";
 
     @Test
     public void testNestedRemoteCalls() throws Exception {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/ResourceFunctionTestCase.java
@@ -42,7 +42,7 @@ import java.util.stream.Collectors;
 public class ResourceFunctionTestCase extends TracingBaseTestCase {
     private static final String FILE_NAME = "02_resource_function.bal";
     private static final String BASE_PATH = "/testServiceTwo";
-    private static final String BASE_URL = "http://localhost:9092";
+    private static final String BASE_URL = "http://localhost:19092";
 
     @DataProvider(name = "success-response-data-provider")
     public Object[][] getSuccessResponseData() {

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -58,7 +58,8 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
 
     @BeforeGroups(value = "tracing-test", alwaysRun = true)
     public void setup() throws Exception {
-        super.setupServer(TEST_SRC_PROJECT_NAME, TEST_SRC_PACKAGE_NAME, new int[] {9090, 9091, 9092, 9093, 9094, 9095});
+        super.setupServer(TEST_SRC_PROJECT_NAME, TEST_SRC_PACKAGE_NAME,
+                new int[] {19090, 19091, 19092, 19093, 19094, 19095});
     }
 
     @AfterGroups(value = "tracing-test", alwaysRun = true)
@@ -75,7 +76,7 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
     }
 
     protected List<BMockSpan> getFinishedSpans(String service) throws IOException {
-        String requestUrl = "http://localhost:9090/mockTracer/getMockTraces";
+        String requestUrl = "http://localhost:19090/mockTracer/getMockTraces";
         String data = HttpClientRequest.doPost(requestUrl, service, Collections.emptyMap()).getData();
         Type type = new TypeToken<List<BMockSpan>>() { }.getType();
         return new Gson().fromJson(data, type);

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/tracing/TracingBaseTestCase.java
@@ -59,7 +59,7 @@ public class TracingBaseTestCase extends ObservabilityBaseTest {
     @BeforeGroups(value = "tracing-test", alwaysRun = true)
     public void setup() throws Exception {
         super.setupServer(TEST_SRC_PROJECT_NAME, TEST_SRC_PACKAGE_NAME,
-                new int[] {19090, 19091, 19092, 19093, 19094, 19095});
+                new int[] {19090, 19091, 19092, 19093, 19094, 19095, 19096});
     }
 
     @AfterGroups(value = "tracing-test", alwaysRun = true)

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/01_main_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/01_main_function.bal
@@ -51,7 +51,7 @@ public function main() returns error? {
             checkpanic caller->respond("Sum of numbers: " + sum.toString());
         }
     };
-    var testObserveListener = new testobserve:Listener(9091);
+    var testObserveListener = new testobserve:Listener(19091);
     check testObserveListener.attach(testServiceInMain, "/testServiceOne");
     check testObserveListener.start();
 }

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/02_resource_function.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-service /testServiceTwo on new testobserve:Listener(9092) {
+service /testServiceTwo on new testobserve:Listener(19092) {
     # Resource function for testing whether no return functions are instrumented properly.
     resource function post resourceOne(testobserve:Caller caller, string body) {
         int numberCount = checkpanic 'int:fromString(body);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/03_remote_call.bal
@@ -16,7 +16,7 @@
 
 import ballerina/testobserve;
 
-service /test/serviceThree on new testobserve:Listener(9093) {
+service /test/serviceThree on new testobserve:Listener(19093) {
     # Resource function for testing remote call which calls another remote call
     resource function post resourceOne(testobserve:Caller caller) {
         testClient->callAnotherRemoteFunction();

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/04_observability_annotation.bal
@@ -18,7 +18,7 @@ import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
 @display { label: "testSvcFour" }
-service /testServiceFour on new testobserve:Listener(9094) {
+service /testServiceFour on new testobserve:Listener(19094) {
     # Resource function for testing function call with observable annotation
     resource function post resourceOne(testobserve:Caller caller) {
         var sum = calculateSumWithObservability(10, 51);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/05_concurrency.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import intg_tests/tracing_tests.utils as utils;
 
-service / on new testobserve:Listener(9095) {
+service / on new testobserve:Listener(19095) {
     # Resource function for testing async remote call wait
     resource function post resourceOne(testobserve:Caller caller) {
         future<int> futureSum = start testClient->calculateSum(6, 17);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/06_custom_trace_spans.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/06_custom_trace_spans.bal
@@ -18,7 +18,7 @@ import ballerina/testobserve;
 import ballerina/observe;
 
 @display { label: "testServiceSix" }
-service /testServiceSix on new testobserve:Listener(9096) {
+service /testServiceSix on new testobserve:Listener(19096) {
     resource function post resourceOne(testobserve:Caller caller) {
         var customSpanOneId = checkpanic observe:startSpan("customSpanOne");
         _ = checkpanic observe:addTagToSpan("resource", "resourceOne", customSpanOneId);

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/commons.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests/commons.bal
@@ -21,7 +21,7 @@ import intg_tests/tracing_tests.utils as utils;
 utils:MockClient testClient = new();
 
 @display { label: "mockTracer" }
-service /mockTracer on new testobserve:Listener(9090) {
+service /mockTracer on new testobserve:Listener(19090) {
     resource function post getMockTraces(testobserve:Caller caller, string serviceName) {
         json spans = testobserve:getFinishedSpans(serviceName);
         checkpanic caller->respond(spans.toJsonString());

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests_old/src/httptracing/01_ootb_chained_resource_functions.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests_old/src/httptracing/01_ootb_chained_resource_functions.bal
@@ -19,13 +19,13 @@ import ballerina/http;
 @http:ServiceConfig {
     basePath:"/test-service"
 }
-service testServiceOne on new http:Listener(9091) {
+service testServiceOne on new http:Listener(19091) {
     @http:ResourceConfig {
         methods: ["GET"],
         path: "/resource-1"
     }
     resource function resourceOne(http:Caller caller, http:Request clientRequest) {
-        http:Client httpEndpoint = new("http://localhost:9091/test-service", {
+        http:Client httpEndpoint = new("http://localhost:19091/test-service", {
             cache: {
                 enabled: false
             }

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests_old/src/httptracing/02_ootb_http_context_propagation.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests_old/src/httptracing/02_ootb_http_context_propagation.bal
@@ -19,7 +19,7 @@ import ballerina/http;
 @http:ServiceConfig {
     basePath:"/test-service"
 }
-service testServiceTwo on new http:Listener(9092) {
+service testServiceTwo on new http:Listener(19092) {
     @http:ResourceConfig {
         methods: ["GET"],
         path: "/resource-1"

--- a/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests_old/src/httptracing/commons.bal
+++ b/tests/jballerina-integration-test/src/test/resources/observability/tracing_tests_old/src/httptracing/commons.bal
@@ -21,7 +21,7 @@ import ballerina/testobserve;
 @http:ServiceConfig {
     basePath:"/mock-tracer"
 }
-service mockTracer on new http:Listener(9090) {
+service mockTracer on new http:Listener(19090) {
     @http:ResourceConfig {
         methods: ["GET"],
         path: "/spans/{serviceName}"

--- a/tests/observability-test-utils/src/test/java/org/ballerina/testobserve/ListenerEndpointTest.java
+++ b/tests/observability-test-utils/src/test/java/org/ballerina/testobserve/ListenerEndpointTest.java
@@ -50,7 +50,7 @@ public class ListenerEndpointTest {
     private static BalServer balServer;
     private static BServerInstance servicesServerInstance;
 
-    private static final String SERVICE_BASE_URL = "http://localhost:9091/testServiceOne";
+    private static final String SERVICE_BASE_URL = "http://localhost:29091/testServiceOne";
 
     @BeforeGroups(value = "mock-listener-tests", alwaysRun = true)
     private void setup() throws Exception {
@@ -75,7 +75,7 @@ public class ListenerEndpointTest {
         servicesServerInstance = new BServerInstance(balServer);
         String sourcesDir = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "listener_tests").getAbsolutePath();
-        servicesServerInstance.startServer(sourcesDir, "listener_tests", null, new String[0], new int[]{9091});
+        servicesServerInstance.startServer(sourcesDir, "listener_tests", null, new String[0], new int[]{29091});
     }
 
     @AfterGroups(value = "mock-listener-tests", alwaysRun = true)

--- a/tests/observability-test-utils/src/test/java/org/ballerina/testobserve/ListenerEndpointTest.java
+++ b/tests/observability-test-utils/src/test/java/org/ballerina/testobserve/ListenerEndpointTest.java
@@ -20,6 +20,7 @@ package org.ballerina.testobserve;
 
 import org.ballerinalang.test.context.BServerInstance;
 import org.ballerinalang.test.context.BalServer;
+import org.ballerinalang.test.context.Utils;
 import org.ballerinalang.test.util.HttpClientRequest;
 import org.ballerinalang.test.util.HttpResponse;
 import org.testng.Assert;
@@ -75,7 +76,9 @@ public class ListenerEndpointTest {
         servicesServerInstance = new BServerInstance(balServer);
         String sourcesDir = new File("src" + File.separator + "test" + File.separator + "resources" + File.separator +
                 "listener_tests").getAbsolutePath();
-        servicesServerInstance.startServer(sourcesDir, "listener_tests", null, new String[0], new int[]{29091});
+        int[] requiredPorts = {29091};
+        servicesServerInstance.startServer(sourcesDir, "listener_tests", null, new String[0], requiredPorts);
+        Utils.waitForPortsToOpen(requiredPorts, 1000 * 60, false, "localhost");
     }
 
     @AfterGroups(value = "mock-listener-tests", alwaysRun = true)

--- a/tests/observability-test-utils/src/test/resources/listener_tests/listener_endpoint_test.bal
+++ b/tests/observability-test-utils/src/test/resources/listener_tests/listener_endpoint_test.bal
@@ -17,7 +17,7 @@
 import ballerina/testobserve;
 import ballerina/lang.'int;
 
-service /testServiceOne on new testobserve:Listener(9091) {
+service /testServiceOne on new testobserve:Listener(29091) {
     resource function post resourceOne(testobserve:Caller caller) {
         var ret = caller->respond("Hello from Resource One");
     }

--- a/tests/observability-test-utils/src/test/resources/testng.xml
+++ b/tests/observability-test-utils/src/test/resources/testng.xml
@@ -19,7 +19,7 @@
 <suite name="jBallerina-Test-Suite">
     <test name="ballerina-observability-tests" parallel="false">
         <classes>
-<!--            <class name="org.ballerina.testobserve.ListenerEndpointTest"/>-->
+            <class name="org.ballerina.testobserve.ListenerEndpointTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> Update Ballerina Observability Test Ports to avoid port conflicts with other test cases when run in parallel. Gradle builds intermittently fails due to this issue and this should fix the issue.