### PR TITLE
Deprecate `typeParameter()` in `MapTypeSymbol` and introduce a new method with the correct return type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaMapTypeSymbol.java
@@ -49,8 +49,18 @@ public class BallerinaMapTypeSymbol extends AbstractTypeSymbol implements MapTyp
     }
 
     @Override
+    public TypeSymbol typeParam() {
+        if (this.memberTypeDesc == null) {
+            TypesFactory typesFactory = TypesFactory.getInstance(this.context);
+            this.memberTypeDesc = typesFactory.getTypeDescriptor(((BMapType) this.getBType()).constraint);
+        }
+
+        return this.memberTypeDesc;
+    }
+
+    @Override
     public String signature() {
-        Optional<TypeSymbol> memberTypeDescriptor = this.typeParameter();
-        return memberTypeDescriptor.map(typeDescriptor -> "map<" + typeDescriptor.signature() + ">").orElse("map");
+        TypeSymbol memberTypeDescriptor = this.typeParam();
+        return "map<" + memberTypeDescriptor.signature() + ">";
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/MapTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/MapTypeSymbol.java
@@ -29,6 +29,15 @@ public interface MapTypeSymbol extends TypeSymbol {
      * Get the element type descriptor.
      *
      * @return {@link TypeSymbol} of the members
+     * @deprecated This method will be removed in a later release. Use `typeParam()` instead.
      */
+    @Deprecated(forRemoval = true, since = "slalpha5")
     Optional<TypeSymbol> typeParameter();
+
+    /**
+     * Gets the type of the values in the fields of the mapping.
+     *
+     * @return The type of the members
+     */
+    TypeSymbol typeParam();
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/common/utils/completion/BLangRecordLiteralUtil.java
@@ -101,14 +101,11 @@ public class BLangRecordLiteralUtil {
 
     private static List<TypeSymbol> getTypeListForMapAndRecords(TypeSymbol typeDesc) {
         if (typeDesc.typeKind() == TypeDescKind.MAP) {
-            Optional<TypeSymbol> memberType = ((MapTypeSymbol) typeDesc).typeParameter();
-            if (memberType.isEmpty()) {
-                return new ArrayList<>();
+            TypeSymbol memberType = ((MapTypeSymbol) typeDesc).typeParam();
+            if (memberType.typeKind() == TypeDescKind.UNION) {
+                return new ArrayList<>(((UnionTypeSymbol) memberType).memberTypeDescriptors());
             }
-            if (memberType.get().typeKind() == TypeDescKind.UNION) {
-                return new ArrayList<>(((UnionTypeSymbol) memberType.get()).memberTypeDescriptors());
-            }
-            return Collections.singletonList(memberType.get());
+            return Collections.singletonList(memberType);
         } else if (typeDesc.typeKind() == TypeDescKind.RECORD) {
             return ((RecordTypeSymbol) typeDesc).fieldDescriptors().values().stream()
                     .map(RecordFieldSymbol::typeDescriptor)

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/ContextTypeResolver.java
@@ -157,7 +157,10 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
     @Override
     public Optional<TypeSymbol> transform(IndexedExpressionNode node) {
         Optional<TypeSymbol> containerType = this.visit(node.containerExpression());
-        return containerType.flatMap(this::getRawContextType);
+        if (containerType.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(this.getRawContextType(containerType.get()));
     }
 
     @Override
@@ -167,7 +170,7 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
         if (typeSymbol.isEmpty()) {
             return Optional.empty();
         }
-        return this.getRawContextType(typeSymbol.get());
+        return Optional.of(this.getRawContextType(typeSymbol.get()));
     }
 
     @Override
@@ -269,17 +272,17 @@ public class ContextTypeResolver extends NodeTransformer<Optional<TypeSymbol>> {
                 .findFirst();
     }
 
-    private Optional<TypeSymbol> getRawContextType(TypeSymbol typeSymbol) {
+    private TypeSymbol getRawContextType(TypeSymbol typeSymbol) {
         TypeSymbol rawType = CommonUtil.getRawType(typeSymbol);
         switch (rawType.typeKind()) {
             case MAP:
-                return ((MapTypeSymbol) rawType).typeParameter();
+                return ((MapTypeSymbol) rawType).typeParam();
             case ARRAY:
-                return Optional.of(((ArrayTypeSymbol) rawType).memberTypeDescriptor());
+                return ((ArrayTypeSymbol) rawType).memberTypeDescriptor();
             case TABLE:
-                return Optional.of(((TableTypeSymbol) rawType).rowTypeParameter());
+                return ((TableTypeSymbol) rawType).rowTypeParameter();
             default:
-                return Optional.of(rawType);
+                return rawType;
         }
     }
 }

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -165,7 +165,7 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
             return Optional.of(((ArrayTypeSymbol) rawType).memberTypeDescriptor());
         }
         if (rawType.typeKind() == TypeDescKind.MAP) {
-            return ((MapTypeSymbol) rawType).typeParameter();
+            return Optional.of(((MapTypeSymbol) rawType).typeParam());
         }
 
         return Optional.empty();

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -154,7 +154,7 @@ public class ExpressionTypeTest {
         TypeSymbol type = getExprType(34, 20, 34, 34);
         assertEquals(type.typeKind(), MAP);
 
-        TypeSymbol constraint = ((MapTypeSymbol) type).typeParameter().get();
+        TypeSymbol constraint = ((MapTypeSymbol) type).typeParam();
         assertEquals(constraint.typeKind(), STRING);
 
         assertType(34, 28, 34, 33, STRING);
@@ -188,7 +188,7 @@ public class ExpressionTypeTest {
         TypeSymbol type = getExprType(42, 13, 42, 40);
         assertEquals(type.typeKind(), MAP);
 
-        TypeSymbol constraint = ((MapTypeSymbol) type).typeParameter().get();
+        TypeSymbol constraint = ((MapTypeSymbol) type).typeParam();
         assertEquals(constraint.typeKind(), JSON);
 
         // Disabled ones due to #26628

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/TypedescriptorTest.java
@@ -196,7 +196,7 @@ public class TypedescriptorTest {
         Symbol symbol = getSymbol(49, 16);
         MapTypeSymbol type = (MapTypeSymbol) ((VariableSymbol) symbol).typeDescriptor();
         assertEquals(type.typeKind(), MAP);
-        assertEquals(type.typeParameter().get().typeKind(), STRING);
+        assertEquals(type.typeParam().typeKind(), STRING);
     }
 
     @Test


### PR DESCRIPTION
## Purpose
This PR deprecates the `typeParameter()` method in `MapTypeSymbol` since the return type of it is not consistent with how the spec defines the map type descriptor. According to the spec, the type parameter is mandatory. But in the map type symbol, we have made it optional. This PR introduces a new method, `typeParam()` instead which returns `TypeSymbol`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
