### PR TITLE
Deprecate parameters() and introduce params() as the alternative

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -152,6 +152,9 @@ public class SymbolFactory {
             if (Symbols.isFlagOn(symbol.flags, Flags.DEFAULTABLE_PARAM)) {
                 return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.DEFAULTABLE);
             }
+            if (Symbols.isFlagOn(symbol.flags, Flags.INCLUDED)) {
+                return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.INCLUDED_RECORD);
+            }
             if (Symbols.isFlagOn(symbol.flags, Flags.REST_PARAM)) {
                 return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.REST);
             }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/AbstractTypeSymbol.java
@@ -134,7 +134,7 @@ public abstract class AbstractTypeSymbol implements TypeSymbol {
         List<FunctionSymbol> filteredFunctions = new ArrayList<>();
 
         for (FunctionSymbol function : functions) {
-            ParameterSymbol firstParam = function.typeDescriptor().parameters().get(0);
+            ParameterSymbol firstParam = function.typeDescriptor().params().get().get(0);
             BType firstParamType = ((AbstractTypeSymbol) firstParam.typeDescriptor()).getBType();
 
             if (types.isAssignable(internalType, firstParamType)) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -93,8 +93,7 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
             return Optional.of(this.params);
         }
 
-        // Becomes null for the function typedesc.
-        if (this.typeSymbol.params == null) {
+        if (Symbols.isFlagOn(this.typeSymbol.flags, Flags.ANY_FUNCTION)) {
             return Optional.empty();
         }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMethodSymbol.java
@@ -42,6 +42,7 @@ import java.util.StringJoiner;
 public class BallerinaMethodSymbol implements MethodSymbol {
 
     private final FunctionSymbol functionSymbol;
+    private String signature;
 
     public BallerinaMethodSymbol(FunctionSymbol functionSymbol) {
         this.functionSymbol = functionSymbol;
@@ -104,6 +105,10 @@ public class BallerinaMethodSymbol implements MethodSymbol {
 
     @Override
     public String signature() {
+        if (this.signature != null) {
+            return this.signature;
+        }
+
         StringJoiner qualifierJoiner = new StringJoiner(" ");
         this.functionSymbol.qualifiers().stream().map(Qualifier::getValue).forEach(qualifierJoiner::add);
         qualifierJoiner.add("function ");
@@ -111,7 +116,7 @@ public class BallerinaMethodSymbol implements MethodSymbol {
         StringBuilder signature = new StringBuilder(qualifierJoiner.toString());
         StringJoiner joiner = new StringJoiner(", ");
         signature.append(this.functionSymbol.getName().get()).append("(");
-        for (ParameterSymbol requiredParam : this.typeDescriptor().parameters()) {
+        for (ParameterSymbol requiredParam : this.typeDescriptor().params().get()) {
             String ballerinaParameterSignature = requiredParam.signature();
             joiner.add(ballerinaParameterSignature);
         }
@@ -121,6 +126,7 @@ public class BallerinaMethodSymbol implements MethodSymbol {
         if (returnTypeSymbol.isPresent() && returnTypeSymbol.get().typeKind() != TypeDescKind.NIL) {
             signature.append(" returns ").append(returnTypeSymbol.get().signature());
         }
-        return signature.toString();
+        this.signature = signature.toString();
+        return this.signature;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaParameterSymbol.java
@@ -89,7 +89,9 @@ public class BallerinaParameterSymbol extends BallerinaSymbol implements Paramet
         StringJoiner joiner = new StringJoiner(" ");
         this.qualifiers().forEach(accessModifier -> joiner.add(accessModifier.getValue()));
         String signature;
-        if (this.paramKind() == ParameterKind.REST) {
+        if (this.paramKind() == ParameterKind.INCLUDED_RECORD) {
+            signature = "*" + this.typeDescriptor().signature();
+        } else if (this.paramKind() == ParameterKind.REST) {
             signature = this.typeDescriptor().signature();
             signature = signature.substring(0, signature.length() - 2) + "...";
         } else {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaResourceMethodSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaResourceMethodSymbol.java
@@ -110,7 +110,7 @@ public class BallerinaResourceMethodSymbol extends BallerinaMethodSymbol impleme
 
         signature.append(this.getName().get()).append(" ").append(this.resourcePath().signature()).append(" (");
 
-        for (ParameterSymbol requiredParam : this.typeDescriptor().parameters()) {
+        for (ParameterSymbol requiredParam : this.typeDescriptor().params().get()) {
             String ballerinaParameterSignature = requiredParam.signature();
             joiner.add(ballerinaParameterSignature);
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionTypeSymbol.java
@@ -30,8 +30,18 @@ public interface FunctionTypeSymbol extends TypeSymbol {
      * Get the required parameters.
      *
      * @return {@link List} of required parameters
+     * @deprecated This method will be removed in a later release. Use `params()` instead.
      */
+    @Deprecated(forRemoval = true)
     List<ParameterSymbol> parameters();
+
+    /**
+     * For regular function types, this will return a list of the non-rest parameters. If this is the `function` type
+     * descriptor, this will return empty.
+     *
+     * @return A {@link List} of required parameters or empty
+     */
+    Optional<List<ParameterSymbol>> params();
 
     /**
      * Get the rest parameter.

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterKind.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/ParameterKind.java
@@ -23,5 +23,5 @@ package io.ballerina.compiler.api.symbols;
  * @since 2.0.0
  */
 public enum ParameterKind {
-    REQUIRED, DEFAULTABLE, REST
+    REQUIRED, DEFAULTABLE, INCLUDED_RECORD, REST
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/CommonUtil.java
@@ -244,7 +244,7 @@ public class CommonUtil {
                 if (objectTypeSymbol.kind() == SymbolKind.CLASS) {
                     ClassSymbol classSymbol = (ClassSymbol) objectTypeSymbol;
                     if (classSymbol.initMethod().isPresent()) {
-                        List<ParameterSymbol> params = classSymbol.initMethod().get().typeDescriptor().parameters();
+                        List<ParameterSymbol> params = classSymbol.initMethod().get().typeDescriptor().params().get();
                         String text = params.stream()
                                 .map(param -> getDefaultValueForType(param.typeDescriptor()))
                                 .collect(Collectors.joining(", "));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/FunctionCompletionItemBuilder.java
@@ -153,7 +153,7 @@ public final class FunctionCompletionItemBuilder {
         Map<String, String> docParamsMap = new HashMap<>();
         docAttachment.ifPresent(documentation -> documentation.parameterMap().forEach(docParamsMap::put));
 
-        List<ParameterSymbol> defaultParams = functionTypeDesc.parameters().stream()
+        List<ParameterSymbol> defaultParams = functionTypeDesc.params().get().stream()
                 .filter(parameter -> parameter.paramKind() == ParameterKind.DEFAULTABLE)
                 .collect(Collectors.toList());
 
@@ -170,7 +170,7 @@ public final class FunctionCompletionItemBuilder {
         documentation.append(description).append(CommonUtil.MD_LINE_SEPARATOR);
 
         StringJoiner joiner = new StringJoiner(CommonUtil.MD_LINE_SEPARATOR);
-        List<ParameterSymbol> functionParameters = new ArrayList<>(functionTypeDesc.parameters());
+        List<ParameterSymbol> functionParameters = new ArrayList<>(functionTypeDesc.params().get());
         if (functionTypeDesc.restParam().isPresent()) {
             functionParameters.add(functionTypeDesc.restParam().get());
         }
@@ -290,7 +290,7 @@ public final class FunctionCompletionItemBuilder {
         boolean skipFirstParam = skipFirstParam(ctx, symbol);
         FunctionTypeSymbol functionTypeDesc = symbol.typeDescriptor();
         Optional<ParameterSymbol> restParam = functionTypeDesc.restParam();
-        List<ParameterSymbol> parameterDefs = new ArrayList<>(functionTypeDesc.parameters());
+        List<ParameterSymbol> parameterDefs = new ArrayList<>(functionTypeDesc.params().get());
         for (int i = 0; i < parameterDefs.size(); i++) {
             if (i == 0 && skipFirstParam) {
                 continue;

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/hover/HoverUtil.java
@@ -299,7 +299,7 @@ public class HoverUtil {
             List<String> params = new ArrayList<>();
             params.add(header(3, ContextConstants.PARAM_TITLE) + CommonUtil.MD_LINE_SEPARATOR);
 
-            params.addAll(symbol.typeDescriptor().parameters().stream()
+            params.addAll(symbol.typeDescriptor().params().get().stream()
                     .map(param -> {
                         if (param.getName().isEmpty()) {
                             return quotedString(CommonUtil.getModifiedTypeName(ctx, param.typeDescriptor()));

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/signature/SignatureHelpUtil.java
@@ -190,7 +190,7 @@ public class SignatureHelpUtil {
             documentation.get().parameterMap().forEach(paramToDesc::put);
         }
         // Add parameters and rest params
-        functionSymbol.typeDescriptor().parameters()
+        functionSymbol.typeDescriptor().params().get()
                 .forEach(param -> parameters.add(new Parameter(param, false, false, context)));
         Optional<ParameterSymbol> restParam = functionSymbol.typeDescriptor().restParam();
         restParam.ifPresent(parameter -> parameters.add(new Parameter(parameter, false, true, context)));

--- a/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
+++ b/misc/debug-adapter/modules/debug-adapter-core/src/main/java/org/ballerinalang/debugadapter/evaluation/engine/InvocationArgProcessor.java
@@ -49,10 +49,13 @@ public class InvocationArgProcessor {
         List<ParameterSymbol> params = new ArrayList<>();
         Map<String, ParameterSymbol> remainingParams = new HashMap<>();
 
-        for (ParameterSymbol parameterSymbol : definition.parameters()) {
-            params.add(parameterSymbol);
-            remainingParams.put(parameterSymbol.getName().get(), parameterSymbol);
+        if (definition.params().isPresent()) {
+            for (ParameterSymbol parameterSymbol : definition.params().get()) {
+                params.add(parameterSymbol);
+                remainingParams.put(parameterSymbol.getName().get(), parameterSymbol);
+            }
         }
+
         if (definition.restParam().isPresent()) {
             params.add(definition.restParam().get());
             remainingParams.put(definition.restParam().get().getName().get(), definition.restParam().get());

--- a/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
+++ b/misc/docerina/src/main/java/org/ballerinalang/docgen/Generator.java
@@ -501,7 +501,7 @@ public class Generator {
                 List<DefaultableVariable> parameters = new ArrayList<>();
                 List<Variable> returnParams = new ArrayList<>();
 
-                methodSymbol.typeDescriptor().parameters().forEach(parameterSymbol -> {
+                methodSymbol.typeDescriptor().params().get().forEach(parameterSymbol -> {
                     boolean parameterDeprecated = parameterSymbol.annotations().stream()
                             .anyMatch(annotationSymbol -> annotationSymbol.getName().get().equals("deprecated"));
                     Type type = new Type(parameterSymbol.typeDescriptor().signature());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -72,7 +72,7 @@ public class ClassSymbolTest {
 
         MethodSymbol initMethod = symbol.initMethod().get();
         assertEquals(initMethod.getName().get(), "init");
-        assertEquals(initMethod.typeDescriptor().parameters().stream()
+        assertEquals(initMethod.typeDescriptor().params().get().stream()
                              .map(p -> p.getName().get())
                              .collect(Collectors.toList()), fieldNames);
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ParameterSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ParameterSymbolTest.java
@@ -37,6 +37,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.ParameterKind.DEFAULTABLE;
+import static io.ballerina.compiler.api.symbols.ParameterKind.INCLUDED_RECORD;
 import static io.ballerina.compiler.api.symbols.ParameterKind.REQUIRED;
 import static io.ballerina.compiler.api.symbols.ParameterKind.REST;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
@@ -86,7 +87,8 @@ public class ParameterSymbolTest {
                 {16, 31, "x", STRING, REQUIRED, "string x"},
                 {16, 38, "y", INT, REQUIRED, "int y"},
                 {16, 47, "f", FLOAT, DEFAULTABLE, "float f"},
-                {16, 68, "rest", ARRAY, REST, "string... rest"},
+                {16, 66, "grades", TYPE_REFERENCE, INCLUDED_RECORD, "*Grades grades"},
+                {16, 84, "rest", ARRAY, REST, "string... rest"},
                 {25, 31, "name", STRING, REQUIRED, "string name"},
                 {25, 41, "age", INT, DEFAULTABLE, "int age"},
                 {25, 61, "other", ARRAY, REST, "anydata... other"},
@@ -117,6 +119,7 @@ public class ParameterSymbolTest {
         assertParam((ParameterSymbol) params.get("x"), "x", REQUIRED, STRING);
         assertParam((ParameterSymbol) params.get("y"), "y", REQUIRED, INT);
         assertParam((ParameterSymbol) params.get("f"), "f", DEFAULTABLE, FLOAT);
+        assertParam((ParameterSymbol) params.get("grades"), "grades", INCLUDED_RECORD, TYPE_REFERENCE);
         assertParam((ParameterSymbol) params.get("rest"), "rest", REST, ARRAY);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -162,7 +162,7 @@ public class TypedescriptorTest {
         FunctionTypeSymbol type = ((FunctionSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), TypeDescKind.FUNCTION);
 
-        List<ParameterSymbol> parameters = type.parameters();
+        List<ParameterSymbol> parameters = type.params().get();
         assertEquals(parameters.size(), 2);
         validateParam(parameters.get(0), "x", REQUIRED, INT);
 
@@ -639,7 +639,7 @@ public class TypedescriptorTest {
     @Test
     public void testFunctionTypedesc() {
         FunctionSymbol symbol = (FunctionSymbol) getSymbol(216, 13);
-        assertEquals(symbol.typeDescriptor().parameters().size(), 0);
+        assertTrue(symbol.typeDescriptor().params().isEmpty());
         assertTrue(symbol.typeDescriptor().restParam().isEmpty());
         assertTrue(symbol.typeDescriptor().returnTypeDescriptor().isEmpty());
         assertEquals(symbol.typeDescriptor().signature(), "function");

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/param_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/param_symbols_test.bal
@@ -14,7 +14,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-function funcWithParams(string x, int y, float f = 12.34, string... rest) {
+function funcWithParams(string x, int y, float f = 12.34, *Grades grades, string... rest) {
     int sum = x + y;
 }
 
@@ -53,3 +53,9 @@ class Person {
 function foo() {
     var fn = function (Person p, anydata... misc) {};
 }
+
+type Grades record {
+    int maths;
+    int physics;
+    int chemistry;
+};


### PR DESCRIPTION
## Purpose
This PR is mainly for introducing a new method for retrieving the params of a function/function type symbol which takes in to account the `function` typedesc. This also addresses a couple of other issues as well, which hindered the introduction of this method.

Fix #29301 
Fix #29714 
Fix #29717 

## Approach
- Introduce a new method: `Optional<List<ParameterSymbol>> params()`
- For regular cases, this will return a list of params as usual. If it is the `function` typedesc, this will return empty.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
