### PR TITLE
Add proper support for match statement and binding patterns

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BaseVisitor.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BaseVisitor.java
@@ -46,7 +46,17 @@ import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangWorker;
 import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
 import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangCaptureBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorCauseBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorFieldBindingPatterns;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorMessageBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangFieldBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangListBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangMappingBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangNamedArgBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangRestBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangSimpleBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangWildCardBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangDoClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
@@ -89,7 +99,6 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecation
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownDocumentationLine;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownParameterDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownReturnParameterDocumentation;
-import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchGuard;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
@@ -133,6 +142,16 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLSequenceLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangConstPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorCauseMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorFieldMatchPatterns;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMessageMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangFieldMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangListMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMappingMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangNamedArgMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangRestMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangSimpleMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangWildCardMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
@@ -150,7 +169,6 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangMatchStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordDestructure;
@@ -350,11 +368,87 @@ abstract class BaseVisitor extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangMatch matchNode) {
+    public void visit(BLangMappingBindingPattern mappingBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangFieldBindingPattern fieldBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangRestBindingPattern restBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangWildCardBindingPattern wildCardBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorBindingPattern errorBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorMessageBindingPattern errorMessageBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorCauseBindingPattern errorCauseBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorFieldBindingPatterns errorFieldBindingPatterns) {
+    }
+
+    @Override
+    public void visit(BLangSimpleBindingPattern simpleBindingPattern) {
+    }
+
+    @Override
+    public void visit(BLangNamedArgBindingPattern namedArgBindingPattern) {
     }
 
     @Override
     public void visit(BLangMatchStatement matchStatementNode) {
+    }
+
+    @Override
+    public void visit(BLangMappingMatchPattern mappingMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangFieldMatchPattern fieldMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangRestMatchPattern restMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangListMatchPattern listMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorMatchPattern errorMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorMessageMatchPattern errorMessageMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorCauseMatchPattern errorCauseMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangErrorFieldMatchPatterns errorFieldMatchPatterns) {
+    }
+
+    @Override
+    public void visit(BLangSimpleMatchPattern simpleMatchPattern) {
+    }
+
+    @Override
+    public void visit(BLangNamedArgMatchPattern namedArgMatchPattern) {
     }
 
     @Override
@@ -379,10 +473,6 @@ abstract class BaseVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangListBindingPattern listBindingPattern) {
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchTypedBindingPatternClause patternClauseNode) {
     }
 
     @Override
@@ -674,14 +764,6 @@ abstract class BaseVisitor extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangMatchExpression bLangMatchExpression) {
-    }
-
-    @Override
-    public void visit(BLangMatchExpression.BLangMatchExprPatternClause bLangMatchExprPatternClause) {
-    }
-
-    @Override
     public void visit(BLangCheckedExpr checkedExpr) {
     }
 
@@ -939,15 +1021,6 @@ abstract class BaseVisitor extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangErrorVariableDef bLangErrorVariableDef) {
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchStaticBindingPatternClause bLangMatchStmtStaticBindingPatternClause) {
-    }
-
-    @Override
-    public void visit(
-            BLangMatch.BLangMatchStructuredBindingPatternClause bLangMatchStmtStructuredBindingPatternClause) {
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/EnvironmentResolver.java
@@ -155,7 +155,6 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangMatchStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordDestructure;
@@ -473,15 +472,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
     }
 
     @Override
-    public void visit(BLangMatch matchNode) {
-        if (PositionUtil.withinBlock(this.linePosition, matchNode.getPosition())) {
-            this.scope = this.symbolEnv;
-            matchNode.patternClauses.forEach(patternClause -> acceptNode(patternClause, this.symbolEnv));
-            this.acceptNode(matchNode.onFailClause, symbolEnv);
-        }
-    }
-
-    @Override
     public void visit(BLangAnnotationAttachment annAttachmentNode) {
         if (!PositionUtil.withinBlock(this.linePosition, annAttachmentNode.getPosition())) {
             return;
@@ -515,16 +505,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
         List<RecordLiteralNode.RecordField> fields = recordLiteral.fields;
         this.scope = recordLiteralEnv;
         fields.forEach(keyValue -> this.acceptNode((BLangNode) keyValue, recordLiteralEnv));
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchStaticBindingPatternClause patternClause) {
-        this.acceptNode(patternClause.body, this.symbolEnv);
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchStructuredBindingPatternClause patternClause) {
-        this.acceptNode(patternClause.body, this.symbolEnv);
     }
 
     @Override
@@ -1223,10 +1203,6 @@ public class EnvironmentResolver extends BLangNodeVisitor {
 
     @Override
     public void visit(BLangListBindingPattern listBindingPattern) {
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchTypedBindingPatternClause patternClauseNode) {
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -78,6 +78,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangElvisExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIndexBasedAccess;
@@ -578,7 +579,11 @@ class NodeFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangRecordVarRef varRefExpr) {
-        // TODO: implement this
+        for (BLangRecordVarRef.BLangRecordVarRefKeyValue recordRefField : varRefExpr.recordRefFields) {
+            lookupNode(recordRefField.getBindingPattern());
+        }
+
+        lookupNode((BLangExpression) varRefExpr.restParam);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -52,6 +52,7 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLetClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLimitClause;
+import org.wso2.ballerinalang.compiler.tree.clauses.BLangMatchClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnConflictClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOrderByClause;
@@ -76,6 +77,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangIsLikeExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLambdaFunction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangLetExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangListConstructorExpr;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchGuard;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryExpr;
@@ -113,6 +115,17 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLSequenceLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangConstPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorCauseMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorFieldMatchPatterns;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMessageMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangFieldMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangListMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMappingMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangNamedArgMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangSimpleMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCompoundAssignment;
@@ -124,8 +137,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch.BLangMatchStructuredBindingPatternClause;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangMatchStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordDestructure;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordVariableDef;
@@ -412,19 +424,6 @@ class NodeFinder extends BaseVisitor {
     public void visit(BLangQueryAction queryAction) {
         lookupNodes(queryAction.queryClauseList);
         lookupNode(queryAction.doClause);
-    }
-
-    @Override
-    public void visit(BLangMatch matchNode) {
-        lookupNode(matchNode.expr);
-        lookupNodes(matchNode.patternClauses);
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchTypedBindingPatternClause patternClauseNode) {
-        lookupNode(patternClauseNode.matchExpr);
-        lookupNode(patternClauseNode.variable);
-        lookupNode(patternClauseNode.body);
     }
 
     @Override
@@ -1100,21 +1099,6 @@ class NodeFinder extends BaseVisitor {
     }
 
     @Override
-    public void visit(BLangMatch.BLangMatchStaticBindingPatternClause bLangMatchStmtStaticBindingPatternClause) {
-        lookupNode(bLangMatchStmtStaticBindingPatternClause.matchExpr);
-        lookupNode(bLangMatchStmtStaticBindingPatternClause.literal);
-        lookupNode(bLangMatchStmtStaticBindingPatternClause.body);
-    }
-
-    @Override
-    public void visit(BLangMatchStructuredBindingPatternClause bLangMatchStmtStructuredBindingPatternClause) {
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.bindingPatternVariable);
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.typeGuardExpr);
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.matchExpr);
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.body);
-    }
-
-    @Override
     public void visit(BLangWorkerFlushExpr workerFlushExpr) {
         setEnclosingNode(workerFlushExpr, workerFlushExpr.workerIdentifier.pos);
     }
@@ -1173,6 +1157,88 @@ class NodeFinder extends BaseVisitor {
         lookupNode(xmlNavigation.expr);
         lookupNode(xmlNavigation.childIndex);
         lookupNodes(xmlNavigation.filters);
+    }
+
+    @Override
+    public void visit(BLangMatchStatement matchStatementNode) {
+        lookupNode(matchStatementNode.expr);
+        lookupNodes(matchStatementNode.matchClauses);
+        lookupNode(matchStatementNode.onFailClause);
+    }
+
+    @Override
+    public void visit(BLangMatchClause matchClause) {
+        lookupNodes(matchClause.matchPatterns);
+        lookupNode(matchClause.matchGuard);
+        lookupNode(matchClause.blockStmt);
+    }
+
+    @Override
+    public void visit(BLangMappingMatchPattern mappingMatchPattern) {
+        lookupNodes(mappingMatchPattern.fieldMatchPatterns);
+        lookupNode(mappingMatchPattern.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangFieldMatchPattern fieldMatchPattern) {
+        lookupNode(fieldMatchPattern.matchPattern);
+    }
+
+    @Override
+    public void visit(BLangListMatchPattern listMatchPattern) {
+        lookupNodes(listMatchPattern.matchPatterns);
+        lookupNode(listMatchPattern.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorMatchPattern errorMatchPattern) {
+        lookupNode(errorMatchPattern.errorTypeReference);
+        lookupNode(errorMatchPattern.errorMessageMatchPattern);
+        lookupNode(errorMatchPattern.errorCauseMatchPattern);
+        lookupNode(errorMatchPattern.errorFieldMatchPatterns);
+    }
+
+    @Override
+    public void visit(BLangErrorMessageMatchPattern errorMessageMatchPattern) {
+        lookupNode(errorMessageMatchPattern.simpleMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorCauseMatchPattern errorCauseMatchPattern) {
+        lookupNode(errorCauseMatchPattern.simpleMatchPattern);
+        lookupNode(errorCauseMatchPattern.errorMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorFieldMatchPatterns errorFieldMatchPatterns) {
+        lookupNodes(errorFieldMatchPatterns.namedArgMatchPatterns);
+        lookupNode(errorFieldMatchPatterns.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangSimpleMatchPattern simpleMatchPattern) {
+        lookupNode(simpleMatchPattern.constPattern);
+        lookupNode(simpleMatchPattern.varVariableName);
+    }
+
+    @Override
+    public void visit(BLangNamedArgMatchPattern namedArgMatchPattern) {
+        lookupNode(namedArgMatchPattern.matchPattern);
+    }
+
+    @Override
+    public void visit(BLangMatchGuard matchGuard) {
+        lookupNode(matchGuard.expr);
+    }
+
+    @Override
+    public void visit(BLangConstPattern constMatchPattern) {
+        lookupNode(constMatchPattern.expr);
+    }
+
+    @Override
+    public void visit(BLangVarBindingPatternMatchPattern varBindingPattern) {
+        lookupNode(varBindingPattern.getBindingPattern());
     }
 
     private boolean setEnclosingNode(BLangNode node, Location pos) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/NodeFinder.java
@@ -47,6 +47,17 @@ import org.wso2.ballerinalang.compiler.tree.BLangTestablePackage;
 import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangCaptureBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorCauseBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorFieldBindingPatterns;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorMessageBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangFieldBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangListBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangMappingBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangNamedArgBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangRestBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangSimpleBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangDoClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
@@ -124,6 +135,7 @@ import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangFieldMatchPattern
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangListMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMappingMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangNamedArgMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangRestMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangSimpleMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
@@ -1239,6 +1251,73 @@ class NodeFinder extends BaseVisitor {
     @Override
     public void visit(BLangVarBindingPatternMatchPattern varBindingPattern) {
         lookupNode(varBindingPattern.getBindingPattern());
+    }
+
+    @Override
+    public void visit(BLangRestMatchPattern restMatchPattern) {
+        // ignore
+    }
+
+    @Override
+    public void visit(BLangMappingBindingPattern mappingBindingPattern) {
+        lookupNodes(mappingBindingPattern.fieldBindingPatterns);
+        lookupNode(mappingBindingPattern.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangFieldBindingPattern fieldBindingPattern) {
+        lookupNode(fieldBindingPattern.bindingPattern);
+    }
+
+    @Override
+    public void visit(BLangRestBindingPattern restBindingPattern) {
+        // ignore
+    }
+
+    @Override
+    public void visit(BLangErrorBindingPattern errorBindingPattern) {
+        lookupNode(errorBindingPattern.errorMessageBindingPattern);
+        lookupNode(errorBindingPattern.errorTypeReference);
+        lookupNode(errorBindingPattern.errorCauseBindingPattern);
+        lookupNode(errorBindingPattern.errorFieldBindingPatterns);
+    }
+
+    @Override
+    public void visit(BLangErrorMessageBindingPattern errorMessageBindingPattern) {
+        lookupNode(errorMessageBindingPattern.simpleBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorCauseBindingPattern errorCauseBindingPattern) {
+        lookupNode(errorCauseBindingPattern.simpleBindingPattern);
+        lookupNode(errorCauseBindingPattern.errorBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorFieldBindingPatterns errorFieldBindingPatterns) {
+        lookupNodes(errorFieldBindingPatterns.namedArgBindingPatterns);
+        lookupNode(errorFieldBindingPatterns.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangSimpleBindingPattern simpleBindingPattern) {
+        lookupNode(simpleBindingPattern.captureBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangNamedArgBindingPattern namedArgBindingPattern) {
+        lookupNode(namedArgBindingPattern.bindingPattern);
+    }
+
+    @Override
+    public void visit(BLangCaptureBindingPattern captureBindingPattern) {
+        setEnclosingNode(captureBindingPattern, captureBindingPattern.getIdentifier().getPosition());
+    }
+
+    @Override
+    public void visit(BLangListBindingPattern listBindingPattern) {
+        lookupNodes(listBindingPattern.bindingPatterns);
+        lookupNode(listBindingPattern.restBindingPattern);
     }
 
     private boolean setEnclosingNode(BLangNode node, Location pos) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -46,7 +46,16 @@ import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
 import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangCaptureBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorCauseBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorFieldBindingPatterns;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorMessageBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangFieldBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangListBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangMappingBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangNamedArgBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangRestBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangSimpleBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangDoClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
@@ -120,10 +129,16 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLSequenceLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangConstPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorCauseMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorFieldMatchPatterns;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMessageMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangFieldMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangListMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMappingMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangNamedArgMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangRestMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangSimpleMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
@@ -137,7 +152,6 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangMatchStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordDestructure;
@@ -438,6 +452,42 @@ public class ReferenceFinder extends BaseVisitor {
     }
 
     @Override
+    public void visit(BLangErrorMatchPattern errorMatchPattern) {
+        find(errorMatchPattern.errorMessageMatchPattern);
+        find(errorMatchPattern.errorTypeReference);
+        find(errorMatchPattern.errorCauseMatchPattern);
+        find(errorMatchPattern.errorFieldMatchPatterns);
+    }
+
+    @Override
+    public void visit(BLangErrorMessageMatchPattern errorMessageMatchPattern) {
+        find(errorMessageMatchPattern.simpleMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorCauseMatchPattern errorCauseMatchPattern) {
+        find(errorCauseMatchPattern.simpleMatchPattern);
+        find(errorCauseMatchPattern.errorMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorFieldMatchPatterns errorFieldMatchPatterns) {
+        find(errorFieldMatchPatterns.namedArgMatchPatterns);
+        find(errorFieldMatchPatterns.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangSimpleMatchPattern simpleMatchPattern) {
+        find(simpleMatchPattern.varVariableName);
+        find(simpleMatchPattern.constPattern);
+    }
+
+    @Override
+    public void visit(BLangNamedArgMatchPattern namedArgMatchPattern) {
+        find(namedArgMatchPattern.matchPattern);
+    }
+
+    @Override
     public void visit(BLangCaptureBindingPattern captureBindingPattern) {
         addIfSameSymbol(captureBindingPattern.symbol, captureBindingPattern.getIdentifier().getPosition());
     }
@@ -446,6 +496,57 @@ public class ReferenceFinder extends BaseVisitor {
     public void visit(BLangListBindingPattern listBindingPattern) {
         find(listBindingPattern.bindingPatterns);
         find(listBindingPattern.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangMappingBindingPattern mappingBindingPattern) {
+        find(mappingBindingPattern.fieldBindingPatterns);
+        find(mappingBindingPattern.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangFieldBindingPattern fieldBindingPattern) {
+        find(fieldBindingPattern.bindingPattern);
+    }
+
+    @Override
+    public void visit(BLangRestBindingPattern restBindingPattern) {
+        addIfSameSymbol(restBindingPattern.symbol, restBindingPattern.getIdentifier().getPosition());
+    }
+
+    @Override
+    public void visit(BLangErrorBindingPattern errorBindingPattern) {
+        find(errorBindingPattern.errorMessageBindingPattern);
+        find(errorBindingPattern.errorTypeReference);
+        find(errorBindingPattern.errorCauseBindingPattern);
+        find(errorBindingPattern.errorFieldBindingPatterns);
+    }
+
+    @Override
+    public void visit(BLangErrorMessageBindingPattern errorMessageBindingPattern) {
+        find(errorMessageBindingPattern.simpleBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorCauseBindingPattern errorCauseBindingPattern) {
+        find(errorCauseBindingPattern.simpleBindingPattern);
+        find(errorCauseBindingPattern.errorBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorFieldBindingPatterns errorFieldBindingPatterns) {
+        find(errorFieldBindingPatterns.namedArgBindingPatterns);
+        find(errorFieldBindingPatterns.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangSimpleBindingPattern simpleBindingPattern) {
+        find(simpleBindingPattern.captureBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangNamedArgBindingPattern namedArgBindingPattern) {
+        find(namedArgBindingPattern.bindingPattern);
     }
 
     @Override
@@ -1058,20 +1159,6 @@ public class ReferenceFinder extends BaseVisitor {
     @Override
     public void visit(BLangErrorVariableDef bLangErrorVariableDef) {
         find(bLangErrorVariableDef.errorVariable);
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchStaticBindingPatternClause bLangMatchStmtStaticBindingPatternClause) {
-        find(bLangMatchStmtStaticBindingPatternClause.body);
-        find(bLangMatchStmtStaticBindingPatternClause.literal);
-    }
-
-    @Override
-    public void visit(
-            BLangMatch.BLangMatchStructuredBindingPatternClause bLangMatchStmtStructuredBindingPatternClause) {
-        find(bLangMatchStmtStructuredBindingPatternClause.body);
-        find(bLangMatchStmtStructuredBindingPatternClause.bindingPatternVariable);
-        find(bLangMatchStmtStructuredBindingPatternClause.typeGuardExpr);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -120,10 +120,11 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLSequenceLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangConstPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangFieldMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangListMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMappingMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangRestMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
-import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangWildCardMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangCompoundAssignment;
@@ -415,13 +416,6 @@ public class ReferenceFinder extends BaseVisitor {
     }
 
     @Override
-    public void visit(BLangMatch matchNode) {
-        find(matchNode.expr);
-        find(matchNode.patternClauses);
-        find(matchNode.onFailClause);
-    }
-
-    @Override
     public void visit(BLangMatchStatement matchStatementNode) {
         find(matchStatementNode.expr);
         find(matchStatementNode.matchClauses);
@@ -439,14 +433,8 @@ public class ReferenceFinder extends BaseVisitor {
     }
 
     @Override
-    public void visit(BLangWildCardMatchPattern wildCardMatchPattern) {
-        find(wildCardMatchPattern.matchExpr);
-    }
-
-    @Override
     public void visit(BLangVarBindingPatternMatchPattern varBindingPattern) {
         find(varBindingPattern.getBindingPattern());
-        find(varBindingPattern.matchExpr);
     }
 
     @Override
@@ -457,13 +445,7 @@ public class ReferenceFinder extends BaseVisitor {
     @Override
     public void visit(BLangListBindingPattern listBindingPattern) {
         find(listBindingPattern.bindingPatterns);
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchTypedBindingPatternClause patternClauseNode) {
-        find(patternClauseNode.body);
-        find(patternClauseNode.variable);
-        find(patternClauseNode.matchExpr);
+        find(listBindingPattern.restBindingPattern);
     }
 
     @Override
@@ -556,9 +538,9 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangMatchClause matchClause) {
+        find(matchClause.matchPatterns);
         find(matchClause.matchGuard);
         find(matchClause.blockStmt);
-        find(matchClause.matchPatterns);
     }
 
     @Override
@@ -1082,7 +1064,6 @@ public class ReferenceFinder extends BaseVisitor {
     public void visit(BLangMatch.BLangMatchStaticBindingPatternClause bLangMatchStmtStaticBindingPatternClause) {
         find(bLangMatchStmtStaticBindingPatternClause.body);
         find(bLangMatchStmtStaticBindingPatternClause.literal);
-        find(bLangMatchStmtStaticBindingPatternClause.matchExpr);
     }
 
     @Override
@@ -1090,7 +1071,6 @@ public class ReferenceFinder extends BaseVisitor {
             BLangMatch.BLangMatchStructuredBindingPatternClause bLangMatchStmtStructuredBindingPatternClause) {
         find(bLangMatchStmtStructuredBindingPatternClause.body);
         find(bLangMatchStmtStructuredBindingPatternClause.bindingPatternVariable);
-        find(bLangMatchStmtStructuredBindingPatternClause.matchExpr);
         find(bLangMatchStmtStructuredBindingPatternClause.typeGuardExpr);
     }
 
@@ -1162,14 +1142,23 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangListMatchPattern listMatchPattern) {
-        find(listMatchPattern.matchExpr);
         find(listMatchPattern.matchPatterns);
         find(listMatchPattern.restMatchPattern);
     }
 
     @Override
+    public void visit(BLangMappingMatchPattern mappingMatchPattern) {
+        find(mappingMatchPattern.fieldMatchPatterns);
+        find(mappingMatchPattern.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangFieldMatchPattern fieldMatchPattern) {
+        find(fieldMatchPattern.matchPattern);
+    }
+
+    @Override
     public void visit(BLangRestMatchPattern restMatchPattern) {
-        find(restMatchPattern.matchExpr);
         addIfSameSymbol(restMatchPattern.symbol, restMatchPattern.variableName.pos);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -87,6 +87,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangConstant;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangElvisExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorConstructorExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangErrorVarRef;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangFieldBasedAccess;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangGroupExpr;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangIgnoreExpr;
@@ -807,7 +808,11 @@ class SymbolFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangRecordVarRef varRefExpr) {
-        // TODO: implement this
+        for (BLangRecordVarRef.BLangRecordVarRefKeyValue recordRefField : varRefExpr.recordRefFields) {
+            lookupNode(recordRefField.getBindingPattern());
+        }
+
+        lookupNode((BLangExpression) varRefExpr.restParam);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -52,6 +52,17 @@ import org.wso2.ballerinalang.compiler.tree.BLangTableKeyTypeConstraint;
 import org.wso2.ballerinalang.compiler.tree.BLangTupleVariable;
 import org.wso2.ballerinalang.compiler.tree.BLangTypeDefinition;
 import org.wso2.ballerinalang.compiler.tree.BLangXMLNS;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangCaptureBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorCauseBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorFieldBindingPatterns;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangErrorMessageBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangFieldBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangListBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangMappingBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangNamedArgBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangRestBindingPattern;
+import org.wso2.ballerinalang.compiler.tree.bindingpatterns.BLangSimpleBindingPattern;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangDoClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
@@ -472,6 +483,68 @@ class SymbolFinder extends BaseVisitor {
     public void visit(BLangQueryAction queryAction) {
         lookupNodes(queryAction.queryClauseList);
         lookupNode(queryAction.doClause);
+    }
+
+    @Override
+    public void visit(BLangCaptureBindingPattern captureBindingPattern) {
+        setEnclosingNode(captureBindingPattern.symbol, captureBindingPattern.getIdentifier().getPosition());
+    }
+
+    @Override
+    public void visit(BLangListBindingPattern listBindingPattern) {
+        lookupNodes(listBindingPattern.bindingPatterns);
+        lookupNode(listBindingPattern.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangMappingBindingPattern mappingBindingPattern) {
+        lookupNodes(mappingBindingPattern.fieldBindingPatterns);
+        lookupNode(mappingBindingPattern.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangFieldBindingPattern fieldBindingPattern) {
+        lookupNode(fieldBindingPattern.bindingPattern);
+    }
+
+    @Override
+    public void visit(BLangRestBindingPattern restBindingPattern) {
+        setEnclosingNode(restBindingPattern.symbol, restBindingPattern.getIdentifier().getPosition());
+    }
+
+    @Override
+    public void visit(BLangErrorBindingPattern errorBindingPattern) {
+        lookupNode(errorBindingPattern.errorTypeReference);
+        lookupNode(errorBindingPattern.errorMessageBindingPattern);
+        lookupNode(errorBindingPattern.errorCauseBindingPattern);
+        lookupNode(errorBindingPattern.errorFieldBindingPatterns);
+    }
+
+    @Override
+    public void visit(BLangErrorMessageBindingPattern errorMessageBindingPattern) {
+        lookupNode(errorMessageBindingPattern.simpleBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorCauseBindingPattern errorCauseBindingPattern) {
+        lookupNode(errorCauseBindingPattern.simpleBindingPattern);
+        lookupNode(errorCauseBindingPattern.errorBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorFieldBindingPatterns errorFieldBindingPatterns) {
+        lookupNodes(errorFieldBindingPatterns.namedArgBindingPatterns);
+        lookupNode(errorFieldBindingPatterns.restBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangSimpleBindingPattern simpleBindingPattern) {
+        lookupNode(simpleBindingPattern.captureBindingPattern);
+    }
+
+    @Override
+    public void visit(BLangNamedArgBindingPattern namedArgBindingPattern) {
+        lookupNode(namedArgBindingPattern.bindingPattern);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -57,6 +57,7 @@ import org.wso2.ballerinalang.compiler.tree.clauses.BLangFromClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangJoinClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLetClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangLimitClause;
+import org.wso2.ballerinalang.compiler.tree.clauses.BLangMatchClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnConflictClause;
 import org.wso2.ballerinalang.compiler.tree.clauses.BLangOnFailClause;
@@ -92,6 +93,7 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkDownDeprecation
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownDocumentationLine;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownParameterDocumentation;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangMarkdownReturnParameterDocumentation;
+import org.wso2.ballerinalang.compiler.tree.expressions.BLangMatchGuard;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNamedArgsExpression;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangNumericLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangQueryAction;
@@ -131,6 +133,18 @@ import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQName;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLQuotedString;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLSequenceLiteral;
 import org.wso2.ballerinalang.compiler.tree.expressions.BLangXMLTextLiteral;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangConstPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorCauseMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorFieldMatchPatterns;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangErrorMessageMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangFieldMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangListMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangMappingMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangNamedArgMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangRestMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangSimpleMatchPattern;
+import org.wso2.ballerinalang.compiler.tree.matchpatterns.BLangVarBindingPatternMatchPattern;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangAssignment;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBlockStmt;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangBreak;
@@ -145,8 +159,7 @@ import org.wso2.ballerinalang.compiler.tree.statements.BLangForeach;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangForkJoin;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangIf;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangLock;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch;
-import org.wso2.ballerinalang.compiler.tree.statements.BLangMatch.BLangMatchStructuredBindingPatternClause;
+import org.wso2.ballerinalang.compiler.tree.statements.BLangMatchStatement;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangPanic;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordDestructure;
 import org.wso2.ballerinalang.compiler.tree.statements.BLangRecordVariableDef;
@@ -462,16 +475,90 @@ class SymbolFinder extends BaseVisitor {
     }
 
     @Override
-    public void visit(BLangMatch matchNode) {
-        lookupNode(matchNode.expr);
-        lookupNodes(matchNode.patternClauses);
+    public void visit(BLangMatchStatement matchStatementNode) {
+        lookupNode(matchStatementNode.expr);
+        lookupNodes(matchStatementNode.matchClauses);
+        lookupNode(matchStatementNode.onFailClause);
     }
 
     @Override
-    public void visit(BLangMatch.BLangMatchTypedBindingPatternClause patternClauseNode) {
-        lookupNode(patternClauseNode.matchExpr);
-        lookupNode(patternClauseNode.variable);
-        lookupNode(patternClauseNode.body);
+    public void visit(BLangMatchClause matchClause) {
+        lookupNodes(matchClause.matchPatterns);
+        lookupNode(matchClause.matchGuard);
+        lookupNode(matchClause.blockStmt);
+    }
+
+    @Override
+    public void visit(BLangConstPattern constMatchPattern) {
+        lookupNode(constMatchPattern.expr);
+    }
+
+    @Override
+    public void visit(BLangVarBindingPatternMatchPattern varBindingPattern) {
+        lookupNode(varBindingPattern.getBindingPattern());
+    }
+
+    @Override
+    public void visit(BLangMappingMatchPattern mappingMatchPattern) {
+        lookupNodes(mappingMatchPattern.fieldMatchPatterns);
+        lookupNode(mappingMatchPattern.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangFieldMatchPattern fieldMatchPattern) {
+        lookupNode(fieldMatchPattern.matchPattern);
+    }
+
+    @Override
+    public void visit(BLangRestMatchPattern restMatchPattern) {
+        setEnclosingNode(restMatchPattern.symbol, restMatchPattern.variableName.pos);
+    }
+
+    @Override
+    public void visit(BLangListMatchPattern listMatchPattern) {
+        lookupNodes(listMatchPattern.matchPatterns);
+        lookupNode(listMatchPattern.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorMatchPattern errorMatchPattern) {
+        lookupNode(errorMatchPattern.errorTypeReference);
+        lookupNode(errorMatchPattern.errorMessageMatchPattern);
+        lookupNode(errorMatchPattern.errorCauseMatchPattern);
+        lookupNode(errorMatchPattern.errorFieldMatchPatterns);
+    }
+
+    @Override
+    public void visit(BLangErrorMessageMatchPattern errorMessageMatchPattern) {
+        lookupNode(errorMessageMatchPattern.simpleMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorCauseMatchPattern errorCauseMatchPattern) {
+        lookupNode(errorCauseMatchPattern.simpleMatchPattern);
+        lookupNode(errorCauseMatchPattern.errorMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangErrorFieldMatchPatterns errorFieldMatchPatterns) {
+        lookupNodes(errorFieldMatchPatterns.namedArgMatchPatterns);
+        lookupNode(errorFieldMatchPatterns.restMatchPattern);
+    }
+
+    @Override
+    public void visit(BLangSimpleMatchPattern simpleMatchPattern) {
+        lookupNode(simpleMatchPattern.constPattern);
+        lookupNode(simpleMatchPattern.varVariableName);
+    }
+
+    @Override
+    public void visit(BLangNamedArgMatchPattern namedArgMatchPattern) {
+        lookupNode(namedArgMatchPattern.matchPattern);
+    }
+
+    @Override
+    public void visit(BLangMatchGuard matchGuard) {
+        lookupNode(matchGuard.expr);
     }
 
     @Override
@@ -1295,21 +1382,6 @@ class SymbolFinder extends BaseVisitor {
     @Override
     public void visit(BLangErrorVariableDef bLangErrorVariableDef) {
         lookupNode(bLangErrorVariableDef.errorVariable);
-    }
-
-    @Override
-    public void visit(BLangMatch.BLangMatchStaticBindingPatternClause bLangMatchStmtStaticBindingPatternClause) {
-        lookupNode(bLangMatchStmtStaticBindingPatternClause.matchExpr);
-        lookupNode(bLangMatchStmtStaticBindingPatternClause.literal);
-        lookupNode(bLangMatchStmtStaticBindingPatternClause.body);
-    }
-
-    @Override
-    public void visit(BLangMatchStructuredBindingPatternClause bLangMatchStmtStructuredBindingPatternClause) {
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.bindingPatternVariable);
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.typeGuardExpr);
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.matchExpr);
-        lookupNode(bLangMatchStmtStructuredBindingPatternClause.body);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/MapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/MapTypeSymbol.java
@@ -19,7 +19,7 @@ package io.ballerina.compiler.api.symbols;
 import java.util.Optional;
 
 /**
- * Represents an array type descriptor.
+ * Represents a map type descriptor.
  *
  * @since 2.0.0
  */

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -4016,6 +4016,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangMatchStatement matchStatement = (BLangMatchStatement) TreeBuilder.createMatchStatementNode();
         BLangExpression matchStmtExpr = createExpression(matchStatementNode.condition());
         matchStatement.setExpression(matchStmtExpr);
+        matchStatement.pos = getPosition(matchStatementNode);
 
         for (MatchClauseNode matchClauseNode : matchStatementNode.matchClauses()) {
             BLangMatchClause bLangMatchClause = (BLangMatchClause) TreeBuilder.createMatchClause();
@@ -4027,6 +4028,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                 matchGuardAvailable = true;
                 BLangMatchGuard bLangMatchGuard = (BLangMatchGuard) TreeBuilder.createMatchGuard();
                 bLangMatchGuard.expr = createExpression(matchClauseNode.matchGuard().get().expression());
+                bLangMatchGuard.pos = getPosition(matchClauseNode.matchGuard().get());
                 bLangMatchClause.setMatchGuard(bLangMatchGuard);
             }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -4016,7 +4016,6 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
         BLangMatchStatement matchStatement = (BLangMatchStatement) TreeBuilder.createMatchStatementNode();
         BLangExpression matchStmtExpr = createExpression(matchStatementNode.condition());
         matchStatement.setExpression(matchStmtExpr);
-        matchStatement.pos = getPosition(matchStatementNode);
 
         for (MatchClauseNode matchClauseNode : matchStatementNode.matchClauses()) {
             BLangMatchClause bLangMatchClause = (BLangMatchClause) TreeBuilder.createMatchClause();

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMatchGuard.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/expressions/BLangMatchGuard.java
@@ -23,7 +23,7 @@ import org.ballerinalang.model.tree.expressions.MatchGuard;
 import org.wso2.ballerinalang.compiler.tree.BLangNodeVisitor;
 
 /**
- * @since Swan Lake
+ * @since 2.0.0
  */
 public class BLangMatchGuard extends BLangExpression implements MatchGuard {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangMatch.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangMatch.java
@@ -38,6 +38,7 @@ import java.util.stream.Collectors;
  *
  * @since 0.966.0
  */
+@Deprecated
 public class BLangMatch extends BLangStatement implements MatchNode {
 
     public BLangMatch() {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangMatchStatement.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/tree/statements/BLangMatchStatement.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * @since Swan Lake
+ * @since 2.0.0
  */
 public class BLangMatchStatement extends BLangStatement implements MatchStatementNode {
     public BLangExpression expr; // TODO : replace with new node `action|expression`

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/BindingPatternTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/BindingPatternTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ArrayTypeSymbol;
+import io.ballerina.compiler.api.symbols.MapTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LineRange;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ANY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ANYDATA;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ARRAY;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.ERROR;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.UNION;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static io.ballerina.tools.text.LinePosition.from;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for binding patterns.
+ *
+ * @since 2.0.0
+ */
+public class BindingPatternTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/binding_patterns_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "CBPPosProvider")
+    public void testCaptureBindingPattern(int line, int col, String name, TypeDescKind typeKind) {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().getName().get(), name);
+        assertEquals(((VariableSymbol) symbol.get()).typeDescriptor().typeKind(), typeKind);
+    }
+
+    @DataProvider(name = "CBPPosProvider")
+    public Object[][] getCBPPos() {
+        return new Object[][]{
+                {18, 8, "cbp1", INT},
+                {19, 8, "cbp2", STRING}
+        };
+    }
+
+    @Test
+    public void testWildcardBindingPattern() {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(22, 4));
+//        assertTrue(symbol.isEmpty());
+
+        Optional<TypeSymbol> type = model.type(LineRange.from(srcFile.name(), from(22, 4), from(22, 5)));
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), ANY);
+    }
+
+    @Test(dataProvider = "PosProvider")
+    public void testListMappingErrorBindingPatterns(int line, int col, String name, TypeDescKind typeKind,
+                                                    TypeDescKind constraintKind) {
+        Optional<Symbol> symbol = model.symbol(srcFile, from(line, col));
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().getName().get(), name);
+
+        TypeSymbol type = ((VariableSymbol) symbol.get()).typeDescriptor();
+        assertEquals(type.typeKind(), typeKind);
+
+        if (constraintKind != null) {
+            switch (type.typeKind()) {
+                case ARRAY:
+                    assertEquals(((ArrayTypeSymbol) type).memberTypeDescriptor().typeKind(), constraintKind);
+                    break;
+                case MAP:
+                    assertEquals(((MapTypeSymbol) type).typeParameter().get().typeKind(), constraintKind);
+                    break;
+            }
+        }
+    }
+
+    @DataProvider(name = "PosProvider")
+    public Object[][] getPos() {
+        return new Object[][]{
+                {28, 5, "lbp1", INT, null},
+                {28, 11, "lbp2", FLOAT, null},
+                {28, 20, "rbp1", ARRAY, UNION},
+                {29, 29, "lbp3", INT, null},
+                {29, 35, "lbp4", FLOAT, null},
+                {29, 44, "rbp2", ARRAY, STRING},
+                {35, 11, "mbp1", STRING, null},
+                {35, 17, "mbp2", INT, null},
+                {35, 26, "rbp3", MAP, STRING},
+                {35, 26, "rbp3", MAP, null},
+                {36, 42, "mbp3", STRING, null},
+                {36, 48, "age", INT, null},
+                {36, 56, "rbp4", MAP, ANYDATA},
+                {44, 16, "msg", STRING, null},
+                {44, 21, "cause", ERROR, null},
+                {44, 33, "code", INT, null},
+                {44, 42, "rbp5", MAP, STRING},
+                {45, 22, "msg1", STRING, null},
+                {45, 28, "cause1", UNION, null},
+                {45, 41, "code1", INT, null},
+                {45, 51, "rbp6", MAP, ANYDATA},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/BindingPatternTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/BindingPatternTest.java
@@ -86,7 +86,8 @@ public class BindingPatternTest {
     @Test
     public void testWildcardBindingPattern() {
         Optional<Symbol> symbol = model.symbol(srcFile, from(22, 4));
-//        assertTrue(symbol.isEmpty());
+        // TODO: Change if needed once https://github.com/ballerina-platform/ballerina-lang/issues/30000 is addressed
+        assertTrue(symbol.isPresent());
 
         Optional<TypeSymbol> type = model.type(LineRange.from(srcFile.name(), from(22, 4), from(22, 5)));
         assertTrue(type.isPresent());

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInMatchStmtTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInMatchStmtTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.allreferences;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+
+/**
+ * Test cases for the find all references API related to match statement contexts.
+ *
+ * @since 2.0.0
+ */
+@Test
+public class FindRefsInMatchStmtTest extends FindAllReferencesTest {
+
+    @DataProvider(name = "PositionProvider")
+    public Object[][] getLookupPositions() {
+        return new Object[][]{
+                {18, 18, List.of(location(18, 18, 21),
+                                 location(19, 10, 13),
+                                 location(21, 20, 23),
+                                 location(24, 20, 23),
+                                 location(27, 20, 23),
+                                 location(32, 20, 23),
+                                 location(36, 24, 27),
+                                 location(37, 20, 23),
+                                 location(40, 20, 23))
+                },
+                {26, 13, List.of(location(26, 13, 14),
+                                 location(28, 24, 25))
+                },
+                {26, 30, List.of(location(26, 30, 34),
+                                 location(29, 24, 28))
+                },
+                {31, 26, List.of(location(31, 26, 27),
+                                 location(33, 24, 25))
+                },
+                {34, 24, List.of(location(31, 36, 40),
+                                 location(34, 24, 28))
+                },
+        };
+    }
+
+    @Override
+    public String getTestSourcePath() {
+        return "test-src/find-all-ref/find_ref_match_stmt_context.bal";
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInMatchStmtTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInMatchStmtTest.java
@@ -24,10 +24,11 @@ import io.ballerina.compiler.api.symbols.ParameterSymbol;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.VariableSymbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
-import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -37,6 +38,7 @@ import java.util.Optional;
 
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static io.ballerina.tools.text.LinePosition.from;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -59,7 +61,7 @@ public class SymbolsInMatchStmtTest {
 
     @Test(dataProvider = "SymbolPosProvider")
     public void testSymbolAtCursor(int line, int col, String name, TypeDescKind typeKind) {
-        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        Optional<Symbol> symbol = model.symbol(srcFile, from(line, col));
 
         assertTrue(symbol.isPresent());
         assertEquals(symbol.get().getName().get(), name);
@@ -94,7 +96,24 @@ public class SymbolsInMatchStmtTest {
                 {34, 36, "rest", TypeDescKind.MAP},
                 {36, 24, "val", TypeDescKind.ANY},
                 {38, 14, "Error", TypeDescKind.ERROR},
+        };
+    }
 
+    @Test(dataProvider = "ExprPosProvider")
+    public void testType(int sLine, int sCol, int eLine, int eCol, TypeDescKind typeKind) {
+        Optional<TypeSymbol> type = model.type(LineRange.from(srcFile.name(), from(sLine, sCol), from(eLine, eCol)));
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+    }
+
+    @DataProvider(name = "ExprPosProvider")
+    public Object[][] getExprPos() {
+        return new Object[][]{
+                {20, 10, 20, 13, TypeDescKind.ANY},
+                {22, 20, 22, 23, TypeDescKind.ANY},
+                {25, 8, 25, 10, TypeDescKind.FLOAT},
+                {26, 20, 26, 23, TypeDescKind.ANY},
+                {30, 24, 30, 25, TypeDescKind.UNION},
         };
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInMatchStmtTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/statements/SymbolsInMatchStmtTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.statements;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.ConstantSymbol;
+import io.ballerina.compiler.api.symbols.ParameterSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.VariableSymbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Test cases for match statement.
+ *
+ * @since 2.0.0
+ */
+public class SymbolsInMatchStmtTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/statements/match_stmt.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "SymbolPosProvider")
+    public void testSymbolAtCursor(int line, int col, String name, TypeDescKind typeKind) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        assertTrue(symbol.isPresent());
+        assertEquals(symbol.get().getName().get(), name);
+
+        switch (symbol.get().kind()) {
+            case VARIABLE:
+                assertEquals(((VariableSymbol) symbol.get()).typeDescriptor().typeKind(), typeKind);
+                return;
+            case PARAMETER:
+                assertEquals(((ParameterSymbol) symbol.get()).typeDescriptor().typeKind(), typeKind);
+                return;
+            case CONSTANT:
+                assertEquals(((ConstantSymbol) symbol.get()).typeDescriptor().typeKind(), typeKind);
+                return;
+            case TYPE:
+                assertEquals(((TypeReferenceTypeSymbol) symbol.get()).typeDescriptor().typeKind(), typeKind);
+                return;
+        }
+
+        throw new AssertionError("Unexpected symbol kind: " + symbol.get().kind());
+    }
+
+    @DataProvider(name = "SymbolPosProvider")
+    public Object[][] getSymbolPos() {
+        return new Object[][]{
+                {20, 10, "val", TypeDescKind.ANY},
+                {21, 12, "x", TypeDescKind.ANY},
+                {25, 8, "PI", TypeDescKind.SINGLETON},
+                {29, 30, "rest", TypeDescKind.ARRAY},
+                {30, 24, "x", TypeDescKind.UNION},
+                {34, 26, "b", TypeDescKind.UNION},
+                {34, 36, "rest", TypeDescKind.MAP},
+                {36, 24, "val", TypeDescKind.ANY},
+                {38, 14, "Error", TypeDescKind.ERROR},
+
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/binding_patterns_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/binding_patterns_test.bal
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function test() {
+    // capture binding pattern (local var decl)
+    int cbp1 = 10;
+    var cbp2 = "Hello World";
+
+    // wildcard binding pattern (destructuring assignment stmt)
+    _ = 3.14;
+
+    // list binding pattern
+    int lbp1;
+    float lbp2;
+    (decimal|string)[] rbp1;
+    [lbp1, lbp2, ...rbp1] = [10, 12.34, 45.6d, "Hello"]; // destructuring assignment stmt
+    [int, float, string...] [lbp3, lbp4, ...rbp2] = [10, 23.45, "Foo", "Bar"]; // local var decl stmt
+
+    // mapping binding pattern
+    string mbp1;
+    int mbp2;
+    map<string> rbp3;
+    {name: mbp1, mbp2, ...rbp3} = <Person1>{name: "Jane Doe", mbp2: 10, "foo": "bar"}; // destructuring assignment stmt
+    record {string name; int age;} {name: mbp3, age, ...rbp4}
+                                       = <Person2>{name: "John Doe", age: 20, "foo": "bar"}; // local var decl stmt
+
+    // error binding pattern
+    string msg;
+    error cause;
+    int code;
+    map<string> rbp5;
+    error Error(msg, cause, code=code, ...rbp5) = error Error("FileNotFound", code = 400); // destructuring assignment stmt
+    Error error Error(msg1, cause1, code=code1, ...rbp6) = error Error("FileNotFound", code = 500); // local var decl stmt
+}
+
+type Error error<record {int code;}>;
+
+type Person1 record {|
+    string name;
+    int mbp2;
+    string...;
+|};
+
+type Person2 record {|
+    string name;
+    int age;
+    string...;
+|};

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_ref_match_stmt_context.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_ref_match_stmt_context.bal
@@ -1,0 +1,44 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const PI = 3.14;
+
+function test(any val) {
+    match val {
+        var x => {
+            any a = val;
+        }
+        PI => {
+            any b = val;
+        }
+        [var x, var y, ...var rest] => {
+            any c = val;
+            string s1 = x.toString();
+            string s2 = rest.toString();
+        }
+        {x: var x, y: var y, ...var rest} => {
+            any d = val;
+            string s1 = y.toString();
+            string s2 = rest.toString();
+        }
+        PI | "Foo" if !(val is decimal) => {
+            any e = val;
+        }
+        _ => {
+            any f = val;
+        }
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/statements/match_stmt.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/statements/match_stmt.bal
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+const PI = 3.14;
+type Error error;
+
+function test(any val) {
+    match val {
+        var x => {
+            any a = val;
+        }
+
+        PI => {
+            any b = val;
+        }
+
+        [var x, var y, ...var rest] => {
+            string s1 = x.toString();
+            string s2 = rest.toString();
+        }
+
+        {x: var a, y: var b, ...var rest} => { }
+
+        PI | "Foo" if !(val is decimal) => { }
+
+        error Error("FileNotFound", error("Msg"), c1=100) => { }
+
+        _ => { }
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -22,6 +22,7 @@
     <test name="semantic-api-test" parallel="false">
         <classes>
             <class name="io.ballerina.semantic.api.test.AnnotationsTest" />
+            <class name="io.ballerina.semantic.api.test.BindingPatternTest" />
             <class name="io.ballerina.semantic.api.test.ClassSymbolTest" />
             <class name="io.ballerina.semantic.api.test.DiagnosticsTest" />
             <class name="io.ballerina.semantic.api.test.DocumentationTest" />

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -47,6 +47,7 @@
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsAcrossFilesTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInExprsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInLambdasTest" />
+            <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInMatchStmtTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInServiceDeclTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInTestsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInWorkersTest" />
@@ -80,6 +81,9 @@
             <class name="io.ballerina.semantic.api.test.typedescriptors.TypeReferenceTSymbolTest" />
 
             <class name="io.ballerina.semantic.api.test.incompletesource.InvalidFieldTypeTest" />
+
+            <!--Statements-->
+            <class name="io.ballerina.semantic.api.test.statements.SymbolsInMatchStmtTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR implements the semantic API methods properly for match statement. Previously, the implementation had only covered the now unused match statement related AST nodes. With this PR, all supported match patterns are supported by the semantic API.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
