### PR TITLE
Fix predeclared-qualifier parsing in xmlns-decl

### DIFF
--- a/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
+++ b/compiler/ballerina-parser/src/main/java/io/ballerina/compiler/internal/parser/BallerinaParser.java
@@ -9038,7 +9038,8 @@ public class BallerinaParser extends AbstractParser {
      * @return Parsed node
      */
     private STNode parseSimpleConstExprInternal() {
-        switch (peek().kind) {
+        STToken nextToken = peek();
+        switch (nextToken.kind) {
             case STRING_LITERAL_TOKEN:
             case DECIMAL_INTEGER_LITERAL_TOKEN:
             case HEX_INTEGER_LITERAL_TOKEN:
@@ -9048,16 +9049,17 @@ public class BallerinaParser extends AbstractParser {
             case FALSE_KEYWORD:
             case NULL_KEYWORD:
                 return parseBasicLiteral();
-            case IDENTIFIER_TOKEN:
-                return parseQualifiedIdentifier(ParserRuleContext.VARIABLE_REF);
             case PLUS_TOKEN:
             case MINUS_TOKEN:
                 return parseSignedIntOrFloat();
             case OPEN_PAREN_TOKEN:
                 return parseNilLiteral();
             default:
-                STToken token = peek();
-                recover(token, ParserRuleContext.CONSTANT_EXPRESSION_START);
+                if (isPredeclaredIdentifier(nextToken.kind)) {
+                    return parseQualifiedIdentifier(ParserRuleContext.VARIABLE_REF);
+                }
+                
+                recover(nextToken, ParserRuleContext.CONSTANT_EXPRESSION_START);
                 return parseSimpleConstExprInternal();
         }
     }

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_01.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_01.bal
@@ -53,3 +53,5 @@ public function bar() {
 
 // Predeclared module prefix in array length
 int[int:SIGNED8_MAX_VALUE] x = [];
+
+xmlns boolean:qux as ns1;

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_02.bal
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_02.bal
@@ -33,6 +33,8 @@ public function foo() returns map: {
     int:
 }
 
+xmlns boolean:
+
 public function main(transaction) {
     // missing colon in var decl
     transaction Info info;

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_01.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_01.json
@@ -3021,6 +3021,70 @@
               ]
             }
           ]
+        },
+        {
+          "kind": "MODULE_XML_NAMESPACE_DECLARATION",
+          "children": [
+            {
+              "kind": "XMLNS_KEYWORD",
+              "leadingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ],
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "QUALIFIED_NAME_REFERENCE",
+              "children": [
+                {
+                  "kind": "IDENTIFIER_TOKEN",
+                  "value": "boolean"
+                },
+                {
+                  "kind": "COLON_TOKEN"
+                },
+                {
+                  "kind": "IDENTIFIER_TOKEN",
+                  "value": "qux",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "WHITESPACE_MINUTIAE",
+                      "value": " "
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "AS_KEYWORD",
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "IDENTIFIER_TOKEN",
+              "value": "ns1"
+            },
+            {
+              "kind": "SEMICOLON_TOKEN",
+              "trailingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ]
+            }
+          ]
         }
       ]
     },

--- a/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_02.json
+++ b/compiler/ballerina-parser/src/test/resources/misc/predeclared-module-prefix/predeclared-module-prefix_assert_02.json
@@ -2617,6 +2617,62 @@
           ]
         },
         {
+          "kind": "MODULE_XML_NAMESPACE_DECLARATION",
+          "hasDiagnostics": true,
+          "children": [
+            {
+              "kind": "XMLNS_KEYWORD",
+              "leadingMinutiae": [
+                {
+                  "kind": "END_OF_LINE_MINUTIAE",
+                  "value": "\n"
+                }
+              ],
+              "trailingMinutiae": [
+                {
+                  "kind": "WHITESPACE_MINUTIAE",
+                  "value": " "
+                }
+              ]
+            },
+            {
+              "kind": "QUALIFIED_NAME_REFERENCE",
+              "hasDiagnostics": true,
+              "children": [
+                {
+                  "kind": "IDENTIFIER_TOKEN",
+                  "value": "boolean"
+                },
+                {
+                  "kind": "COLON_TOKEN",
+                  "trailingMinutiae": [
+                    {
+                      "kind": "END_OF_LINE_MINUTIAE",
+                      "value": "\n"
+                    }
+                  ]
+                },
+                {
+                  "kind": "IDENTIFIER_TOKEN",
+                  "isMissing": true,
+                  "hasDiagnostics": true,
+                  "diagnostics": [
+                    "ERROR_MISSING_IDENTIFIER"
+                  ]
+                }
+              ]
+            },
+            {
+              "kind": "SEMICOLON_TOKEN",
+              "isMissing": true,
+              "hasDiagnostics": true,
+              "diagnostics": [
+                "ERROR_MISSING_SEMICOLON_TOKEN"
+              ]
+            }
+          ]
+        },
+        {
           "kind": "FUNCTION_DEFINITION",
           "hasDiagnostics": true,
           "children": [


### PR DESCRIPTION
## Purpose
$subject.

Fixes #30069

## Approach
N/A

## Samples
N/A

## Remarks
```bal
xmlns boolean:qux as ns1; // predeclared prefix was not allowed in xmlns-decl before.
```

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples