### PR TITLE
Normalize xml attribute values

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -3253,10 +3253,13 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             quotedString.textFragments.add(emptyLiteral);
         } else {
             for (Node value : xmlAttributeValue.value()) {
-                Token token = (Token) value;
-                String textVal = token.text();
-                quotedString.textFragments.add(
-                        createStringLiteral(XmlFactory.XMLTextUnescape.unescape(textVal), getPosition(value)));
+                if (value.kind() == SyntaxKind.XML_TEXT_CONTENT) {
+                    Token token = (Token) value;
+                    String normalizedValue = XmlFactory.XMLTextUnescape.unescape(token.text());
+                    quotedString.textFragments.add(createStringLiteral(normalizedValue, getPosition(value)));
+                } else {
+                    quotedString.textFragments.add(createExpression(value));
+                }
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -225,6 +225,7 @@ import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
 import io.ballerina.compiler.syntax.tree.XMLTextNode;
 import io.ballerina.compiler.syntax.tree.XmlTypeDescriptorNode;
 import io.ballerina.runtime.api.utils.IdentifierUtils;
+import io.ballerina.runtime.internal.XmlFactory;
 import io.ballerina.tools.diagnostics.DiagnosticCode;
 import io.ballerina.tools.diagnostics.Location;
 import io.ballerina.tools.text.LinePosition;
@@ -3252,7 +3253,10 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             quotedString.textFragments.add(emptyLiteral);
         } else {
             for (Node value : xmlAttributeValue.value()) {
-                quotedString.textFragments.add(createExpression(value));
+                Token token = (Token) value;
+                String textVal = token.text();
+                quotedString.textFragments.add(
+                        createStringLiteral(XmlFactory.XMLTextUnescape.unescape(textVal), getPosition(value)));
             }
         }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/NodeCloner.java
@@ -1369,7 +1369,6 @@ public class NodeCloner extends BLangNodeVisitor {
         source.cloneRef = clone;
         clone.textFragments = cloneList(source.textFragments);
         clone.quoteType = source.quoteType;
-        clone.concatExpr = clone(source.concatExpr);
     }
 
     @Override

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributesTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/xml/XMLAttributesTest.java
@@ -262,6 +262,11 @@ public class XMLAttributesTest {
     }
 
     @Test
+    public void testCharacterReferencesInXmlAttributeValue() {
+        BRunUtil.invoke(xmlAttrProgFile, "testCharacterReferencesInXmlAttributeValue");
+    }
+
+    @Test
     public void testPrintAttribMap() {
         PrintStream original = System.out;
         ByteArrayOutputStream outContent = new ByteArrayOutputStream();

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-attributes.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-attributes.bal
@@ -226,12 +226,17 @@ function testPrintAttribMap() {
 }
 
 function testCharacterReferencesInXmlAttributeValue() {
-    var x = xml`<p att="x&amp;y"/>`;
+    string u9 = "\u{9}";
+    string uA = "\u{A}";
+    string uD = "\u{D}";
+
+    var x = xml`<p att="x&amp;y|${u9}|${uA}|${uD}|&lt;&gt;"/>`; // last segment: space followed by a tab character
     string att = checkpanic x.att;
-    if (att == "x&y") {
+    string expected = string `x&y|${u9}|${uA}|${uD}|<>`;
+    if (att == expected) {
         return;
     }
-    panic error("Assertion error, expected `x&y`, found `" + att + "`");
+    panic error("Assertion error, expected `" + expected + "`, found `" + att + "`");
 }
 
 public function print(any|error... values) = @java:Method {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-attributes.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/xml/xml-attributes.bal
@@ -225,6 +225,15 @@ function testPrintAttribMap() {
     print(attrMap);
 }
 
+function testCharacterReferencesInXmlAttributeValue() {
+    var x = xml`<p att="x&amp;y"/>`;
+    string att = checkpanic x.att;
+    if (att == "x&y") {
+        return;
+    }
+    panic error("Assertion error, expected `x&y`, found `" + att + "`");
+}
+
 public function print(any|error... values) = @java:Method {
     'class: "org.ballerinalang.test.utils.interop.Utils"
 } external;


### PR DESCRIPTION
## Purpose
```ballerina
var x = xml`<p att="x&amp;y"/>`;
string att = check x.att; // att = "x&y"
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/28305

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
