### PR TITLE
Fix issue in finding module prefix references in annotations

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -313,6 +313,13 @@ public class ReferenceFinder extends BaseVisitor {
     @Override
     public void visit(BLangAnnotationAttachment annAttachmentNode) {
         find(annAttachmentNode.expr);
+
+        if (!annAttachmentNode.pkgAlias.value.isEmpty()
+                && annAttachmentNode.annotationSymbol != null
+                && addIfSameSymbol(annAttachmentNode.annotationSymbol.owner, annAttachmentNode.pkgAlias.pos)) {
+            return;
+        }
+
         addIfSameSymbol(annAttachmentNode.annotationSymbol, annAttachmentNode.annotationName.pos);
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
@@ -18,12 +18,14 @@
 
 package io.ballerina.semantic.api.test.allreferences;
 
-import org.ballerinalang.test.bala.BalaCreator;
-import org.testng.annotations.AfterClass;
+import org.ballerinalang.test.BCompileUtil;
+import org.ballerinalang.test.CompileResult;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -36,20 +38,24 @@ public class FindModulePrefixRefsTest extends FindAllReferencesTest {
 
     @BeforeClass
     public void setup() {
-        BalaCreator.cleanCacheDirectories();
-        BalaCreator.createAndSetupBala("test-src/test-project", "testorg", "baz");
+        CompileResult compileResult = BCompileUtil.compileAndCacheBala("test-src/testproject");
+        if (compileResult.getErrorCount() != 0) {
+            Arrays.stream(compileResult.getDiagnostics()).forEach(System.out::println);
+            Assert.fail("Compilation contains error");
+        }
         super.setup();
     }
 
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {16, 15, List.of(location(16, 15, 18),
-                                 location(19, 0, 3),
-                                 location(22, 4, 7),
-                                 location(36, 27, 30),
-                                 location(39, 28, 31),
-                                 location(40, 18, 21))
+                {16, 15, List.of(location(16, 15, 26),
+                                 location(19, 0, 11),
+                                 location(44, 1, 12),
+                                 location(22, 4, 15),
+                                 location(36, 27, 38),
+                                 location(39, 28, 39),
+                                 location(40, 18, 29))
                 },
                 {25, 16, List.of(location(25, 16, 20),
                                  location(31, 24, 28)),
@@ -63,10 +69,5 @@ public class FindModulePrefixRefsTest extends FindAllReferencesTest {
     @Override
     public String getTestSourcePath() {
         return "test-src/find-all-ref/find_var_ref_in_module_prefix.bal";
-    }
-
-    @AfterClass
-    public void tearDown() {
-        BalaCreator.clearPackageFromRepository("test-src/test-project", "testorg", "baz");
     }
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_in_module_prefix.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_in_module_prefix.bal
@@ -14,13 +14,13 @@
 // specific language governing permissions and limitations
 // under the License.
 
-import testorg/baz;
+import testorg/testproject;
 import ballerina/lang.'string as str;
 
-baz:Digit zero = 0;
+testproject:Digit zero = 0;
 
 function test() {
-    baz:Person p = {name: "John Doe", age: 24};
+    testproject:Person p = {name: "John Doe", age: 24};
 
     if (true) {
         int x = 'int:fromString("100");
@@ -34,10 +34,14 @@ function test() {
 
             int f = 60;
             byte[] bytes = str:toBytes(p.name);
-            var pObj = new baz:PersonObj("Jane", 20);
+            var pObj = new testproject:PersonObj("Jane", 20);
         }
 
-        float circum  = 2 * baz:PI * 10;
-        int xum = baz:add(10, 20);
+        float circum  = 2 * testproject:PI * 10;
+        int xum = testproject:add(10, 20);
     }
+}
+
+@testproject:Config {host: "localhost""}
+function foo() {
 }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/annotations.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/annotations.bal
@@ -1,0 +1,17 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+public annotation Annot Config on function;

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/testproject/type_defs.bal
@@ -80,3 +80,7 @@ public type Student record {|
 public type Cat object {
     *Pet;
 };
+
+public type Annot record {|
+    string host;
+|};

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -42,8 +42,7 @@
             <class name="io.ballerina.semantic.api.test.ServiceSemanticAPITest" />
 
             <class name="io.ballerina.semantic.api.test.allreferences.AnnotationRefsTest" />
-            <!--            The following is disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/27049-->
-            <!--            <class name="io.ballerina.semantic.api.test.allreferences.FindModulePrefixRefsTest" />-->
+            <class name="io.ballerina.semantic.api.test.allreferences.FindModulePrefixRefsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsAcrossFilesTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInExprsTest" />
             <class name="io.ballerina.semantic.api.test.allreferences.FindRefsInLambdasTest" />


### PR DESCRIPTION
## Purpose
This PR fixes an issue with finding the references of a module prefix when the prefix is referred to in an annotation.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
