### PR TITLE
Avoid throwing IllegalStateException in Project API for missing org name

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ModuleLoadRequest.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/projects/environment/ModuleLoadRequest.java
@@ -46,10 +46,6 @@ public class ModuleLoadRequest {
                              PackageVersion version,
                              PackageDependencyScope scope,
                              DependencyResolutionType dependencyResolvedType) {
-        if (orgName != null && orgName.value().isEmpty()) {
-            throw new IllegalArgumentException("The orgName cannot be an empty string. " +
-                    "It should be either null or a non-empty string value");
-        }
         this.orgName = orgName;
         this.packageName = packageName;
         this.moduleName = moduleName;


### PR DESCRIPTION
## Purpose
> Avoid throwing IllegalStateException in Project API for missing org name. This is validated at the compiler.
Fixes #26719
> Introduces #30068

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
