### PR TITLE
Introduce syntaxTreeNode API for document service

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentService.java
@@ -50,4 +50,7 @@ public interface BallerinaDocumentService {
 
     @JsonRequest
     CompletableFuture<List<PublishDiagnosticsParams>> diagnostics(BallerinaProjectParams params);
+
+    @JsonRequest
+    CompletableFuture<SyntaxTreeNodeResponse> syntaxTreeNode(SyntaxTreeNodeRequest params);
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/BallerinaDocumentServiceImpl.java
@@ -284,4 +284,25 @@ public class BallerinaDocumentServiceImpl implements BallerinaDocumentService {
             }
         });
     }
+
+    @Override
+    public CompletableFuture<SyntaxTreeNodeResponse> syntaxTreeNode(SyntaxTreeNodeRequest params) {
+        return CompletableFuture.supplyAsync(() -> {
+            SyntaxTreeNodeResponse syntaxTreeNodeResponse = new SyntaxTreeNodeResponse();
+            try {
+                Optional<Path> filePath = CommonUtil.getPathFromURI(params.getDocumentIdentifier().getUri());
+                if (filePath.isEmpty()) {
+                    return syntaxTreeNodeResponse;
+                }
+                SyntaxTree syntaxTree = this.workspaceManager.syntaxTree(filePath.get()).orElseThrow();
+                NonTerminalNode currentNode = CommonUtil.findNode(params.getRange(), syntaxTree);
+                syntaxTreeNodeResponse.setKind(currentNode.kind().name());
+            } catch (Throwable e) {
+                String msg = "Operation 'ballerinaDocument/syntaxTreeNode' failed!";
+                this.clientLogger.logError(DocumentContext.DC_SYNTAX_TREE_NODE, msg, e, params.getDocumentIdentifier(),
+                        (Position) null);
+            }
+            return syntaxTreeNodeResponse;
+        });
+    }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/DocumentContext.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/DocumentContext.java
@@ -29,7 +29,8 @@ public enum DocumentContext implements LSOperation {
     DC_SYNTAX_TREE_LOCATE("ballerinaDocument/syntaxTreeLocate"),
     DC_AST("ballerinaDocument/ast"),
     DC_PROJECT("ballerinaDocument/project"),
-    DC_DIAGNOSTICS("ballerinaDocument/diagnostics");
+    DC_DIAGNOSTICS("ballerinaDocument/diagnostics"),
+    DC_SYNTAX_TREE_NODE("ballerinaDocument/syntaxTreeNode");
 
     private final String name;
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/SyntaxTreeNodeRequest.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/SyntaxTreeNodeRequest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.extensions.ballerina.document;
+
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+
+/**
+ * Represents the request for syntaxTreeNode API.
+ */
+public class SyntaxTreeNodeRequest {
+
+    private TextDocumentIdentifier documentIdentifier;
+    private Range range;
+
+    public void setDocumentIdentifiers(TextDocumentIdentifier documentIdentifier) {
+        this.documentIdentifier = documentIdentifier;
+    }
+
+    protected TextDocumentIdentifier getDocumentIdentifier() {
+        return documentIdentifier;
+    }
+
+    public void setRange(Range range) {
+        this.range = range;
+    }
+
+    protected Range getRange() {
+        return range;
+    }
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/SyntaxTreeNodeResponse.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/extensions/ballerina/document/SyntaxTreeNodeResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.extensions.ballerina.document;
+
+/**
+ * Represents the response for syntaxTreeNode API.
+ */
+public class SyntaxTreeNodeResponse {
+
+    private String kind;
+
+    public String getKind() {
+        return kind;
+    }
+
+    public void setKind(String kind) {
+        this.kind = kind;
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/stnode/SyntaxTreeNodeTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/stnode/SyntaxTreeNodeTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.langserver.stnode;
+
+import com.google.gson.JsonParser;
+import org.ballerinalang.langserver.util.FileUtils;
+import org.ballerinalang.langserver.util.TestUtil;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.Endpoint;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+/**
+ * Tests syntaxTreeNode API in Language Server.
+ */
+public class SyntaxTreeNodeTest {
+
+    private static final JsonParser JSON_PARSER = new JsonParser();
+    private static final String STRING_LITERAL = "STRING_LITERAL";
+
+    private Path resource;
+    private Endpoint serviceEndpoint;
+
+    @BeforeClass
+    public void init() {
+        this.resource = FileUtils.RES_DIR.resolve("stnode").resolve("stnode_test.bal");
+        this.serviceEndpoint = TestUtil.initializeLanguageSever();
+    }
+
+    @Test(description = "Test syntaxTreeNode API", dataProvider = "stnode-data-provider")
+    public void syntaxTreeNodeTestCase(int start, int end, String expected) throws IOException {
+        TestUtil.openDocument(serviceEndpoint, resource);
+        Range range = new Range(new Position(start, end), new Position(start, end));
+        String response = TestUtil.getSyntaxTreeNodeResponse(serviceEndpoint,
+                this.resource.toAbsolutePath().toString(), range);
+        String actual = JSON_PARSER.parse(response).getAsJsonObject().getAsJsonObject("result")
+                .getAsJsonPrimitive("kind").getAsString();
+        Assert.assertEquals(actual, expected,
+                "Document syntaxTreeNode testcase failed for range " + start + " and " + end + ".");
+    }
+
+    @AfterClass
+    public void cleanupLanguageServer() {
+        TestUtil.shutdownLanguageServer(this.serviceEndpoint);
+    }
+
+    @DataProvider(name = "stnode-data-provider")
+    public Object[][] getDataProvider() {
+        return new Object[][]{
+                {0, 0, "IMPORT_DECLARATION"},
+                {2, 25, STRING_LITERAL},
+                {4, 20, "FUNCTION_DEFINITION"},
+                {5, 30, STRING_LITERAL},
+                {8, 15, "CAPTURE_BINDING_PATTERN"},
+                {9, 25, STRING_LITERAL},
+                {14, 10, "MODULE_VAR_DECL"},
+                {14, 30, STRING_LITERAL},
+                {19, 10, "RETURN_STATEMENT"},
+                {19, 30, STRING_LITERAL},
+                {16, 5, "SERVICE_DECLARATION"},
+                {12, 5, "RECORD_TYPE_DESC"},
+                {8, 3, "PARAMETERIZED_TYPE_DESC"},
+                {2, 5, "CONST_DECLARATION"},
+                {18, 45, "RETURN_TYPE_DESCRIPTOR"}
+        };
+    }
+}

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/TestUtil.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/util/TestUtil.java
@@ -30,6 +30,7 @@ import org.ballerinalang.langserver.commons.LanguageServerContext;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceDocumentException;
 import org.ballerinalang.langserver.commons.workspace.WorkspaceManager;
 import org.ballerinalang.langserver.contexts.ContextBuilder;
+import org.ballerinalang.langserver.extensions.ballerina.document.SyntaxTreeNodeRequest;
 import org.ballerinalang.langserver.extensions.ballerina.packages.PackageComponentsRequest;
 import org.ballerinalang.langserver.extensions.ballerina.packages.PackageMetadataRequest;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -115,6 +116,8 @@ public class TestUtil {
     private static final String PACKAGE_METADATA = "ballerinaPackage/metadata";
 
     private static final String PACKAGE_COMPONENTS = "ballerinaPackage/components";
+
+    private static final String DOCUMENT_SYNTAX_TREE_NODE = "ballerinaDocument/syntaxTreeNode";
 
     private static final Gson GSON = new Gson();
 
@@ -339,6 +342,21 @@ public class TestUtil {
         });
         packageComponentsRequest.setDocumentIdentifiers(documentIdentifiers.toArray(new TextDocumentIdentifier[0]));
         return getResponseString(serviceEndpoint.request(PACKAGE_COMPONENTS, packageComponentsRequest));
+    }
+
+    /**
+     * Returns syntaxTreeNode API response.
+     *
+     * @param serviceEndpoint Language Server Service endpoint
+     * @param filePath        File path to evaluate
+     * @param range           Document position
+     * @return {@link String} Document syntaxTree node response
+     */
+    public static String getSyntaxTreeNodeResponse(Endpoint serviceEndpoint, String filePath, Range range) {
+        SyntaxTreeNodeRequest request = new SyntaxTreeNodeRequest();
+        request.setDocumentIdentifiers(getTextDocumentIdentifier(filePath));
+        request.setRange(range);
+        return getResponseString(serviceEndpoint.request(DOCUMENT_SYNTAX_TREE_NODE, request));
     }
 
     /**

--- a/language-server/modules/langserver-core/src/test/resources/stnode/stnode_test.bal
+++ b/language-server/modules/langserver-core/src/test/resources/stnode/stnode_test.bal
@@ -1,0 +1,22 @@
+import ballerina/http;
+
+const CONST_VALUE = "This is a constant value.";
+
+public function main() {
+    string stringValue = "This is inside function.";
+}
+
+map<string> mapValues = {
+    "stringValue": "This is inside map."
+};
+
+record {|
+    string stringVal;
+|} value = {stringVal: "This is inside record."};
+
+service /hello on new http:Listener(9093) {
+
+    resource function get satyHello() returns string {
+        return "This is inside resource.";
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/testng.xml
+++ b/language-server/modules/langserver-core/src/test/resources/testng.xml
@@ -48,6 +48,7 @@ under the License.
             <package name="org.ballerinalang.langserver.foldingrange.*" />
             <package name="org.ballerinalang.langserver.common.utils.*" />
             <package name="org.ballerinalang.langserver.packages.*" />
+            <package name="org.ballerinalang.langserver.stnode.*" />
         </packages>
         <classes>
             <class name="org.ballerinalang.langserver.workspace.TestWorkspaceManager" />


### PR DESCRIPTION


## Purpose
Introduce literalNode API for the Ballerina document service to enable string split capability for the VSCode plugin.

Related issue https://github.com/ballerina-platform/plugin-vscode/issues/215

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
