### PR TITLE
Show central package url when pushing already existing package to the central

### DIFF
--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -60,7 +60,7 @@ import static io.ballerina.projects.util.ProjectConstants.SETTINGS_FILE_NAME;
 import static io.ballerina.projects.util.ProjectUtils.initializeProxy;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
 import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_PLATFORMS;
-import static org.wso2.ballerinalang.util.RepoUtils.getRemoteRepoURL;
+import static org.wso2.ballerinalang.util.RepoUtils.getCentralPackageURL;
 
 /**
  * This class represents the "bal push" command.
@@ -210,8 +210,9 @@ public class PushCommand implements BLauncherCmd {
                     + pkgAsDependency.version().toString();
             throw new ProjectException(
                     "package '" + pkg + "' already exists in " + "remote repository("
-                            + getRemoteRepoURL() + "). build and push after "
-                            + "updating the version in the Ballerina.toml.");
+                            + getCentralPackageURL(project.currentPackage().packageOrg().value(),
+                                                   project.currentPackage().packageName().value())
+                            + "). build and push after updating the version in the Ballerina.toml.");
         }
 
         // bala file path

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/cmd/PushCommand.java
@@ -55,12 +55,12 @@ import java.util.zip.ZipInputStream;
 import static io.ballerina.cli.cmd.Constants.PUSH_COMMAND;
 import static io.ballerina.cli.utils.CentralUtils.authenticate;
 import static io.ballerina.cli.utils.CentralUtils.getBallerinaCentralCliTokenUrl;
+import static io.ballerina.cli.utils.CentralUtils.getCentralPackageURL;
 import static io.ballerina.cli.utils.CentralUtils.readSettings;
 import static io.ballerina.projects.util.ProjectConstants.SETTINGS_FILE_NAME;
 import static io.ballerina.projects.util.ProjectUtils.initializeProxy;
 import static io.ballerina.runtime.api.constants.RuntimeConstants.SYSTEM_PROP_BAL_DEBUG;
 import static org.wso2.ballerinalang.programfile.ProgramFileConstants.SUPPORTED_PLATFORMS;
-import static org.wso2.ballerinalang.util.RepoUtils.getCentralPackageURL;
 
 /**
  * This class represents the "bal push" command.
@@ -209,10 +209,10 @@ public class PushCommand implements BLauncherCmd {
                     + pkgAsDependency.name().toString() + ":"
                     + pkgAsDependency.version().toString();
             throw new ProjectException(
-                    "package '" + pkg + "' already exists in " + "remote repository("
+                    "package '" + pkg + "' already exists in " + "remote repository :"
                             + getCentralPackageURL(project.currentPackage().packageOrg().value(),
                                                    project.currentPackage().packageName().value())
-                            + "). build and push after updating the version in the Ballerina.toml.");
+                            + ". build and push after updating the version in the Ballerina.toml.");
         }
 
         // bala file path

--- a/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/CentralUtils.java
+++ b/cli/ballerina-cli/src/main/java/io/ballerina/cli/utils/CentralUtils.java
@@ -40,6 +40,10 @@ import static org.wso2.ballerinalang.util.RepoUtils.SET_BALLERINA_STAGE_CENTRAL;
  */
 public class CentralUtils {
 
+    private static final String BALLERINA_CENTRAL_PRODUCTION_URL = "https://central.ballerina.io";
+    private static final String BALLERINA_CENTRAL_STAGING_URL = "https://staging-central.ballerina.io";
+    private static final String BALLERINA_CENTRAL_DEV_URL = "https://dev-central.ballerina.io";
+
     private CentralUtils() {
     }
 
@@ -155,5 +159,21 @@ public class CentralUtils {
         } else {
             return "https://central.ballerina.io/cli-token";
         }
+    }
+
+    /**
+     * Get the central package URL.
+     *
+     * @param org     package org
+     * @param pkgName package name
+     * @return central package URL
+     */
+    public static String getCentralPackageURL(String org, String pkgName) {
+        if (SET_BALLERINA_STAGE_CENTRAL) {
+            return BALLERINA_CENTRAL_STAGING_URL + "/" + org + "/" + pkgName;
+        } else if (SET_BALLERINA_DEV_CENTRAL) {
+            return BALLERINA_CENTRAL_DEV_URL + "/" + org + "/" + pkgName;
+        }
+        return BALLERINA_CENTRAL_PRODUCTION_URL + "/" + org + "/" + pkgName;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -54,8 +54,6 @@ public class RepoUtils {
     private static final String STAGING_URL = "https://api.staging-central.ballerina.io/2.0/registry";
     private static final String DEV_URL = "https://api.dev-central.ballerina.io/2.0/registry";
 
-    private static final String BALLERINA_CENTRAL_URL = "https://central.ballerina.io";
-
     private static final String BALLERINA_ORG = "ballerina";
     private static final String BALLERINAX_ORG = "ballerinax";
 
@@ -151,10 +149,6 @@ public class RepoUtils {
             return DEV_URL;
         }
         return PRODUCTION_URL;
-    }
-
-    public static String getCentralPackageURL(String org, String pkgName) {
-        return BALLERINA_CENTRAL_URL + "/" + org + "/" + pkgName;
     }
 
     /**

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/util/RepoUtils.java
@@ -54,6 +54,8 @@ public class RepoUtils {
     private static final String STAGING_URL = "https://api.staging-central.ballerina.io/2.0/registry";
     private static final String DEV_URL = "https://api.dev-central.ballerina.io/2.0/registry";
 
+    private static final String BALLERINA_CENTRAL_URL = "https://central.ballerina.io";
+
     private static final String BALLERINA_ORG = "ballerina";
     private static final String BALLERINAX_ORG = "ballerinax";
 
@@ -149,6 +151,10 @@ public class RepoUtils {
             return DEV_URL;
         }
         return PRODUCTION_URL;
+    }
+
+    public static String getCentralPackageURL(String org, String pkgName) {
+        return BALLERINA_CENTRAL_URL + "/" + org + "/" + pkgName;
     }
 
     /**


### PR DESCRIPTION


## Purpose
> Changed error messaged to below message:
```
ballerina: package 'pramodya/xa:0.1.12' already exists in remote repository(https://central.ballerina.io/pramodya/xa). build and push after updating the version in the Ballerina.toml.
```

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/29499

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
