### PR TITLE
Add support for looking up path param symbols by node

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFactory.java
@@ -158,6 +158,12 @@ public class SymbolFactory {
             if (Symbols.isFlagOn(symbol.flags, Flags.REST_PARAM)) {
                 return createBallerinaParameter((BVarSymbol) symbol, ParameterKind.REST);
             }
+            if (symbol.kind == SymbolKind.PATH_PARAMETER) {
+                return createPathParamSymbol((BVarSymbol) symbol, PathSegment.Kind.PATH_PARAMETER);
+            }
+            if (symbol.kind == SymbolKind.PATH_REST_PARAMETER) {
+                return createPathParamSymbol((BVarSymbol) symbol, PathSegment.Kind.PATH_REST_PARAMETER);
+            }
 
             // return the variable symbol
             return createVariableSymbol((BVarSymbol) symbol, name);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SyntaxNodeToLocationMapper.java
@@ -67,6 +67,7 @@ import io.ballerina.compiler.syntax.tree.RecordFieldNode;
 import io.ballerina.compiler.syntax.tree.RecordFieldWithDefaultValueNode;
 import io.ballerina.compiler.syntax.tree.RemoteMethodCallActionNode;
 import io.ballerina.compiler.syntax.tree.RequiredParameterNode;
+import io.ballerina.compiler.syntax.tree.ResourcePathParameterNode;
 import io.ballerina.compiler.syntax.tree.RestParameterNode;
 import io.ballerina.compiler.syntax.tree.ServiceDeclarationNode;
 import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
@@ -176,6 +177,11 @@ public class SyntaxNodeToLocationMapper extends NodeTransformer<Optional<Locatio
         }
 
         return restParameterNode.paramName().get().apply(this);
+    }
+
+    @Override
+    public Optional<Location> transform(ResourcePathParameterNode resourcePathParameterNode) {
+        return resourcePathParameterNode.paramName().apply(this);
     }
 
     @Override


### PR DESCRIPTION
## Purpose
This PR adds support for looking up resource path param symbols by node in the Semantic API.

Fix #28428

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
