### PR TITLE
Change typeguard completion behaviour to suggest on uniontype field access

### DIFF
--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeGuardCompletionItemBuilder.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/builder/TypeGuardCompletionItemBuilder.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.completions.builder;
+
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.List;
+
+/**
+ * This class is being used to build typeguard completion item.
+ *
+ * @since 2.0
+ */
+public class TypeGuardCompletionItemBuilder {
+
+    private TypeGuardCompletionItemBuilder() {
+    }
+
+    /**
+     * Creates and return a snippet type completion item.
+     *
+     * @param snippet             text to be inserted
+     * @param label               label of the completion item
+     * @param detail              detail of the completion item
+     * @param additionalTextEdits textedits consisting the range to be replaced by the completion item.
+     * @return {@link CompletionItem} generated completion item
+     */
+    public static CompletionItem build(String snippet, String label, String detail,
+                                       List<TextEdit> additionalTextEdits) {
+        CompletionItem completionItem = new CompletionItem();
+        String insertText = snippet;
+        completionItem.setInsertText(insertText);
+        completionItem.setLabel(label);
+        completionItem.setDetail(detail);
+        completionItem.setAdditionalTextEdits(additionalTextEdits);
+        completionItem.setKind(CompletionItemKind.Snippet);
+        return completionItem;
+    }
+
+}

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/FieldAccessCompletionResolver.java
@@ -198,8 +198,18 @@ public class FieldAccessCompletionResolver extends NodeTransformer<Optional<Type
      * @return {@link List}
      */
     public List<Symbol> getVisibleEntries(Node node) {
-        Optional<TypeSymbol> typeSymbol = node.apply(this);
+        Optional<TypeSymbol> typeSymbol = getTypeSymbol(node);
         return typeSymbol.map(tSymbol -> this.getVisibleEntries(tSymbol, node)).orElse(Collections.emptyList());
+    }
+
+    /**
+     * returns the TypeSymbol given the node.
+     *
+     * @param node Node of which the TypeSymbol should be resolved
+     * @return {@link TypeSymbol}
+     */
+    public Optional<TypeSymbol> getTypeSymbol(Node node) {
+        return node.apply(this);
     }
 
     private Optional<Symbol> getSymbolByName(List<Symbol> visibleSymbols, String name) {

--- a/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/TypeGuardUtil.java
+++ b/language-server/modules/langserver-core/src/main/java/org/ballerinalang/langserver/completions/util/TypeGuardUtil.java
@@ -1,0 +1,122 @@
+/*
+ *  Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ */
+package org.ballerinalang.langserver.completions.util;
+
+import io.ballerina.compiler.api.symbols.TypeDescKind;
+import io.ballerina.compiler.api.symbols.TypeSymbol;
+import io.ballerina.compiler.api.symbols.UnionTypeSymbol;
+import io.ballerina.compiler.syntax.tree.BlockStatementNode;
+import io.ballerina.compiler.syntax.tree.ExpressionStatementNode;
+import io.ballerina.compiler.syntax.tree.FieldAccessExpressionNode;
+import io.ballerina.compiler.syntax.tree.FunctionBodyNode;
+import io.ballerina.compiler.syntax.tree.SimpleNameReferenceNode;
+import org.ballerinalang.langserver.common.utils.CommonUtil;
+import org.ballerinalang.langserver.commons.BallerinaCompletionContext;
+import org.ballerinalang.langserver.commons.completion.LSCompletionItem;
+import org.ballerinalang.langserver.completions.StaticCompletionItem;
+import org.ballerinalang.langserver.completions.builder.TypeGuardCompletionItemBuilder;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextEdit;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/**
+ * Dynamic snippet constructs for typeguards.
+ */
+public class TypeGuardUtil {
+
+    private static final String TYPE_GUARD_LABEL = "typeguard";
+
+    private TypeGuardUtil() {
+    }
+
+    /**
+     * Given a union type variable symbol, returns the typeguard snippet destructuring the
+     * member types of the given symbol.
+     *
+     * @param symbol Uniontype symbol
+     * @param ctx    Completion context
+     * @return {@link LSCompletionItem} generated completion item
+     */
+    public static LSCompletionItem getTypeGuardDestructedItem(UnionTypeSymbol symbol,
+                                                              BallerinaCompletionContext ctx,
+                                                              FieldAccessExpressionNode expr) {
+        String symbolName = ((SimpleNameReferenceNode) expr.expression()).name().text();
+        List<TypeSymbol> members = new ArrayList<>(symbol.memberTypeDescriptors());
+        String detail = "Destructure the variable " + symbolName + " with typeguard";
+        String snippet = "";
+        snippet += IntStream.range(0, members.size() - 1).mapToObj(value -> {
+            TypeSymbol bType = members.get(value);
+            String placeHolder = "\t${" + (value + 1) + "}";
+            return "if " + symbolName + " is " + CommonUtil.getModifiedTypeName(ctx, bType) + " {"
+                    + CommonUtil.LINE_SEPARATOR + placeHolder + CommonUtil.LINE_SEPARATOR + "}";
+        }).collect(Collectors.joining(" else ")) + " else {" + CommonUtil.LINE_SEPARATOR + "\t${"
+                + members.size() + "}" + CommonUtil.LINE_SEPARATOR + "}";
+
+        //create the text edit item to replace the field accession text.
+        List<TextEdit> textEdits = new ArrayList<>();
+        TextEdit textEdit = new TextEdit();
+        textEdit.setNewText("");
+        Position start = new Position(expr.lineRange().startLine().line(), expr.lineRange().startLine().offset());
+        Position end = new Position(expr.lineRange().endLine().line(), expr.lineRange().endLine().offset());
+        textEdit.setRange(new Range(start, end));
+        textEdits.add(textEdit);
+        CompletionItem completionItem =
+                TypeGuardCompletionItemBuilder.build(snippet, TYPE_GUARD_LABEL, detail, textEdits);
+        return new StaticCompletionItem(ctx, completionItem, StaticCompletionItem.Kind.OTHER);
+    }
+
+    /**
+     * Returns Typeguard completion items for union type variable symbols for the given
+     * expression node in the given completion context.
+     *
+     * @param ctx  Completion context
+     * @param expr expression node
+     * @return List of typeguard completion items
+     */
+    public static List<LSCompletionItem> getTypeGuardDestructedItems(BallerinaCompletionContext ctx,
+                                                                     FieldAccessExpressionNode expr,
+                                                                     Optional<TypeSymbol> typeSymbol) {
+        List<LSCompletionItem> completionItems = new ArrayList<>();
+        if (TypeGuardUtil.isInFunctionBlockBodyContext(expr)) {
+            completionItems.addAll(typeSymbol.stream().filter(tSymbol -> tSymbol.typeKind() == TypeDescKind.UNION).map(
+                    tSymbol -> TypeGuardUtil.getTypeGuardDestructedItem((UnionTypeSymbol) tSymbol,
+                            ctx, expr)).collect(Collectors.toList()));
+        }
+
+        return completionItems;
+    }
+
+    /**
+     * Check if the given node is within a FunctionBodyBlockNode context.
+     *
+     * @param node Expression node of which the context is checked
+     * @return
+     */
+    public static boolean isInFunctionBlockBodyContext(FieldAccessExpressionNode node) {
+        return node.parent() instanceof ExpressionStatementNode &&
+                (node.parent().parent() instanceof FunctionBodyNode ||
+                        node.parent().parent() instanceof BlockStatementNode);
+    }
+}

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config1.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config1.json
@@ -1,0 +1,79 @@
+{
+  "position": {
+    "line": 2,
+    "character": 10
+  },
+  "source": "statement_context/source/typeguard_stmt_source1.bal",
+  "items": [
+    {
+      "label": "typeguard",
+      "kind": "Snippet",
+      "detail": "Destructure the variable myVar with typeguard",
+      "sortText": "Q",
+      "insertText": "if myVar is string {\n\t${1}\n} else if myVar is int {\n\t${2}\n} else if myVar is boolean {\n\t${3}\n} else {\n\t${4}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 2,
+              "character": 4
+            },
+            "end": {
+              "line": 2,
+              "character": 10
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(Cloneable)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(typedesc<any> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}
+

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config2.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config2.json
@@ -1,0 +1,56 @@
+{
+  "position": {
+    "line": 2,
+    "character": 17
+  },
+  "source": "statement_context/source/typeguard_stmt_source2.bal",
+  "items": [
+    {
+      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(Cloneable)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(typedesc<any> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}
+

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config3.json
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/config/typeguard_stmt_config3.json
@@ -1,0 +1,79 @@
+{
+  "position": {
+    "line": 3,
+    "character": 14
+  },
+  "source": "statement_context/source/typeguard_stmt_source3.bal",
+  "items": [
+    {
+      "label": "typeguard",
+      "kind": "Snippet",
+      "detail": "Destructure the variable myVar with typeguard",
+      "sortText": "Q",
+      "insertText": "if myVar is string {\n\t${1}\n} else if myVar is int {\n\t${2}\n} else if myVar is boolean {\n\t${3}\n} else {\n\t${4}\n}",
+      "insertTextFormat": "Snippet",
+      "additionalTextEdits": [
+        {
+          "range": {
+            "start": {
+              "line": 3,
+              "character": 8
+            },
+            "end": {
+              "line": 3,
+              "character": 14
+            }
+          },
+          "newText": ""
+        }
+      ]
+    },
+    {
+      "label": "cloneReadOnly()(Cloneable & readonly)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v` that is read-only, i.e. immutable.\nIt corresponds to the ImmutableClone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable & readonly`   \n- immutable clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "cloneReadOnly()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "clone()(Cloneable)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nReturns a clone of `v`.\nA clone is a deep copy that does not copy immutable subtrees.\nA clone can therefore safely be used concurrently with the original.\nIt corresponds to the Clone(v) abstract operation,\ndefined in the Ballerina Language Specification.\n  \n  \n  \n**Returns** `Cloneable`   \n- clone of `v`  \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "clone()",
+      "insertTextFormat": "Snippet"
+    },
+    {
+      "label": "ensureType(typedesc<any> t)(t|error)",
+      "kind": "Function",
+      "detail": "Function",
+      "documentation": {
+        "right": {
+          "kind": "markdown",
+          "value": "**Package:** _ballerina/lang.value:1.0.0_  \n  \nSafely casts a value to a type.\nThis casts a value to a type in the same way as a type cast expression,\nbut returns an error if the cast cannot be done, rather than panicking.  \n**Params**  \n- `typedesc<any>` t: a typedesc for the type to which to cast it\nreturn - `v` cast to the type described by `t`, or an error, if the cast cannot be done(Defaultable)  \n  \n**Returns** `t|error`   \n  \n"
+        }
+      },
+      "sortText": "D",
+      "insertText": "ensureType(${1})",
+      "insertTextFormat": "Snippet",
+      "command": {
+        "title": "editor.action.triggerParameterHints",
+        "command": "editor.action.triggerParameterHints"
+      }
+    }
+  ]
+}
+

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/typeguard_stmt_source1.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/typeguard_stmt_source1.bal
@@ -1,0 +1,8 @@
+public function testFunction(){
+    string|int|boolean|myErr1|error myVar;
+    myVar.
+}
+
+type myErr1 error;
+
+

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/typeguard_stmt_source2.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/typeguard_stmt_source2.bal
@@ -1,0 +1,12 @@
+public function testFunction(){
+    string|int|boolean|myErr1|error myVar;
+    myFunc(myVar.)
+}
+
+function myFunc(int arg1) {
+
+}
+
+type myErr1 error;
+
+

--- a/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/typeguard_stmt_source3.bal
+++ b/language-server/modules/langserver-core/src/test/resources/completion/statement_context/source/typeguard_stmt_source3.bal
@@ -1,0 +1,12 @@
+public function testFunction(){
+    string|int|boolean|myErr1|error myVar = 1;
+    while(true){
+        myVar.
+    }
+}
+
+function myFunc(int arg1) {
+
+}
+
+type myErr1 error;


### PR DESCRIPTION
## Purpose
> Refactor the previous behaviour to provide the completion item only on uniontype field access.

Fixes #29979

## Approach
> Removing the typeguard completion from `BlockNodeContext` provider and  adding it to `FieldAccessContext` provider.


## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
