### PR TITLE
Add a version of `references()` for getting references without definition location

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/SemanticModel.java
@@ -77,7 +77,7 @@ public interface SemanticModel {
     /**
      * Finds all the references of the specified symbol within the relevant scope.
      *
-     * @param symbol a {@link Symbol} insance
+     * @param symbol a {@link Symbol} instance
      * @return A {@link List} of line ranges of all the references
      */
     List<Location> references(Symbol symbol);
@@ -87,10 +87,31 @@ public interface SemanticModel {
      * the specified symbol within the relevant scope.
      *
      * @param sourceDocument The source file document in which to look up the position
-     * @param position   a cursor position in the source
+     * @param position       a cursor position in the source
      * @return A {@link List} of line ranges of all the references
      */
     List<Location> references(Document sourceDocument, LinePosition position);
+
+    /**
+     * Finds all the references of the specified symbol within the relevant scope. This list excludes the reference in
+     * the definition.
+     *
+     * @param symbol         a {@link Symbol} instance
+     * @param withDefinition Whether the definition should be counted as a reference or not
+     * @return A {@link List} of line ranges of all the references except the definition
+     */
+    List<Location> references(Symbol symbol, boolean withDefinition);
+
+    /**
+     * If there's an identifier associated with a symbol at the specified cursor position, finds all the references of
+     * the specified symbol within the relevant scope. This list excludes the reference in the definition.
+     *
+     * @param sourceDocument The source file document in which to look up the position
+     * @param position       a cursor position in the source
+     * @param withDefinition Whether the definition should be counted as a reference or not
+     * @return A {@link List} of line ranges of all the references except the definition
+     */
+    List<Location> references(Document sourceDocument, LinePosition position, boolean withDefinition);
 
     /**
      * Retrieves the type of the expression in the specified text range. If it's not a valid expression, returns an

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/BallerinaSemanticModel.java
@@ -163,6 +163,19 @@ public class BallerinaSemanticModel implements SemanticModel {
      */
     @Override
     public List<Location> references(Symbol symbol) {
+        return references(symbol, true);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<Location> references(Document sourceDocument, LinePosition position) {
+        return references(sourceDocument, position, true);
+    }
+
+    @Override
+    public List<Location> references(Symbol symbol, boolean withDefinition) {
         Optional<Location> symbolLocation = symbol.getLocation();
 
         // Assumption is that the location will be null for regular type symbols
@@ -172,15 +185,12 @@ public class BallerinaSemanticModel implements SemanticModel {
 
         BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolLocation.get().lineRange());
 
-        ReferenceFinder refFinder = new ReferenceFinder();
+        ReferenceFinder refFinder = new ReferenceFinder(withDefinition);
         return refFinder.findReferences(node, getInternalSymbol(symbol));
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
-    public List<Location> references(Document sourceDocument, LinePosition position) {
+    public List<Location> references(Document sourceDocument, LinePosition position, boolean withDefinition) {
         BLangCompilationUnit compilationUnit = getCompilationUnit(sourceDocument);
         SymbolFinder symbolFinder = new SymbolFinder();
         BSymbol symbolAtCursor = symbolFinder.lookup(compilationUnit, position);
@@ -191,7 +201,7 @@ public class BallerinaSemanticModel implements SemanticModel {
 
         BLangNode node = new NodeFinder().lookupEnclosingContainer(this.bLangPackage, symbolAtCursor.pos.lineRange());
 
-        ReferenceFinder refFinder = new ReferenceFinder();
+        ReferenceFinder refFinder = new ReferenceFinder(withDefinition);
         return refFinder.findReferences(node, symbolAtCursor);
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -197,8 +197,13 @@ import static org.ballerinalang.model.symbols.SymbolOrigin.VIRTUAL;
  */
 public class ReferenceFinder extends BaseVisitor {
 
+    private final boolean withDefinition;
     private List<Location> referenceLocations;
     private BSymbol targetSymbol;
+
+    public ReferenceFinder(boolean withDefinition) {
+        this.withDefinition = withDefinition;
+    }
 
     public List<Location> findReferences(BLangNode node, BSymbol symbol) {
         this.referenceLocations = new ArrayList<>();
@@ -1262,7 +1267,8 @@ public class ReferenceFinder extends BaseVisitor {
         if (symbol != null
                 && this.targetSymbol.name.equals(symbol.name)
                 && this.targetSymbol.pkgID.equals(symbol.pkgID)
-                && this.targetSymbol.pos.equals(symbol.pos)) {
+                && this.targetSymbol.pos.equals(symbol.pos)
+                && (this.withDefinition || !symbol.pos.equals(location))) {
             this.referenceLocations.add(location);
             return true;
         }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/ReferenceFinder.java
@@ -249,7 +249,13 @@ public class ReferenceFinder extends BaseVisitor {
 
     @Override
     public void visit(BLangImportPackage importPkgNode) {
-        addIfSameSymbol(importPkgNode.symbol, importPkgNode.alias.pos);
+        if (importPkgNode.symbol != null
+                && this.targetSymbol.name.equals(importPkgNode.symbol.name)
+                && this.targetSymbol.pkgID.equals(importPkgNode.symbol.pkgID)
+                && this.targetSymbol.pos.equals(importPkgNode.symbol.pos)
+                && this.withDefinition) {
+            this.referenceLocations.add(importPkgNode.alias.pos);
+        }
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -2336,8 +2336,9 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         Name name = new Name(captureBindingPattern.getIdentifier().getValue());
         captureBindingPattern.type = captureBindingPattern.type == null ? symTable.anyOrErrorType :
                 captureBindingPattern.type;
-        captureBindingPattern.symbol = symbolEnter.defineVarSymbol(captureBindingPattern.pos, Flags.unMask(0),
-                captureBindingPattern.type, name, env, false);
+        captureBindingPattern.symbol = symbolEnter.defineVarSymbol(captureBindingPattern.getIdentifier().getPosition(),
+                                                                   Flags.unMask(0), captureBindingPattern.type, name,
+                                                                   env, false);
         captureBindingPattern.declaredVars.put(name.value, captureBindingPattern.symbol);
     }
 
@@ -2368,8 +2369,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         BSymbol symbol = symResolver.lookupSymbolInMainSpace(env, name);
         if (symbol == symTable.notFoundSymbol) {
             symbol = new BVarSymbol(0, name, env.enclPkg.packageID, restBindingPattern.type, env.scope.owner,
-                    restBindingPattern.pos, SOURCE);
-            symbolEnter.defineSymbol(restBindingPattern.pos, symbol, env);
+                    restBindingPattern.variableName.pos, SOURCE);
+            symbolEnter.defineSymbol(restBindingPattern.variableName.pos, symbol, env);
         }
         restBindingPattern.symbol = (BVarSymbol) symbol;
         restBindingPattern.declaredVars.put(name.value, restBindingPattern.symbol);
@@ -2587,8 +2588,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
     @Override
     public void visit(BLangRestMatchPattern restMatchPattern) {
         Name name = new Name(restMatchPattern.variableName.value);
-        restMatchPattern.symbol = symbolEnter.defineVarSymbol(restMatchPattern.pos, Flags.unMask(0),
-                restMatchPattern.type, name, env, false);
+        restMatchPattern.symbol = symbolEnter.defineVarSymbol(restMatchPattern.variableName.pos, Flags.unMask(0),
+                                                              restMatchPattern.type, name, env, false);
         restMatchPattern.declaredVars.put(name.value, restMatchPattern.symbol);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -816,7 +816,7 @@ public class SymbolEnter extends BLangNodeVisitor {
         BAnnotationSymbol annotationSymbol = Symbols.createAnnotationSymbol(Flags.asMask(annotationNode.flagSet),
                                                                             annotationNode.getAttachPoints(),
                                                                             annotName, env.enclPkg.symbol.pkgID, null,
-                                                                            env.scope.owner, annotationNode.pos,
+                                                                            env.scope.owner, annotationNode.name.pos,
                                                                             getOrigin(annotName));
         annotationSymbol.markdownDocumentation =
                 getMarkdownDocAttachment(annotationNode.markdownDocumentationAttachment);

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1062,7 +1062,7 @@ public class SymbolEnter extends BLangNodeVisitor {
 
         Name prefix = names.fromIdNode(xmlnsNode.prefix);
         BXMLNSSymbol xmlnsSymbol = Symbols.createXMLNSSymbol(prefix, nsURI, env.enclPkg.symbol.pkgID, env.scope.owner,
-                                                             xmlnsNode.pos, getOrigin(prefix));
+                                                             xmlnsNode.prefix.pos, getOrigin(prefix));
         xmlnsNode.symbol = xmlnsSymbol;
 
         // First check for package-imports with the same alias.

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolEnter.java
@@ -1061,8 +1061,9 @@ public class SymbolEnter extends BLangNodeVisitor {
         }
 
         Name prefix = names.fromIdNode(xmlnsNode.prefix);
+        Location nsSymbolPos = prefix.value.isEmpty() ? xmlnsNode.pos : xmlnsNode.prefix.pos;
         BXMLNSSymbol xmlnsSymbol = Symbols.createXMLNSSymbol(prefix, nsURI, env.enclPkg.symbol.pkgID, env.scope.owner,
-                                                             xmlnsNode.prefix.pos, getOrigin(prefix));
+                                                             nsSymbolPos, getOrigin(prefix));
         xmlnsNode.symbol = xmlnsSymbol;
 
         // First check for package-imports with the same alias.

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/AnnotationRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/AnnotationRefsTest.java
@@ -34,26 +34,31 @@ public class AnnotationRefsTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {37, 24, List.of(location(37, 24, 26),
-                                 location(45, 1, 3),
-                                 location(60, 1, 3),
-                                 location(57, 22, 24))
+                {37, 24, location(37, 24, 26),
+                        List.of(location(37, 24, 26),
+                                location(45, 1, 3),
+                                location(60, 1, 3),
+                                location(57, 22, 24))
                 },
-                {63, 1, List.of(location(38, 19, 21),
+                {63, 1, location(38, 19, 21),
+                        List.of(location(38, 19, 21),
                                 location(63, 1, 3),
                                 location(66, 1, 3))
                 },
-                {38, 19, List.of(location(38, 19, 21),
-                                 location(63, 1, 3),
-                                 location(66, 1, 3))
+                {38, 19, location(38, 19, 21),
+                        List.of(location(38, 19, 21),
+                                location(63, 1, 3),
+                                location(66, 1, 3))
                 },
-                {39, 24, List.of(location(39, 24, 26),
-                                 location(72, 5, 7))
+                {39, 24, location(39, 24, 26),
+                        List.of(location(39, 24, 26),
+                                location(72, 5, 7))
                 },
-                {40, 17, List.of(location(40, 17, 19),
-                                 location(75, 29, 31),
-                                 location(76, 29, 31),
-                                 location(77, 29, 31))
+                {40, 17, location(40, 17, 19),
+                        List.of(location(40, 17, 19),
+                                location(75, 29, 31),
+                                location(76, 29, 31),
+                                location(77, 29, 31))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/CyclicUnionRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/CyclicUnionRefsTest.java
@@ -18,6 +18,7 @@
 
 package io.ballerina.semantic.api.test.allreferences;
 
+import io.ballerina.tools.diagnostics.Location;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -33,34 +34,35 @@ public class CyclicUnionRefsTest extends FindAllReferencesTest {
 
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
+        Location defLocation = location(16, 5, 16);
         return new Object[][]{
-                {16, 13, List.of(
-                        location(16, 21, 32),
-                        location(16, 5, 16),
-                        location(17, 21, 32),
-                        location(19, 14, 25),
-                        location(20, 4, 15))
+                {16, 13, defLocation,
+                        List.of(location(16, 21, 32),
+                                defLocation,
+                                location(17, 21, 32),
+                                location(19, 14, 25),
+                                location(20, 4, 15))
                 },
-                {17,  30, List.of(
-                        location(16, 21, 32),
-                        location(16, 5, 16),
-                        location(17, 21, 32),
-                        location(19, 14, 25),
-                        location(20, 4, 15))
+                {17, 30, defLocation,
+                        List.of(location(16, 21, 32),
+                                defLocation,
+                                location(17, 21, 32),
+                                location(19, 14, 25),
+                                location(20, 4, 15))
                 },
-                {19, 21, List.of(
-                        location(16, 21, 32),
-                        location(16, 5, 16),
-                        location(17, 21, 32),
-                        location(19, 14, 25),
-                        location(20, 4, 15))
+                {19, 21, defLocation,
+                        List.of(location(16, 21, 32),
+                                defLocation,
+                                location(17, 21, 32),
+                                location(19, 14, 25),
+                                location(20, 4, 15))
                 },
-                {20, 11, List.of(
-                        location(16, 21, 32),
-                        location(16, 5, 16),
-                        location(17, 21, 32),
-                        location(19, 14, 25),
-                        location(20, 4, 15))
+                {20, 11, defLocation,
+                        List.of(location(16, 21, 32),
+                                defLocation,
+                                location(17, 21, 32),
+                                location(19, 14, 25),
+                                location(20, 4, 15))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindAllReferencesTest.java
@@ -59,13 +59,13 @@ public abstract class FindAllReferencesTest {
     }
 
     @Test(dataProvider = "PositionProvider")
-    public void testFindAllReferencesUsingLocation(int line, int col, List<Location> expLocations) {
+    public void testFindAllReferencesUsingLocation(int line, int col, Location def, List<Location> expLocations) {
         List<Location> locations = model.references(srcFile, LinePosition.from(line, col));
         assertLocations(locations, expLocations);
     }
 
     @Test(dataProvider = "PositionProvider")
-    public void testFindAllReferencesUsingSymbol(int line, int col, List<Location> expLocations) {
+    public void testFindAllReferencesUsingSymbol(int line, int col, Location def, List<Location> expLocations) {
         Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
 
         if (expLocations.isEmpty()) {
@@ -75,6 +75,30 @@ public abstract class FindAllReferencesTest {
 
         List<Location> locations = model.references(symbol.get());
         assertLocations(locations, expLocations);
+    }
+
+    @Test(dataProvider = "PositionProvider")
+    public void testFindAllReferencesUsingLocationSansDef(int line, int col, Location def,
+                                                          List<Location> expLocations) {
+        List<Location> locations = model.references(srcFile, LinePosition.from(line, col), false);
+        List<Location> expLocationsSansDef = new ArrayList<>(expLocations);
+        expLocationsSansDef.remove(def);
+        assertLocations(locations, expLocationsSansDef);
+    }
+
+    @Test(dataProvider = "PositionProvider")
+    public void testFindAllReferencesUsingSymbolSansDef(int line, int col, Location def, List<Location> expLocations) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+
+        if (expLocations.isEmpty()) {
+            assertTrue(symbol.isEmpty());
+            return;
+        }
+
+        List<Location> locations = model.references(symbol.get(), false);
+        List<Location> expLocationsSansDef = new ArrayList<>(expLocations);
+        expLocationsSansDef.remove(def);
+        assertLocations(locations, expLocationsSansDef);
     }
 
     @DataProvider(name = "PositionProvider")

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindModulePrefixRefsTest.java
@@ -49,19 +49,22 @@ public class FindModulePrefixRefsTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {16, 15, List.of(location(16, 15, 26),
-                                 location(19, 0, 11),
-                                 location(44, 1, 12),
-                                 location(22, 4, 15),
-                                 location(36, 27, 38),
-                                 location(39, 28, 39),
-                                 location(40, 18, 29))
+                {16, 15, location(16, 15, 26),
+                        List.of(location(16, 15, 26),
+                                location(19, 0, 11),
+                                location(44, 1, 12),
+                                location(22, 4, 15),
+                                location(36, 27, 38),
+                                location(39, 28, 39),
+                                location(40, 18, 29))
                 },
-                {25, 16, List.of(location(25, 16, 20),
-                                 location(31, 24, 28)),
+                {25, 16, null,
+                        List.of(location(25, 16, 20),
+                                location(31, 24, 28)),
                 },
-                {35, 27, List.of(location(17, 33, 36),
-                                 location(35, 27, 30)),
+                {35, 27, location(17, 33, 36),
+                        List.of(location(17, 33, 36),
+                                location(35, 27, 30)),
                 }
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsAcrossFilesTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsAcrossFilesTest.java
@@ -50,14 +50,17 @@ public class FindRefsAcrossFilesTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {22, 42, List.of(location(18, 6, 10, "constants.bal"),
-                                 location(22, 42, 46, getFileName()))
+                {22, 42, location(18, 6, 10),
+                        List.of(location(18, 6, 10, "constants.bal"),
+                                location(22, 42, 46, getFileName()))
                 },
-                {22, 56, List.of(location(16, 12, 18, "type_defs.bal"),
-                                 location(22, 56, 62, getFileName()))
+                {22, 56, location(16, 12, 18),
+                        List.of(location(16, 12, 18, "type_defs.bal"),
+                                location(22, 56, 62, getFileName()))
                 },
-                {16, 16, List.of(location(16, 16, 19, getFileName()),
-                                 location(25, 14, 17, "tests/test1.bal"))
+                {16, 16, location(16, 16, 19),
+                        List.of(location(16, 16, 19, getFileName()),
+                                location(25, 14, 17, "tests/test1.bal"))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInExprsTest.java
@@ -35,71 +35,85 @@ public class FindRefsInExprsTest extends FindAllReferencesTest {
     public Object[][] getLookupPositions() {
         return new Object[][]{
                 // Simple var refs, binary exprs
-                {22, 12, List.of(location(22, 12, 13),
-                                 location(23, 21, 22),
-                                 location(29, 37, 38),
-                                 location(32, 25, 26))
+                {22, 12, location(22, 12, 13),
+                        List.of(location(22, 12, 13),
+                                location(23, 21, 22),
+                                location(29, 37, 38),
+                                location(32, 25, 26))
                 },
-                {23, 25, List.of(location(19, 8, 9),
-                                 location(23, 25, 26),
-                                 location(29, 29, 30),
-                                 location(35, 21, 22))
+                {23, 25, location(19, 8, 9),
+                        List.of(location(19, 8, 9),
+                                location(23, 25, 26),
+                                location(29, 29, 30),
+                                location(35, 21, 22))
                 },
-                {16, 4, List.of(location(16, 4, 5),
+                {16, 4, location(16, 4, 5),
+                        List.of(location(16, 4, 5),
                                 location(19, 17, 18)),
                 },
-                {29, 20, List.of(location(29, 20, 21))},
-                {29, 19, EMPTY_LIST},
+                {29, 20, location(29, 20, 21), List.of(location(29, 20, 21))},
+                {29, 19, null, EMPTY_LIST},
 
                 // function and action invocations
-                {41, 4, List.of(location(41, 4, 7),
+                {41, 4, location(52, 9, 12),
+                        List.of(location(41, 4, 7),
                                 location(44, 8, 11),
                                 location(49, 22, 25),
                                 location(49, 32, 35),
                                 location(52, 9, 12))
                 },
-                {58, 19, List.of(location(55, 9, 12),
-                                 location(58, 19, 22),
-                                 location(61, 19, 22))
+                {58, 19, location(55, 9, 12),
+                        List.of(location(55, 9, 12),
+                                location(58, 19, 22),
+                                location(61, 19, 22))
                 },
-                {58, 8, List.of(location(58, 8, 10),
+                {58, 8, location(58, 8, 10),
+                        List.of(location(58, 8, 10),
                                 location(59, 17, 19),
                                 location(62, 23, 25))
                 },
                 // Template literals
-                {76, 8, List.of(location(76, 8, 9),
+                {76, 8, location(76, 8, 9),
+                        List.of(location(76, 8, 9),
                                 location(77, 25, 26),
                                 location(77, 29, 30),
                                 location(78, 64, 65),
                                 location(79, 25, 26))
                 },
                 // List and map constructors
-                {82, 44, List.of(location(82, 44, 45),
-                                 location(83, 20, 21),
-                                 location(83, 23, 24),
-                                 location(84, 25, 26))
+                {82, 44, location(82, 44, 45),
+                        List.of(location(82, 44, 45),
+                                location(83, 20, 21),
+                                location(83, 23, 24),
+                                location(84, 25, 26))
                 },
                 // Access exprs
-                {88, 14, List.of(location(88, 14, 18),
-                                 location(89, 18, 22))
+                {88, 14, location(88, 14, 18),
+                        List.of(location(88, 14, 18),
+                                location(89, 18, 22))
                 },
-                {89, 23, List.of(location(66, 11, 15),
-                                 location(70, 13, 17),
-                                 location(89, 23, 27))
+                {89, 23, location(66, 11, 15),
+                        List.of(location(66, 11, 15),
+                                location(70, 13, 17),
+                                location(89, 23, 27))
                 },
-                {92, 15, List.of(location(92, 15, 19),
-                                 location(95, 18, 22))
+                {92, 15, location(92, 15, 19),
+                        List.of(location(92, 15, 19),
+                                location(95, 18, 22))
                 },
-                {93, 12, List.of(location(93, 12, 15),
-                                 location(96, 23, 26))
+                {93, 12, location(93, 12, 15),
+                        List.of(location(93, 12, 15),
+                                location(96, 23, 26))
                 },
-                {94, 7, List.of(location(94, 7, 13),
+                {94, 7, location(94, 7, 13),
+                        List.of(location(94, 7, 13),
                                 location(95, 11, 17),
                                 location(96, 15, 21),
                                 location(98, 19, 25))
                 },
-                {98, 26, List.of(location(92, 15, 19),
-                                 location(95, 18, 22))
+                {98, 26, location(92, 15, 19),
+                        List.of(location(92, 15, 19),
+                                location(95, 18, 22))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInLambdasTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInLambdasTest.java
@@ -34,33 +34,41 @@ public class FindRefsInLambdasTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {16, 7, List.of(location(16, 7, 15),
+                {16, 7, location(16, 7, 15),
+                        List.of(location(16, 7, 15),
                                 location(19, 11, 19),
                                 location(26, 15, 23),
                                 location(29, 44, 52))
                 },
-                {26, 32, List.of(location(23, 11, 15),
-                                 location(26, 32, 36),
-                                 location(29, 61, 65),
-                                 location(31, 65, 69))
+                {26, 32, location(23, 11, 15),
+                        List.of(location(23, 11, 15),
+                                location(26, 32, 36),
+                                location(29, 61, 65),
+                                location(31, 65, 69))
                 },
-                {31, 44, List.of(location(31, 44, 49),
-                                 location(31, 78, 83))
+                {31, 44, location(31, 44, 49),
+                        List.of(location(31, 44, 49),
+                                location(31, 78, 83))
                 },
-                {35, 8, List.of(location(35, 8, 9),
+                {35, 8, location(35, 8, 9),
+                        List.of(location(35, 8, 9),
                                 location(41, 19, 20))
                 },
-                {38, 12, List.of(location(38, 12, 13),
-                                 location(41, 28, 29))
+                {38, 12, location(38, 12, 13),
+                        List.of(location(38, 12, 13),
+                                location(41, 28, 29))
                 },
-                {37, 28, List.of(location(37, 28, 30),
-                                 location(41, 23, 25))
+                {37, 28, location(37, 28, 30),
+                        List.of(location(37, 28, 30),
+                                location(41, 23, 25))
                 },
-                {40, 32, List.of(location(40, 32, 34),
-                                 location(41, 32, 34))
+                {40, 32, location(40, 32, 34),
+                        List.of(location(40, 32, 34),
+                                location(41, 32, 34))
                 },
                 // TODO: disabled due to https://github.com/ballerina-platform/ballerina-lang/issues/26893
-//                {47, 8, List.of(location(47, 8, 9),
+//                {47, 8, location(47, 8, 9),
+//                        List.of(location(47, 8, 9),
 //                                location(50, 77, 78))
 //                }
         };

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInMatchStmtTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInMatchStmtTest.java
@@ -34,27 +34,32 @@ public class FindRefsInMatchStmtTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {18, 18, List.of(location(18, 18, 21),
-                                 location(19, 10, 13),
-                                 location(21, 20, 23),
-                                 location(24, 20, 23),
-                                 location(27, 20, 23),
-                                 location(32, 20, 23),
-                                 location(36, 24, 27),
-                                 location(37, 20, 23),
-                                 location(40, 20, 23))
+//                {18, 18, location(18, 18, 21),
+//                        List.of(location(18, 18, 21),
+//                                location(19, 10, 13),
+//                                location(21, 20, 23),
+//                                location(24, 20, 23),
+//                                location(27, 20, 23),
+//                                location(32, 20, 23),
+//                                location(36, 24, 27),
+//                                location(37, 20, 23),
+//                                location(40, 20, 23))
+//                },
+//                {26, 13, location(26, 13, 14),
+//                        List.of(location(26, 13, 14),
+//                                location(28, 24, 25))
+//                },
+                {26, 30, location(26, 30, 34),
+                        List.of(location(26, 30, 34),
+                                location(29, 24, 28))
                 },
-                {26, 13, List.of(location(26, 13, 14),
-                                 location(28, 24, 25))
+                {31, 26, location(31, 26, 27),
+                        List.of(location(31, 26, 27),
+                                location(33, 24, 25))
                 },
-                {26, 30, List.of(location(26, 30, 34),
-                                 location(29, 24, 28))
-                },
-                {31, 26, List.of(location(31, 26, 27),
-                                 location(33, 24, 25))
-                },
-                {34, 24, List.of(location(31, 36, 40),
-                                 location(34, 24, 28))
+                {34, 24, location(31, 36, 40),
+                        List.of(location(31, 36, 40),
+                                location(34, 24, 28))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInServiceDeclTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInServiceDeclTest.java
@@ -34,23 +34,29 @@ public class FindRefsInServiceDeclTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {16, 5, List.of(location(16, 5, 17),
+                {16, 5, location(16, 5, 17),
+                        List.of(location(16, 5, 17),
                                 location(23, 5, 17))
                 },
-                {48, 24, List.of(location(47, 38, 39),
-                                 location(48, 24, 25))
+                {48, 24, location(47, 38, 39),
+                        List.of(location(47, 38, 39),
+                                location(48, 24, 25))
                 },
-                {47, 52, List.of(location(47, 52, 53),
-                                 location(49, 32, 33))
+                {47, 52, location(47, 52, 53),
+                        List.of(location(47, 52, 53),
+                                location(49, 32, 33))
                 },
-                {60, 18, List.of(location(60, 18, 21),
-                                 location(66, 31, 34))
+                {60, 18, location(60, 18, 21),
+                        List.of(location(60, 18, 21),
+                                location(66, 31, 34))
                 },
-                {62, 5, List.of(location(66, 8, 25),
+                {62, 5, location(62, 5, 22),
+                        List.of(location(66, 8, 25),
                                 location(62, 5, 22))
                 },
-                {68, 18, List.of(location(68, 18, 23),
-                                 location(70, 74, 79))
+                {68, 18, location(68, 18, 23),
+                        List.of(location(68, 18, 23),
+                                location(70, 74, 79))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInTestsTest.java
@@ -50,11 +50,13 @@ public class FindRefsInTestsTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {25, 14, List.of(location(16, 16, 19, "functions.bal"),
-                                 location(25, 14, 17, getFileName()))
+                {25, 14, location(16, 16, 19, "functions.bal"),
+                        List.of(location(16, 16, 19, "functions.bal"),
+                                location(25, 14, 17, getFileName()))
                 },
-                {20, 22, List.of(location(16, 13, 15, "constants.bal"),
-                                 location(20, 22, 24, getFileName()))
+                {20, 22, location(16, 13, 15, "constants.bal"),
+                        List.of(location(16, 13, 15, "constants.bal"),
+                                location(20, 22, 24, getFileName()))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInWorkersTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/FindRefsInWorkersTest.java
@@ -34,30 +34,37 @@ public class FindRefsInWorkersTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {17, 8, List.of(location(17, 8, 9),
+                {17, 8, location(17, 8, 9),
+                        List.of(location(17, 8, 9),
                                 location(20, 7, 8),
                                 location(34, 11, 12))
                 },
-                {19, 11, List.of(location(19, 11, 13),
-                                 location(32, 9, 11))
+                {19, 11, location(19, 11, 13),
+                        List.of(location(19, 11, 13),
+                                location(32, 9, 11))
                 },
-                {23, 11, List.of(location(23, 11, 13),
-                                 location(31, 22, 24))
+                {23, 11, location(23, 11, 13),
+                        List.of(location(23, 11, 13),
+                                location(31, 22, 24))
                 },
-                {38, 11, List.of(location(38, 11, 13),
-                                 location(45, 13, 15),
-                                 location(49, 25, 27))
+                {38, 11, location(38, 11, 13),
+                        List.of(location(38, 11, 13),
+                                location(45, 13, 15),
+                                location(49, 25, 27))
                 },
-                {40, 11, List.of(location(40, 11, 13),
-                                 location(43, 11, 13),
-                                 location(49, 29, 31))
+                {40, 11, location(43, 11, 13),
+                        List.of(location(40, 11, 13),
+                                location(43, 11, 13),
+                                location(49, 29, 31))
                 },
-                {53, 11, List.of(location(53, 11, 13),
-                                 location(61, 13, 15))
+                {53, 11, location(53, 11, 13),
+                        List.of(location(53, 11, 13),
+                                location(61, 13, 15))
                 },
-                {59, 11, List.of(location(55, 12, 14),
-                                 location(56, 25, 27),
-                                 location(59, 11, 13))
+                {59, 11, location(59, 11, 13),
+                        List.of(location(55, 12, 14),
+                                location(56, 25, 27),
+                                location(59, 11, 13))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/XMLRefsTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/allreferences/XMLRefsTest.java
@@ -34,16 +34,18 @@ public class XMLRefsTest extends FindAllReferencesTest {
     @DataProvider(name = "PositionProvider")
     public Object[][] getLookupPositions() {
         return new Object[][]{
-                {16, 33, List.of(location(16, 33, 36),
-                                 location(21, 24, 27),
-                                 location(26, 17, 20),
-                                 location(27, 17, 20),
-                                 location(29, 16, 19))
+                {16, 33, location(16, 33, 36),
+                        List.of(location(16, 33, 36),
+                                location(21, 24, 27),
+                                location(26, 17, 20),
+                                location(27, 17, 20),
+                                location(29, 16, 19))
                 },
-                {23, 25, List.of(location(19, 37, 40),
-                                 location(23, 25, 28),
-                                 location(27, 23, 26),
-                                 location(28, 17, 20))
+                {23, 25, location(19, 37, 40),
+                        List.of(location(19, 37, 40),
+                                location(23, 25, 28),
+                                location(27, 23, 26),
+                                location(28, 17, 20))
                 },
         };
     }

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_cyclic_unions.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/find-all-ref/find_var_ref_cyclic_unions.bal
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 //
 // WSO2 Inc. licenses this file to you under the Apache License,
 // Version 2.0 (the "License"); you may not use this file except


### PR DESCRIPTION
## Purpose
This PR adds overloaded versions of `references()` which takes an additional boolean param which specifies whether to include the symbol's definition location in the list of referenced locations returned.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
