### PR TITLE
Fix incorrect type symbol setting issue for BLangTypeInit nodes

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/SymbolFinder.java
@@ -870,7 +870,7 @@ class SymbolFinder extends BaseVisitor {
     @Override
     public void visit(BLangTypeInit typeInit) {
         lookupNodes(typeInit.argsExpr);
-        setEnclosingNode(typeInit.type.tsymbol, typeInit.pos);
+        lookupNode(typeInit.userDefinedType);
     }
 
     @Override

--- a/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction41.json
+++ b/language-server/modules/langserver-core/src/test/resources/codeaction/create-variable/config/variableAssignmentRequiredCodeAction41.json
@@ -16,7 +16,7 @@
                             "character": 4
                         }
                     },
-                    "newText": "File|error unionResult \u003d "
+                    "newText": "File|error file \u003d "
                 }
             ]
         }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ClassSymbolTest.java
@@ -23,21 +23,26 @@ import io.ballerina.compiler.api.symbols.ClassSymbol;
 import io.ballerina.compiler.api.symbols.MethodSymbol;
 import io.ballerina.compiler.api.symbols.Qualifier;
 import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeReferenceTypeSymbol;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.projects.Document;
 import io.ballerina.projects.Project;
 import io.ballerina.tools.text.LinePosition;
+import io.ballerina.tools.text.LineRange;
 import org.ballerinalang.test.BCompileUtil;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
 import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.OBJECT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.STRING;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.TYPE_REFERENCE;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.assertList;
 import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
@@ -111,21 +116,46 @@ public class ClassSymbolTest {
 
     @Test(dataProvider = "TypeInitPosProvider")
     public void testTypeInit(int line, int col, String name) {
-        Symbol symbol = model.symbol(srcFile, LinePosition.from(line, col)).get();
-        ClassSymbol clazz = (ClassSymbol) ((TypeReferenceTypeSymbol) symbol).typeDescriptor();
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        if (name == null) {
+            assertTrue(symbol.isEmpty());
+            return;
+        }
+
+        ClassSymbol clazz = (ClassSymbol) ((TypeReferenceTypeSymbol) symbol.get()).typeDescriptor();
         assertEquals(clazz.getName().get(), name);
     }
 
     @DataProvider(name = "TypeInitPosProvider")
     public Object[][] getTypeInit() {
         return new Object[][]{
-                {40, 17, "Person1"},
-                {40, 21, "Person1"},
-                {40, 30, "Person1"},
-                {41, 17, "Person2"},
-                {42, 9, "Person2"},
+                {40, 17, null},
+                {40, 21, null},
+                {40, 30, null},
+                {41, 17, null},
+                {42, 9, null},
                 {42, 13, "Person2"},
-                {42, 21, "Person2"},
+                {42, 21, null},
+        };
+    }
+
+    @Test(dataProvider = "TypeInitPosProvider2")
+    public void testTypeInit2(int line, int sCol, int eCol, TypeDescKind typeKind, String name) {
+        Optional<TypeSymbol> type = model.type(
+                LineRange.from(srcFile.name(), LinePosition.from(line, sCol), LinePosition.from(line, eCol)));
+        assertTrue(type.isPresent());
+        assertEquals(type.get().typeKind(), typeKind);
+        type.get().getName().ifPresent(tName -> assertEquals(tName, name));
+    }
+
+    @DataProvider(name = "TypeInitPosProvider2")
+    public Object[][] getTypeInit2() {
+        return new Object[][]{
+                {40, 17, 42, TYPE_REFERENCE, "Person1"},
+                {40, 21, 29, STRING, null},
+                {41, 17, 20, TYPE_REFERENCE, "Person2"},
+                {42, 9, 22, TYPE_REFERENCE, "Person2"},
         };
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbolbynode/SymbolByClassTest.java
@@ -21,6 +21,7 @@ import io.ballerina.compiler.api.SemanticModel;
 import io.ballerina.compiler.api.symbols.Symbol;
 import io.ballerina.compiler.api.symbols.SymbolKind;
 import io.ballerina.compiler.syntax.tree.ClassDefinitionNode;
+import io.ballerina.compiler.syntax.tree.ExplicitNewExpressionNode;
 import io.ballerina.compiler.syntax.tree.FunctionDefinitionNode;
 import io.ballerina.compiler.syntax.tree.MethodCallExpressionNode;
 import io.ballerina.compiler.syntax.tree.Node;
@@ -35,7 +36,9 @@ import java.util.Optional;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS;
 import static io.ballerina.compiler.api.symbols.SymbolKind.CLASS_FIELD;
 import static io.ballerina.compiler.api.symbols.SymbolKind.METHOD;
+import static io.ballerina.compiler.api.symbols.SymbolKind.TYPE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * Test cases for looking up a symbol given a class.
@@ -56,8 +59,9 @@ public class SymbolByClassTest extends SymbolByNodeTest {
 
             @Override
             public void visit(ClassDefinitionNode classDefinitionNode) {
-                assertSymbol(classDefinitionNode, model, CLASS, "Person");
-                assertSymbol(classDefinitionNode.className(), model, CLASS, "Person");
+                String className = classDefinitionNode.className().text();
+                assertSymbol(classDefinitionNode, model, CLASS, className);
+                assertSymbol(classDefinitionNode.className(), model, CLASS, className);
 
                 for (Node member : classDefinitionNode.members()) {
                     member.accept(this);
@@ -91,12 +95,18 @@ public class SymbolByClassTest extends SymbolByNodeTest {
                 assertSymbol(remoteMethodCallActionNode, model, METHOD, "getAge");
                 assertSymbol(remoteMethodCallActionNode.methodName(), model, METHOD, "getAge");
             }
+
+            @Override
+            public void visit(ExplicitNewExpressionNode explicitNewExpressionNode) {
+                assertSymbol(explicitNewExpressionNode.typeDescriptor(), model, TYPE, "Employee");
+                assertTrue(model.symbol(explicitNewExpressionNode).isEmpty());
+            }
         };
     }
 
     @Override
     void verifyAssertCount() {
-        assertEquals(getAssertCount(), 13);
+        assertEquals(getAssertCount(), 17);
     }
 
     private void assertSymbol(Node node, SemanticModel model, SymbolKind kind, String name) {

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_class_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbol-by-node/symbol_by_class_test.bal
@@ -32,4 +32,10 @@ function test() {
     Person p = new("John Doe", 25);
     string s = p.getName();
     int a = p->getAge();
+
+    Employee|error e = new Employee();
+}
+
+class Employee {
+    function init() returns error? {}
 }


### PR DESCRIPTION
## Purpose
Fixes a bug in the `SymbolFinder` where the new expr's type's symbol was being set as the symbol at cursor. With this PR, `symbol()` method will no longer return a symbol for `new` or `new T()` expressions. In the latter case, a symbol would only be returned if looking it up for `T`.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
