### PR TITLE
Fix agent port of observability-test-utils tests to avoid port conflicts

### DIFF
--- a/tests/observability-test-utils/build.gradle
+++ b/tests/observability-test-utils/build.gradle
@@ -98,6 +98,7 @@ test {
     systemProperty 'ballerina.agent.path', configurations.testUtils.asPath
     systemProperty 'observability.test.utils.bala', "$buildDir/ballerina-src/target/testobserve.zip"
     systemProperty 'observability.test.utils.jar', tasks.shadowJar.archiveFile.get().asFile
+    systemProperty 'ballerina.agent.port.start.value', 27000
     useTestNG() {
         suites 'src/test/resources/testng.xml'
     }


### PR DESCRIPTION
## Purpose
> Fix agent port of observability-test-utils tests to avoid port conflicts. Related to #29613