### PR TITLE
Fix compiler crash when there's an invalid unicode escape sequence

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -5183,6 +5183,7 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                 }
             }
             String originalText = text; // to log the errors
+            Location pos = getPosition(literal);
             Matcher matcher = IdentifierUtils.UNICODE_PATTERN.matcher(text);
             int position = 0;
             while (matcher.find(position)) {
@@ -5192,7 +5193,6 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                         || hexDecimalVal > Constants.MAX_UNICODE) {
                     String hexStringWithBraces = matcher.group(0);
                     int offset = originalText.indexOf(hexStringWithBraces) + 1;
-                    Location pos = getPosition(literal);
                     dlog.error(new BLangDiagnosticLocation(currentCompUnitName,
                                     pos.lineRange().startLine().line(),
                                     pos.lineRange().endLine().line(),
@@ -5205,7 +5205,11 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
                 matcher = IdentifierUtils.UNICODE_PATTERN.matcher(text);
             }
             if (type != SyntaxKind.TEMPLATE_STRING && type != SyntaxKind.XML_TEXT_CONTENT) {
-                text = StringEscapeUtils.unescapeJava(text);
+                try {
+                    text = StringEscapeUtils.unescapeJava(text);
+                } catch (Exception e) {
+                    dlog.error(pos, DiagnosticErrorCode.INVALID_UNICODE, originalText);
+                }
             }
 
             typeTag = TypeTags.STRING;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeNegativeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/string/UnicodeNegativeTest.java
@@ -45,6 +45,8 @@ public class UnicodeNegativeTest {
         BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{DAFF}'", 24, 46);
         BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{12FFFF}'", 25, 18);
         BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{DFFFAAA}'", 25, 33);
-        BAssertUtil.validateError(compileResult, index, "invalid unicode '\\u{FFFFFFF}'", 25, 49);
+        BAssertUtil.validateError(compileResult, index++, "invalid unicode '\\u{FFFFFFF}'", 25, 49);
+        BAssertUtil.validateError(compileResult, index++, "invalid string numeric escape sequence", 26, 17);
+        BAssertUtil.validateError(compileResult, index, "invalid unicode '\\u{001B['", 26, 17);
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/string/unicode-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/string/unicode-negative.bal
@@ -23,4 +23,5 @@ function testUnicodeNegative() {
     string s6 = "\u{DFFF}\u{DAFF}";
     string s7 = "\u{12FFFF} ABC \u{DFFF} DEF \u{DAFF}";
     string s8 = "\u{12FFFF} ABC \u{DFFFAAA} DEF \u{FFFFFFF}";
+    string s9 = "\u{001B[";
 }


### PR DESCRIPTION
## Purpose
$title

Fixes #29163

## Approach
n/a

## Samples
ref: tests.

## Remarks
- #29163

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [x] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
