### PR TITLE
[Debugger] Fix non-ballerina files handling

### DIFF
--- a/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/run/DebugEngageTest.java
+++ b/tests/jballerina-debugger-integration-test/src/test/java/org/ballerinalang/debugger/test/adapter/run/DebugEngageTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.ballerinalang.debugger.test.adapter.run;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.ballerinalang.debugger.test.BaseTestCase;
+import org.ballerinalang.debugger.test.utils.BallerinaTestDebugPoint;
+import org.ballerinalang.debugger.test.utils.DebugTestRunner;
+import org.ballerinalang.debugger.test.utils.DebugUtils;
+import org.ballerinalang.test.context.BallerinaTestException;
+import org.eclipse.lsp4j.debug.StoppedEventArguments;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.nio.file.Paths;
+
+/**
+ * Test class for debugger engaging in debug launch mode.
+ *
+ * @since 2.0.0
+ */
+public class DebugEngageTest extends BaseTestCase {
+
+    DebugTestRunner debugTestRunner;
+
+    @BeforeClass
+    public void setup() {
+        String testProjectName = "breakpoint-tests";
+        String testModuleFileName = "Ballerina.toml";
+        debugTestRunner = new DebugTestRunner(testProjectName, testModuleFileName, true);
+    }
+
+    @Test(description = "Debug engage test for launch mode, with special ballerina project files as input(i.e. " +
+            "Ballerina.toml, Dependencies.toml, etc.)")
+    public void testNonBallerinaInputSource() throws BallerinaTestException {
+        String breakpointFilePath = Paths.get(debugTestRunner.testProjectPath, "main.bal").toString();
+        debugTestRunner.addBreakPoint(new BallerinaTestDebugPoint(breakpointFilePath, 22));
+        debugTestRunner.initDebugSession(DebugUtils.DebuggeeExecutionKind.RUN);
+
+        // Test for debug engage
+        Pair<BallerinaTestDebugPoint, StoppedEventArguments> debugHitInfo = debugTestRunner.waitForDebugHit(25000);
+        Assert.assertEquals(debugHitInfo.getLeft(), debugTestRunner.testBreakpoints.get(0));
+    }
+
+    @AfterMethod(alwaysRun = true)
+    public void cleanUp() {
+        debugTestRunner.terminateDebugSession();
+    }
+}

--- a/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
+++ b/tests/jballerina-debugger-integration-test/src/test/resources/testng.xml
@@ -50,6 +50,7 @@ under the License.
             <class name="org.ballerinalang.debugger.test.adapter.DebugInstructionTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.LangLibDebugTest"/>
             <class name="org.ballerinalang.debugger.test.adapter.ConditionalBreakpointTest"/>
+            <class name="org.ballerinalang.debugger.test.adapter.run.DebugEngageTest"/>
 
             <!--Debug Variables Tests-->
             <class name="org.ballerinalang.debugger.test.adapter.variables.VariableVisibilityTest"/>


### PR DESCRIPTION
## Purpose
This PR
- allows ballerina sources debugging even if the currently open/active file in the front-end is a non-ballerina source (i.e. Ballerina.toml, Dependencies.toml).
- adds integration tests to cover the related scenarios.
- fixes https://github.com/ballerina-platform/ballerina-lang/issues/29560

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
