### PR TITLE
Introduce a separate symbol kind for enum members

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaConstantSymbol.java
@@ -21,13 +21,17 @@ import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
-import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BSymbol;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
+import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
+
+import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
+import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM_MEMBER;
+import static org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols.isFlagOn;
 
 /**
  * Represent Constant Symbol.
@@ -42,7 +46,8 @@ public class BallerinaConstantSymbol extends BallerinaVariableSymbol implements 
     private BallerinaConstantSymbol(String name, List<Qualifier> qualifiers, List<AnnotationSymbol> annots,
                                     TypeSymbol typeDescriptor, TypeSymbol broaderType, Object constValue,
                                     BSymbol bSymbol, CompilerContext context) {
-        super(name, SymbolKind.CONSTANT, qualifiers, annots, typeDescriptor, bSymbol, context);
+        super(name, isFlagOn(bSymbol.flags, Flags.ENUM_MEMBER) ? ENUM_MEMBER : CONSTANT, qualifiers, annots,
+              typeDescriptor, bSymbol, context);
         this.constValue = constValue;
         this.broaderType = broaderType;
     }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/SymbolKind.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/SymbolKind.java
@@ -40,6 +40,7 @@ public enum SymbolKind {
     OBJECT_FIELD,
     CLASS_FIELD,
     ENUM,
+    ENUM_MEMBER,
     PARAMETER,
     PATH_PARAMETER
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
@@ -176,5 +176,9 @@ public enum Flag {
     /**
      * Indicates flagged node allows never type.
      */
-    NEVER_ALLOWED;
+    NEVER_ALLOWED,
+    /**
+     * Indicates flagged node is a member of an enum
+     */
+    ENUM_MEMBER
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/Flag.java
@@ -178,7 +178,7 @@ public enum Flag {
      */
     NEVER_ALLOWED,
     /**
-     * Indicates flagged node is a member of an enum
+     * Indicates flagged node is a member of an enum.
      */
     ENUM_MEMBER
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3475,6 +3475,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangConstant bLangConstant = (BLangConstant) TreeBuilder.createConstantNode();
         bLangConstant.pos = getPosition(member);
         bLangConstant.flagSet.add(Flag.CONSTANT);
+        bLangConstant.flagSet.add(Flag.ENUM_MEMBER);
         if (publicQualifier) {
             bLangConstant.flagSet.add(Flag.PUBLIC);
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/Flags.java
@@ -79,6 +79,7 @@ public class Flags {
     public static final long FIELD = REST_PARAM << 1;                           //  38
     public static final long ANY_FUNCTION = FIELD << 1;                         //  39
     public static final long INFER = ANY_FUNCTION << 1;                         //  40
+    public static final long ENUM_MEMBER = INFER << 1;                          //  41
 
 
     public static long asMask(Set<Flag> flagSet) {
@@ -196,6 +197,9 @@ public class Flags {
                 case ANY_FUNCTION:
                     mask |= ANY_FUNCTION;
                     break;
+                case ENUM_MEMBER:
+                    mask |= ENUM_MEMBER;
+                    break;
             }
         }
         return mask;
@@ -310,6 +314,9 @@ public class Flags {
                     break;
                 case ANY_FUNCTION:
                     flagVal = ANY_FUNCTION;
+                    break;
+                case ENUM_MEMBER:
+                    flagVal = ENUM_MEMBER;
                     break;
                 default:
                     continue;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/SymbolUtil.java
@@ -216,6 +216,7 @@ public class SymbolUtil {
             case METHOD:
                 return Optional.ofNullable(((FunctionSymbol) symbol).typeDescriptor());
             case CONSTANT:
+            case ENUM_MEMBER:
                 return Optional.ofNullable(((ConstantSymbol) symbol).typeDescriptor());
             case CLASS:
                 return Optional.of((ClassSymbol) symbol);

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ConstantCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/ConstantCompletionItemBuilder.java
@@ -19,6 +19,7 @@ package org.ballerinalang.langserver.completions.builder;
 
 import io.ballerina.compiler.api.symbols.ConstantSymbol;
 import io.ballerina.compiler.api.symbols.Documentation;
+import io.ballerina.compiler.api.symbols.SymbolKind;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.ballerinalang.langserver.commons.CompletionContext;
 import org.eclipse.lsp4j.CompletionItem;
@@ -49,7 +50,12 @@ public class ConstantCompletionItemBuilder {
         completionItem.setInsertText(constantSymbol.getName().get());
         completionItem.setDetail(CommonUtil.getModifiedTypeName(context, constantSymbol.typeDescriptor()));
         completionItem.setDocumentation(getDocumentation(constantSymbol));
-        completionItem.setKind(CompletionItemKind.Variable);
+
+        if (constantSymbol.kind() == SymbolKind.ENUM_MEMBER) {
+            completionItem.setKind(CompletionItemKind.EnumMember);
+        } else {
+            completionItem.setKind(CompletionItemKind.Variable);
+        }
 
         return completionItem;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/AbstractCompletionProvider.java
@@ -157,7 +157,7 @@ public abstract class AbstractCompletionProvider<T extends Node> implements Ball
             }
             if (symbol.kind() == FUNCTION || symbol.kind() == METHOD) {
                 completionItems.add(populateBallerinaFunctionCompletionItem(symbol, ctx));
-            } else if (symbol.kind() == SymbolKind.CONSTANT) {
+            } else if (symbol.kind() == SymbolKind.CONSTANT || symbol.kind() == SymbolKind.ENUM_MEMBER) {
                 CompletionItem constantCItem = ConstantCompletionItemBuilder.build((ConstantSymbol) symbol, ctx);
                 completionItems.add(new SymbolCompletionItem(ctx, symbol, constantCItem));
             } else if (symbol.kind() == SymbolKind.VARIABLE) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ArrayTypeDescriptorNodeContext.java
@@ -72,7 +72,7 @@ public class ArrayTypeDescriptorNodeContext extends AbstractCompletionProvider<A
 
     private Predicate<Symbol> constantFilter() {
         return symbol -> {
-            if (symbol.kind() != SymbolKind.CONSTANT) {
+            if (symbol.kind() != SymbolKind.CONSTANT && symbol.kind() != SymbolKind.ENUM_MEMBER) {
                 return false;
             }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/BlockNodeContextProvider.java
@@ -75,12 +75,7 @@ public class BlockNodeContextProvider<T extends Node> extends AbstractCompletion
                 }
              */
             QualifiedNameReferenceNode nameRef = (QualifiedNameReferenceNode) nodeAtCursor;
-            Predicate<Symbol> filter = symbol ->
-                    symbol.kind() == SymbolKind.TYPE_DEFINITION
-                            || symbol.kind() == SymbolKind.VARIABLE
-                            || symbol.kind() == SymbolKind.CONSTANT
-                            || symbol.kind() == SymbolKind.FUNCTION
-                            || symbol.kind() == SymbolKind.CLASS;
+            Predicate<Symbol> filter = symbol -> symbol.kind() != SymbolKind.SERVICE_DECLARATION;
             List<Symbol> moduleContent = QNameReferenceUtil.getModuleContent(context, nameRef, filter);
 
             completionItems.addAll(this.getCompletionItemList(moduleContent, context));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConstantDeclarationNodeContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/ConstantDeclarationNodeContext.java
@@ -61,7 +61,8 @@ public class ConstantDeclarationNodeContext extends AbstractCompletionProvider<C
                 completionItems.addAll(this.getModuleCompletionItems(context));
             }
         } else if (this.onExpressionContext(context, node)) {
-            Predicate<Symbol> predicate = symbol -> symbol.kind() == SymbolKind.CONSTANT;
+            Predicate<Symbol> predicate =
+                    symbol -> symbol.kind() == SymbolKind.CONSTANT || symbol.kind() == SymbolKind.ENUM_MEMBER;
             List<Symbol> constants;
             if (QNameReferenceUtil.onQualifiedNameIdentifier(context, nodeAtCursor)) {
                 QualifiedNameReferenceNode qNameRef = (QualifiedNameReferenceNode) nodeAtCursor;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchStatementContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/providers/context/MatchStatementContext.java
@@ -61,6 +61,6 @@ public abstract class MatchStatementContext<T extends Node> extends AbstractComp
 
     protected Predicate<Symbol> constantFilter() {
         // also, should include the enum members as well. Since currently both are same, this is fine
-        return symbol -> symbol.kind() == SymbolKind.CONSTANT;
+        return symbol -> symbol.kind() == SymbolKind.CONSTANT || symbol.kind() == SymbolKind.ENUM_MEMBER;
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -89,6 +89,7 @@ public class HoverUtil {
             case CONSTANT:
             case ANNOTATION:
             case ENUM:
+            case ENUM_MEMBER:
             case VARIABLE:
                 return getDescriptionOnlyHoverObject(symbol);
             case TYPE:

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config4.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config4.json
@@ -1,347 +1,347 @@
 {
-    "position": {
-        "line": 21,
-        "character": 8
+  "position": {
+    "line": 21,
+    "character": 8
+  },
+  "source": "statement_context/source/match_stmt_ctx_source4.bal",
+  "items": [
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
     },
-    "source": "statement_context/source/match_stmt_ctx_source4.bal",
-    "items": [
-        {
-            "label": "true",
-            "kind": "Keyword",
-            "detail": "Keyword",
-            "sortText": "P",
-            "insertText": "true",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "false",
-            "kind": "Keyword",
-            "detail": "Keyword",
-            "sortText": "P",
-            "insertText": "false",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "var",
-            "kind": "Keyword",
-            "detail": "Keyword",
-            "sortText": "P",
-            "insertText": "var ",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONST1",
-            "kind": "Variable",
-            "detail": "Test Const",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "CONST1",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "BLUE",
-            "kind": "Variable",
-            "detail": "BLUE",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "BLUE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GREEN",
-            "kind": "Variable",
-            "detail": "GREEN",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "GREEN",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "RED",
-            "kind": "Variable",
-            "detail": "RED",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "RED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "module1",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "N",
-            "insertText": "module1",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ballerina/lang.test",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "test",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.test;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.array",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "array",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.array;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/jballerina.java",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "java",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/jballerina.java;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.value",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "value",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.value;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.query",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "query",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.query;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.runtime",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "runtime",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.runtime;\n"
-                }
-            ]
-        },
-        {
-            "label": "boolean",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "boolean",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "decimal",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "decimal",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "error",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "error",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "float",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "float",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "future",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "future",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "int",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "int",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "map",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "map",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "object",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "object",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "stream",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "stream",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "string",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "string",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "table",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "table",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "transaction",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "transaction",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "typedesc",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "typedesc",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "xml",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "xml",
-            "insertTextFormat": "Snippet"
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "var",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "var ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "BLUE",
+      "kind": "EnumMember",
+      "detail": "BLUE",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
         }
-    ]
+      },
+      "sortText": "H",
+      "insertText": "BLUE",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "GREEN",
+      "kind": "EnumMember",
+      "detail": "GREEN",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "H",
+      "insertText": "GREEN",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "CONST1",
+      "kind": "Variable",
+      "detail": "Test Const",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "B",
+      "insertText": "CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RED",
+      "kind": "EnumMember",
+      "detail": "RED",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "H",
+      "insertText": "RED",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "N",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.query",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "query",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.query;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config5.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/match_stmt_ctx_config5.json
@@ -1,347 +1,347 @@
 {
-    "position": {
-        "line": 21,
-        "character": 9
+  "position": {
+    "line": 21,
+    "character": 9
+  },
+  "source": "statement_context/source/match_stmt_ctx_source5.bal",
+  "items": [
+    {
+      "label": "true",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "true",
+      "insertTextFormat": "Snippet"
     },
-    "source": "statement_context/source/match_stmt_ctx_source5.bal",
-    "items": [
-        {
-            "label": "true",
-            "kind": "Keyword",
-            "detail": "Keyword",
-            "sortText": "P",
-            "insertText": "true",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "false",
-            "kind": "Keyword",
-            "detail": "Keyword",
-            "sortText": "P",
-            "insertText": "false",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "var",
-            "kind": "Keyword",
-            "detail": "Keyword",
-            "sortText": "P",
-            "insertText": "var ",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "CONST1",
-            "kind": "Variable",
-            "detail": "Test Const",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "CONST1",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "BLUE",
-            "kind": "Variable",
-            "detail": "BLUE",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "BLUE",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "GREEN",
-            "kind": "Variable",
-            "detail": "GREEN",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "GREEN",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "RED",
-            "kind": "Variable",
-            "detail": "RED",
-            "documentation": {
-                "right": {
-                    "kind": "markdown",
-                    "value": ""
-                }
-            },
-            "sortText": "B",
-            "insertText": "RED",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "module1",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "N",
-            "insertText": "module1",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "ballerina/lang.test",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "test",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.test;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.array",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "array",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.array;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/jballerina.java",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "java",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/jballerina.java;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.value",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "value",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.value;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.query",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "query",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.query;\n"
-                }
-            ]
-        },
-        {
-            "label": "ballerina/lang.runtime",
-            "kind": "Module",
-            "detail": "Module",
-            "sortText": "Q",
-            "insertText": "runtime",
-            "insertTextFormat": "Snippet",
-            "additionalTextEdits": [
-                {
-                    "range": {
-                        "start": {
-                            "line": 0,
-                            "character": 0
-                        },
-                        "end": {
-                            "line": 0,
-                            "character": 0
-                        }
-                    },
-                    "newText": "import ballerina/lang.runtime;\n"
-                }
-            ]
-        },
-        {
-            "label": "boolean",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "boolean",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "decimal",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "decimal",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "error",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "error",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "float",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "float",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "future",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "future",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "int",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "int",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "map",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "map",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "object",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "object",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "stream",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "stream",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "string",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "string",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "table",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "table",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "transaction",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "transaction",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "typedesc",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "typedesc",
-            "insertTextFormat": "Snippet"
-        },
-        {
-            "label": "xml",
-            "kind": "Unit",
-            "detail": "type",
-            "sortText": "Q",
-            "insertText": "xml",
-            "insertTextFormat": "Snippet"
+    {
+      "label": "false",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "false",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "var",
+      "kind": "Keyword",
+      "detail": "Keyword",
+      "sortText": "P",
+      "insertText": "var ",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "BLUE",
+      "kind": "EnumMember",
+      "detail": "BLUE",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
         }
-    ]
+      },
+      "sortText": "H",
+      "insertText": "BLUE",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "GREEN",
+      "kind": "EnumMember",
+      "detail": "GREEN",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "H",
+      "insertText": "GREEN",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "CONST1",
+      "kind": "Variable",
+      "detail": "Test Const",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "B",
+      "insertText": "CONST1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "RED",
+      "kind": "EnumMember",
+      "detail": "RED",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": ""
+        }
+      },
+      "sortText": "H",
+      "insertText": "RED",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "module1",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "N",
+      "insertText": "module1",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ballerina/lang.test",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "test",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.test;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.array",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "array",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.array;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/jballerina.java",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "java",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/jballerina.java;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.value",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "value",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.value;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.query",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "query",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.query;\n"
+        }
+      ]
+    },
+    {
+      "label": "ballerina/lang.runtime",
+      "kind": "Module",
+      "detail": "Module",
+      "sortText": "Q",
+      "insertText": "runtime",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 0,
+              "character": 0
+            },
+            "end": {
+              "line": 0,
+              "character": 0
+            }
+          },
+          "newText": "import ballerina/lang.runtime;\n"
+        }
+      ]
+    },
+    {
+      "label": "boolean",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "boolean",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "decimal",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "decimal",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "error",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "error",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "float",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "float",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "future",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "future",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "int",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "int",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "map",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "map",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "object",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "object",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "stream",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "stream",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "string",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "string",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "table",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "table",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "transaction",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "transaction",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "typedesc",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "typedesc",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "xml",
+      "kind": "Unit",
+      "detail": "type",
+      "sortText": "Q",
+      "insertText": "xml",
+      "insertTextFormat": "Snippet"
+    }
+  ]
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/AnnotationsTest.java
@@ -38,6 +38,7 @@ import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS_FIELD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
+import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM_MEMBER;
 import static io.ballerina.compiler.api.symbols.SymbolKind.FUNCTION;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.PARAMETER;
@@ -95,7 +96,7 @@ public class AnnotationsTest {
                 {87, 22, RESOURCE_METHOD, of("v3")},
 //                {96, 11, WORKER, of("v1")} // TODO: Uncomment after fixing #27461
                 {105, 5, ENUM, of("v1", "v5")},
-                {109, 4, CONSTANT, of("v1")}
+                {109, 4, ENUM_MEMBER, of("v1")}
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByEnumTest.java
@@ -29,8 +29,8 @@ import org.testng.annotations.Test;
 
 import java.util.Optional;
 
-import static io.ballerina.compiler.api.symbols.SymbolKind.CONSTANT;
 import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM;
+import static io.ballerina.compiler.api.symbols.SymbolKind.ENUM_MEMBER;
 import static org.testng.Assert.assertEquals;
 
 /**
@@ -61,12 +61,12 @@ public class SymbolByEnumTest extends SymbolByNodeTest {
 
             @Override
             public void visit(EnumMemberNode enumMemberNode) {
-                assertSymbol(enumMemberNode, model, CONSTANT, enumMemberNode.identifier().text());
+                assertSymbol(enumMemberNode, model, ENUM_MEMBER, enumMemberNode.identifier().text());
             }
 
             @Override
             public void visit(VariableDeclarationNode variableDeclarationNode) {
-                assertSymbol(variableDeclarationNode.initializer().get(), model, CONSTANT, "RED");
+                assertSymbol(variableDeclarationNode.initializer().get(), model, ENUM_MEMBER, "RED");
             }
         };
     }


### PR DESCRIPTION
## Purpose
This PR introduces a new symbol kind for distinguishing between regular constants and constants which are members of enums.
 
## Approach
- Introduce a separate symbol kind named `ENUM_MEMBER`
- For `ConstantSymbol` instances who happen to be enum members, `kind()` returns `ENUM_MEMBER` instead of `CONSTANT`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
