### PR TITLE
Fix the `withinBlock()` check in `PositionUtil`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
@@ -41,18 +41,21 @@ class PositionUtil {
         int cursorLine = cursorPos.line();
         int cursorColumn = cursorPos.offset();
 
-        if (cursorLine < startLine || cursorLine > endLine) {
+        // Eliminates the cases where the cursor falls outside of a block
+        // 1) The line the cursor is at is outside of either the starting line or the ending line of the block
+        // 2) If the cursor is at the same line as the starting line, see if the starting column is ahead of the
+        // cursor's column.
+        // 3) If the cursor is at the same line as the ending line, see if the ending column is before the cursor's
+        // column. If the cursor's column is the same as the ending column, it is still considered as outside of the
+        // block.
+        if ((cursorLine < startLine || cursorLine > endLine)
+                || cursorLine == startLine && cursorColumn < startColumn
+                || cursorLine == endLine && cursorColumn >= endColumn) {
             return false;
         }
 
-        if (cursorLine == startLine && cursorColumn < startColumn) {
-            return false;
-        }
-
-        if (cursorLine == endLine && cursorColumn >= endColumn) {
-            return false;
-        }
-
+        // 4) The above scenarios are the only cases where the cursor can be outside the block. Any other location is
+        // within the block.
         return true;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/PositionUtil.java
@@ -41,11 +41,19 @@ class PositionUtil {
         int cursorLine = cursorPos.line();
         int cursorColumn = cursorPos.offset();
 
-        return (startLine < cursorLine && endLine > cursorLine)
-                || (startLine < cursorLine && endLine == cursorLine && endColumn > cursorColumn)
-                || (startLine == cursorLine && endLine > cursorLine)
-                || (startLine == endLine && startLine == cursorLine
-                && startColumn <= cursorColumn && endColumn > cursorColumn);
+        if (cursorLine < startLine || cursorLine > endLine) {
+            return false;
+        }
+
+        if (cursorLine == startLine && cursorColumn < startColumn) {
+            return false;
+        }
+
+        if (cursorLine == endLine && cursorColumn >= endColumn) {
+            return false;
+        }
+
+        return true;
     }
 
     static boolean withinRange(LineRange specifiedRange, Location nodePosition) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_service_decl_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_service_decl_test.bal
@@ -21,7 +21,13 @@ type HelloWorld service object {
 @v1 {
     foo: "annot on service"
 }
-service HelloWorld /foo/bar on new Listener() {
+service HelloWorld /foo/bar on new Listener({
+                                                host: "pop.example.com",
+                                                username: "abc@example.com",
+                                                password: "pass123",
+                                                pollingInterval: 2,
+                                                port: 995
+                                            }) {
 
     public string greeting = "Hello World!";
 
@@ -37,6 +43,9 @@ service HelloWorld /foo/bar on new Listener() {
 }
 
 public class Listener {
+
+    public function init(PopListenerConfiguration config) {
+    }
 
     public function 'start() returns error? {
     }
@@ -65,3 +74,11 @@ type Annot record {
 };
 
 public const annotation Annot v1 on source service;
+
+public type PopListenerConfiguration record {|
+    string host;
+    string username;
+    string password;
+    decimal pollingInterval = 60;
+    int port = 995;
+|};


### PR DESCRIPTION
## Purpose
This fixes the `withinBlock()` check in `PositionUtil`. The previous check had an incorrect condition which caused incorrect symbols to be returned when using the Semantic API.

## Approach
Instead of writing the conditions for the cursor to be within a block, wrote the conditions in which the cursor is considered outside of the block. 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
