### PR TITLE
Add APIs for getting deprecated doc info

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaDocumentation.java
@@ -79,4 +79,24 @@ public class BallerinaDocumentation implements Documentation {
         }
         return Optional.ofNullable(this.markdownDocAttachment.returnValueDescription);
     }
+
+    @Override
+    public Optional<String> deprecatedDescription() {
+        if (this.markdownDocAttachment == null) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(this.markdownDocAttachment.deprecatedDocumentation);
+    }
+
+    @Override
+    public Map<String, String> deprecatedParametersMap() {
+        HashMap<String, String> paramMap = new LinkedHashMap<>();
+        if (this.markdownDocAttachment != null) {
+            this.markdownDocAttachment.deprecatedParams
+                    .forEach(parameter -> paramMap.put(parameter.name, parameter.description));
+        }
+
+        return paramMap;
+    }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Documentation.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/Documentation.java
@@ -47,4 +47,19 @@ public interface Documentation {
      * @return {@link Optional} return description
      */
     Optional<String> returnDescription();
+
+    /**
+     * Gets the deprecated documentation if the user has specified it.
+     *
+     * @return The text if there is a deprecation documentation
+     */
+    Optional<String> deprecatedDescription();
+
+    /**
+     * Gets the parameters in the "Deprecated parameters" section as a mapping between the parameter name and the
+     * deprecated documentation for it. If there isn't a deprecated parameters section, the map will be empty.
+     *
+     * @return A map of deprecated parameters and their descriptions
+     */
+    Map<String, String> deprecatedParametersMap();
 }

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/MarkdownDocAttachment.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/elements/MarkdownDocAttachment.java
@@ -31,9 +31,12 @@ public class MarkdownDocAttachment {
     public String description;
     public List<Parameter> parameters;
     public String returnValueDescription;
+    public String deprecatedDocumentation;
+    public List<Parameter> deprecatedParams;
 
     public MarkdownDocAttachment(int paramCount) {
         this.parameters = new ArrayList<>(paramCount);
+        this.deprecatedParams = new ArrayList<>();
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/MarkDownDocumentationDeprecationAttributeNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/tree/expressions/MarkDownDocumentationDeprecationAttributeNode.java
@@ -26,4 +26,6 @@ public interface MarkDownDocumentationDeprecationAttributeNode extends Expressio
     void addDeprecationDocumentationLine(String text);
 
     void addDeprecationLine(String text);
+
+    String getDocumentation();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -513,17 +513,28 @@ public class BIRPackageSymbolEnter {
 
         markdownDocAttachment.description = descCPIndex >= 0 ? getStringCPEntryValue(descCPIndex) : null;
         markdownDocAttachment.returnValueDescription
-                = retDescCPIndex  >= 0 ? getStringCPEntryValue(retDescCPIndex) : null;
+                = retDescCPIndex >= 0 ? getStringCPEntryValue(retDescCPIndex) : null;
+        readAndSetParamDocumentation(dataInStream, markdownDocAttachment.parameters, paramLength);
 
-        for (int i = 0; i < paramLength; i++) {
-            int nameCPIndex = dataInStream.readInt();
-            int paramDescCPIndex = dataInStream.readInt();
+        int deprecatedDescCPIndex = dataInStream.readInt();
+        int deprecatedParamLength = dataInStream.readInt();
+        markdownDocAttachment.deprecatedDocumentation = deprecatedDescCPIndex >= 0
+                ? getStringCPEntryValue(deprecatedDescCPIndex) : null;
+        readAndSetParamDocumentation(dataInStream, markdownDocAttachment.deprecatedParams, deprecatedParamLength);
+
+        symbol.markdownDocumentation = markdownDocAttachment;
+    }
+
+    private void readAndSetParamDocumentation(DataInputStream inputStream, List<MarkdownDocAttachment.Parameter> params,
+                                              int nParams) throws IOException {
+        for (int i = 0; i < nParams; i++) {
+            int nameCPIndex = inputStream.readInt();
+            int paramDescCPIndex = inputStream.readInt();
             String name = nameCPIndex >= 0 ? getStringCPEntryValue(nameCPIndex) : null;
             String description = paramDescCPIndex >= 0 ? getStringCPEntryValue(paramDescCPIndex) : null;
             MarkdownDocAttachment.Parameter parameter = new MarkdownDocAttachment.Parameter(name, description);
-            markdownDocAttachment.parameters.add(parameter);
+            params.add(parameter);
         }
-        symbol.markdownDocumentation = markdownDocAttachment;
     }
 
     private BType readBType(DataInputStream dataInStream) throws IOException {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -487,6 +487,18 @@ public class BIRTypeWriter implements TypeVisitor {
                 birbuf.writeInt(parameter.description == null ? -1
                         : addStringCPEntry(parameter.description));
             }
+
+            if (markdownDocAttachment.deprecatedDocumentation != null) {
+                birbuf.writeInt(addStringCPEntry(markdownDocAttachment.deprecatedDocumentation));
+            } else {
+                birbuf.writeInt(-1);
+            }
+
+            birbuf.writeInt(markdownDocAttachment.deprecatedParams.size());
+            for (MarkdownDocAttachment.Parameter param : markdownDocAttachment.deprecatedParams) {
+                birbuf.writeInt(addStringCPEntry(param.name));
+                birbuf.writeInt(addStringCPEntry(param.description));
+            }
         }
         int length = birbuf.nioBuffer().limit();
         buf.writeInt(length);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -479,14 +479,8 @@ public class BIRTypeWriter implements TypeVisitor {
             birbuf.writeInt(markdownDocAttachment.description == null ? -1
                     : addStringCPEntry(markdownDocAttachment.description));
             birbuf.writeInt(markdownDocAttachment.returnValueDescription == null ? -1
-                    : addStringCPEntry(markdownDocAttachment.returnValueDescription));
-            birbuf.writeInt(markdownDocAttachment.parameters.size());
-            for (MarkdownDocAttachment.Parameter parameter : markdownDocAttachment.parameters) {
-                birbuf.writeInt(parameter.name == null ? -1
-                        : addStringCPEntry(parameter.name));
-                birbuf.writeInt(parameter.description == null ? -1
-                        : addStringCPEntry(parameter.description));
-            }
+                                    : addStringCPEntry(markdownDocAttachment.returnValueDescription));
+            writeParamDocs(birbuf, markdownDocAttachment.parameters);
 
             if (markdownDocAttachment.deprecatedDocumentation != null) {
                 birbuf.writeInt(addStringCPEntry(markdownDocAttachment.deprecatedDocumentation));
@@ -494,15 +488,19 @@ public class BIRTypeWriter implements TypeVisitor {
                 birbuf.writeInt(-1);
             }
 
-            birbuf.writeInt(markdownDocAttachment.deprecatedParams.size());
-            for (MarkdownDocAttachment.Parameter param : markdownDocAttachment.deprecatedParams) {
-                birbuf.writeInt(addStringCPEntry(param.name));
-                birbuf.writeInt(addStringCPEntry(param.description));
-            }
+            writeParamDocs(birbuf, markdownDocAttachment.deprecatedParams);
         }
         int length = birbuf.nioBuffer().limit();
         buf.writeInt(length);
         buf.writeBytes(birbuf.nioBuffer().array(), 0, length);
+    }
+
+    private void writeParamDocs(ByteBuf birBuf, List<MarkdownDocAttachment.Parameter> params) {
+        birBuf.writeInt(params.size());
+        for (MarkdownDocAttachment.Parameter param : params) {
+            birBuf.writeInt(addStringCPEntry(param.name));
+            birBuf.writeInt(addStringCPEntry(param.description));
+        }
     }
 
     private void throwUnimplementedError(BType bType) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -111,6 +111,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecatedParametersDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecationDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownParameterDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
@@ -3991,8 +3992,14 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         docAttachment.deprecatedDocumentation = deprecatedDocs.getDocumentation();
 
-        for (BLangMarkdownParameterDocumentation param :
-                docNode.getDeprecatedParametersDocumentation().getParameters()) {
+        BLangMarkDownDeprecatedParametersDocumentation deprecatedParamsDocs =
+                docNode.getDeprecatedParametersDocumentation();
+
+        if (deprecatedParamsDocs == null) {
+            return docAttachment;
+        }
+
+        for (BLangMarkdownParameterDocumentation param : deprecatedParamsDocs.getParameters()) {
             docAttachment.deprecatedParams.add(
                     new MarkdownDocAttachment.Parameter(param.parameterName.value, param.getParameterDocumentation()));
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -111,6 +111,8 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLiteral;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecationDocumentation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownParameterDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangSimpleVarRef;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLAttribute;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
@@ -3975,11 +3977,26 @@ public class SymbolEnter extends BLangNodeVisitor {
         MarkdownDocAttachment docAttachment = new MarkdownDocAttachment(docNode.getParameters().size());
         docAttachment.description = docNode.getDocumentation();
 
-        docNode.getParameters().forEach(p ->
-                docAttachment.parameters.add(new MarkdownDocAttachment.Parameter(p.parameterName.value,
-                        p.getParameterDocumentation())));
+        for (BLangMarkdownParameterDocumentation p : docNode.getParameters()) {
+            docAttachment.parameters.add(new MarkdownDocAttachment.Parameter(p.parameterName.value,
+                                                                             p.getParameterDocumentation()));
+        }
 
         docAttachment.returnValueDescription = docNode.getReturnParameterDocumentation();
+        BLangMarkDownDeprecationDocumentation deprecatedDocs = docNode.getDeprecationDocumentation();
+
+        if (deprecatedDocs == null) {
+            return docAttachment;
+        }
+
+        docAttachment.deprecatedDocumentation = deprecatedDocs.getDocumentation();
+
+        for (BLangMarkdownParameterDocumentation param :
+                docNode.getDeprecatedParametersDocumentation().getParameters()) {
+            docAttachment.deprecatedParams.add(
+                    new MarkdownDocAttachment.Parameter(param.parameterName.value, param.getParameterDocumentation()));
+        }
+
         return docAttachment;
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkDownDeprecationDocumentation.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMarkDownDeprecationDocumentation.java
@@ -54,6 +54,11 @@ public class BLangMarkDownDeprecationDocumentation extends BLangExpression
     }
 
     @Override
+    public String getDocumentation() {
+        return String.join("\n", this.deprecationDocumentationLines).replaceAll("\r", "");
+    }
+
+    @Override
     public void accept(BLangNodeVisitor visitor) {
         visitor.visit(this);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -25,9 +25,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 57;
-    public static final short MIN_SUPPORTED_VERSION = 57;
-    public static final short MAX_SUPPORTED_VERSION = 57;
+    public static final int BIR_VERSION_NUMBER = 58;
+    public static final short MIN_SUPPORTED_VERSION = 58;
+    public static final short MAX_SUPPORTED_VERSION = 58;
 
     // todo move this to a proper place
     public static final String[] SUPPORTED_PLATFORMS = {"java11"};

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -691,6 +691,14 @@ types:
         type: markdown_parameter
         repeat: expr
         repeat-expr: parameters_count
+      - id: deprecated_docs_cp_index
+        type: s4
+      - id: deprecated_params_count
+        type: s4
+      - id: deprecated_params
+        type: markdown_parameter
+        repeat: expr
+        repeat-expr: deprecated_params_count
   markdown_parameter:
     seq:
       - id: name_cp_index

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -243,19 +243,36 @@ class BIRTestUtils {
         assertMarkdownEntry(constantPoolEntries, actualDocContent.descriptionCpIndex(), expectedDocument.description);
 
         assertMarkdownEntry(constantPoolEntries, actualDocContent.returnValueDescriptionCpIndex(),
-                expectedDocument.returnValueDescription);
+                            expectedDocument.returnValueDescription);
 
         List<MarkdownDocAttachment.Parameter> expectedParameters = expectedDocument.parameters;
         Assert.assertEquals(actualDocContent.parametersCount(), expectedParameters.size());
         ArrayList<Bir.MarkdownParameter> actualParameters = actualDocContent.parameters();
-        for (int i = 0; i < actualParameters.size(); i++) {
-            Bir.MarkdownParameter actualParameter = actualParameters.get(i);
-            MarkdownDocAttachment.Parameter expectedParameter = expectedParameters.get(i);
+
+        assertMarkdownParams(constantPoolEntries, actualParameters, expectedParameters);
+
+        assertMarkdownEntry(constantPoolEntries, actualDocContent.deprecatedDocsCpIndex(),
+                            expectedDocument.deprecatedDocumentation);
+
+        List<MarkdownDocAttachment.Parameter> expDeprecatedParams = expectedDocument.deprecatedParams;
+        ArrayList<Bir.MarkdownParameter> actualDeprecatedParams = actualDocContent.deprecatedParams();
+        Assert.assertEquals(actualDocContent.deprecatedParamsCount(), expDeprecatedParams.size());
+        Assert.assertEquals(actualDeprecatedParams.size(), actualDocContent.deprecatedParamsCount());
+
+        assertMarkdownParams(constantPoolEntries, actualDeprecatedParams, expDeprecatedParams);
+    }
+
+    private static void assertMarkdownParams(ArrayList<Bir.ConstantPoolEntry> constantPoolEntries,
+                                             ArrayList<Bir.MarkdownParameter> actualParams,
+                                             List<MarkdownDocAttachment.Parameter> expParams) {
+        for (int i = 0; i < actualParams.size(); i++) {
+            Bir.MarkdownParameter actualParameter = actualParams.get(i);
+            MarkdownDocAttachment.Parameter expectedParameter = expParams.get(i);
 
             assertMarkdownEntry(constantPoolEntries, actualParameter.nameCpIndex(), expectedParameter.name);
 
             assertMarkdownEntry(constantPoolEntries, actualParameter.descriptionCpIndex(),
-                    expectedParameter.description);
+                                expectedParameter.description);
         }
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/command/docs/DocAttachmentInfo.java
@@ -19,6 +19,7 @@ import io.ballerina.compiler.api.symbols.Documentation;
 import org.ballerinalang.langserver.common.utils.CommonUtil;
 import org.eclipse.lsp4j.Position;
 
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -68,6 +69,16 @@ public class DocAttachmentInfo implements Documentation {
     @Override
     public Optional<String> returnDescription() {
         return Optional.ofNullable(returnDesc);
+    }
+
+    @Override
+    public Optional<String> deprecatedDescription() {
+        return Optional.empty();
+    }
+
+    @Override
+    public Map<String, String> deprecatedParametersMap() {
+        return Collections.emptyMap();
     }
 
     public Position getDocStartPos() {

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/DocumentationTest.java
@@ -132,6 +132,28 @@ public class DocumentationTest {
         assertDescriptionOnly(documentation.get(), "This is a variable");
     }
 
+    @Test
+    public void testDeprecatedDocs() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(83, 16));
+        Optional<Documentation> documentation = ((Documentable) symbol.get()).documentation();
+        Map<String, String> expParams =
+                Map.of("fname", "First name of the person",
+                       "lname", "Last name of the person",
+                       "street", "Street the person is living at",
+                       "city", "The city the person is living in",
+                       "countryCode", "The country code for the country the person is living in");
+        Map<String, String> expDeprecatedParams = Map.of("street", "deprecated for removal",
+                                                         "countryCode", "deprecated for removal");
+
+        assertDocumentation(documentation.get(), "Creates and returns a `Person` object given the parameters.\n",
+                            expParams, "A new Person string\n");
+        assertEquals(documentation.get().deprecatedDescription().get(),
+                     "This function is deprecated in favour of `Person` type.");
+        assertEquals(documentation.get().deprecatedParametersMap().size(), expDeprecatedParams.size());
+        expDeprecatedParams.forEach(
+                (param, doc) -> assertEquals(documentation.get().deprecatedParametersMap().get(param), doc));
+    }
+
     // util methods
 
     private void assertDescriptionOnly(Documentation documentation, String description) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/documentation_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/documentation_test.bal
@@ -65,3 +65,23 @@ function sum(int x, int y) returns int => x + y;
 
 # This is a variable
 string greet = "Hello";
+
+# Creates and returns a `Person` object given the parameters.
+#
+# + fname - First name of the person
+# + lname - Last name of the person
+# + street - Street the person is living at
+# + city - The city the person is living in
+# + countryCode - The country code for the country the person is living in
+# + return - A new Person string
+#
+# # Deprecated parameters
+# + street - deprecated for removal
+# + countryCode - deprecated for removal
+# # Deprecated
+# This function is deprecated in favour of `Person` type.
+@deprecated
+public function createPerson(string fname, string lname, @deprecated string street,
+                             string city, @deprecated string countryCode) returns string {
+    return "";
+}


### PR DESCRIPTION
## Purpose
This PR adds new APIs to `Documentation` for retrieving the deprecated doc info of constructs.

Fix #28873

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
