### PR TITLE
Map service decl node start location to the location of the service keyword

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -287,7 +287,7 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
 
     @Override
     public Optional<Location> transform(ServiceDeclarationNode serviceDeclarationNode) {
-        return Optional.of(serviceDeclarationNode.location());
+        return Optional.of(serviceDeclarationNode.serviceKeyword().location());
     }
 
     @Override

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_service_decl_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_service_decl_test.bal
@@ -18,6 +18,9 @@ type HelloWorld service object {
     remote function sayHello() returns string;
 };
 
+@v1 {
+    foo: "annot on service"
+}
 service HelloWorld /foo/bar on new Listener() {
 
     public string greeting = "Hello World!";
@@ -25,16 +28,17 @@ service HelloWorld /foo/bar on new Listener() {
     resource function get greet/[int x]/hello/[float y]/[string... rest] () returns json => { output: self.greeting };
 
     resource function delete pets () returns record{|Error body;|} {
+        return {body:{id: 10, code: "FailedToDelete"}};
     }
 
-    remote function sayHello() return string => self.greeting;
+    remote function sayHello() returns string => self.greeting;
 
     function createError() returns @tainted error? => ();
 }
 
 public class Listener {
 
-    public function start() returns error? {
+    public function 'start() returns error? {
     }
 
     public function gracefulStop() returns error? {
@@ -54,3 +58,10 @@ type Error record {
     int id;
     string code;
 };
+
+type Annot record {
+    string foo;
+    int bar?;
+};
+
+public const annotation Annot v1 on source service;


### PR DESCRIPTION
## Purpose
This PR fixes an issue with the syntax node to location mapper mapping a service declaration node's start position considering the metadata as well. Since in AST, we drop the metadata locations from the AST node, need to map the location to the location of the `service` keyword.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
