### PR TITLE
Add an API to type ref symbol to get the associated definition symbol 

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaTypeReferenceTypeSymbol.java
@@ -20,6 +20,7 @@ import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.ModuleSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
@@ -46,6 +47,7 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     private Location location;
     private String signature;
     private ModuleSymbol module;
+    private Symbol definition;
     private boolean moduleEvaluated;
 
     public BallerinaTypeReferenceTypeSymbol(CompilerContext context, ModuleID moduleID, BType bType,
@@ -72,6 +74,17 @@ public class BallerinaTypeReferenceTypeSymbol extends AbstractTypeSymbol impleme
     @Override
     public String name() {
         return this.definitionName;
+    }
+
+    @Override
+    public Symbol definition() {
+        if (this.definition != null) {
+            return this.definition;
+        }
+
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+        this.definition = symbolFactory.getBCompiledSymbol(this.getBType().tsymbol, this.name());
+        return this.definition;
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeReferenceTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/TypeReferenceTypeSymbol.java
@@ -34,6 +34,15 @@ public interface TypeReferenceTypeSymbol extends TypeSymbol {
      * Get the reference name.
      *
      * @return {@link String} name of the definition
+     * @deprecated Use {@link  #getName()} instead.
      */
+    @Deprecated
     String name();
+
+    /**
+     * Returns the definition symbol associated with this type symbol.
+     *
+     * @return The definition symbol for the symbol represented by this type symbol
+     */
+    Symbol definition();
 }

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateModulePartNode.json
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateModulePartNode.json
@@ -403,6 +403,17 @@
                         "moduleName":"lang.annotations",
                         "version":"1.0.0"
                       },
+                      "definition":{
+                        "readonly":false,
+                        "deprecated":false,
+                        "moduleID":{
+                          "orgName":"ballerina",
+                          "moduleName":"lang.annotations",
+                          "version":"1.0.0"
+                        },
+                        "kind":"TYPE_DEFINITION",
+                        "moduleQualifiedName":"annotations:int"
+                      },
                       "kind":"TYPE",
                       "signature":"int"
                     },
@@ -726,6 +737,17 @@
                         "orgName":"ballerina",
                         "moduleName":"lang.annotations",
                         "version":"1.0.0"
+                      },
+                      "definition":{
+                        "readonly":false,
+                        "deprecated":false,
+                        "moduleID":{
+                          "orgName":"ballerina",
+                          "moduleName":"lang.annotations",
+                          "version":"1.0.0"
+                        },
+                        "kind":"TYPE_DEFINITION",
+                        "moduleQualifiedName":"annotations:int"
                       },
                       "kind":"TYPE",
                       "signature":"int"

--- a/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateNodeList.json
+++ b/language-server/modules/langserver-core/src/test/resources/extensions/document/syntaxTree/locate/locateNodeList.json
@@ -403,6 +403,17 @@
                         "moduleName":"lang.annotations",
                         "version":"1.0.0"
                       },
+                      "definition":{
+                        "readonly":false,
+                        "deprecated":false,
+                        "moduleID":{
+                          "orgName":"ballerina",
+                          "moduleName":"lang.annotations",
+                          "version":"1.0.0"
+                        },
+                        "kind":"TYPE_DEFINITION",
+                        "moduleQualifiedName":"annotations:int"
+                      },
                       "kind":"TYPE",
                       "signature":"int"
                     },
@@ -726,6 +737,17 @@
                         "orgName":"ballerina",
                         "moduleName":"lang.annotations",
                         "version":"1.0.0"
+                      },
+                      "definition":{
+                        "readonly":false,
+                        "deprecated":false,
+                        "moduleID":{
+                          "orgName":"ballerina",
+                          "moduleName":"lang.annotations",
+                          "version":"1.0.0"
+                        },
+                        "kind":"TYPE_DEFINITION",
+                        "moduleQualifiedName":"annotations:int"
                       },
                       "kind":"TYPE",
                       "signature":"int"

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
@@ -40,6 +40,7 @@ import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaul
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
 import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
 
 /**
  * Test cases for the type reference type descriptor.
@@ -67,6 +68,7 @@ public class TypeReferenceTSymbolTest {
         assertEquals(definition.getName().get(), type.getName().get());
         assertEquals(((TypeDefinitionSymbol) definition).documentation().get().description().get(),
                      "Represents a person.");
+        assertSame(type.definition(), definition);
     }
 
     @Test
@@ -77,6 +79,7 @@ public class TypeReferenceTSymbolTest {
         assertEquals(clazz.kind(), CLASS);
         assertEquals(clazz.getName().get(), type.getName().get());
         assertEquals(((ClassSymbol) clazz).documentation().get().description().get(), "Represents an employee.");
+        assertSame(type.definition(), clazz);
     }
 
     @Test
@@ -87,6 +90,7 @@ public class TypeReferenceTSymbolTest {
         assertEquals(enm.kind(), ENUM);
         assertEquals(enm.getName().get(), type.getName().get());
         assertEquals(((EnumSymbol) enm).documentation().get().description().get(), "An enumeration of colours.");
+        assertSame(type.definition(), enm);
     }
 
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/typedescriptors/TypeReferenceTSymbolTest.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.typedescriptors;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ClassSymbol;
+import io.ballerina.compiler.api.symbols.EnumSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDefinitionSymbol;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
+import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE_DEFINITION;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for the type reference type descriptor.
+ *
+ * @since 2.0.0
+ */
+public class TypeReferenceTSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/typedescriptors/typeref_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test
+    public void testTypeDef() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(34, 11));
+        TypeReferenceTypeSymbol type = (TypeReferenceTypeSymbol) ((VariableSymbol) symbol.get()).typeDescriptor();
+        Symbol definition = type.definition();
+        assertEquals(definition.kind(), TYPE_DEFINITION);
+        assertEquals(definition.getName().get(), type.getName().get());
+        assertEquals(((TypeDefinitionSymbol) definition).documentation().get().description().get(),
+                     "Represents a person.");
+    }
+
+    @Test
+    public void testClass() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(35, 13));
+        TypeReferenceTypeSymbol type = (TypeReferenceTypeSymbol) ((VariableSymbol) symbol.get()).typeDescriptor();
+        Symbol clazz = type.definition();
+        assertEquals(clazz.kind(), CLASS);
+        assertEquals(clazz.getName().get(), type.getName().get());
+        assertEquals(((ClassSymbol) clazz).documentation().get().description().get(), "Represents an employee.");
+    }
+
+    @Test
+    public void testEnum() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(36, 11));
+        TypeReferenceTypeSymbol type = (TypeReferenceTypeSymbol) ((VariableSymbol) symbol.get()).typeDescriptor();
+        Symbol enm = type.definition();
+        assertEquals(enm.kind(), ENUM);
+        assertEquals(enm.getName().get(), type.getName().get());
+        assertEquals(((EnumSymbol) enm).documentation().get().description().get(), "An enumeration of colours.");
+    }
+
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/typedescriptors/typeref_test.bal
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+# Represents a person.
+type Person record {
+    string name;
+    int age;
+};
+
+# Represents an employee.
+class Employee {
+    string name;
+    string designation;
+}
+
+# An enumeration of colours.
+enum Colour {
+    RED, GREEN, BLUE
+}
+
+function test() {
+    Person p;
+    Employee e;
+    Colour c;
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -76,6 +76,8 @@
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByReferenceTest" />
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByTemplateExprTest" />
             <class name="io.ballerina.semantic.api.test.typebynode.TypeByTypeExprTest" />
+
+            <class name="io.ballerina.semantic.api.test.typedescriptors.TypeReferenceTSymbolTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR adds a new method to `TypeReferenceTypeSymbol` to get the definition symbol the type ref is referring to.

Fix #29287 
Fix #27804 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
