### PR TITLE
Fix record intersection and type checking with never rest type

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/internal/TypeChecker.java
@@ -1287,7 +1287,17 @@ public class TypeChecker {
         }
 
         if (targetType.sealed) {
-            return targetFieldNames.containsAll(sourceFields.keySet());
+            for (String sourceFieldName : sourceFields.keySet()) {
+                if (targetFieldNames.contains(sourceFieldName)) {
+                    continue;
+                }
+
+                if (!checkIsNeverTypeOrStructureTypeWithARequiredNeverMember(
+                        sourceFields.get(sourceFieldName).getFieldType())) {
+                    return false;
+                }
+            }
+            return true;
         }
 
         for (Map.Entry<String, Field> targetFieldEntry : sourceFields.entrySet()) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/Types.java
@@ -2931,10 +2931,24 @@ public class Types {
             rhsFields.remove(lhsField.name.value);
         }
 
+        if (lhsType.sealed) {
+            for (BField field : rhsFields.values()) {
+                if (!isNeverTypeOrStructureTypeWithARequiredNeverMember(field.type)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
         // If there are any remaining RHS fields, the types of those should be assignable to the rest field type of
         // the LHS record.
-        return rhsFields.entrySet().stream().allMatch(
-                fieldEntry -> isAssignable(fieldEntry.getValue().type, lhsType.restFieldType, unresolvedTypes));
+        BType lhsRestFieldType = lhsType.restFieldType;
+        for (BField field : rhsFields.values()) {
+            if (!isAssignable(field.type, lhsRestFieldType, unresolvedTypes)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     private BAttachedFunction getMatchingInvokableType(List<BAttachedFunction> rhsFuncList, BAttachedFunction lhsFunc,
@@ -4093,36 +4107,51 @@ public class Types {
         return intersectionErrorType;
     }
 
-    private BType createRecordIntersection(IntersectionContext diagnosticContext,
+    private BType createRecordIntersection(IntersectionContext intersectionContext,
                                            BRecordType recordTypeOne, BRecordType recordTypeTwo, SymbolEnv env) {
+        LinkedHashMap<String, BField> recordOneFields = recordTypeOne.fields;
+        LinkedHashMap<String, BField> recordTwoFields = recordTypeTwo.fields;
+
+        Set<String> recordOneKeys = recordOneFields.keySet();
+        Set<String> recordTwoKeys = recordTwoFields.keySet();
+
+        boolean isRecordOneClosed = recordTypeOne.sealed;
+        boolean isRecordTwoClosed = recordTypeTwo.sealed;
+
+        BType effectiveRecordOneRestFieldType = getConstraint(recordTypeOne);
+        BType effectiveRecordTwoRestFieldType = getConstraint(recordTypeTwo);
 
         BRecordType newType = createAnonymousRecord(env);
+        BTypeSymbol newTypeSymbol = newType.tsymbol;
+        Set<String> addedKeys = new HashSet<>();
 
-        BType recordTypeOneRestFieldConstraintType = getConstraint(recordTypeOne);
-        BType recordTypeTwoRestFieldConstraintType = getConstraint(recordTypeTwo);
+        LinkedHashMap<String, BField> newTypeFields = newType.fields;
 
-        if (!populateRecordFields(diagnosticContext.switchLeft(), newType, recordTypeOne, env,
-                                  recordTypeTwoRestFieldConstraintType) ||
-                !populateRecordFields(diagnosticContext.switchRight(), newType, recordTypeTwo, env,
-                                      recordTypeOneRestFieldConstraintType)) {
+        if (!populateFields(intersectionContext.switchLeft(), recordTypeOne, env, recordOneFields, recordTwoFields,
+                            recordOneKeys, recordTwoKeys, isRecordTwoClosed, effectiveRecordTwoRestFieldType,
+                            newTypeSymbol, addedKeys, newTypeFields)) {
             return symTable.semanticError;
         }
 
-        BType restFieldType = getTypeIntersection(diagnosticContext, recordTypeOneRestFieldConstraintType,
-                                                  recordTypeTwoRestFieldConstraintType, env);
-        if (restFieldType == symTable.semanticError) {
-            newType.restFieldType = symTable.semanticError;
+        if (!populateFields(intersectionContext.switchRight(), recordTypeTwo, env, recordTwoFields, recordOneFields,
+                            recordTwoKeys, recordOneKeys, isRecordOneClosed, effectiveRecordOneRestFieldType,
+                            newTypeSymbol, addedKeys, newTypeFields)) {
             return symTable.semanticError;
         }
 
-        if (restFieldType == symTable.neverType) {
-            newType.sealed = true;
-            newType.restFieldType = symTable.noType;
-        } else {
-            newType.restFieldType = restFieldType;
+        BType restFieldType = getTypeIntersection(intersectionContext, effectiveRecordOneRestFieldType,
+                effectiveRecordTwoRestFieldType, env);
+        if (setRestType(newType, restFieldType) == symTable.semanticError) {
+            return symTable.semanticError;
         }
 
-        if (!diagnosticContext.compilerInternalIntersectionTest) {
+        if ((newType.sealed || newType.restFieldType == symTable.neverType) &&
+                (newTypeFields.isEmpty() || allReadOnlyFields(newTypeFields))) {
+            newType.flags |= Flags.READONLY;
+            newTypeSymbol.flags |= Flags.READONLY;
+        }
+
+        if (!intersectionContext.compilerInternalIntersectionTest) {
             BLangRecordTypeNode recordTypeNode = TypeDefBuilderHelper.createRecordTypeNode(
                     newType, env.enclPkg.packageID, symTable, symTable.builtinPos);
             BLangTypeDefinition recordTypeDef = TypeDefBuilderHelper.addTypeDefinition(
@@ -4132,6 +4161,114 @@ public class Types {
         }
 
         return newType;
+    }
+
+    private boolean populateFields(IntersectionContext intersectionContext, BRecordType lhsRecord, SymbolEnv env,
+                                   LinkedHashMap<String, BField> lhsRecordFields,
+                                   LinkedHashMap<String, BField> rhsRecordFields,
+                                   Set<String> lhsRecordKeys, Set<String> rhsRecordKeys,
+                                   boolean isRhsRecordClosed, BType effectiveRhsRecordRestFieldType,
+                                   BTypeSymbol newTypeSymbol, Set<String> addedKeys,
+                                   LinkedHashMap<String, BField> newTypeFields) {
+        for (String key : lhsRecordKeys) {
+            BField lhsRecordField = lhsRecordFields.get(key);
+
+            if (!validateRecordFieldDefaultValueForIntersection(intersectionContext, lhsRecordField, lhsRecord)) {
+                return false;
+            }
+
+            if (!addedKeys.add(key)) {
+                continue;
+            }
+            
+            BType intersectionFieldType;
+
+            long intersectionFlags = lhsRecordField.symbol.flags;
+
+            BType recordOneFieldType = lhsRecordField.type;
+            if (!rhsRecordKeys.contains(key)) {
+                if (isRhsRecordClosed) {
+                    if (!Symbols.isFlagOn(lhsRecordField.symbol.flags, Flags.OPTIONAL)) {
+                        return false;
+                    }
+                    continue;
+                }
+
+                if (isNeverTypeOrStructureTypeWithARequiredNeverMember(effectiveRhsRecordRestFieldType) &&
+                        !isNeverTypeOrStructureTypeWithARequiredNeverMember(recordOneFieldType)) {
+                    return false;
+                }
+
+                intersectionFieldType = getIntersection(intersectionContext, recordOneFieldType, env,
+                                                        effectiveRhsRecordRestFieldType);
+            } else {
+                BField rhsRecordField = rhsRecordFields.get(key);
+                intersectionFieldType = getIntersection(intersectionContext, recordOneFieldType, env,
+                                                        rhsRecordField.type);
+
+                long rhsFieldFlags = rhsRecordField.symbol.flags;
+                if (Symbols.isFlagOn(rhsFieldFlags, Flags.READONLY)) {
+                    intersectionFlags |= Flags.READONLY;
+                }
+
+                if (!Symbols.isFlagOn(rhsFieldFlags, Flags.OPTIONAL) &&
+                        Symbols.isFlagOn(intersectionFlags, Flags.OPTIONAL)) {
+                    intersectionFlags &= ~Flags.OPTIONAL;
+                }
+
+                if (Symbols.isFlagOn(rhsFieldFlags, Flags.REQUIRED) &&
+                        !Symbols.isFlagOn(intersectionFlags, Flags.REQUIRED)) {
+                    intersectionFlags |= Flags.REQUIRED;
+                }
+            }
+
+            if (intersectionFieldType == null || intersectionFieldType == symTable.semanticError) {
+                return false;
+            }
+
+            org.wso2.ballerinalang.compiler.util.Name name = lhsRecordField.name;
+            BVarSymbol recordFieldSymbol = new BVarSymbol(intersectionFlags, name, env.enclPkg.packageID,
+                                                          intersectionFieldType, newTypeSymbol, lhsRecordField.pos,
+                                                          SOURCE);
+
+            if (intersectionFieldType.tag == TypeTags.INVOKABLE && intersectionFieldType.tsymbol != null) {
+                BInvokableTypeSymbol tsymbol = (BInvokableTypeSymbol) intersectionFieldType.tsymbol;
+                BInvokableSymbol invokableSymbol = (BInvokableSymbol) recordFieldSymbol;
+                invokableSymbol.params = tsymbol.params;
+                invokableSymbol.restParam = tsymbol.restParam;
+                invokableSymbol.retType = tsymbol.returnType;
+                invokableSymbol.flags = tsymbol.flags;
+            }
+
+            newTypeFields.put(key, new BField(name, null, recordFieldSymbol));
+            newTypeSymbol.scope.define(name,  recordFieldSymbol);
+        }
+        return true;
+    }
+
+    private boolean allReadOnlyFields(LinkedHashMap<String, BField> fields) {
+        for (BField field : fields.values()) {
+            if (!Symbols.isFlagOn(field.symbol.flags, Flags.READONLY)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private BType setRestType(BRecordType recordType, BType restType) {
+        if (restType == symTable.semanticError) {
+            recordType.restFieldType = symTable.semanticError;
+            return symTable.semanticError;
+        }
+
+        if (restType == symTable.neverType) {
+            recordType.sealed = true;
+            recordType.restFieldType = symTable.noType;
+            return symTable.noType;
+        }
+
+        recordType.restFieldType = restType;
+        return restType;
     }
 
     private BType getConstraint(BRecordType recordType) {
@@ -4178,9 +4315,9 @@ public class Types {
             return intersectionRecord;
         }
 
-        intersectionRecord.restFieldType = getRestFieldIntersectionType(intersectionContext,
+        BType restFieldType = getRestFieldIntersectionType(intersectionContext,
                 type, (BMapType) mapType, env);
-        if (intersectionRecord.restFieldType == symTable.semanticError) {
+        if (setRestType(intersectionRecord, restFieldType) == symTable.semanticError) {
             return symTable.semanticError;
         }
 
@@ -4200,7 +4337,7 @@ public class Types {
                                                BType type, BMapType mapType, SymbolEnv env) {
         if (type.tag == TypeTags.RECORD) {
             return getTypeIntersection(intersectionContext,
-                    ((BRecordType) type).restFieldType, mapType.constraint, env);
+                    getConstraint((BRecordType) type), mapType.constraint, env);
         } else {
             return getTypeIntersection(intersectionContext,
                     ((BMapType) type).constraint, mapType.constraint, env);
@@ -4258,6 +4395,12 @@ public class Types {
             BVarSymbol recordFieldSymbol = new BVarSymbol(origField.symbol.flags, origFieldName,
                                                           env.enclPkg.packageID, recordFieldType,
                                                           intersectionRecordSymbol, origField.pos, SOURCE);
+
+            if (recordFieldType == symTable.neverType && Symbols.isFlagOn(recordFieldSymbol.flags, Flags.OPTIONAL)) {
+                recordFieldSymbol.flags &= (~Flags.REQUIRED);
+                recordFieldSymbol.flags |= Flags.OPTIONAL;
+            }
+
             if (recordFieldType.tag == TypeTags.INVOKABLE && recordFieldType.tsymbol != null) {
                 BInvokableTypeSymbol tsymbol = (BInvokableTypeSymbol) recordFieldType.tsymbol;
                 BInvokableSymbol invokableSymbol = (BInvokableSymbol) recordFieldSymbol;
@@ -4296,10 +4439,7 @@ public class Types {
         }
 
         BType fieldType = getTypeIntersection(intersectionContext, origField.type, constraint, env);
-        if (fieldType.tag == TypeTags.NEVER) {
-            if (Symbols.isOptional(origField.symbol)) {
-                return origField.type;
-            }
+        if (fieldType.tag == TypeTags.NEVER && !Symbols.isOptional(origField.symbol)) {
             return symTable.semanticError;
         }
 
@@ -4308,7 +4448,7 @@ public class Types {
         }
 
         if (Symbols.isOptional(origField.symbol)) {
-            return null;
+            return symTable.neverType;
         }
 
         return symTable.semanticError;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/expressions/binaryoperations/TypeTestExprTest.java
@@ -167,9 +167,11 @@ public class TypeTestExprTest {
                 "'anydata'", 330, 8);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: 'anydata' will not be matched to 'object " +
                 "{ }[]'", 336, 8);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: 'Record' will not be matched to " +
+                "'RecordWithIntFieldAndNeverRestField'", 358, 18);
         BAssertUtil.validateError(negativeResult, i, "incompatible types: 'Record' will not be matched to " +
-                "'RecordWithIntFieldAndNeverRestField'", 353, 18);
-        Assert.assertEquals(negativeResult.getErrorCount(), 25);
+                "'RecordWithIntFieldAndEffectivelyNeverRestField'", 359, 18);
+        Assert.assertEquals(negativeResult.getErrorCount(), 26);
     }
 
     @Test
@@ -756,5 +758,10 @@ public class TypeTestExprTest {
     @Test
     public void testRecordIntersections() {
         BRunUtil.invoke(result, "testRecordIntersections");
+    }
+
+    @Test
+    public void testRecordIntersectionWithEffectivelyNeverFields() {
+        BRunUtil.invoke(result, "testRecordIntersectionWithEffectivelyNeverFields");
     }
 }

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -78,6 +78,13 @@ public class TypeGuardTest {
                 "incompatible types: '(Baz|int)' will not be matched to 'Bar'", 150, 15);
         BAssertUtil.validateError(negativeResult, i++,
                 "incompatible types: '(Baz|int)' will not be matched to 'Qux'", 156, 15);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'record {| int i; boolean b; |}' will not be matched to 'ClosedRec'", 187, 8);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'record {| int i; boolean...; |}' will not be matched to 'ClosedRec'", 191, 8);
+        BAssertUtil.validateError(negativeResult, i++,
+                "incompatible types: 'map<(int|string)>' will not be matched to 'record {| int i; float f; |}'", 198,
+                8);
 
         Assert.assertEquals(negativeResult.getDiagnostics().length, i);
     }
@@ -177,6 +184,11 @@ public class TypeGuardTest {
                 "'record {| byte i?; boolean b; |}'", 393, 37);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'record {| byte i?;" +
                 " boolean b; |}'", 402, 17);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected " +
+                "'RecordWithReadOnlyFieldAndNonReadOnlyField', found 'record {| readonly int i; |} & readonly'", 425,
+                56);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'readonly', found 'record {| " +
+                "readonly int i; string s; |}'", 429, 22);
 
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
@@ -637,6 +649,21 @@ public class TypeGuardTest {
     @Test
     public void testRecordIntersectionWithClosedRecordAndRecordWithOptionalField() {
         BRunUtil.invoke(result, "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField");
+    }
+
+    @Test
+    public void testRecordIntersectionWithClosedRecordAndRecordWithOptionalField2() {
+        BRunUtil.invoke(result, "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField2");
+    }
+
+    @Test
+    public void testClosedRecordAndMapIntersection() {
+        BRunUtil.invoke(result, "testClosedRecordAndMapIntersection");
+    }
+
+    @Test
+    public void testIntersectionReadOnlyness() {
+        BRunUtil.invoke(result, "testIntersectionReadOnlyness");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -173,6 +173,8 @@ public class TypeGuardTest {
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'int?'", 343, 22);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'int?'", 355, 22);
         BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'j'", 377, 17);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| byte...; |}', found " +
+                "'record {| byte i?; boolean b; |}'", 393, 37);
 
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }
@@ -628,6 +630,11 @@ public class TypeGuardTest {
     public void testTypetestForTypedefs2() {
         BValue[] returns = BRunUtil.invoke(result, "testTypeDescTypeTest2");
         Assert.assertEquals(BBoolean.TRUE, returns[0]);
+    }
+
+    @Test
+    public void testRecordIntersectionWithClosedRecordAndRecordWithOptionalField() {
+        BRunUtil.invoke(result, "testRecordIntersectionWithClosedRecordAndRecordWithOptionalField");
     }
 
     @Test

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/statements/ifelse/TypeGuardTest.java
@@ -175,6 +175,8 @@ public class TypeGuardTest {
         BAssertUtil.validateError(negativeResult, i++, "undefined symbol 'j'", 377, 17);
         BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'record {| byte...; |}', found " +
                 "'record {| byte i?; boolean b; |}'", 393, 37);
+        BAssertUtil.validateError(negativeResult, i++, "incompatible types: expected 'int', found 'record {| byte i?;" +
+                " boolean b; |}'", 402, 17);
 
         Assert.assertEquals(negativeResult.getErrorCount(), i);
     }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr-negative.bal
@@ -343,6 +343,11 @@ type RecordWithIntFieldAndNeverRestField record {|
     never...;
 |};
 
+type RecordWithIntFieldAndEffectivelyNeverRestField record {|
+    int i;
+    [never, int]...;
+|};
+
 type Record record {|
     int i;
     string s;
@@ -351,4 +356,5 @@ type Record record {|
 function testRecordNegative2() {
     Record rec = {i: 1, s: ""};
     boolean b2 = rec is RecordWithIntFieldAndNeverRestField;
+    boolean b3 = rec is RecordWithIntFieldAndEffectivelyNeverRestField;
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/expressions/binaryoperations/type-test-expr.bal
@@ -1159,6 +1159,38 @@ type ClosedRecordWithIntField record {|
     int i;
 |};
 
+type RecordWithIntFieldAndNeverField record {|
+    int i;
+    never j?;
+|};
+
+type RecordWithIntFieldAndEffectivelyNeverField record {|
+    int i;
+    [never, int] j?;
+|};
+
+type OpenRecordWithIntFieldAndEffectivelyNeverRestField record {|
+    int i;
+    [never]...;
+|};
+
+function testRecordIntersectionWithEffectivelyNeverFields() {
+    RecordWithIntFieldAndNeverField rec = {i: 1};
+    assertTrue(rec is ClosedRecordWithIntField);
+    assertTrue(rec is OpenRecordWithIntFieldAndEffectivelyNeverRestField);
+
+    RecordWithIntFieldAndEffectivelyNeverField rec2 = {i: 1};
+    assertTrue(rec2 is ClosedRecordWithIntField);
+    assertTrue(rec2 is OpenRecordWithIntFieldAndEffectivelyNeverRestField);
+
+    OpenRecordWithIntFieldAndEffectivelyNeverRestField rec3 = {i: 1};
+    assertTrue(rec3 is record {| int...; |});
+
+    record {| int...; |} rec4 = {"i": 1};
+    assertFalse(rec4 is OpenRecordWithIntFieldAndEffectivelyNeverRestField);
+    assertFalse(rec4 is ClosedRecordWithIntField);
+}
+
 function assertTrue(anydata actual) {
     assertEquality(true, actual);
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-negative.bal
@@ -176,3 +176,25 @@ type Qux record {
 readonly class Class {
 
 }
+
+type ClosedRec record {|
+    int i;
+    string s?;
+|};
+
+function testRecordIntersectionNegative() {
+    record {| int i; boolean b; |} y = {i: 1, b: true};
+    if y is ClosedRec {
+    }
+    
+    record {| int i; boolean...; |} z = {i: 1, "b": true};
+    if z is ClosedRec {
+    }
+}
+
+function testClosedRecordAndMapIntersectionNegative() {
+    map<int|string> m = {};
+
+    if m is record {| int i; float f; |} {
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
@@ -385,11 +385,20 @@ type ClosedRec record {|
     boolean b;
 |};
 
-public function testRecordIntersectionWithClosedRecordAndRecordWithOptionalFieldNegative() {
+function testRecordIntersectionWithClosedRecordAndRecordWithOptionalFieldNegative() {
     record {| boolean b; |} x = {b: true};
     record {| byte i?; boolean b?; |} y = x;
 
     if y is ClosedRec {
         record {| byte...; |} rec = y;
+    }
+}
+
+function testRecordIntersectionWithClosedRecordAndRecordWithOptionalFieldNegativeTwo() {
+    record {| boolean b; |} x = {b: true};
+    record {| byte i?; boolean b?; |} y = x;
+
+    if y is ClosedRec {
+        int a = y;
     }
 }

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
@@ -402,3 +402,30 @@ function testRecordIntersectionWithClosedRecordAndRecordWithOptionalFieldNegativ
         int a = y;
     }
 }
+
+type RecordWithNonReadOnlyField record {|
+    int i;
+    string s?;
+|};
+
+type RecordWithReadOnlyFieldAndOptionalNonReadOnlyField record {|
+    readonly int i;
+    boolean b?;
+|};
+
+type RecordWithReadOnlyFieldAndNonReadOnlyField record {|
+    readonly int i;
+    string|boolean s;
+|};
+
+function testIntersectionReadOnlyness() {
+    RecordWithNonReadOnlyField r1 = {i: 1};
+
+    if r1 is RecordWithReadOnlyFieldAndOptionalNonReadOnlyField {
+        RecordWithReadOnlyFieldAndNonReadOnlyField x = r1;
+    }
+
+    if r1 is RecordWithReadOnlyFieldAndNonReadOnlyField {
+        readonly x = r1;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard-semantics-negative.bal
@@ -379,3 +379,17 @@ function testInvalidAccessOfOutOfScopeVar() {
 }
 
 type ErrorD error<Detail>;
+
+type ClosedRec record {|
+    int i?;
+    boolean b;
+|};
+
+public function testRecordIntersectionWithClosedRecordAndRecordWithOptionalFieldNegative() {
+    record {| boolean b; |} x = {b: true};
+    record {| byte i?; boolean b?; |} y = x;
+
+    if y is ClosedRec {
+        record {| byte...; |} rec = y;
+    }
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -1289,3 +1289,33 @@ type OpenRecordWithIntField record {
 type ClosedRecordWithIntField record {|
     int i;
 |};
+
+type ClosedRec record {|
+    int i?;
+    boolean b;
+|};
+
+public function testRecordIntersectionWithClosedRecordAndRecordWithOptionalField() {
+    record {| boolean b; |} x = {b: true};
+    record {| byte i?; boolean b?; |} y = x;
+
+    assertEquality(true, y is ClosedRec);
+
+    if y is ClosedRec {
+        record {| byte i?; boolean b; |} rec = y;
+        assertEquality(true, rec.b);
+        assertEquality((), rec?.i);
+
+        record {| byte i?; boolean...; |} rec2 = y;
+        assertEquality(true, rec2["b"]);
+        assertEquality((), rec2?.i);
+    }
+}
+
+function assertEquality(anydata expected, anydata actual) {
+    if expected == actual {
+        return;
+    }
+
+    panic error("expected '" + expected.toString() + "', found '" + actual.toString () + "'");
+}

--- a/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/statements/ifelse/type-guard.bal
@@ -1312,6 +1312,74 @@ public function testRecordIntersectionWithClosedRecordAndRecordWithOptionalField
     }
 }
 
+type ClosedRecTwo record {|
+    int i;
+    string s?;
+|};
+
+function testRecordIntersectionWithClosedRecordAndRecordWithOptionalField2() {
+    record {| int i; |} x = {i: 1};
+    record {| int i; boolean b?; |} y = x;
+
+    assertEquality(true, y is ClosedRecTwo);
+
+    if y is ClosedRecTwo {
+        record {| int i; |} z = y;
+        assertEquality(1, z.i);
+    }
+}
+
+function testClosedRecordAndMapIntersection() {
+    record {| byte i; |} x = {i: 123};
+    map<int|string> m = x;
+
+    assertEquality(true, m is record {| int i; float f?; |});
+
+    if m is record {| int i; float f?; |} {
+        record {| int i; |} rec = m;
+        assertEquality(123, rec.i);
+    }
+}
+
+type RecordWithNonReadOnlyField record {|
+    int i;
+    string s?;
+|};
+
+type RecordWithReadOnlyFieldAndOptionalNonReadOnlyField record {|
+    readonly int i;
+    boolean b?;
+|};
+
+type RecordWithReadOnlyFieldAndNonReadOnlyField record {|
+    readonly int i;
+    string|boolean s;
+|};
+
+function testIntersectionReadOnlyness() {
+    record {| int i; |} & readonly r1 = {i: 1};
+    RecordWithNonReadOnlyField r2 = r1;
+
+    assertEquality(true, r2 is RecordWithReadOnlyFieldAndOptionalNonReadOnlyField);
+    assertEquality(false, r2 is RecordWithReadOnlyFieldAndNonReadOnlyField);
+
+    if r2 is RecordWithReadOnlyFieldAndOptionalNonReadOnlyField {
+        readonly x = r2;
+        record {| readonly int i; |} y = r2;
+        assertEquality(1, y.i);
+    }
+
+    record {| readonly int i; string s; |} r3 = {i: 123, s: "hello"};
+    RecordWithNonReadOnlyField r4 = r3;
+
+    assertEquality(true, r4 is RecordWithReadOnlyFieldAndNonReadOnlyField);
+    if r2 is RecordWithReadOnlyFieldAndNonReadOnlyField {
+        record {| readonly int i; string s; |} x = r2;
+        assertEquality(123, x.i);
+        assertEquality("hello", x.s);
+    }
+}
+
 function assertEquality(anydata expected, anydata actual) {
     if expected == actual {
         return;


### PR DESCRIPTION
## Purpose
$title.

Fixes #30056 - Invalid record intersection generated with optional fields
Fixes #30059 - Invalid "will not be matched" error with closed record vs record with optional field
Fixes #30060 - Bad, sad error with record and map intersection when the record has an optional field
Fixes #30061 - Inconsistent intersection computation with effectively never record fields
Fixes #30065 - Always true type test at compile-time returns false at runtime
Fixes #30070 - Read-onlyness of fields isn't propagated with record intersections

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
