### PR TITLE
Remove configurable support for records

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -820,7 +820,6 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
                     types.isAssignable(lhsType, symTable.decimalType) ||
                     types.isAssignable(lhsType, symTable.xmlType) ||
                     types.isAssignable(lhsType, symTable.arrayType) ||
-                    types.isAssignable(lhsType, symTable.mapAnydataType) ||
                     types.isAssignable(lhsType, symTable.tableType))) {
                 // TODO: remove this check once runtime support all configurable types
                 dlog.error(varNode.typeNode.pos,

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/configurables/ConfigurableTest.java
@@ -281,12 +281,12 @@ public class ConfigurableTest extends BaseTest {
         return new Object[][]{
                 {"invalidComplexArray", "[Config.toml:(2:17,2:41)] configurable variable 'main:intComplexArr' with " +
                         "type '(int[] & readonly)[] & readonly' is not supported"},
-                {"invalidRecordField", "[Config.toml:(4:1,4:40)] field type '(string[][] & readonly)' in configurable" +
-                        " variable 'main:testUser' is not supported"},
+                {"invalidRecordField", " [Config.toml:(4:1,4:40)] field type 'string[][]' in configurable variable " +
+                        "'main:testUsers' is not supported"},
                 {"invalidByteRange", "value provided for byte variable 'main:byteVar' is out of range. " +
                         "Expected range is (0-255), found '355'"},
-                {"invalidMapType",
-                        "configurable variable 'main:intMap' with type 'map<int> & readonly' is not supported"},
+                {"invalidMapType", "[main.bal:(17:14,17:33)] configurable variable currently not supported for '" +
+                        "(map<int> & readonly)'"},
                 {"invalidTableConstraint", "[Config.toml:(1:1,2:16)] table constraint type 'map<string>' in " +
                         "configurable variable 'main:tab' is not supported"}
         };
@@ -341,19 +341,9 @@ public class ConfigurableTest extends BaseTest {
                 {"array_multi_type", "[array_multi_type.toml:(4:15,4:21)] configurable variable 'main:intArr[1]' is " +
                         "expected to be of type 'int', but found 'string'"},
                 {"additional_field", "[additional_field.toml:(7:1,7:19)] additional field 'scopes' provided for " +
-                        "configurable variable 'main:testUser' of record " +
-                        "'main:(testOrg/main:0.1.0:AuthInfo & readonly)' is not supported"},
-                {"missing_record_field", "[missing_record_field.toml:(4:1,5:22)] value not provided for " +
-                        "non-defaultable required field 'username' of record " +
-                        "'main:(testOrg/main:0.1.0:AuthInfo & readonly)' in configurable variable 'main:testUser'"},
-                {"record_type_error", "[record_type_error.toml:(3:1,3:39)] configurable variable 'main:testUser' is" +
-                        " expected to be of type " +
-                        "'main:(testOrg/main:0.1.0:AuthInfo & readonly)', but found 'string'"},
-                {"record_field_structure_error", "[record_field_structure_error.toml:(5:1,5:28)] field 'username' " +
-                        "from configurable variable 'main:testUser' is expected to be of type 'string', " +
-                        "but found 'record'"},
-                {"record_field_type_error", "[record_field_type_error.toml:(5:12,5:16)] field 'username' from " +
-                        "configurable variable 'main:testUser' is expected to be of type 'string', but found 'int'"},
+                        "configurable variable 'main:users' of record 'main:AuthInfo' is not supported"},
+                {"missing_record_field", "[missing_record_field.toml:(4:1,5:22)] value required for key 'username'" +
+                        " of type 'table<main:AuthInfo> key(username)' in configurable variable 'main:users'"},
                 {"missing_table_key", "[missing_table_key.toml:(8:1,9:21)] value required for key 'username' of type " +
                         "'table<main:AuthInfo> key(username)' in configurable variable 'main:users'"},
                 {"table_type_error", "[table_type_error.toml:(4:1,6:21)] configurable variable 'main:users' is " +
@@ -362,8 +352,8 @@ public class ConfigurableTest extends BaseTest {
                         "configurable variable 'main:users' is expected to be of type 'string', but found 'int'"},
                 {"table_field_structure_error", "[table_field_structure_error.toml:(5:1,5:29)] field 'username' from " +
                         "configurable variable 'main:users' is expected to be of type 'string', but found 'record'"},
-                {"warning_defaultable_field", "[warning_defaultable_field.toml:(11:1,13:17)] defaultable readonly " +
-                        "record field 'name' in configurable variable 'main:employee' is not supported"}
+                {"warning_defaultable_field", "[warning_defaultable_field.toml:(8:1,10:17)] defaultable readonly " +
+                        "record field 'name' in configurable variable 'main:employees' is not supported"}
         };
     }
 

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/Config.toml
@@ -13,20 +13,6 @@ stringArr = ["red", "yellow", "green"]
 booleanArr = [true, false, false, true]
 decimalArr = [8.9, 4.5, 6.2]
 
-[main.admin]
-username = "jack"
-password = "password"
-scopes = ["write","read","execute"]
-isAdmin = true
-
-[main.personInfo]
-name = "harry"
-age = 28
-
-[main.empInfo]
-id = 34
-salary = 75000.0
-
 [[main.users]]
 username = "alice"
 id = 11

--- a/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/main/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/configurableProject/main/main.bal
@@ -75,10 +75,7 @@ type PersonInfoTable table<PersonInfo> & readonly;
 
 type EmpInfoTable table<EmployeeInfo>;
 
-configurable AuthInfo & readonly admin = ?;
 configurable UserTable & readonly users = ?;
-configurable PersonInfo personInfo = ?;
-configurable EmployeeInfo & readonly empInfo = ?;
 configurable EmployeeTable employees = ?;
 configurable PersonTable people = ?;
 configurable nonKeyTable & readonly nonKeyUsers = ?;
@@ -88,7 +85,6 @@ configurable EmpInfoTable & readonly empInfoTab = ?;
 public function main() {
     testSimpleValues();
     testArrayValues();
-    testRecordValues();
     testTableValues();
 
     print("Tests passed");
@@ -120,28 +116,13 @@ function testArrayValues() {
     test:assertEquals(byteArr, resultArr2);
 }
 
-function testRecordValues() {
-    test:assertEquals("jack", admin.username);
-    test:assertEquals("password", admin.password);
-    test:assertEquals(["write", "read", "execute"], admin["scopes"]);
-    test:assertTrue(admin.isAdmin);
-
-    test:assertEquals("harry", personInfo.name);
-    test:assertEquals("Colombo", personInfo.address);
-    test:assertEquals(28, personInfo["age"]);
-
-    test:assertEquals(34, empInfo.id);
-    test:assertEquals("test", empInfo.name);
-    test:assertEquals(75000.0, empInfo["salary"]);
-}
-
 function testTableValues() {
 
     test:assertEquals(3, users.length());
     test:assertEquals(3, nonKeyUsers.length());
     test:assertEquals(3, employees.length());
     test:assertEquals(3, people.length());
-    test:assertEquals(3, personInfo.length());
+    test:assertEquals(3, peopleInfo.length());
     test:assertEquals(3, empInfoTab.length());
 
     AuthInfo & readonly user1 = {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/configProject/main/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/configProject/main/main.bal
@@ -28,12 +28,12 @@ type Employee record {|
 |};
 
 type UserTable table<AuthInfo> key(username);
+type EmployeeTable table<Employee> key(id);
 
 configurable int intVar = 5;
 configurable string stringVar = ?;
 configurable int[] & readonly intArr = [11, 33];
-configurable AuthInfo & readonly testUser = {username: "Anna"};
-configurable Employee employee = {id: 121, salary: 35000.0};
+configurable EmployeeTable & readonly employees = table [{id: 121, salary: 35000.0}];
 configurable UserTable & readonly users = table [{username: "Tom"}];
 
 public function main() {

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/additional_field.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/additional_field.toml
@@ -1,7 +1,7 @@
 [main]
 stringVar = "required"
 
-[main.testUser]
+[[main.users]]
 username = "Jane"
 password = "password"
 scopes = ["write"]

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/missing_record_field.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/missing_record_field.toml
@@ -1,5 +1,5 @@
 [main]
 stringVar = "required"
 
-[main.testUser]
+[[main.users]]
 password = "password"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/record_field_structure_error.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/record_field_structure_error.toml
@@ -1,7 +1,0 @@
-[main]
-stringVar = "required"
-
-[main.testUser]
-username.structure = "Jane"
-password = "password"
-scopes = ["write"]

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/record_field_type_error.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/record_field_type_error.toml
@@ -1,7 +1,0 @@
-[main]
-stringVar = "required"
-
-[main.testUser]
-username = 1234
-password = "password"
-scopes = ["write"]

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/record_type_error.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/record_type_error.toml
@@ -1,3 +1,0 @@
-[main]
-stringVar = "required"
-testUser = "this is a record variable"

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/warning_defaultable_field.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/config_files/warning_defaultable_field.toml
@@ -5,9 +5,6 @@ stringVar = "required variable"
 username = "alice"
 password="password1"
 
-[main.testUser]
-username = "user"
-
-[main.employee]
+[[main.employees]]
 id = 222
 salary = 34000.0

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/invalidRecordField/Config.toml
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/invalidRecordField/Config.toml
@@ -1,4 +1,4 @@
-[main.testUser]
+[[main.testUsers]]
 username = "Jane"
 password = "password"
 invalidField = [["a", "b"], ["c", "d"]]

--- a/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/invalidRecordField/main/main.bal
+++ b/tests/jballerina-integration-test/src/test/resources/configurables/negative_tests/invalidRecordField/main/main.bal
@@ -15,12 +15,14 @@
 // under the License.
 
 type AuthInfo record {
-   readonly string username = "";
+   readonly string username;
    string password;
    string[][] invalidField;
 };
 
-configurable AuthInfo & readonly testUser = ?;
+type UserTable table<AuthInfo> key(username);
+
+configurable UserTable & readonly testUsers = ?;
 
 public function main() {
     //do nothing


### PR DESCRIPTION
## Purpose
As per the latest spec [1][2], configurable variables of type `map<anydata>` is not supported for TOML & CLI methods. 
Hence, removing the support provided for record types.

[1] https://github.com/ballerina-platform/ballerina-spec/blob/master/configurable/spec.md#toml-syntax
[2] https://github.com/ballerina-platform/ballerina-spec/blob/master/configurable/spec.md#command-line-arguments

Fixes #28998

## Approach
Added compilation error for `map<anydata>` type configurable variables.

## Samples

## Remarks

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
