### PR TITLE
Remove duplicate local variables from BIR text dump

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/emit/BIREmitter.java
@@ -223,9 +223,6 @@ public class BIREmitter {
         funcString += emitSpaces(1);
         funcString += "{";
         funcString += emitLBreaks(1);
-        funcString += emitLocalVar(func.returnVariable, tabs + 1);
-        funcString += emitLBreaks(1);
-        funcString += emitArguments(func.parameters, tabs + 1);
         funcString += emitLocalVars(func.localVars, tabs + 1);
         funcString += emitLBreaks(1);
         funcString += emitBasicBlocks(func.basicBlocks, tabs + 1);


### PR DESCRIPTION
## Purpose
Currently BIR text contain duplicate local vars. 
Eg:
```
public add function(int, int) -> int {
    %0(RETURN) int; // duplicate
    %1(ARG) int; // duplicate
    %2(ARG) int; // duplicate
    %0(RETURN) int;
    %1(ARG) int;
    %2(ARG) int;    bb0 {
        %0 = %1 + %2;
        GOTO bb2;
    }
    bb1 {
        GOTO bb2;
    }
    bb2 {
        return;
    }

}
```

This pr will remove those.
<!--
## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
-->
