### PR TITLE
Fix renaming support from within service declaration

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -291,7 +291,9 @@ class SymbolFinder extends BaseVisitor {
         lookupNode(serviceNode.serviceClass);
         lookupNodes(serviceNode.attachedExprs);
 
-        if (PositionUtil.withinBlock(this.cursorPos, serviceNode.pos) && this.symbolAtCursor == null) {
+        // A service decl is a special case. Since there isn't a name associated with it, we take the starting
+        // position of the node to lookup the service symbol.
+        if (this.symbolAtCursor == null && this.cursorPos.equals(serviceNode.pos.lineRange().startLine())) {
             this.symbolAtCursor = serviceNode.symbol;
         }
     }

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/RenameTest.java
@@ -77,6 +77,9 @@ public class RenameTest {
                 {"rename_with_cursor_at_end.json", "myIntVal"},
                 {"rename_with_cursor_at_end2.json", "x"},
                 {"rename_on_fail.json", "myVarName"},
+                {"rename_within_service1.json", "ep1"},
+                {"rename_within_service2.json", "baz"},
+                {"rename_within_service3.json", "baz"}
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_within_service1.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_within_service1.json
@@ -1,0 +1,41 @@
+{
+  "source": {
+    "file": "rename_within_service.bal"
+  },
+  "position": {
+    "line": 19,
+    "character": 18
+  },
+  "result": {
+    "changes": {
+      "rename_within_service.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 17,
+              "character": 23
+            },
+            "end": {
+              "line": 17,
+              "character": 28
+            }
+          },
+          "newText": "ep1"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 19,
+              "character": 13
+            },
+            "end": {
+              "line": 19,
+              "character": 18
+            }
+          },
+          "newText": "ep1"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_within_service2.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_within_service2.json
@@ -1,0 +1,41 @@
+{
+  "source": {
+    "file": "rename_within_service.bal"
+  },
+  "position": {
+    "line": 23,
+    "character": 19
+  },
+  "result": {
+    "changes": {
+      "rename_within_service.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 16,
+              "character": 4
+            },
+            "end": {
+              "line": 16,
+              "character": 7
+            }
+          },
+          "newText": "baz"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 23,
+              "character": 16
+            },
+            "end": {
+              "line": 23,
+              "character": 19
+            }
+          },
+          "newText": "baz"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_within_service3.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/single/rename_within_service3.json
@@ -1,0 +1,41 @@
+{
+  "source": {
+    "file": "rename_within_service.bal"
+  },
+  "position": {
+    "line": 24,
+    "character": 24
+  },
+  "result": {
+    "changes": {
+      "rename_within_service.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 20,
+              "character": 8
+            },
+            "end": {
+              "line": 20,
+              "character": 11
+            }
+          },
+          "newText": "baz"
+        },
+        {
+          "range": {
+            "start": {
+              "line": 24,
+              "character": 21
+            },
+            "end": {
+              "line": 24,
+              "character": 24
+            }
+          },
+          "newText": "baz"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_within_service.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/single/rename_within_service.bal
@@ -1,0 +1,27 @@
+// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+int foo = 10;
+listener http:Listener lstnr = new http:Listener(9090);
+
+service / on lstnr {
+    int bar = 20;
+
+    resource function get getResource() {
+        int x = foo;
+        int y = self.bar;
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ServiceSemanticAPITest.java
@@ -279,6 +279,12 @@ public class ServiceSemanticAPITest {
         assertEquals(type.getName().get(), "BarListener");
     }
 
+    @Test
+    public void testServiceDeclNegative() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(66, 34));
+        assertTrue(symbol.isEmpty());
+    }
+
     private Object[][] getExpValues() {
         return new Object[][]{
                 {null, null, null, null},


### PR DESCRIPTION
## Purpose
This PR fixes an issue which caused renaming to not work if the user highlighted the identifier from within a service declaration and tried to rename it.

## Approach
Handled the position comparison for service declarations differently to the others. Instead of checking whether the cursor was within the the service node, checked whether the cursor is at the start of the service declaration node.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
