### PR TITLE
Fix isolation analysis for resources and service declarations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3743,10 +3743,12 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
     @Override
     public BLangNode transform(ServiceDeclarationNode serviceDeclarationNode) {
         Location pos = getPositionWithoutMetadata(serviceDeclarationNode);
-        BLangClassDefinition annonClassDef = transformObjectCtorExpressionBody(serviceDeclarationNode.members());
-        annonClassDef.isServiceDecl = true;
-        annonClassDef.pos = pos;
-        annonClassDef.flagSet.add(SERVICE);
+        BLangClassDefinition anonClassDef = transformObjectCtorExpressionBody(serviceDeclarationNode.members());
+        anonClassDef.isServiceDecl = true;
+        anonClassDef.pos = pos;
+        anonClassDef.flagSet.add(SERVICE);
+
+        setClassQualifiers(serviceDeclarationNode.qualifiers(), anonClassDef);
 
         List<IdentifierNode> absResourcePathPath = new ArrayList<>();
         NodeList<Node> pathList = serviceDeclarationNode.absoluteResourcePath();
@@ -3768,23 +3770,23 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         // Generate a name for the anonymous class
         String genName = anonymousModelHelper.getNextAnonymousTypeKey(packageID);
         IdentifierNode anonTypeGenName = createIdentifier(pos, genName);
-        annonClassDef.setName(anonTypeGenName);
-        annonClassDef.flagSet.add(Flag.PUBLIC);
+        anonClassDef.setName(anonTypeGenName);
+        anonClassDef.flagSet.add(Flag.PUBLIC);
 
         Optional<TypeDescriptorNode> typeReference = serviceDeclarationNode.typeDescriptor();
         typeReference.ifPresent(typeReferenceNode -> {
             BLangType typeNode = createTypeNode(typeReferenceNode);
-            annonClassDef.typeRefs.add(typeNode);
+            anonClassDef.typeRefs.add(typeNode);
         });
 
-        annonClassDef.annAttachments = applyAll(getAnnotations(serviceDeclarationNode.metadata()));
-        annonClassDef.markdownDocumentationAttachment =
+        anonClassDef.annAttachments = applyAll(getAnnotations(serviceDeclarationNode.metadata()));
+        anonClassDef.markdownDocumentationAttachment =
                 createMarkdownDocumentationAttachment(getDocumentationString(serviceDeclarationNode.metadata()));
 
-        addToTop(annonClassDef);
+        addToTop(anonClassDef);
 
         BLangIdentifier identifier = (BLangIdentifier) TreeBuilder.createIdentifierNode();
-        BLangUserDefinedType userDefinedType = createUserDefinedType(pos, identifier, annonClassDef.name);
+        BLangUserDefinedType userDefinedType = createUserDefinedType(pos, identifier, anonClassDef.name);
 
         BLangTypeInit initNode = (BLangTypeInit) TreeBuilder.createInitNode();
         initNode.pos = pos;
@@ -3801,7 +3803,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         initNode.argsExpr.addAll(invocationNode.argExprs);
         initNode.initInvocation = invocationNode;
 
-        BLangSimpleVariable serviceVariable = createServiceVariable(pos, annonClassDef, initNode);
+        BLangSimpleVariable serviceVariable = createServiceVariable(pos, anonClassDef, initNode);
 
         List<BLangExpression> exprs = new ArrayList<>();
         for (var exp : serviceDeclarationNode.expressions()) {
@@ -3811,10 +3813,10 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangService service = (BLangService) TreeBuilder.createServiceNode();
         service.serviceVariable = serviceVariable;
         service.attachedExprs = exprs;
-        service.serviceClass = annonClassDef;
+        service.serviceClass = anonClassDef;
         service.absoluteResourcePath = absResourcePathPath;
         service.serviceNameLiteral = serviceNameLiteral;
-        service.annAttachments = annonClassDef.annAttachments;
+        service.annAttachments = anonClassDef.annAttachments;
         service.pos = pos;
         service.name = createIdentifier(pos, anonymousModelHelper.getNextAnonymousServiceVarKey(packageID));
         return service;
@@ -3855,29 +3857,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             }
         });
 
-        for (Token qualifier : classDefinitionNode.classTypeQualifiers()) {
-            SyntaxKind kind = qualifier.kind();
-
-            switch (kind) {
-                case DISTINCT_KEYWORD:
-                    blangClass.flagSet.add(Flag.DISTINCT);
-                    break;
-                case CLIENT_KEYWORD:
-                    blangClass.flagSet.add(Flag.CLIENT);
-                    break;
-                case READONLY_KEYWORD:
-                    blangClass.flagSet.add(Flag.READONLY);
-                    break;
-                case SERVICE_KEYWORD:
-                    blangClass.flagSet.add(Flag.SERVICE);
-                    break;
-                case ISOLATED_KEYWORD:
-                    blangClass.flagSet.add(Flag.ISOLATED);
-                    break;
-                default:
-                    throw new RuntimeException("Syntax kind is not supported: " + kind);
-            }
-        }
+        setClassQualifiers(classDefinitionNode.classTypeQualifiers(), blangClass);
 
         NodeList<Node> members = classDefinitionNode.members();
         for (Node node : members) {
@@ -6069,5 +6049,31 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                                                           upTo.lineRange().endLine().offset());
 
         return trimmedLocation;
+    }
+
+    private void setClassQualifiers(NodeList<Token> qualifiers, BLangClassDefinition blangClass) {
+        for (Token qualifier : qualifiers) {
+            SyntaxKind kind = qualifier.kind();
+
+            switch (kind) {
+                case DISTINCT_KEYWORD:
+                    blangClass.flagSet.add(Flag.DISTINCT);
+                    break;
+                case CLIENT_KEYWORD:
+                    blangClass.flagSet.add(Flag.CLIENT);
+                    break;
+                case READONLY_KEYWORD:
+                    blangClass.flagSet.add(Flag.READONLY);
+                    break;
+                case SERVICE_KEYWORD:
+                    blangClass.flagSet.add(Flag.SERVICE);
+                    break;
+                case ISOLATED_KEYWORD:
+                    blangClass.flagSet.add(Flag.ISOLATED);
+                    break;
+                default:
+                    throw new RuntimeException("Syntax kind is not supported: " + kind);
+            }
+        }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/IsolationAnalyzer.java
@@ -2651,7 +2651,8 @@ public class IsolationAnalyzer extends BLangNodeVisitor {
     private boolean isInIsolatedObjectMethod(SymbolEnv env, boolean ignoreInit) {
         BLangInvokableNode enclInvokable = env.enclInvokable;
 
-        if (enclInvokable == null || enclInvokable.getKind() != NodeKind.FUNCTION) {
+        if (enclInvokable == null ||
+                (enclInvokable.getKind() != NodeKind.FUNCTION && enclInvokable.getKind() != NodeKind.RESOURCE_FUNC)) {
             return false;
         }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolatedObjectTest.java
@@ -185,6 +185,49 @@ public class IsolatedObjectTest {
         validateError(result, i++, ERROR_INVALID_TRANSFER_IN_IN_LOCK_WITH_RESTRICTED_VAR_USAGE, 493, 40);
         validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 505, 6);
         validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 505, 6);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 516, 5);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 519, 9);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 523, 9);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 527, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 531, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 535, 9);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 540, 13);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 541, 13);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 547, 5);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 550, 9);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 554, 9);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 558, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 562, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 566, 9);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 571, 13);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 572, 13);
+        validateError(result, i++, "invalid non-private mutable field in an 'isolated' object", 578, 5);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 581, 9);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 585, 9);
+        validateError(result, i++, "invalid access of a mutable field of an 'isolated' object outside a 'lock' " +
+                "statement", 589, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 593, 9);
+        validateError(result, i++, ERROR_INVALID_ACCESS_OF_MUTABLE_STORAGE_IN_ISOLATED_FUNC, 597, 9);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 602, 13);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 603, 13);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 609, 13);
+        validateError(result, i++, "cannot access more than one variable for which usage is restricted in a single " +
+                "'lock' statement", 610, 13);
         Assert.assertEquals(result.getErrorCount(), i);
     }
 

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/isolation/IsolationAnalysisTest.java
@@ -146,9 +146,13 @@ public class IsolationAnalysisTest {
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 101, 22);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 105, 25);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 124, 17);
+        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
+                      128, 9);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 129, 28);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 133, 17);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 139, 17);
+        validateError(result, i++, "invalid reference to 'self' outside a 'lock' statement in an 'isolated' object",
+                      143, 9);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 144, 28);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 148, 17);
         validateError(result, i++, INVALID_MUTABLE_STORAGE_ACCESS_ERROR, 155, 20);

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects.bal
@@ -491,6 +491,111 @@ isolated client class IsolatedClientClassWithPrivateMutableFields {
     }
 }
 
+isolated int[] isolatedArr = [];
+
+isolated service / on new Listener() {
+    private int[] x = [];
+
+    remote function foo() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    resource function get bar() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    function baz() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    resource function get corge() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+}
+
+service object {} ser = isolated service object {
+    private int[] x = [];
+
+    remote function foo() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    resource function get bar() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    function baz() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    resource function get corge() {
+        lock {
+            isolatedArr = [];
+        }
+    }
+};
+
+isolated service class ServiceClass {
+    private int[] x = [];
+
+    remote function foo() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    resource function get bar() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    function baz() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+
+    resource function get corge() {
+        lock {
+            isolatedArr = [];
+        }
+    }
+
+    function quuz() {
+        lock {
+            self.x = [2, 3];
+        }
+    }
+}
+
+public class Listener {
+
+    public function 'start() returns error? {}
+
+    public function gracefulStop() returns error? {}
+
+    public function immediateStop() returns error? {}
+
+    public function detach(service object {} s) returns error? {}
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {}
+}
+
 function assertTrue(any|error actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolated-objects/isolated_objects_isolation_negative.bal
@@ -509,3 +509,118 @@ service isolated class InvalidIsolatedServiceClassNotOverridingMutableFieldsInIn
         self.b = [];
     }
 }
+
+isolated int[] isolatedArr = [];
+
+isolated service / on new Listener() {
+    int[] x = [];
+
+    remote function foo() {
+        self.x = [2, 3];
+    }
+
+    resource function get bar() {
+        self.x = [2, 3];
+    }
+
+    function baz() {
+        self.x = [2, 3];
+    }
+
+    isolated function qux() {
+        globIntArr = [];
+    }
+
+    isolated resource function get quux() {
+        globIntArr = [];
+    }
+
+    resource function get corge() {
+        lock {
+            self.x = [2, 3];
+            isolatedArr = [];
+        }
+    }
+}
+
+service object {} ser = isolated service object {
+    int[] x = [];
+
+    remote function foo() {
+        self.x = [2, 3];
+    }
+
+    resource function get bar() {
+        self.x = [2, 3];
+    }
+
+    function baz() {
+        self.x = [2, 3];
+    }
+
+    isolated function qux() {
+        globIntArr = [];
+    }
+
+    isolated resource function get quux() {
+        globIntArr = [];
+    }
+
+    resource function get corge() {
+        lock {
+            self.x = [2, 3];
+            isolatedArr = [];
+        }
+    }
+};
+
+isolated service class ServiceClass {
+    int[] x = [];
+
+    remote function foo() {
+        self.x = [2, 3];
+    }
+
+    resource function get bar() {
+        self.x = [2, 3];
+    }
+
+    function baz() {
+        self.x = [2, 3];
+    }
+
+    isolated function qux() {
+        globIntArr = [];
+    }
+
+    isolated resource function get quux() {
+        globIntArr = [];
+    }
+
+    resource function get corge() {
+        lock {
+            self.x = [2, 3];
+            isolatedArr = [];
+        }
+    }
+
+    function quuz() {
+        lock {
+            self.x = [2, 3];
+            isolatedArr = [];
+        }
+    }
+}
+
+public class Listener {
+
+    public function 'start() returns error? {}
+
+    public function gracefulStop() returns error? {}
+
+    public function immediateStop() returns error? {}
+
+    public function detach(service object {} s) returns error? {}
+
+    public function attach(service object {} s, string[]? name = ()) returns error? {}
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/isolation-analysis/isolation_analysis.bal
@@ -90,7 +90,9 @@ service /s1 on new Listener() {
     }
 
     resource isolated function get res2(string str) returns error? {
-        self.res3();
+        lock {
+            self.res3();
+        }
         return error(str + <string> ms["first"]);
     }
 
@@ -105,7 +107,9 @@ service object {} s2 = service object {
     }
 
     resource isolated function get res2(string str) returns error? {
-        self.res3();
+        lock {
+            self.res3();
+        }
         return error(str + <string> ms["first"]);
     }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/services/error_return_function.bal
@@ -39,17 +39,19 @@ isolated function externAttach(service object {} s) returns error? = @java:Metho
 } external;
 
 listener Listener lsn = new();
-error err = error("An Error");
+final error err = error("An Error");
 error diff = error("A different error");
 service /hello on lsn {
     resource function get processRequest() returns error? {
         error? aDifferentError = createADifferentError();
         assertEquals(diff, aDifferentError);
-        error? anotherErr = self.createError();
-        assertEquals(err, anotherErr);
+        lock {
+            error? anotherErr = self.createError();
+            assertEquals(err, anotherErr);
+        }
     }
 
-    function createError() returns @tainted error? {
+    isolated function createError() returns @tainted error? {
         return err;
     }
 }
@@ -70,7 +72,7 @@ public function testErrorFunction() {
     }
 }
 
-function assertEquals(anydata|error expected, anydata|error actual) {
+isolated function assertEquals(anydata|error expected, anydata|error actual) {
     if isEqual(actual, expected) {
         return;
     }


### PR DESCRIPTION
## Purpose
$title.

Fixes #29682 - Isolation analysis does not happen for service declarations with the isolated qualifier
Fixes #29691 - `self` is not considered a protected variable in a resource method of an isolated service object

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
