### PR TITLE
Fix checking the relative order of () and NaN values

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueComparisonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueComparisonUtils.java
@@ -108,7 +108,7 @@ public class ValueComparisonUtils {
      */
     public static boolean compareValueLessThan(double lhsValue, double rhsValue) {
         try {
-            return compareValues(lhsValue, rhsValue) < 0;
+            return compareFloatValues(lhsValue, rhsValue) < 0;
         } catch (BError error) {
             return false;
         }
@@ -123,7 +123,7 @@ public class ValueComparisonUtils {
      */
     public static boolean compareValueLessThanOrEqual(double lhsValue, double rhsValue) {
         try {
-            return compareValues(lhsValue, rhsValue) <= 0;
+            return compareFloatValues(lhsValue, rhsValue) <= 0;
         } catch (BError error) {
             return false;
         }
@@ -138,7 +138,7 @@ public class ValueComparisonUtils {
      */
     public static boolean compareValueGreaterThan(double lhsValue, double rhsValue) {
         try {
-            return compareValues(lhsValue, rhsValue) > 0;
+            return compareFloatValues(lhsValue, rhsValue) > 0;
         } catch (BError error) {
             return false;
         }
@@ -154,7 +154,7 @@ public class ValueComparisonUtils {
      */
     public static boolean compareValueGreaterThanOrEqual(double lhsValue, double rhsValue) {
         try {
-            return compareValues(lhsValue, rhsValue) >= 0;
+            return compareFloatValues(lhsValue, rhsValue) >= 0;
         } catch (BError error) {
             return false;
         }

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueComparisonUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/ValueComparisonUtils.java
@@ -20,6 +20,7 @@ package io.ballerina.runtime.internal;
 
 import io.ballerina.runtime.api.TypeTags;
 import io.ballerina.runtime.api.values.BArray;
+import io.ballerina.runtime.api.values.BError;
 import io.ballerina.runtime.internal.values.DecimalValue;
 import io.ballerina.runtime.internal.values.TupleValueImpl;
 
@@ -42,7 +43,11 @@ public class ValueComparisonUtils {
      * @return True if left hand side ordered type value is less than right hand side ordered type value, else false.
      */
     public static boolean compareValueLessThan(Object lhsValue, Object rhsValue) {
-        return compareValues(lhsValue, rhsValue) < 0;
+        try {
+            return compareValues(lhsValue, rhsValue) < 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -54,7 +59,11 @@ public class ValueComparisonUtils {
      * value, else false.
      */
     public static boolean compareValueLessThanOrEqual(Object lhsValue, Object rhsValue) {
-        return compareValues(lhsValue, rhsValue) <= 0;
+        try {
+            return compareValues(lhsValue, rhsValue) <= 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -66,7 +75,11 @@ public class ValueComparisonUtils {
      * false.
      */
     public static boolean compareValueGreaterThan(Object lhsValue, Object rhsValue) {
-        return compareValues(lhsValue, rhsValue) > 0;
+        try {
+            return compareValues(lhsValue, rhsValue) > 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -79,7 +92,11 @@ public class ValueComparisonUtils {
      * false.
      */
     public static boolean compareValueGreaterThanOrEqual(Object lhsValue, Object rhsValue) {
-        return compareValues(lhsValue, rhsValue) >= 0;
+        try {
+            return compareValues(lhsValue, rhsValue) >= 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -90,7 +107,11 @@ public class ValueComparisonUtils {
      * @return True if left hand side float value is less than right hand side float value, else false.
      */
     public static boolean compareValueLessThan(double lhsValue, double rhsValue) {
-        return compareFloatValues(lhsValue, rhsValue) < 0;
+        try {
+            return compareValues(lhsValue, rhsValue) < 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -101,7 +122,11 @@ public class ValueComparisonUtils {
      * @return True if left hand side float value is less than or equal to the right hand side float value, else false.
      */
     public static boolean compareValueLessThanOrEqual(double lhsValue, double rhsValue) {
-        return compareFloatValues(lhsValue, rhsValue) <= 0;
+        try {
+            return compareValues(lhsValue, rhsValue) <= 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -112,7 +137,11 @@ public class ValueComparisonUtils {
      * @return True if left hand side float value is greater than the right hand side float value, else false.
      */
     public static boolean compareValueGreaterThan(double lhsValue, double rhsValue) {
-        return compareFloatValues(lhsValue, rhsValue) > 0;
+        try {
+            return compareValues(lhsValue, rhsValue) > 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     /**
@@ -124,7 +153,11 @@ public class ValueComparisonUtils {
      * false.
      */
     public static boolean compareValueGreaterThanOrEqual(double lhsValue, double rhsValue) {
-        return compareFloatValues(lhsValue, rhsValue) >= 0;
+        try {
+            return compareValues(lhsValue, rhsValue) >= 0;
+        } catch (BError error) {
+            return false;
+        }
     }
 
     private static int compareValues(Object lhsValue, Object rhsValue) {

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/GreaterLessThanOperationTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/GreaterLessThanOperationTest.java
@@ -19,7 +19,6 @@ package org.ballerinalang.test.expressions.binaryoperations;
 import org.ballerinalang.core.model.values.BFloat;
 import org.ballerinalang.core.model.values.BInteger;
 import org.ballerinalang.core.model.values.BValue;
-import org.ballerinalang.core.util.exceptions.BLangRuntimeException;
 import org.ballerinalang.test.BAssertUtil;
 import org.ballerinalang.test.BCompileUtil;
 import org.ballerinalang.test.BRunUtil;
@@ -236,63 +235,15 @@ public class GreaterLessThanOperationTest {
                 "testUnionComparison1",
                 "testUnionComparison2",
                 "testUnionComparison3",
-                "testUnionComparison4"
+                "testUnionComparison4",
+                "testUnorderedTypeComparison1",
+                "testUnorderedTypeComparison2",
+                "testUnorderedTypeComparison3",
+                "testUnorderedTypeComparison4",
+                "testUnorderedTypeComparison5",
+                "testUnorderedTypeComparison6",
+                "testUnorderedTypeComparison7",
+                "testUnorderedTypeComparison8"
         };
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'ABC' is unordered with respect to '\\(\\)'\"}.*")
-    public void testUnorderedTypeComparison1() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison1");
-        Assert.fail();
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'NaN' is unordered with respect to '123\\.432'\"}.*")
-    public void testUnorderedTypeComparison2() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison2");
-        Assert.fail();
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'NaN' is unordered with respect to 'NaN'\"}.*")
-    public void testUnorderedTypeComparison3() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison3");
-        Assert.fail();
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'\\(\\)' is unordered with respect to 'ABC'\"}.*")
-    public void testUnorderedTypeComparison4() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison4");
-        Assert.fail();
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'400' is unordered with respect to '\\(\\)'\"}.*")
-    public void testUnorderedTypeComparison5() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison5");
-        Assert.fail();
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'400\\.123' is unordered with respect to 'NaN'\"}.*")
-    public void testUnorderedTypeComparison6() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison6");
-        Assert.fail();
-    }
-
-    @Test(expectedExceptions = BLangRuntimeException.class,
-            expectedExceptionsMessageRegExp =
-                    "error: UnorderedTypesError \\{\"message\":\"'NaN' is unordered with respect to 'NaN'\"}.*")
-    public void testUnorderedTypeComparison7() {
-        BRunUtil.invoke(result, "testUnorderedTypeComparison7");
-        Assert.fail();
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/greater-less-than-operation.bal
@@ -330,54 +330,78 @@ function testUnorderedTypeComparison1() {
     [int, string?] a = [59215, "ABC"];
     [int, string?] b = [59215, ()];
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison2() {
     [int, float] a = [59215, (0.0/0.0)];
     [int, float] b = [59215, 123.432];
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison3() {
     [int, float] a = [59215, (0.0/0.0)];
     [int, float] b = [59215, (0.0/0.0)];
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison4() {
     string? a = ();
     string? b = "ABC";
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison5() {
     int? a = 400;
     int? b = ();
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison6() {
     float a = 400.123;
     float b = (0.0/0.0);
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison7() {
     float a = (0.0/0.0);
     float b = (0.0/0.0);
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }
 
 function testUnorderedTypeComparison8() {
     float a = (0.0/0.0);
     float b = 40.34;
 
-    boolean x = a > b;
+    test:assertFalse(a < b);
+    test:assertFalse(a <= b);
+    test:assertFalse(a > b);
+    test:assertFalse(a >= b);
 }


### PR DESCRIPTION
## Purpose
$title

Fixes #<Issue Number>

## Approach
```
int? x = 1;
int? y = ();
boolean a = x > y; //false
boolean b = x < y; //false
boolean c = x >= y; //false
boolean d = x <= y; //false
```

```
float x = (0.0/0.0);
float y = 40.34;;
boolean a = x > y; //false
boolean b = x < y; //false
boolean c = x >= y; //false
boolean d = x <= y; //false
```

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
