### PR TITLE
Add an API to service decl symbol to get the attached listener types

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -97,7 +97,7 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
         BServiceSymbol serviceSymbol = (BServiceSymbol) this.getInternalSymbol();
         Set<TypeSymbol> listenerTypes = new LinkedHashSet<>();
 
-        for (BType listenerType : serviceSymbol.getAttachExprTypes()) {
+        for (BType listenerType : serviceSymbol.getListenerTypes()) {
             listenerTypes.add(typesFactory.getTypeDescriptor(listenerType));
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -41,11 +41,9 @@ import org.wso2.ballerinalang.compiler.util.Name;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.StringJoiner;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.SERVICE_DECLARATION;
@@ -62,7 +60,7 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
     private final TypeSymbol typeDescriptor;
     private final ServiceAttachPoint attachPoint;
 
-    private Set<TypeSymbol> listenerTypes;
+    private List<TypeSymbol> listenerTypes;
     private Map<String, ClassFieldSymbol> fields;
     private Map<String, MethodSymbol> methods;
     private Documentation docAttachment;
@@ -88,20 +86,20 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
     }
 
     @Override
-    public Set<TypeSymbol> listenerTypes() {
+    public List<TypeSymbol> listenerTypes() {
         if (this.listenerTypes != null) {
             return this.listenerTypes;
         }
 
         TypesFactory typesFactory = TypesFactory.getInstance(this.context);
         BServiceSymbol serviceSymbol = (BServiceSymbol) this.getInternalSymbol();
-        Set<TypeSymbol> listenerTypes = new LinkedHashSet<>();
+        List<TypeSymbol> listenerTypes = new ArrayList<>();
 
         for (BType listenerType : serviceSymbol.getListenerTypes()) {
             listenerTypes.add(typesFactory.getTypeDescriptor(listenerType));
         }
 
-        this.listenerTypes = Collections.unmodifiableSet(listenerTypes);
+        this.listenerTypes = Collections.unmodifiableList(listenerTypes);
         return this.listenerTypes;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaServiceDeclarationSymbol.java
@@ -34,15 +34,18 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BServiceSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BField;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BObjectType;
+import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.compiler.util.Name;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.StringJoiner;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.SERVICE_DECLARATION;
@@ -59,6 +62,7 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
     private final TypeSymbol typeDescriptor;
     private final ServiceAttachPoint attachPoint;
 
+    private Set<TypeSymbol> listenerTypes;
     private Map<String, ClassFieldSymbol> fields;
     private Map<String, MethodSymbol> methods;
     private Documentation docAttachment;
@@ -81,6 +85,24 @@ public class BallerinaServiceDeclarationSymbol extends BallerinaSymbol implement
     @Override
     public Optional<ServiceAttachPoint> attachPoint() {
         return Optional.ofNullable(this.attachPoint);
+    }
+
+    @Override
+    public Set<TypeSymbol> listenerTypes() {
+        if (this.listenerTypes != null) {
+            return this.listenerTypes;
+        }
+
+        TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+        BServiceSymbol serviceSymbol = (BServiceSymbol) this.getInternalSymbol();
+        Set<TypeSymbol> listenerTypes = new LinkedHashSet<>();
+
+        for (BType listenerType : serviceSymbol.getAttachExprTypes()) {
+            listenerTypes.add(typesFactory.getTypeDescriptor(listenerType));
+        }
+
+        this.listenerTypes = Collections.unmodifiableSet(listenerTypes);
+        return this.listenerTypes;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ServiceDeclarationSymbol.java
@@ -23,6 +23,7 @@ import io.ballerina.tools.text.LinePosition;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Represents a service declaration. Unlike other module level symbols, service declaration symbols aren't associated
@@ -49,6 +50,13 @@ public interface ServiceDeclarationSymbol extends Symbol, Annotatable, Documenta
      * @return The attach point if it is specified, returns empty otherwise
      */
     Optional<ServiceAttachPoint> attachPoint();
+
+    /**
+     * Returns the set of types of the listeners this service is attached to.
+     *
+     * @return Set of the types of the listeners
+     */
+    Set<TypeSymbol> listenerTypes();
 
     /**
      * Returns the user specified fields of this service declaration.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ServiceDeclarationSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ServiceDeclarationSymbol.java
@@ -21,9 +21,9 @@ package io.ballerina.compiler.api.symbols;
 import io.ballerina.projects.Document;
 import io.ballerina.tools.text.LinePosition;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Represents a service declaration. Unlike other module level symbols, service declaration symbols aren't associated
@@ -52,11 +52,13 @@ public interface ServiceDeclarationSymbol extends Symbol, Annotatable, Documenta
     Optional<ServiceAttachPoint> attachPoint();
 
     /**
-     * Returns the set of types of the listeners this service is attached to.
+     * Returns the list of types of the listeners this service is attached to. The types are ordered in the list such
+     * that a type at particular position is the type of the corresponding expression in the expression list of the
+     * service declaration.
      *
-     * @return Set of the types of the listeners
+     * @return List of the types of the listeners
      */
-    Set<TypeSymbol> listenerTypes();
+    List<TypeSymbol> listenerTypes();
 
     /**
      * Returns the user specified fields of this service declaration.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -690,6 +690,12 @@ public class BIRPackageSymbolEnter {
         BServiceSymbol serviceDecl = new BServiceSymbol((BClassSymbol) classSymbol, flags,
                                                         names.fromString(serviceName), this.env.pkgSymbol.pkgID, type,
                                                         this.env.pkgSymbol, pos, SymbolOrigin.toOrigin(origin));
+
+        int nListeners = inputStream.readInt();
+        for (int i = 0; i < nListeners; i++) {
+            serviceDecl.addListenerType(readBType(inputStream));
+        }
+        
         serviceDecl.setAttachPointStringLiteral(attachPointLiteral);
         serviceDecl.setAbsResourcePath(attachPoint);
         this.env.pkgSymbol.scope.define(names.fromString(serviceName), serviceDecl);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -549,9 +549,9 @@ public class BIRGen extends BLangNodeVisitor {
         List<String> attachPoint = symbol.getAbsResourcePath().orElse(null);
         String attachPointLiteral = symbol.getAttachPointStringLiteral().orElse(null);
         BIRNode.BIRServiceDeclaration serviceDecl =
-                new BIRNode.BIRServiceDeclaration(attachPoint, attachPointLiteral, symbol.name,
-                                                  symbol.getAssociatedClassSymbol().name, symbol.type, symbol.origin,
-                                                  symbol.flags, symbol.pos);
+                new BIRNode.BIRServiceDeclaration(attachPoint, attachPointLiteral, symbol.getListenerTypes(),
+                                                  symbol.name, symbol.getAssociatedClassSymbol().name, symbol.type,
+                                                  symbol.origin, symbol.flags, symbol.pos);
         serviceDecl.setMarkdownDocAttachment(symbol.markdownDocumentation);
         this.env.enclPkg.serviceDecls.add(serviceDecl);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -863,14 +863,14 @@ public abstract class BIRNode {
 
         public List<String> attachPoint;
         public String attachPointLiteral;
-        public Set<BType> listenerTypes;
+        public List<BType> listenerTypes;
         public Name generatedName;
         public Name associatedClassName;
         public BType type;
         public SymbolOrigin origin;
         public long flags;
 
-        public BIRServiceDeclaration(List<String> attachPoint, String attachPointLiteral, Set<BType> listenerTypes,
+        public BIRServiceDeclaration(List<String> attachPoint, String attachPointLiteral, List<BType> listenerTypes,
                                      Name generatedName, Name associatedClassName, BType type, SymbolOrigin origin,
                                      long flags, Location location) {
             super(location);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -863,18 +863,20 @@ public abstract class BIRNode {
 
         public List<String> attachPoint;
         public String attachPointLiteral;
+        public Set<BType> listenerTypes;
         public Name generatedName;
         public Name associatedClassName;
         public BType type;
         public SymbolOrigin origin;
         public long flags;
 
-        public BIRServiceDeclaration(List<String> attachPoint, String attachPointLiteral, Name generatedName,
-                                     Name associatedClassName, BType type, SymbolOrigin origin, long flags,
-                                     Location location) {
+        public BIRServiceDeclaration(List<String> attachPoint, String attachPointLiteral, Set<BType> listenerTypes,
+                                     Name generatedName, Name associatedClassName, BType type, SymbolOrigin origin,
+                                     long flags, Location location) {
             super(location);
             this.attachPoint = attachPoint;
             this.attachPointLiteral = attachPointLiteral;
+            this.listenerTypes = listenerTypes;
             this.generatedName = generatedName;
             this.associatedClassName = associatedClassName;
             this.type = type;

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -468,6 +468,11 @@ public class BIRBinaryWriter {
         if (birServiceDecl.attachPointLiteral != null) {
             buf.writeInt(addStringCPEntry(birServiceDecl.attachPointLiteral));
         }
+
+        buf.writeInt(birServiceDecl.listenerTypes.size());
+        for (BType listenerType : birServiceDecl.listenerTypes) {
+            writeType(buf, listenerType);
+        }
     }
 
     private int addIntCPEntry(long value) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -48,6 +48,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSym
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BObjectTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BOperatorSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BRecordTypeSymbol;
+import org.wso2.ballerinalang.compiler.semantics.model.symbols.BServiceSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
@@ -2942,6 +2943,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
 
         BType serviceType = serviceNode.type = serviceNode.serviceClass.type;
+        BServiceSymbol serviceSymbol = (BServiceSymbol) serviceNode.symbol;
 
         for (BLangExpression attachExpr : serviceNode.attachedExprs) {
             final BType exprType = typeChecker.checkExpr(attachExpr, env);
@@ -2978,6 +2980,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                     }
                 }
             }
+
+            serviceSymbol.addAttachExprType(exprType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2981,7 +2981,7 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                 }
             }
 
-            serviceSymbol.addAttachExprType(exprType);
+            serviceSymbol.addListenerType(exprType);
         }
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
@@ -23,10 +23,9 @@ import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * {@link BServiceSymbol} represents a service symbol in a scope.
@@ -36,7 +35,7 @@ import java.util.Set;
 public class BServiceSymbol extends BSymbol {
 
     private final BClassSymbol associatedClass;
-    private final Set<BType> listenerTypes;
+    private final List<BType> listenerTypes;
     private List<String> absResourcePath;
     private String attachPointStringLiteral;
 
@@ -45,7 +44,7 @@ public class BServiceSymbol extends BSymbol {
         super(SymTag.SERVICE, flags, name, pkgID, type, owner, pos, origin);
         this.associatedClass = associatedClass;
         this.kind = SymbolKind.SERVICE;
-        this.listenerTypes = new LinkedHashSet<>();
+        this.listenerTypes = new ArrayList<>();
     }
 
     public Optional<List<String>> getAbsResourcePath() {
@@ -60,7 +59,7 @@ public class BServiceSymbol extends BSymbol {
         return this.associatedClass;
     }
 
-    public Set<BType> getListenerTypes() {
+    public List<BType> getListenerTypes() {
         return this.listenerTypes;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
@@ -36,7 +36,7 @@ import java.util.Set;
 public class BServiceSymbol extends BSymbol {
 
     private final BClassSymbol associatedClass;
-    private final Set<BType> attachExprTypes;
+    private final Set<BType> listenerTypes;
     private List<String> absResourcePath;
     private String attachPointStringLiteral;
 
@@ -45,7 +45,7 @@ public class BServiceSymbol extends BSymbol {
         super(SymTag.SERVICE, flags, name, pkgID, type, owner, pos, origin);
         this.associatedClass = associatedClass;
         this.kind = SymbolKind.SERVICE;
-        this.attachExprTypes = new LinkedHashSet<>();
+        this.listenerTypes = new LinkedHashSet<>();
     }
 
     public Optional<List<String>> getAbsResourcePath() {
@@ -60,8 +60,8 @@ public class BServiceSymbol extends BSymbol {
         return this.associatedClass;
     }
 
-    public Set<BType> getAttachExprTypes() {
-        return this.attachExprTypes;
+    public Set<BType> getListenerTypes() {
+        return this.listenerTypes;
     }
 
     public void setAbsResourcePath(List<String> absResourcePath) {
@@ -72,8 +72,8 @@ public class BServiceSymbol extends BSymbol {
         this.attachPointStringLiteral = attachPointStringLiteral;
     }
 
-    public void addAttachExprType(BType type) {
+    public void addListenerType(BType type) {
         assert type != null;
-        this.attachExprTypes.add(type);
+        this.listenerTypes.add(type);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BServiceSymbol.java
@@ -23,8 +23,10 @@ import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
 import org.wso2.ballerinalang.compiler.util.Name;
 
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * {@link BServiceSymbol} represents a service symbol in a scope.
@@ -34,6 +36,7 @@ import java.util.Optional;
 public class BServiceSymbol extends BSymbol {
 
     private final BClassSymbol associatedClass;
+    private final Set<BType> attachExprTypes;
     private List<String> absResourcePath;
     private String attachPointStringLiteral;
 
@@ -42,6 +45,7 @@ public class BServiceSymbol extends BSymbol {
         super(SymTag.SERVICE, flags, name, pkgID, type, owner, pos, origin);
         this.associatedClass = associatedClass;
         this.kind = SymbolKind.SERVICE;
+        this.attachExprTypes = new LinkedHashSet<>();
     }
 
     public Optional<List<String>> getAbsResourcePath() {
@@ -56,11 +60,20 @@ public class BServiceSymbol extends BSymbol {
         return this.associatedClass;
     }
 
+    public Set<BType> getAttachExprTypes() {
+        return this.attachExprTypes;
+    }
+
     public void setAbsResourcePath(List<String> absResourcePath) {
         this.absResourcePath = absResourcePath;
     }
 
     public void setAttachPointStringLiteral(String attachPointStringLiteral) {
         this.attachPointStringLiteral = attachPointStringLiteral;
+    }
+
+    public void addAttachExprType(BType type) {
+        assert type != null;
+        this.attachExprTypes.add(type);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -25,9 +25,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 56;
-    public static final short MIN_SUPPORTED_VERSION = 56;
-    public static final short MAX_SUPPORTED_VERSION = 56;
+    public static final int BIR_VERSION_NUMBER = 57;
+    public static final short MIN_SUPPORTED_VERSION = 57;
+    public static final short MAX_SUPPORTED_VERSION = 57;
 
     // todo move this to a proper place
     public static final String[] SUPPORTED_PLATFORMS = {"java11"};

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -542,6 +542,12 @@ types:
       - id: attach_point_literal
         type: s4
         if: has_attach_point_literal != 0
+      - id: listener_types_count
+        type: s4
+      - id: listener_types
+        type: s4
+        repeat: expr
+        repeat-expr: listener_types_count
   annotation:
     seq:
       - id: name_cp_index

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -545,9 +545,13 @@ types:
       - id: listener_types_count
         type: s4
       - id: listener_types
-        type: s4
+        type: listener_type
         repeat: expr
         repeat-expr: listener_types_count
+  listener_type:
+    seq:
+      - id: type_cp_index
+        type: s4
   annotation:
     seq:
       - id: name_cp_index

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -496,6 +497,15 @@ class BIRTestUtils {
             if (expServiceDecl.attachPointLiteral != null) {
                 assertConstantPoolEntry(constantPoolEntries.get(actualServiceDecl.attachPointLiteral()),
                                         expServiceDecl.attachPointLiteral);
+            }
+
+            // assert listener types
+            Assert.assertEquals(actualServiceDecl.listenerTypes().size(), expServiceDecl.listenerTypes.size());
+
+            Iterator<BType> iterator = expServiceDecl.listenerTypes.iterator();
+            for (int j = 0; j < expServiceDecl.listenerTypes.size(); j++) {
+                assertConstantPoolEntry(constantPoolEntries.get(actualServiceDecl.listenerTypes().get(j)),
+                                        iterator.next());
             }
         }
     }

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -504,7 +504,7 @@ class BIRTestUtils {
 
             Iterator<BType> iterator = expServiceDecl.listenerTypes.iterator();
             for (int j = 0; j < expServiceDecl.listenerTypes.size(); j++) {
-                assertConstantPoolEntry(constantPoolEntries.get(actualServiceDecl.listenerTypes().get(j)),
+                assertConstantPoolEntry(constantPoolEntries.get(actualServiceDecl.listenerTypes().get(j).typeCpIndex()),
                                         iterator.next());
             }
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -48,10 +48,8 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -265,15 +263,18 @@ public class ServiceSemanticAPITest {
                 .filter(s -> s.kind() == SERVICE_DECLARATION)
                 .collect(Collectors.toList());
         ServiceDeclarationSymbol service = (ServiceDeclarationSymbol) services.get(0);
-        Set<TypeSymbol> listenerTypes = service.listenerTypes();
-        assertEquals(listenerTypes.size(), 2);
+        List<TypeSymbol> listenerTypes = service.listenerTypes();
+        assertEquals(listenerTypes.size(), 3);
 
-        Iterator<TypeSymbol> iterator = listenerTypes.iterator();
-        TypeSymbol type = iterator.next();
+        TypeSymbol type = listenerTypes.get(0);
         assertEquals(type.typeKind(), TYPE_REFERENCE);
         assertEquals(type.getName().get(), "FooListener");
 
-        type = iterator.next();
+        type = listenerTypes.get(1);
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "FooListener");
+
+        type = listenerTypes.get(2);
         assertEquals(type.typeKind(), TYPE_REFERENCE);
         assertEquals(type.getName().get(), "BarListener");
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -48,8 +48,10 @@ import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -254,6 +256,26 @@ public class ServiceSemanticAPITest {
         PathRestParam resourcePath = (PathRestParam) method.resourcePath();
         assertEquals(resourcePath.parameter().getName().get(), "rest");
         assertEquals(resourcePath.parameter().typeDescriptor().typeKind(), ARRAY);
+    }
+
+    @Test
+    public void testMultipleListenerAttaching() {
+        SemanticModel model = getDefaultModulesSemanticModel("test-src/service_with_multiple_listeners.bal");
+        List<Symbol> services = model.moduleSymbols().stream()
+                .filter(s -> s.kind() == SERVICE_DECLARATION)
+                .collect(Collectors.toList());
+        ServiceDeclarationSymbol service = (ServiceDeclarationSymbol) services.get(0);
+        Set<TypeSymbol> listenerTypes = service.listenerTypes();
+        assertEquals(listenerTypes.size(), 2);
+
+        Iterator<TypeSymbol> iterator = listenerTypes.iterator();
+        TypeSymbol type = iterator.next();
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "FooListener");
+
+        type = iterator.next();
+        assertEquals(type.typeKind(), TYPE_REFERENCE);
+        assertEquals(type.getName().get(), "BarListener");
     }
 
     private Object[][] getExpValues() {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_with_multiple_listeners.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_with_multiple_listeners.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except
@@ -17,7 +17,7 @@
 listener FooListener foo = new();
 listener BarListener bar = new();
 
-service ProcessingService / on foo, new FooListener(), bar {
+service / on foo, new FooListener(), bar {
 }
 
 public class FooListener {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_with_multiple_listeners.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/service_with_multiple_listeners.bal
@@ -1,0 +1,57 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+listener FooListener foo = new();
+listener BarListener bar = new();
+
+service ProcessingService / on foo, new FooListener(), bar {
+}
+
+public class FooListener {
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+
+    public function detach(service object {} s) returns error? {
+    }
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}
+
+public class BarListener {
+
+    public function 'start() returns error? {
+    }
+
+    public function gracefulStop() returns error? {
+    }
+
+    public function immediateStop() returns error? {
+    }
+
+    public function detach(service object {} s) returns error? {
+    }
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {
+    }
+}


### PR DESCRIPTION
## Purpose
This PR adds a new method(`listenerTypes()`) to `ServiceDeclarationSymbol` for retrieving the types of the listeners to which the service is attached. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
