### PR TITLE
 Improve the error which gives, when it passes `string` to `decimal:fromString` function

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/api/constants/RuntimeConstants.java
@@ -75,6 +75,7 @@ public class RuntimeConstants {
     public static final String TABLE_LANG_LIB = "lang.table";
     public static final String INT_LANG_LIB = "lang.int";
     public static final String FLOAT_LANG_LIB = "lang.float";
+    public static final String DECIMAL_LANG_LIB = "lang.decimal";
     public static final String BOOLEAN_LANG_LIB = "lang.boolean";
     public static final String TRANSACTION_LANG_LIB = "lang.transaction";
 

--- a/bvm/ballerina-runtime/src/main/java/module-info.java
+++ b/bvm/ballerina-runtime/src/main/java/module-info.java
@@ -58,7 +58,8 @@ module io.ballerina.runtime {
     exports io.ballerina.runtime.internal.util.exceptions to io.ballerina.lang.value, io.ballerina.lang.integer,
             io.ballerina.java, io.ballerina.lang.internal, io.ballerina.lang.array, io.ballerina.lang.bool,
             io.ballerina.lang.floatingpoint, io.ballerina.lang.map, io.ballerina.lang.string, io.ballerina.lang.table,
-            io.ballerina.lang.xml, io.ballerina.testerina.core, io.ballerina.cli.utils, io.ballerina.cli;
+            io.ballerina.lang.xml, io.ballerina.testerina.core, io.ballerina.cli.utils, io.ballerina.cli,
+            io.ballerina.lang.decimal;
     exports io.ballerina.runtime.internal.values to io.ballerina.testerina.core, io.ballerina.testerina.runtime,
             io.ballerina.lang.xml;
     exports io.ballerina.runtime.internal.configurable to io.ballerina.lang.internal;

--- a/langlib/lang.decimal/src/main/java/org/ballerinalang/langlib/decimal/FromString.java
+++ b/langlib/lang.decimal/src/main/java/org/ballerinalang/langlib/decimal/FromString.java
@@ -18,10 +18,16 @@
 
 package org.ballerinalang.langlib.decimal;
 
+import io.ballerina.runtime.api.PredefinedTypes;
 import io.ballerina.runtime.api.creators.ErrorCreator;
-import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.values.BString;
 import io.ballerina.runtime.internal.TypeConverter;
+import io.ballerina.runtime.internal.util.exceptions.BLangExceptionHelper;
+import io.ballerina.runtime.internal.util.exceptions.RuntimeErrors;
+
+import static io.ballerina.runtime.api.constants.RuntimeConstants.DECIMAL_LANG_LIB;
+import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.NUMBER_PARSING_ERROR_IDENTIFIER;
+import static io.ballerina.runtime.internal.util.exceptions.BallerinaErrorReasons.getModulePrefixedReason;
 
 /**
  * Native implementation of lang.decimal:fromString(string).
@@ -36,12 +42,17 @@ import io.ballerina.runtime.internal.TypeConverter;
 //)
 public class FromString {
 
+    private static final BString ERROR_REASON = getModulePrefixedReason(DECIMAL_LANG_LIB,
+                                                                        NUMBER_PARSING_ERROR_IDENTIFIER);
+
     public static Object fromString(BString s) {
         try {
             return TypeConverter.stringToDecimal(s.getValue());
         } catch (NumberFormatException e) {
-            // TODO: 6/21/19 Improve this error value
-            return ErrorCreator.createError(StringUtils.fromString(e.getMessage()), e);
+            return ErrorCreator.createError(ERROR_REASON,
+                                            BLangExceptionHelper.getErrorMessage(
+                                                    RuntimeErrors.INCOMPATIBLE_SIMPLE_TYPE_CONVERT_OPERATION,
+                                                    PredefinedTypes.TYPE_STRING, s, PredefinedTypes.TYPE_DECIMAL));
         }
     }
 }

--- a/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibDecimalTest.java
+++ b/langlib/langlib-test/src/test/java/org/ballerinalang/langlib/test/LangLibDecimalTest.java
@@ -296,4 +296,9 @@ public class LangLibDecimalTest {
                 { "-504023030303030303030.3030303", "-504023030303030303030.3030303"}
         };
     }
+
+    @Test
+    public void testFromStringWithStringArg() {
+        BRunUtil.invoke(compileResult, "testFromStringWithStringArg");
+    }
 }

--- a/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
+++ b/langlib/langlib-test/src/test/resources/test-src/decimallib_test.bal
@@ -79,3 +79,29 @@ function testFloorAsMethodInvok(decimal x) returns decimal {
 function testCeilingAsMethodInvok(decimal x) returns decimal {
     return x.ceiling();
 }
+
+function value() returns decimal|error {
+    return 'decimal:fromString("x");
+}
+
+function testFromStringWithStringArg() {
+    decimal|error res = value();
+    assertEquality(true, res is error);
+
+    error resError = <error> res;
+    assertEquality("'string' value 'x' cannot be converted to 'decimal'", resError.detail().get("message"));
+}
+
+function assertEquality(any|error expected, any|error actual) {
+    if expected is anydata && actual is anydata && expected == actual {
+        return;
+    }
+
+    if expected === actual {
+        return;
+    }
+
+    string expectedValAsString = expected is error ? expected.toString() : expected.toString();
+    string actualValAsString = actual is error ? actual.toString() : actual.toString();
+    panic error("expected '" + expectedValAsString + "', found '" + actualValAsString + "'");
+}


### PR DESCRIPTION
## Purpose
> $title.

Fixes #23202 

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
