### PR TITLE
Fix bugs in project API

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/DocumentContext.java
@@ -40,6 +40,8 @@ import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.StringJoiner;
 
+import static io.ballerina.projects.util.ProjectConstants.MODULE_NAME_SEPARATOR;
+
 /**
  * Maintains the internal state of a {@code Document} instance.
  * <p>
@@ -160,8 +162,8 @@ class DocumentContext {
         String firstModuleNamePart = handleQuotedIdentifier(identifierTokenList.get(0).text());
 
         // Check for langLib packages
-        if (PackageOrg.BALLERINA_ORG.equals(orgName) &&
-                PackageName.LANG_LIB_PACKAGE_NAME_PREFIX.equals(firstModuleNamePart)) {
+        String langLibModulePrefix = PackageName.LANG_LIB_PACKAGE_NAME_PREFIX + MODULE_NAME_SEPARATOR;
+        if (PackageOrg.BALLERINA_ORG.equals(orgName) && langLibModulePrefix.equals(firstModuleNamePart)) {
             // This a request to load a lang lib package
             // Lang lib package names take the form lang.{identifier}
             //  e.g, lang.int, lang.boolean lang.stream

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleName.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/ModuleName.java
@@ -19,13 +19,14 @@ package io.ballerina.projects;
 
 import java.util.Objects;
 
+import static io.ballerina.projects.util.ProjectConstants.MODULE_NAME_SEPARATOR;
+
 /**
  * Represents the name of a {@code Package}.
  *
  * @since 2.0.0
  */
 public class ModuleName {
-    private static final String MODULE_NAME_SEPARATOR = ".";
 
     private final PackageName packageName;
     private final String moduleNamePart;

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/ManifestBuilder.java
@@ -42,15 +42,20 @@ import io.ballerina.toml.semantic.ast.TomlTableArrayNode;
 import io.ballerina.toml.semantic.ast.TomlTableNode;
 import io.ballerina.toml.semantic.ast.TomlValueNode;
 import io.ballerina.toml.semantic.ast.TopLevelNode;
+import io.ballerina.toml.semantic.diagnostics.TomlDiagnostic;
 import io.ballerina.toml.validator.TomlValidator;
 import io.ballerina.toml.validator.schema.Schema;
 import io.ballerina.tools.diagnostics.Diagnostic;
+import io.ballerina.tools.diagnostics.DiagnosticInfo;
+import io.ballerina.tools.diagnostics.DiagnosticSeverity;
 import io.ballerina.tools.text.LinePosition;
 import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.compiler.CompilerOptionName;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -329,8 +334,18 @@ public class ManifestBuilder {
                             for (TomlTableNode platformEntryTable : children) {
                                 if (!platformEntryTable.entries().isEmpty()) {
                                     Map<String, Object> platformEntryMap = new HashMap<>();
+                                    String pathValue = getStringValueFromPlatformEntry(platformEntryTable, "path");
+                                    if (pathValue != null) {
+                                        Path path = Paths.get(pathValue);
+                                        if (!path.isAbsolute()) {
+                                            path = this.projectPath.resolve(path);
+                                        }
+                                        if (Files.notExists(path)) {
+                                            reportInvalidPathDiagnostic(platformEntryTable, pathValue);
+                                        }
+                                    }
                                     platformEntryMap.put("path",
-                                            getStringValueFromPlatformEntry(platformEntryTable, "path"));
+                                            pathValue);
                                     platformEntryMap.put("groupId",
                                             getStringValueFromPlatformEntry(platformEntryTable, "groupId"));
                                     platformEntryMap.put("artifactId",
@@ -352,6 +367,16 @@ public class ManifestBuilder {
         }
 
         return platforms;
+    }
+
+    private void reportInvalidPathDiagnostic(TomlTableNode tomlTableNode, String path) {
+        DiagnosticInfo diagnosticInfo =
+                new DiagnosticInfo(null, "error.invalid.path", DiagnosticSeverity.ERROR);
+        TomlDiagnostic tomlDiagnostic = new TomlDiagnostic(
+                tomlTableNode.entries().get("path").location(),
+                diagnosticInfo,
+                "could not locate dependency path '" + path + "'");
+        tomlTableNode.addDiagnostic(tomlDiagnostic);
     }
 
     private BuildOptions setBuildOptions(TomlTableNode tomlTableNode) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/BallerinaUserHome.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/BallerinaUserHome.java
@@ -94,7 +94,7 @@ public final class BallerinaUserHome {
         // If directory does not exists, create it
         if (Files.notExists(ballerinaUserHomeDirPath) || !Files.isDirectory(ballerinaUserHomeDirPath)) {
             try {
-                Files.createDirectory(ballerinaUserHomeDirPath);
+                Files.createDirectories(ballerinaUserHomeDirPath);
             } catch (IOException e) {
                 throw new ProjectException(
                         "Ballerina user home directory does not exists in '" + ballerinaUserHomeDirPath

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/internal/environment/DefaultPackageResolver.java
@@ -214,9 +214,7 @@ public class DefaultPackageResolver implements PackageResolver {
             }
         }
 
-        return resolvedPackage.orElseThrow(() -> new IllegalStateException(
-                "Ballerina langlib package cannot be found in Ballerina distribution: org=" +
-                        resolutionRequest.orgName() + ", name=" + resolutionRequest.packageName()));
+        return resolvedPackage.orElse(null);
     }
 
     private PackageVersion findLatest(List<PackageVersion> packageVersions) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/util/ProjectConstants.java
@@ -86,6 +86,7 @@ public class ProjectConstants {
     public static final String DOT = ".";
     public static final String DEFAULT_VERSION = "0.0.0";
     public static final String INTERNAL_VERSION = "0.1.0";
+    public static final String MODULE_NAME_SEPARATOR = DOT;
 
     // Constants related to file system repo
     public static final String REPO_BALA_DIR_NAME = TARGET_BALA_DIR_NAME;

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/additional-props-ballerina.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/additional-props-ballerina.toml
@@ -8,13 +8,13 @@ keywords= ["toml", "ballerina"]
 repository= "https://github.com/ballerina-platform/ballerina-lang"
 
 [[platform.java11.dependency]]
-path = "/user/sameera/libs/toml4j.jar"
+path = "../dummy-jars/toml4j.txt"
 artifactId = "toml4j"
 version = "0.7.2"
 groupId = "com.moandjiezana.toml"
 
 [[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "../dummy-jars/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/inline-table.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/inline-table.toml
@@ -11,7 +11,7 @@ repository= "https://github.com/ballerina-platform/ballerina-lang"
 dependency = [{path = "/user/sameera/libs/toml4j.jar", artifactId = "toml4j", version = "0.7.2", groupId = "com.moandjiezana.toml"}]
 
 [[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "path/to/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/invalid-entries.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/invalid-entries.toml
@@ -8,13 +8,13 @@ keywords= ["toml", "ballerina"]
 repository=true
 
 [[platform.java11.dependency]]
-path = "/user/sameera/libs/toml4j.jar"
+path = "../dummy-jars/toml4j.txt"
 artifactId = "toml4j"
 version = "0.7.2"
 groupId = "com.moandjiezana.toml"
 
 [[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "path/to/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/invalid-org-name-version.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/invalid-org-name-version.toml
@@ -8,13 +8,13 @@ keywords= ["toml", "ballerina"]
 repository= "https://github.com/ballerina-platform/ballerina-lang"
 
 [[platform.java11.dependency]]
-path = "/user/sameera/libs/toml4j.jar"
+path = "../dummy-jars/toml4j.txt"
 artifactId = "toml4j"
 version = "0.7.2"
 groupId = "com.moandjiezana.toml"
 
 [[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "../dummy-jars/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/platfoms-with-scope.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/platfoms-with-scope.toml
@@ -8,22 +8,16 @@ keywords= ["toml", "ballerina"]
 repository= "https://github.com/ballerina-platform/ballerina-lang"
 
 [[platform.java11.dependency]]
-path = "/user/sameera/libs/toml4j.jar"
+path = "../dummy-jars/toml4j.txt"
 artifactId = "toml4j"
 version = "0.7.2"
 groupId = "com.moandjiezana.toml"
 
 [[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "../dummy-jars/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"
-
-[[platform.java11.dependency]]
-artifactId = "ldap"
-version = "1.0.0"
-path = "./libs/ballerina-io-1.2.0-java.txt"
-groupId = "ballerina"
 scope = "testOnly"
 
 [build-options]

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/platform-missing-dependency.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/platform-missing-dependency.toml
@@ -14,7 +14,7 @@ version = "0.7.2"
 groupId = "com.moandjiezana.toml"
 
 [[platform.java11]]
-path = "path/to/swagger.jar"
+path = "path/to/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/platform-without-org-name-version.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/platform-without-org-name-version.toml
@@ -5,13 +5,7 @@ keywords= ["toml", "ballerina"]
 repository= "https://github.com/ballerina-platform/ballerina-lang"
 
 [[platform.java11.dependency]]
-path = "/user/sameera/libs/toml4j.jar"
-artifactId = "toml4j"
-version = "0.7.2"
-groupId = "com.moandjiezana.toml"
-
-[[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "../dummy-jars/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/compiler/ballerina-lang/src/test/resources/ballerina-toml/valid-ballerina.toml
+++ b/compiler/ballerina-lang/src/test/resources/ballerina-toml/valid-ballerina.toml
@@ -8,13 +8,13 @@ keywords= ["toml", "ballerina"]
 repository= "https://github.com/ballerina-platform/ballerina-lang"
 
 [[platform.java11.dependency]]
-path = "/user/sameera/libs/toml4j.jar"
+path = "<USER_DIR>/src/test/resources/dummy-jars/toml4j.txt"
 artifactId = "toml4j"
 version = "0.7.2"
 groupId = "com.moandjiezana.toml"
 
 [[platform.java11.dependency]]
-path = "path/to/swagger.jar"
+path = "../dummy-jars/swagger.txt"
 artifactId = "swagger"
 version = "0.7.2"
 groupId = "swagger.io"

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -30,6 +30,7 @@ import io.ballerina.projects.DiagnosticResult;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.DocumentConfig;
 import io.ballerina.projects.DocumentId;
+import io.ballerina.projects.EmitResult;
 import io.ballerina.projects.JBallerinaBackend;
 import io.ballerina.projects.JvmTarget;
 import io.ballerina.projects.Module;
@@ -124,6 +125,37 @@ public class TestBuildProject {
         Assert.assertEquals(noOfSrcDocuments, 4);
         Assert.assertEquals(noOfTestDocuments, 3);
 
+    }
+
+    @Test (description = "tests loading a build project containing invalid platformdependency paths")
+    public void testBuildProjectWithInvalidDependencyPaths() {
+        Path projectPath = RESOURCE_DIRECTORY.resolve("myproject_invalidDependencyPath");
+
+        // 1) Initialize the project instance
+        BuildProject project = null;
+        try {
+            project = BuildProject.load(projectPath);
+        } catch (Exception e) {
+            Assert.fail(e.getMessage());
+        }
+        // 2) Load the package
+        Package currentPackage = project.currentPackage();
+        // 3) Load the default module
+        Module defaultModule = currentPackage.getDefaultModule();
+        Assert.assertEquals(defaultModule.documentIds().size(), 1);
+
+        PackageCompilation packageCompilation = project.currentPackage().getCompilation();
+        Assert.assertEquals(packageCompilation.diagnosticResult().diagnosticCount(), 1);
+        Assert.assertEquals(packageCompilation.diagnosticResult().diagnostics().stream().findFirst().get().toString(),
+                "ERROR [Ballerina.toml:(3:0,3:43)] could not locate dependency path './libs/ballerina-io-1.0.0-java.txt'");
+        JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_11);
+        Assert.assertEquals(jBallerinaBackend.diagnosticResult().diagnosticCount(), 1);
+
+        EmitResult emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, Paths.get("myproject.jar"));
+        Assert.assertFalse(emitResult.successful());
+
+        emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALA, Paths.get(System.getProperty("user.dir")));
+        Assert.assertFalse(emitResult.successful());
     }
 
     @Test (description = "tests loading a build project with no read permission")

--- a/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
+++ b/project-api/project-api-test/src/test/java/io/ballerina/projects/test/TestBuildProject.java
@@ -147,14 +147,15 @@ public class TestBuildProject {
         PackageCompilation packageCompilation = project.currentPackage().getCompilation();
         Assert.assertEquals(packageCompilation.diagnosticResult().diagnosticCount(), 1);
         Assert.assertEquals(packageCompilation.diagnosticResult().diagnostics().stream().findFirst().get().toString(),
-                "ERROR [Ballerina.toml:(3:0,3:43)] could not locate dependency path './libs/ballerina-io-1.0.0-java.txt'");
+                "ERROR [Ballerina.toml:(3:0,3:43)] " +
+                        "could not locate dependency path './libs/ballerina-io-1.0.0-java.txt'");
         JBallerinaBackend jBallerinaBackend = JBallerinaBackend.from(packageCompilation, JvmTarget.JAVA_11);
         Assert.assertEquals(jBallerinaBackend.diagnosticResult().diagnosticCount(), 1);
 
-        EmitResult emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, Paths.get("myproject.jar"));
+        EmitResult emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.EXEC, Paths.get("test.jar"));
         Assert.assertFalse(emitResult.successful());
 
-        emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALA, Paths.get(System.getProperty("user.dir")));
+        emitResult = jBallerinaBackend.emit(JBallerinaBackend.OutputType.BALA, projectPath);
         Assert.assertFalse(emitResult.successful());
     }
 

--- a/project-api/project-api-test/src/test/resources/myproject_invalidDependencyPath/Ballerina.toml
+++ b/project-api/project-api-test/src/test/resources/myproject_invalidDependencyPath/Ballerina.toml
@@ -1,0 +1,5 @@
+[[platform.java11.dependency]]
+artifactId = "ldap"
+version = "1.0.0"
+path = "./libs/ballerina-io-1.0.0-java.txt"
+groupId = "ballerina"

--- a/project-api/project-api-test/src/test/resources/myproject_invalidDependencyPath/main.bal
+++ b/project-api/project-api-test/src/test/resources/myproject_invalidDependencyPath/main.bal
@@ -1,0 +1,2 @@
+public function main() {
+}


### PR DESCRIPTION
## Purpose
> Validate dependency paths in Ballerina.toml - Fixes #29174
> Fix IndexOutOfBoundsException for lang package name and
> Avoid throwing IllegalStateException when langlib package is not resolved - Fixes #28677
> Fix creation of directory structure for custom user home - Fixes #29169

## Approach
> For dependency path validation, when constructing the manifest, a TomlDiagnostic would be added for each non-existent dependency jar path. Therefore code generation will not take place if any invalid dependency jar paths were found.

Output of `$ bal build` will be similar to the following:
```
Compiling source
	asmaj/proj1:0.4.0
ERROR [Ballerina.toml:(9:1,9:44)] could not locate dependency path './libs/ballerina-io-1.0.0-java.jar'
error: compilation contains errors

```


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [x] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
