### PR TITLE
[Testerina] Add test when actual value is an error in assertEquals

### DIFF
--- a/tests/testerina-integration-test/src/test/resources/project-based-tests/assertions/tests/assert-test.bal
+++ b/tests/testerina-integration-test/src/test/resources/project-based-tests/assertions/tests/assert-test.bal
@@ -271,6 +271,14 @@ function testAssertTypeNotEquals() {
     test:assertNotEquals(arr1, arr2);
 }
 
+@test:Config {}
+function testAssertErrorEquals(){
+    error testError = error("test", message = "actual value is an error.");
+    // When actual value is an error, equality check should fail.
+    error? err = trap test:assertEquals(testError, 1);
+    test:assertTrue(err is error);
+}
+
 function intAdd(int a, int b) returns (int) {
     return a + b;
 }


### PR DESCRIPTION
## Purpose

Add test when actual value is an error.

Fixes #28818

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
