### PR TITLE
Add capability to manually close obs context

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserveUtils.java
@@ -267,12 +267,23 @@ public class ObserveUtils {
             return;
         }
 
+        if (!observerContext.isManuallyClosed()) {
+            stopObservationWithContext(observerContext);
+        }
+        setObserverContextToCurrentFrame(env, observerContext.getParent());
+    }
+
+    /**
+     * Notify observers to stop observations and set finished to observer context.
+     *
+     * @param observerContext Observer context
+     */
+    public static void stopObservationWithContext(ObserverContext observerContext) {
         if (observerContext.isServer()) {
             observers.forEach(observer -> observer.stopServerObservation(observerContext));
         } else {
             observers.forEach(observer -> observer.stopClientObservation(observerContext));
         }
-        setObserverContextToCurrentFrame(env, observerContext.getParent());
         observerContext.setFinished();
     }
 

--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserverContext.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/ObserverContext.java
@@ -72,6 +72,8 @@ public class ObserverContext {
 
     private boolean isSystemSpan;
 
+    private boolean manuallyClosed;
+
     public ObserverContext() {
         this.properties = new HashMap<>();
         this.tags = new HashMap<>();
@@ -193,6 +195,14 @@ public class ObserverContext {
 
     public void setSystemSpan(boolean userSpan) {
         isSystemSpan = userSpan;
+    }
+
+    public boolean isManuallyClosed() {
+        return manuallyClosed;
+    }
+
+    public void setManuallyClosed(boolean manuallyClosed) {
+        this.manuallyClosed = manuallyClosed;
     }
 
     @Deprecated


### PR DESCRIPTION
## Purpose
We need to provide the lister with the capability to manually close the observer context after adding status code to resource span. It is required when the user has put a return statement instead of a caller->respond method in the resource function.