### PR TITLE
Set the location of a var ref to the position of the var name

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -665,10 +665,11 @@ public class ReferenceFinder extends BaseVisitor {
             return;
         }
 
-        if (!varRefExpr.pkgAlias.value.isEmpty()) {
-            addIfSameSymbol(varRefExpr.symbol.owner, varRefExpr.pkgAlias.pos);
+        if (!varRefExpr.pkgAlias.value.isEmpty() && addIfSameSymbol(varRefExpr.symbol.owner, varRefExpr.pkgAlias.pos)) {
+            return;
         }
-        addIfSameSymbol(varRefExpr.symbol, varRefExpr.pos);
+
+        addIfSameSymbol(varRefExpr.symbol, varRefExpr.variableName.pos);
     }
 
     @Override
@@ -1174,13 +1175,15 @@ public class ReferenceFinder extends BaseVisitor {
 
     // Private methods
 
-    private void addIfSameSymbol(BSymbol symbol, Location location) {
+    private boolean addIfSameSymbol(BSymbol symbol, Location location) {
         if (symbol != null
                 && this.targetSymbol.name.equals(symbol.name)
                 && this.targetSymbol.pkgID.equals(symbol.pkgID)
                 && this.targetSymbol.pos.equals(symbol.pos)) {
             this.referenceLocations.add(location);
+            return true;
         }
+        return false;
     }
 
     private boolean isGeneratedClassDefForService(BLangClassDefinition clazz) {

--- a/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/ProjectRenameTest.java
+++ b/language-server/modules/langserver-core/src/test/java/org/ballerinalang/langserver/rename/ProjectRenameTest.java
@@ -79,6 +79,7 @@ public class ProjectRenameTest {
         return new Object[][]{
                 {"rename_class_result.json", "Student"},
                 {"rename_function_result.json", "getStudents"},
+                {"rename_global_var_result.json", "path"},
         };
     }
 

--- a/language-server/modules/langserver-core/src/test/resources/rename/expected/project/rename_global_var_result.json
+++ b/language-server/modules/langserver-core/src/test/resources/rename/expected/project/rename_global_var_result.json
@@ -1,0 +1,43 @@
+{
+  "source": {
+    "file": "modules/module2/module2.bal"
+  },
+  "position": {
+    "line": 51,
+    "character": 14
+  },
+  "result": {
+    "changes": {
+      "modules/module2/module2.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 51,
+              "character": 14
+            },
+            "end": {
+              "line": 51,
+              "character": 27
+            }
+          },
+          "newText": "path"
+        }
+      ],
+      "modules/module1/module1.bal": [
+        {
+          "range": {
+            "start": {
+              "line": 17,
+              "character": 19
+            },
+            "end": {
+              "line": 17,
+              "character": 32
+            }
+          },
+          "newText": "path"
+        }
+      ]
+    }
+  }
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/project/modules/module1/module1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/project/modules/module1/module1.bal
@@ -13,3 +13,7 @@ public class School {
         self.students.push(p);
     }
 }
+
+function getPath() returns string {
+    return module2:directoryPath + "module2";
+}

--- a/language-server/modules/langserver-core/src/test/resources/rename/sources/project/modules/module2/module2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/rename/sources/project/modules/module2/module2.bal
@@ -47,3 +47,6 @@ public function getPeople() returns Person[] {
 public function addPerson(Person p) {
     people.push(p);
 }
+
+# Directory path
+public string directoryPath = "/";


### PR DESCRIPTION
## Purpose
Previously when vars from other modules were referred, the position of such fully qualified references were calculated taking the module prefix into account. This resulted in the `references()` API feeding in incorrect position to the renaming feature which in turn resulted in incorrect renamings. With this PR, that behaviour is changed to return the position of the var name when it is a fully qualified var ref.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
