### PR TITLE
Add `boolean|int|float|decimal|string` union support for expr of string template

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/TypeChecker.java
@@ -4195,7 +4195,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
     public void visit(BLangXMLTextLiteral bLangXMLTextLiteral) {
         List<BLangExpression> literalValues = bLangXMLTextLiteral.textFragments;
-        checkStringTemplateExprs(literalValues, false);
+        checkStringTemplateExprs(literalValues);
         BLangExpression xmlExpression = literalValues.get(0);
         if (literalValues.size() == 1 && xmlExpression.getKind() == NodeKind.LITERAL &&
                 ((String) ((BLangLiteral) xmlExpression).value).isEmpty()) {
@@ -4206,7 +4206,7 @@ public class TypeChecker extends BLangNodeVisitor {
     }
 
     public void visit(BLangXMLCommentLiteral bLangXMLCommentLiteral) {
-        checkStringTemplateExprs(bLangXMLCommentLiteral.textFragments, false);
+        checkStringTemplateExprs(bLangXMLCommentLiteral.textFragments);
 
         if (expType == symTable.noType) {
             resultType = types.checkType(bLangXMLCommentLiteral, symTable.xmlCommentType, expType);
@@ -4218,7 +4218,7 @@ public class TypeChecker extends BLangNodeVisitor {
 
     public void visit(BLangXMLProcInsLiteral bLangXMLProcInsLiteral) {
         checkExpr(bLangXMLProcInsLiteral.target, env, symTable.stringType);
-        checkStringTemplateExprs(bLangXMLProcInsLiteral.dataFragments, false);
+        checkStringTemplateExprs(bLangXMLProcInsLiteral.dataFragments);
         if (expType == symTable.noType) {
             resultType = types.checkType(bLangXMLProcInsLiteral, symTable.xmlPIType, expType);
             return;
@@ -4227,7 +4227,7 @@ public class TypeChecker extends BLangNodeVisitor {
     }
 
     public void visit(BLangXMLQuotedString bLangXMLQuotedString) {
-        checkStringTemplateExprs(bLangXMLQuotedString.textFragments, false);
+        checkStringTemplateExprs(bLangXMLQuotedString.textFragments);
         resultType = types.checkType(bLangXMLQuotedString, symTable.stringType, expType);
     }
 
@@ -4238,7 +4238,7 @@ public class TypeChecker extends BLangNodeVisitor {
     }
 
     public void visit(BLangStringTemplateLiteral stringTemplateLiteral) {
-        checkStringTemplateExprs(stringTemplateLiteral.exprs, false);
+        checkStringTemplateExprs(stringTemplateLiteral.exprs);
         resultType = types.checkType(stringTemplateLiteral, symTable.stringType, expType);
     }
 
@@ -6246,7 +6246,7 @@ public class TypeChecker extends BLangNodeVisitor {
         dlog.error(bLangXMLElementLiteral.pos, DiagnosticErrorCode.XML_TAGS_MISMATCH);
     }
 
-    private void checkStringTemplateExprs(List<? extends BLangExpression> exprs, boolean allowXml) {
+    private void checkStringTemplateExprs(List<? extends BLangExpression> exprs) {
         for (BLangExpression expr : exprs) {
             checkExpr(expr, env);
 
@@ -6256,17 +6256,7 @@ public class TypeChecker extends BLangNodeVisitor {
                 continue;
             }
 
-            if (type.tag >= TypeTags.JSON) {
-                if (allowXml) {
-                    if (type.tag != TypeTags.XML) {
-                        dlog.error(expr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES,
-                                BUnionType.create(null, symTable.intType, symTable.floatType,
-                                        symTable.decimalType, symTable.stringType,
-                                        symTable.booleanType, symTable.xmlType), type);
-                    }
-                    continue;
-                }
-
+            if (!types.isUnionOfSimpleBasicTypesExceptNilType(type)) {
                 dlog.error(expr.pos, DiagnosticErrorCode.INCOMPATIBLE_TYPES,
                         BUnionType.create(null, symTable.intType, symTable.floatType,
                                 symTable.decimalType, symTable.stringType,

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -4622,6 +4622,19 @@ public class Types {
         return isSimpleBasicType(type.tag);
     }
 
+    public boolean isUnionOfSimpleBasicTypesExceptNilType(BType type) {
+        if (type.tag == TypeTags.UNION) {
+            Set<BType> memberTypes = ((BUnionType) type).getMemberTypes();
+            for (BType memType : memberTypes) {
+                if (memType.tag == TypeTags.NIL || !isSimpleBasicType(memType.tag)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+        return type.tag != TypeTags.NIL && isSimpleBasicType(type.tag);
+    }
+
     public boolean isSubTypeOfReadOnlyOrIsolatedObjectUnion(BType type) {
         if (isInherentlyImmutableType(type) || Symbols.isFlagOn(type.flags, Flags.READONLY)) {
             return true;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralNegativeTest.java
@@ -35,15 +35,19 @@ public class StringTemplateLiteralNegativeTest {
     @Test(description = "Test string template literal with errors")
     public void testStringTemplateLiteralNegativeCases() {
         resultNegative = BCompileUtil.compile("test-src/types/string/string-template-literal-negative.bal");
-        Assert.assertEquals(resultNegative.getErrorCount(), 2);
+        Assert.assertEquals(resultNegative.getErrorCount(), 4);
         //testUndefinedSymbol
         BAssertUtil.validateError(resultNegative, 0, "undefined symbol 'name'", 2, 32);
         //testIncompatibleTypes
         BAssertUtil.validateError(resultNegative, 1,
                 "incompatible types: expected '(int|float|decimal|string|boolean)', found 'json'", 8, 32);
+        BAssertUtil.validateError(resultNegative, 2,
+                "incompatible types: expected '(int|float|decimal|string|boolean)', found 'Foo'", 16, 21);
+        BAssertUtil.validateError(resultNegative, 3,
+                "incompatible types: expected '(int|float|decimal|string|boolean)', found '()'", 21, 21);
     }
 
-    @Test(description = "Test string template literal syntax errors", groups = { "disableOnOldParser" })
+    @Test(description = "Test string template literal syntax errors")
     public void testStringTemplateLiteralSyntaxNegativeCases() {
         resultNegative = BCompileUtil.compile("test-src/types/string/string-template-literal-syntax-negative.bal");
         Assert.assertEquals(resultNegative.getErrorCount(), 13);
@@ -60,7 +64,7 @@ public class StringTemplateLiteralNegativeTest {
         BAssertUtil.validateError(resultNegative, index++, "complex variable must be initialized", 10, 39);
         BAssertUtil.validateError(resultNegative, index++, "missing semicolon token", 10, 39);
         BAssertUtil.validateError(resultNegative, index++, "invalid token ';\n    return s;\n}\n'", 13, 1);
-        BAssertUtil.validateError(resultNegative, index++, "invalid token '`'", 13, 1);
+        BAssertUtil.validateError(resultNegative, index, "invalid token '`'", 13, 1);
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/StringTemplateLiteralTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 /**
  * Test class for String Template Literal.
  */
-@Test(groups = { "disableOnOldParser" })
 public class StringTemplateLiteralTest {
 
     private CompileResult result;
@@ -303,6 +302,11 @@ public class StringTemplateLiteralTest {
         Assert.assertTrue(returns[0] instanceof BString);
         Assert.assertEquals(returns[0].stringValue(),
                 "Hello \\n$\\\\$$\\{Dummy\\tText\\`\\\\test Ballerina endText\\\\{{{{{innerStartText 7 }}!!!");
+    }
+
+    @Test
+    public void testStringTemplateExprWithUnionType() {
+        BRunUtil.invoke(result, "testStringTemplateExprWithUnionType");
     }
 
     @AfterClass

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal-negative.bal
@@ -8,3 +8,15 @@ function stringTemplate2() returns (string) {
     string s = string `Hello ${name}`;
     return s;
 }
+
+public type Foo int|float|decimal|string|boolean|();
+
+function tringTemplate3() returns string {
+    Foo foo = 4;
+    return string`${foo}`;
+}
+
+function tringTemplate4() returns string {
+    () foo = ();
+    return string`${foo}`;
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/string-template-literal.bal
@@ -188,3 +188,39 @@ function complexStringTemplateExpr() returns (string) {
     string s1 = "Ballerina";
     return string `Hello \n$\\$$\{Dummy\tText\${"`"}\\test ${s1} endText\\{{{{{innerStartText ${4 + 3} }}!!!`;
 }
+
+public type Foo int|float|decimal|string|boolean;
+
+function stringTemplateExprWithUnionType1() returns string {
+    Foo foo = 4;
+    return string`${foo}`;
+}
+
+function stringTemplateExprWithUnionType2() returns string {
+    Foo foo = 4.5;
+    return string`${foo}`;
+}
+
+function stringTemplateExprWithUnionType3() returns string {
+    Foo foo = "chirans";
+    return string`${foo}`;
+}
+
+function stringTemplateExprWithUnionType4() returns string {
+    Foo foo = true;
+    return string`${foo}`;
+}
+
+function testStringTemplateExprWithUnionType() {
+    assertEquality("4", stringTemplateExprWithUnionType1());
+    assertEquality("4.5", stringTemplateExprWithUnionType2());
+    assertEquality("chirans", stringTemplateExprWithUnionType3());
+    assertEquality("true", stringTemplateExprWithUnionType4());
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString() + "'");
+}


### PR DESCRIPTION
## Purpose
> $title.

Fixes #29674 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
