### PR TITLE
[LS] Remove langlib function suggestions from object field access suggestions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -18,6 +18,7 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.ObjectFieldSymbol;
 import io.ballerina.compiler.api.symbols.ObjectTypeSymbol;
@@ -167,6 +168,24 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
                 .append(methodJoiner.toString())
                 .append("}")
                 .toString();
+    }
+
+    /**
+     * As per the spec, {@code lang.value} functions should not be available on objects. Therefore, they are filtered
+     * here.
+     *
+     * @param functions    Functions to be filtered
+     * @param internalType Internal type
+     * @return Filtered langlib functions
+     */
+    @Override
+    protected List<FunctionSymbol> filterLangLibMethods(List<FunctionSymbol> functions, BType internalType) {
+        List<FunctionSymbol> functionSymbols = super.filterLangLibMethods(functions, internalType);
+        return functionSymbols.stream()
+                .filter(functionSymbol -> functionSymbol.getModule().isPresent())
+                .filter(functionSymbol -> !"ballerina".equals(functionSymbol.getModule().get().id().orgName()) ||
+                        !"lang.value".equals(functionSymbol.getModule().get().id().moduleName()))
+                .collect(Collectors.toList());
     }
 
     private void addIfFlagSet(List<Qualifier> quals, final long mask, final long flag, Qualifier qualifier) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaObjectTypeSymbol.java
@@ -50,6 +50,9 @@ import java.util.stream.Collectors;
  */
 public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements ObjectTypeSymbol {
 
+    private static final String ORG_NAME_BALLERINA = "ballerina";
+    private static final String MODULE_NAME_LANG_VALUE = "lang.value";
+
     private List<Qualifier> qualifiers;
     private Map<String, ObjectFieldSymbol> objectFields;
     private Map<String, MethodSymbol> methods;
@@ -183,8 +186,8 @@ public class BallerinaObjectTypeSymbol extends AbstractTypeSymbol implements Obj
         List<FunctionSymbol> functionSymbols = super.filterLangLibMethods(functions, internalType);
         return functionSymbols.stream()
                 .filter(functionSymbol -> functionSymbol.getModule().isPresent())
-                .filter(functionSymbol -> !"ballerina".equals(functionSymbol.getModule().get().id().orgName()) ||
-                        !"lang.value".equals(functionSymbol.getModule().get().id().moduleName()))
+                .filter(functionSymbol -> !ORG_NAME_BALLERINA.equals(functionSymbol.getModule().get().id().orgName()) ||
+                        !MODULE_NAME_LANG_VALUE.equals(functionSymbol.getModule().get().id().moduleName()))
                 .collect(Collectors.toList());
     }
 

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -219,15 +219,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
         List<Symbol> visibleEntries = new ArrayList<>();
         TypeSymbol rawType = CommonUtil.getRawType(typeSymbol);
         switch (rawType.typeKind()) {
-            case RECORD:
-                // If the invoked for field access expression, then avoid suggesting the optional fields
-                List<RecordFieldSymbol> filteredEntries =
-                        ((RecordTypeSymbol) rawType).fieldDescriptors().values().stream()
-                                .filter(recordFieldSymbol -> this.optionalFieldAccess
-                                        || !recordFieldSymbol.isOptional())
-                                .collect(Collectors.toList());
-                visibleEntries.addAll(filteredEntries);
-                break;
+            // lang.value functions shouldn't be shown for object field accesses
             case OBJECT:
                 // add class field access test case as well
                 Optional<Package> currentPkg = context.workspace()
@@ -249,10 +241,18 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                         .collect(Collectors.toList());
                 visibleEntries.addAll(methodSymbols);
                 break;
+            case RECORD:
+                // If the invoked for field access expression, then avoid suggesting the optional fields
+                List<RecordFieldSymbol> filteredEntries =
+                        ((RecordTypeSymbol) rawType).fieldDescriptors().values().stream()
+                                .filter(recordFieldSymbol -> this.optionalFieldAccess
+                                        || !recordFieldSymbol.isOptional())
+                                .collect(Collectors.toList());
+                visibleEntries.addAll(filteredEntries);
             default:
+                visibleEntries.addAll(typeSymbol.langLibMethods());
                 break;
         }
-        visibleEntries.addAll(typeSymbol.langLibMethods());
 
         return visibleEntries;
     }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -248,8 +248,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
                                 currentModule.get().moduleId()))
                         .collect(Collectors.toList());
                 visibleEntries.addAll(methodSymbols);
-                // lang.value functions shouldn't be shown for object field accesses
-                return visibleEntries;
+                break;
             default:
                 break;
         }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config12.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config12.json
@@ -12,52 +12,6 @@
       "sortText": "A",
       "insertText": "url",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config14.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config14.json
@@ -50,52 +50,6 @@
       "sortText": "D",
       "insertText": "getModel()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config15.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config15.json
@@ -12,52 +12,6 @@
       "sortText": "A",
       "insertText": "field1",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config17.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config17.json
@@ -18,52 +18,6 @@
       "sortText": "D",
       "insertText": "next()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config22.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config22.json
@@ -32,52 +32,6 @@
       "sortText": "D",
       "insertText": "function2()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config23.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config23.json
@@ -18,52 +18,6 @@
       "sortText": "D",
       "insertText": "publicFunction1()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config24.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config24.json
@@ -60,52 +60,6 @@
       "sortText": "D",
       "insertText": "privateFunction4()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config25.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config25.json
@@ -18,52 +18,6 @@
       "sortText": "D",
       "insertText": "publicFunction1()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config6.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/expression_context/config/field_access_ctx_config6.json
@@ -26,52 +26,6 @@
       "sortText": "D",
       "insertText": "testMethod()",
       "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "toBalString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nConverts a value to a string that describes the value in Ballerina syntax.  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nIf `v` is anydata and does not have cycles, then the result will  \nconform to the grammar for a Ballerina expression and when evaluated  \nwill result in a value that is == to v.  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the expression style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toBalString()",
-      "insertTextFormat": "Snippet"
-    },
-    {
-      "label": "ensureType(typedesc<any> t)(t|error)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \n  \n**Params**  \n- `typedesc<any>` t  \n  \n**Returns** `t|error`   \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "ensureType(${1})",
-      "insertTextFormat": "Snippet",
-      "command": {
-        "title": "editor.action.triggerParameterHints",
-        "command": "editor.action.triggerParameterHints"
-      }
-    },
-    {
-      "label": "toString()(string)",
-      "kind": "Function",
-      "detail": "Function",
-      "documentation": {
-        "right": {
-          "kind": "markdown",
-          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nPerforms a direct conversion of a value to a string.\nThe conversion is direct in the sense that when applied to a value that is already\na string it leaves the value unchanged.\n  \n  \n  \n**Returns** `string`   \n- a string resulting from the conversion  \n  \nThe details of the conversion are specified by the ToString abstract operation  \ndefined in the Ballerina Language Specification, using the direct style.  \n  \n"
-        }
-      },
-      "sortText": "D",
-      "insertText": "toString()",
-      "insertTextFormat": "Snippet"
     }
   ]
 }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/LangLibFunctionTest.java
@@ -34,6 +34,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -226,7 +227,7 @@ public class LangLibFunctionTest {
         ClassSymbol clazz = ((ClassSymbol) symbol);
         assertEquals(clazz.typeKind(), OBJECT);
 
-        List<String> expFunctions = List.of("toString", "toBalString", "ensureType");
+        List<String> expFunctions = Collections.emptyList();
         assertLangLibList(clazz.langLibMethods(), expFunctions);
     }
 


### PR DESCRIPTION
## Purpose
Since object expressions should not suggest lang.value functions,
this prevent them from being suggested for object field accesses.

Fixes #29870

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
