### PR TITLE
Disable failing observability test class

### DIFF
--- a/tests/observability-test-utils/src/test/resources/testng.xml
+++ b/tests/observability-test-utils/src/test/resources/testng.xml
@@ -19,7 +19,7 @@
 <suite name="jBallerina-Test-Suite">
     <test name="ballerina-observability-tests" parallel="false">
         <classes>
-            <class name="org.ballerina.testobserve.ListenerEndpointTest"/>
+<!--            <class name="org.ballerina.testobserve.ListenerEndpointTest"/>-->
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
> Disables `org.ballerina.testobserve.ListenerEndpointTest`

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
