### PR TITLE
Improve the java cast function

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -62,4 +62,5 @@ module io.ballerina.runtime {
     exports io.ballerina.runtime.internal.values to io.ballerina.testerina.core, io.ballerina.testerina.runtime,
             io.ballerina.lang.xml;
     exports io.ballerina.runtime.internal.configurable to io.ballerina.lang.internal;
+    exports io.ballerina.runtime.internal.types to io.ballerina.java;
 }

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -62,5 +62,4 @@ module io.ballerina.runtime {
     exports io.ballerina.runtime.internal.values to io.ballerina.testerina.core, io.ballerina.testerina.runtime,
             io.ballerina.lang.xml;
     exports io.ballerina.runtime.internal.configurable to io.ballerina.lang.internal;
-    exports io.ballerina.runtime.internal.types to io.ballerina.java;
 }

--- a/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
+++ b/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
@@ -113,7 +113,7 @@ isolated function getStringValue(int v) returns string = @Method {
 # + value - The `JObject` instance which is to be casted
 # + castType - The `JObject` implementation type ``typedesc<JObject>`` to which the given object is casted to if assignable
 # + return - The `JObject|error`, which refers to the new `JObject` instance or an `error`
-public isolated function cast(JObject value, typedesc<JObject> T) returns T|error = @Method {
+public isolated function cast(JObject value, typedesc<JObject> T = <>) returns T|error = @Method {
     'class: "org.ballerinalang.langlib.java.Cast",
     name: "cast"
 } external;

--- a/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
+++ b/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
@@ -101,18 +101,16 @@ isolated function getStringValue(int v) returns string = @Method {
     paramTypes: ["java.lang.Long"]
 } external;
 
-# Returns an `JObject|error`, which is obtained after casting the provided `JObject` instance
-# to the given `JObject` type depending on assignability.
+# Performs a Java cast operation on a value.
+# This casts a value describing a `JObject` to a type describing a `JObject` based on Java assignability,
+# returns an error if the cast cannot be done.
 # ```ballerina
-# JObject|error obj = java:cast(inputStream, typedesc<FileInputStream>);
-# if (obj is JObject) {
-#   FileInputStream fileInputStream = <FileInputStream>obj;
-# }
+# FileInputStream|error obj = java:cast(inputStream);
 # ```
 #
-# + value - The `JObject` instance which is to be casted
-# + castType - The `JObject` implementation type ``typedesc<JObject>`` to which the given object is casted to if assignable
-# + return - The `JObject|error`, which refers to the new `JObject` instance or an `error`
+# + value - A value describing a `JObject` which is to be casted
+# + T - A type describing a `JObject` to which the `value` is to be casted
+# + return - A value belonging to type `T` or an error if this cast cannot be done
 public isolated function cast(JObject value, typedesc<JObject> T = <>) returns T|error = @Method {
     'class: "org.ballerinalang.langlib.java.Cast",
     name: "cast"

--- a/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
+++ b/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
@@ -109,9 +109,9 @@ isolated function getStringValue(int v) returns string = @Method {
 # ```
 #
 # + value - A value describing a `JObject` which is to be casted
-# + T - A type describing a `JObject` to which the `value` is to be casted
-# + return - A value belonging to type `T` or an error if this cast cannot be done
-public isolated function cast(JObject value, typedesc<JObject> T = <>) returns T|error = @Method {
+# + t - A type describing a `JObject` to which the `value` is to be casted
+# + return - A value belonging to type `t` or an error if this cast cannot be done
+public isolated function cast(JObject value, typedesc<JObject> t = <>) returns t|error = @Method {
     'class: "org.ballerinalang.langlib.java.Cast",
     name: "cast"
 } external;

--- a/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
+++ b/langlib/jballerina.java/src/main/ballerina/ballerina_values_to_Java.bal
@@ -113,7 +113,7 @@ isolated function getStringValue(int v) returns string = @Method {
 # + value - The `JObject` instance which is to be casted
 # + castType - The `JObject` implementation type ``typedesc<JObject>`` to which the given object is casted to if assignable
 # + return - The `JObject|error`, which refers to the new `JObject` instance or an `error`
-public isolated function cast(JObject value, typedesc<JObject> castType) returns JObject|error = @Method {
+public isolated function cast(JObject value, typedesc<JObject> T) returns T|error = @Method {
     'class: "org.ballerinalang.langlib.java.Cast",
     name: "cast"
 } external;

--- a/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/Cast.java
+++ b/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/Cast.java
@@ -21,13 +21,13 @@ package org.ballerinalang.langlib.java;
 import io.ballerina.runtime.api.types.Field;
 import io.ballerina.runtime.api.types.ObjectType;
 import io.ballerina.runtime.api.types.Type;
-import io.ballerina.runtime.api.types.TypedescType;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BHandle;
 import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
+import io.ballerina.runtime.internal.types.BObjectType;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
 import static io.ballerina.runtime.api.creators.ValueCreator.createHandleValue;
@@ -68,11 +68,10 @@ public class Cast {
             }
             Type describingBType = castType.getDescribingType();
             BString castObjClass;
-            ObjectType castObjType;
+            BObjectType castObjType;
             String castObjTypeName;
             try {
-                TypedescType describingType = (TypedescType) describingBType;
-                castObjType = (ObjectType) describingType.getConstraint();
+                castObjType = (BObjectType) describingBType;
                 castObjTypeName = castObjType.getName();
                 Field objField = castObjType.getFields().get(jObjField);
                 if (objField == null) {
@@ -84,9 +83,8 @@ public class Cast {
                         "parameter: " + e));
             }
             try {
-                BMap castObjAnnotation = (BMap) castObjType.getAnnotation(
-                        StringUtils.fromString(annotationType));
-                castObjClass = (BString) castObjAnnotation.getStringValue(StringUtils.fromString(classAttribute));
+                BMap castObjAnnotation = (BMap) castObjType.getAnnotation(StringUtils.fromString(annotationType));
+                castObjClass = castObjAnnotation.getStringValue(StringUtils.fromString(classAttribute));
             } catch (Exception e) {
                 return createError(StringUtils.fromString(moduleName + " Error while retrieving details of the `" +
                         annotationName + "` annotation from `" + castObjTypeName + "` typedesc: " + e));

--- a/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/Cast.java
+++ b/langlib/jballerina.java/src/main/java/org/ballerinalang/langlib/java/Cast.java
@@ -27,7 +27,6 @@ import io.ballerina.runtime.api.values.BMap;
 import io.ballerina.runtime.api.values.BObject;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.api.values.BTypedesc;
-import io.ballerina.runtime.internal.types.BObjectType;
 
 import static io.ballerina.runtime.api.creators.ErrorCreator.createError;
 import static io.ballerina.runtime.api.creators.ValueCreator.createHandleValue;
@@ -68,10 +67,10 @@ public class Cast {
             }
             Type describingBType = castType.getDescribingType();
             BString castObjClass;
-            BObjectType castObjType;
+            ObjectType castObjType;
             String castObjTypeName;
             try {
-                castObjType = (BObjectType) describingBType;
+                castObjType = (ObjectType) describingBType;
                 castObjTypeName = castObjType.getName();
                 Field objField = castObjType.getFields().get(jObjField);
                 if (objField == null) {

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
@@ -12,14 +12,14 @@ public function testJavaCastFunction() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String1 castedValue = <String1>check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result, String1Typedesc);
     return castedValue.toString();
 }
 
 // Incorrect Java class cast.
 public function testIncorrectJavaCast() returns string|error {
     String1 strValue = newString1("cast this object");
-    ArrayList1 castedValue = <ArrayList1>check java:cast(strValue, ArrayList1Typedesc);
+    ArrayList1 castedValue = check java:cast(strValue, ArrayList1Typedesc);
     return castedValue.toString();
 }
 
@@ -29,7 +29,7 @@ public function testJavaCastForInvalidTypedesc3() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String4 castedValue = <String4>check java:cast(result, String4Typedesc);
+    String4 castedValue = check java:cast(result, String4Typedesc);
     return castedValue.toString();
 }
 
@@ -39,7 +39,7 @@ public function testJavaCastForInvalidClass1() returns string|error {
     String3 strValue = newString3("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String3 castedValue = <String3>check java:cast(result, String3Typedesc);
+    String3 castedValue = check java:cast(result, String3Typedesc);
     return castedValue.toString();
 }
 
@@ -49,7 +49,7 @@ public function testJavaCastForInvalidClass2() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object3 result = arrayList.get(0);
-    String1 castedValue = <String1>check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result, String1Typedesc);
     return castedValue.toString();
 }
 
@@ -60,7 +60,7 @@ public function testJavaCastFunctionNulljObj() returns string|error {
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
     result.jObj = java:createNull();
-    String1 castedValue = <String1>check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result, String1Typedesc);
     return castedValue.toString();
 }
 
@@ -70,7 +70,7 @@ public function testJavaCastMissingAnnotation1() returns string|error {
     String2 strValue = newString2("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String2 castedValue = <String2>check java:cast(result, String2Typedesc);
+    String2 castedValue = check java:cast(result, String2Typedesc);
     return castedValue.toString();
 }
 
@@ -80,7 +80,7 @@ public function testJavaCastMissingAnnotation2() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object2 result = arrayList.get(0);
-    String1 castedValue = <String1>check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result, String1Typedesc);
     return castedValue.toString();
 }
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/javainterop/basic/java_cast_test.bal
@@ -1,25 +1,19 @@
 import ballerina/jballerina.java;
 
-type String1Typedesc typedesc<String1>;
-type String2Typedesc typedesc<String2>;
-type String3Typedesc typedesc<String3>;
-type String4Typedesc typedesc<String4>;
-type ArrayList1Typedesc typedesc<ArrayList1>;
-
 // Correct use case.
 public function testJavaCastFunction() returns string|error {
     ArrayList1 arrayList = newArrayList1();
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String1 castedValue = check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 
 // Incorrect Java class cast.
 public function testIncorrectJavaCast() returns string|error {
     String1 strValue = newString1("cast this object");
-    ArrayList1 castedValue = check java:cast(strValue, ArrayList1Typedesc);
+    ArrayList1 castedValue = check java:cast(strValue);
     return castedValue.toString();
 }
 
@@ -29,7 +23,7 @@ public function testJavaCastForInvalidTypedesc3() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String4 castedValue = check java:cast(result, String4Typedesc);
+    String4 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 
@@ -39,7 +33,7 @@ public function testJavaCastForInvalidClass1() returns string|error {
     String3 strValue = newString3("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String3 castedValue = check java:cast(result, String3Typedesc);
+    String3 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 
@@ -49,7 +43,7 @@ public function testJavaCastForInvalidClass2() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object3 result = arrayList.get(0);
-    String1 castedValue = check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 
@@ -60,7 +54,7 @@ public function testJavaCastFunctionNulljObj() returns string|error {
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
     result.jObj = java:createNull();
-    String1 castedValue = check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 
@@ -70,7 +64,7 @@ public function testJavaCastMissingAnnotation1() returns string|error {
     String2 strValue = newString2("cast this object");
     _ = arrayList.add(strValue);
     Object1 result = arrayList.get(0);
-    String2 castedValue = check java:cast(result, String2Typedesc);
+    String2 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 
@@ -80,7 +74,7 @@ public function testJavaCastMissingAnnotation2() returns string|error {
     String1 strValue = newString1("cast this object");
     _ = arrayList.add(strValue);
     Object2 result = arrayList.get(0);
-    String1 castedValue = check java:cast(result, String1Typedesc);
+    String1 castedValue = check java:cast(result);
     return castedValue.toString();
 }
 


### PR DESCRIPTION
## Purpose
The previous cast operation for `JObject` classes (java binding classes) provided by the `ballerina/jballerina.java` module required an additional casting logic, that is removed through this PR.

**Previous Implementation:**
```bal
type StringTypedesc typedesc<String>;
String stringVal = <String>check java:cast(value, StringTypedesc);
```

**New Implementation:**
```bal
String stringVal = check java:cast(value);
```

Fixes #27538

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
