### PR TITLE
Fix the issue of specifying current directory in bindgen output path

### DIFF
--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindgenCommand.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/command/BindgenCommand.java
@@ -116,9 +116,9 @@ public class BindgenCommand implements BLauncherCmd {
         BindingsGenerator bindingsGenerator = new BindingsGenerator(outStream, outError);
         if (this.outputPath != null) {
             if (Paths.get(outputPath).isAbsolute()) {
-                targetOutputPath = Paths.get(outputPath);
+                targetOutputPath = Paths.get(outputPath).normalize();
             } else {
-                targetOutputPath = Paths.get(targetOutputPath.toString(), outputPath);
+                targetOutputPath = Paths.get(targetOutputPath.toString(), outputPath).normalize();
             }
             bindingsGenerator.setOutputPath(targetOutputPath.toString());
         } else if (modulesFlag) {

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
@@ -142,7 +142,7 @@ public class BindgenMvnResolver {
                 if (parent != null) {
                     fileWriter.write("# transitive dependency of " + parent + "\n");
                 }
-                fileWriter.write("\n[[platform.java11.dependency]]\n");
+                fileWriter.write("[[platform.java11.dependency]]\n");
                 String moduleName = getModuleName(projectRoot, env.getOutputPath());
                 if (moduleName != null) {
                     fileWriter.write("modules = [\"" + moduleName + "\"]\n");

--- a/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
+++ b/misc/ballerina-bindgen/src/main/java/org/ballerinalang/bindgen/utils/BindgenMvnResolver.java
@@ -142,7 +142,7 @@ public class BindgenMvnResolver {
                 if (parent != null) {
                     fileWriter.write("# transitive dependency of " + parent + "\n");
                 }
-                fileWriter.write("[[platform.java11.dependency]]\n");
+                fileWriter.write("\n[[platform.java11.dependency]]\n");
                 String moduleName = getModuleName(projectRoot, env.getOutputPath());
                 if (moduleName != null) {
                     fileWriter.write("modules = [\"" + moduleName + "\"]\n");

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/bindgen/BindgenTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/bindgen/BindgenTestCase.java
@@ -64,17 +64,22 @@ public class BindgenTestCase extends BaseTest {
         String buildMsg = "target/bin/bindgen.jar";
         LogLeecher buildLeecher = new LogLeecher(buildMsg);
 
-        String bindgenMsg = "class could not be generated.";
-        LogLeecher bindgenLeecher = new LogLeecher(bindgenMsg, ERROR);
+        String bindgenMsg1 = "class could not be generated.";
+        LogLeecher bindgenLeecher1 = new LogLeecher(bindgenMsg1, ERROR);
+
+        String bindgenMsg2 = "Oh no, something really went wrong. Bad. Sad.";
+        LogLeecher bindgenLeecher2 = new LogLeecher(bindgenMsg2, ERROR);
 
         String[] args = {"-mvn=org.yaml:snakeyaml:1.25", "-o=.", "org.yaml.snakeyaml.Yaml"};
         try {
             balClient.runMain("bindgen", args, null, new String[]{},
-                    new LogLeecher[]{bindgenLeecher}, tempProjectsDir.toString());
+                    new LogLeecher[]{bindgenLeecher1, bindgenLeecher2}, tempProjectsDir.toString());
             throw new BallerinaTestException("Contains classes not generated.");
         } catch (BallerinaTestException e) {
-            if (bindgenLeecher.isTextFound()) {
-                throw new BallerinaTestException("Contains classes not generated.", e);
+            if (bindgenLeecher1.isTextFound()) {
+                throw new BallerinaTestException("Bindings for some classes not generated.");
+            } else if (bindgenLeecher2.isTextFound()) {
+                throw new BallerinaTestException("Error while generating bindings: Bad. Sad. error occurred.");
             }
         }
 


### PR DESCRIPTION
## Purpose
This PR fixes the Bad. Sad. error produced when a user-specified output path in the bindgen command contains a current directory notation such as `./` or `.`. 

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28128

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
