### PR TITLE
Remove isolated keyword from object.iterable

### DIFF
--- a/langlib/lang.object/src/main/ballerina/object.bal
+++ b/langlib/lang.object/src/main/ballerina/object.bal
@@ -22,6 +22,6 @@ public type Iterable distinct object {
     #
     # + return - a new iterator object
     public function iterator() returns object {
-        public isolated function next() returns record {| any|error value; |}|error?;
+        public function next() returns record {| any|error value; |}|error?;
     };
 };

--- a/langlib/lang.query/src/main/ballerina/types.bal
+++ b/langlib/lang.query/src/main/ballerina/types.bal
@@ -49,6 +49,10 @@ type _CloseableIterator object {
 # An abstract `_Iterable` object.
 type _Iterable object {
     *lang_object:Iterable;
+    public function iterator() returns
+        object {
+            public isolated function next() returns record {|Type value;|}|ErrorType?;
+        };
 };
 
 type _StreamFunction object {

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachIterableObjectTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/statements/foreach/ForeachIterableObjectTest.java
@@ -96,13 +96,13 @@ public class ForeachIterableObjectTest {
         BAssertUtil.validateError(negativeResult, i++, "invalid iterable type 'Iterable13': an iterable object must " +
                 "be a subtype of 'ballerina/lang.object:1.0.0:Iterable'", 248, 25);
         BAssertUtil.validateError(negativeResult, i++, "mismatched function signatures: expected 'public function" +
-                " iterator() returns object { public isolated function next () returns ((" +
+                " iterator() returns object { public function next () returns ((" +
                 "record {| (any|error) value; |}|error)?); }', found 'public function iterator() returns " +
                 "object { public function foo () returns (record {| int value; |}?); }'", 254, 5);
         BAssertUtil.validateError(negativeResult, i++, "no implementation found for the method 'iterator' of class" +
                 " 'Iterable11'", 276, 1);
         BAssertUtil.validateError(negativeResult, i++, "mismatched function signatures: expected 'public function" +
-                " iterator() returns object { public isolated function next () returns ((" +
+                " iterator() returns object { public function next () returns ((" +
                 "record {| (any|error) value; |}|error)?); }', found 'public function iterator() returns " +
                 "object { public isolated function next () returns (record {| int x; |}?); }'", 302, 5);
         Assert.assertEquals(negativeResult.getErrorCount(), i);

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/query/QueryExpressionIterableObjectTest.java
@@ -131,7 +131,7 @@ public class QueryExpressionIterableObjectTest {
         validateError(negativeResult, index++, "invalid iterable type 'IterableObject': an iterable object must be" +
                         " a subtype of 'ballerina/lang.object:1.0.0:Iterable'", 73, 39);
         validateError(negativeResult, index++, "mismatched function signatures: expected 'public function iterator()" +
-                        " returns object { public isolated function next () returns ((record {| (any|error) value; " +
+                        " returns object { public function next () returns ((record {| (any|error) value; " +
                 "|}|error)?); }', found 'public function iterator() returns _Iterator'", 90, 9);
     }
 


### PR DESCRIPTION
## Purpose
This PR is fixing a spec deviation introduced by #28714
This is a blocker for range-expression BBE

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
