### PR TITLE
Add an API for getting the annots attached to return types of functions

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -18,6 +18,8 @@ package io.ballerina.compiler.api.impl.symbols;
 
 import io.ballerina.compiler.api.ModuleID;
 import io.ballerina.compiler.api.impl.SymbolFactory;
+import io.ballerina.compiler.api.symbols.Annotatable;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
 import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
 import io.ballerina.compiler.api.symbols.ParameterKind;
 import io.ballerina.compiler.api.symbols.ParameterSymbol;
@@ -28,6 +30,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BInvokableTypeSym
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BVarSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.util.CompilerContext;
 import org.wso2.ballerinalang.util.Flags;
 
@@ -55,6 +58,7 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     private List<ParameterSymbol> params;
     private ParameterSymbol restParam;
     private TypeSymbol returnType;
+    private Annotatable returnTypeAnnots;
     private final BInvokableTypeSymbol typeSymbol;
     private String signature;
 
@@ -140,6 +144,29 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
     }
 
     @Override
+    public Optional<Annotatable> returnTypeAnnotations() {
+        if (this.returnTypeAnnots != null) {
+            return Optional.of(this.returnTypeAnnots);
+        }
+
+        if (this.typeSymbol.returnTypeAnnots.isEmpty()) {
+            return Optional.empty();
+        }
+
+        SymbolFactory symbolFactory = SymbolFactory.getInstance(this.context);
+        List<AnnotationSymbol> annots = new ArrayList<>();
+
+        for (BLangAnnotationAttachment annot : this.typeSymbol.returnTypeAnnots) {
+            annots.add(symbolFactory.createAnnotationSymbol(annot.annotationSymbol));
+        }
+
+        AnnotatableReturnType annotatableReturnType = new AnnotatableReturnType();
+        annotatableReturnType.setAnnotations(Collections.unmodifiableList(annots));
+
+        return Optional.of(annotatableReturnType);
+    }
+
+    @Override
     public String signature() {
         if (this.signature != null) {
             return this.signature;
@@ -161,5 +188,19 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
         this.returnTypeDescriptor().ifPresent(typeDescriptor -> signature.append(" returns ")
                 .append(typeDescriptor.signature()));
         return signature.toString();
+    }
+
+    private static class AnnotatableReturnType implements Annotatable {
+
+        private List<AnnotationSymbol> annots;
+
+        @Override
+        public List<AnnotationSymbol> annotations() {
+            return this.annots;
+        }
+
+        void setAnnotations(List<AnnotationSymbol> annots) {
+            this.annots = annots;
+        }
     }
 }

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaFunctionTypeSymbol.java
@@ -162,8 +162,9 @@ public class BallerinaFunctionTypeSymbol extends AbstractTypeSymbol implements F
 
         AnnotatableReturnType annotatableReturnType = new AnnotatableReturnType();
         annotatableReturnType.setAnnotations(Collections.unmodifiableList(annots));
+        this.returnTypeAnnots = annotatableReturnType;
 
-        return Optional.of(annotatableReturnType);
+        return Optional.of(this.returnTypeAnnots);
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/symbols/FunctionTypeSymbol.java
@@ -56,4 +56,12 @@ public interface FunctionTypeSymbol extends TypeSymbol {
      * @return {@link Optional} return type
      */
     Optional<TypeSymbol> returnTypeDescriptor();
+
+    /**
+     * Retrieves an instance which captures the info regarding the annotations attached to the return type descriptor.
+     * Returns empty if there aren't any annotations attached to the return type descriptor.
+     *
+     * @return An {@link Annotatable} instance representing the annotations attached to the return type
+     */
+    Optional<Annotatable> returnTypeAnnotations();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -428,6 +428,9 @@ public class BIRPackageSymbolEnter {
         // Skip annotation attachments for now
         dataInStream.skip(dataInStream.readLong());
 
+        // Skip return type annotations
+        dataInStream.skip(dataInStream.readLong());
+
         // set parameter symbols to the function symbol
         setParamSymbols(invokableSymbol, dataInStream);
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/BIRGen.java
@@ -653,6 +653,9 @@ public class BIRGen extends BLangNodeVisitor {
         // Populate annotation attachments on function in BIRFunction node
         populateBIRAnnotAttachments(astFunc.annAttachments, birFunc.annotAttachments, this.env);
 
+        // Populate annotation attachments on return type
+        populateBIRAnnotAttachments(astFunc.returnTypeAnnAttachments, birFunc.returnTypeAnnots, this.env);
+
         birFunc.argsCount = astFunc.requiredParams.size()
                 + (astFunc.restParam != null ? 1 : 0) + astFunc.paramClosureMap.size();
         if (astFunc.flagSet.contains(Flag.ATTACHED) && typeDefs.containsKey(astFunc.receiver.type.tsymbol)) {

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JBIRFunction.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/interop/JBIRFunction.java
@@ -33,6 +33,6 @@ public class JBIRFunction extends BIRNode.BIRFunction {
               birFunction.localVars, birFunction.returnVariable,
               birFunction.parameters, birFunction.basicBlocks, birFunction.errorTable, birFunction.workerName,
               birFunction.workerChannels, birFunction.taintTable, birFunction.annotAttachments,
-              birFunction.dependentGlobalVars);
+              birFunction.returnTypeAnnots, birFunction.dependentGlobalVars);
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/model/BIRNode.java
@@ -326,6 +326,8 @@ public abstract class BIRNode {
 
         public List<BIRAnnotationAttachment> annotAttachments;
 
+        public List<BIRAnnotationAttachment> returnTypeAnnots;
+
         public Set<BIRGlobalVariableDcl> dependentGlobalVars = new TreeSet<>();
 
         public BIRFunction(Location pos, Name name, long flags, SymbolOrigin origin, BInvokableType type,
@@ -335,6 +337,7 @@ public abstract class BIRNode {
                            List<BIRBasicBlock> basicBlocks, List<BIRErrorEntry> errorTable, Name workerName,
                            ChannelDetails[] workerChannels, TaintTable taintTable,
                            List<BIRAnnotationAttachment> annotAttachments,
+                           List<BIRAnnotationAttachment> returnTypeAnnots,
                            Set<BIRGlobalVariableDcl> dependentGlobalVars) {
             super(pos);
             this.name = name;
@@ -354,6 +357,7 @@ public abstract class BIRNode {
             this.workerChannels = workerChannels;
             this.taintTable = taintTable;
             this.annotAttachments = annotAttachments;
+            this.returnTypeAnnots = returnTypeAnnots;
             this.dependentGlobalVars = dependentGlobalVars;
         }
 
@@ -372,6 +376,7 @@ public abstract class BIRNode {
             this.workerChannels = new ChannelDetails[sendInsCount];
             this.taintTable = taintTable;
             this.annotAttachments = new ArrayList<>();
+            this.returnTypeAnnots = new ArrayList<>();
             this.origin = origin;
         }
 
@@ -389,6 +394,7 @@ public abstract class BIRNode {
             f.errorTable = errorTable;
             f.workerChannels = workerChannels;
             f.annotAttachments = annotAttachments;
+            f.returnTypeAnnots = returnTypeAnnots;
             return f;
 
         }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRBinaryWriter.java
@@ -208,6 +208,9 @@ public class BIRBinaryWriter {
         // Store annotations here...
         writeAnnotAttachments(buf, birFunction.annotAttachments);
 
+        // Store return type annotations
+        writeAnnotAttachments(buf, birFunction.returnTypeAnnots);
+
         buf.writeInt(birFunction.requiredParams.size());
         for (BIRParameter parameter : birFunction.requiredParams) {
             buf.writeInt(addStringCPEntry(parameter.name.value));

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/writer/BIRTypeWriter.java
@@ -186,19 +186,23 @@ public class BIRTypeWriter implements TypeVisitor {
     public void visit(BInvokableType bInvokableType) {
         boolean isAnyFunction = Symbols.isFlagOn(bInvokableType.flags, Flags.ANY_FUNCTION);
         buff.writeBoolean(isAnyFunction); // write 1 if it’s an any function if not write 0
-        if (!isAnyFunction) {
-            buff.writeInt(bInvokableType.paramTypes.size());
-            for (BType params : bInvokableType.paramTypes) {
-                writeTypeCpIndex(params);
-            }
 
-            boolean restTypeExist = bInvokableType.restType != null;
-            buff.writeBoolean(restTypeExist);
-            if (restTypeExist) {
-                writeTypeCpIndex(bInvokableType.restType);
-            }
-            writeTypeCpIndex(bInvokableType.retType);
+        if (isAnyFunction) {
+            return;
         }
+
+        buff.writeInt(bInvokableType.paramTypes.size());
+        for (BType params : bInvokableType.paramTypes) {
+            writeTypeCpIndex(params);
+        }
+
+        boolean restTypeExist = bInvokableType.restType != null;
+        buff.writeBoolean(restTypeExist);
+        if (restTypeExist) {
+            writeTypeCpIndex(bInvokableType.restType);
+        }
+        writeTypeCpIndex(bInvokableType.retType);
+
     }
 
     @Override

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SemanticAnalyzer.java
@@ -431,6 +431,8 @@ public class SemanticAnalyzer extends BLangNodeVisitor {
         }
 
         funcNode.symbol.annAttachments.addAll(funcNode.annAttachments);
+        ((BInvokableTypeSymbol) funcNode.symbol.type.tsymbol)
+                .returnTypeAnnots.addAll(funcNode.returnTypeAnnAttachments);
 
         this.processWorkers(funcNode, funcEnv);
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/symbols/BInvokableTypeSymbol.java
@@ -23,6 +23,7 @@ import org.ballerinalang.model.elements.PackageID;
 import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.wso2.ballerinalang.compiler.semantics.model.types.BType;
+import org.wso2.ballerinalang.compiler.tree.BLangAnnotationAttachment;
 import org.wso2.ballerinalang.compiler.util.Names;
 
 import java.util.ArrayList;
@@ -40,6 +41,7 @@ public class BInvokableTypeSymbol extends BTypeSymbol {
     public List<BVarSymbol> params;
     public BVarSymbol restParam;
     public BType returnType;
+    public List<BLangAnnotationAttachment> returnTypeAnnots;
     public Map<String, BType> paramDefaultValTypes;
 
     public BInvokableTypeSymbol(int symTag, long flags, PackageID pkgID, BType type, BSymbol owner,
@@ -47,6 +49,7 @@ public class BInvokableTypeSymbol extends BTypeSymbol {
                                 SymbolOrigin origin) {
         super(symTag, flags, Names.EMPTY, pkgID, type, owner, location, origin);
         this.params = new ArrayList<>();
+        this.returnTypeAnnots = new ArrayList<>();
         this.paramDefaultValTypes = new HashMap<>();
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/programfile/ProgramFileConstants.java
@@ -25,9 +25,9 @@ public class ProgramFileConstants {
 
     public static final int MAGIC_NUMBER = 0xBA1DA4CE;
     public static final short VERSION_NUMBER = 50;
-    public static final int BIR_VERSION_NUMBER = 59;
-    public static final short MIN_SUPPORTED_VERSION = 59;
-    public static final short MAX_SUPPORTED_VERSION = 59;
+    public static final int BIR_VERSION_NUMBER = 60;
+    public static final short MIN_SUPPORTED_VERSION = 60;
+    public static final short MAX_SUPPORTED_VERSION = 60;
 
     // todo move this to a proper place
     public static final String[] SUPPORTED_PLATFORMS = {"java11"};

--- a/docs/bir-spec/src/main/resources/kaitai/bir.ksy
+++ b/docs/bir-spec/src/main/resources/kaitai/bir.ksy
@@ -718,6 +718,8 @@ types:
         type: s4
       - id: annotation_attachments_content
         type: annotation_attachments_content
+      - id: return_type_annotations
+        type: annotation_attachments_content
       - id: required_param_count
         type: s4
       - id: required_params

--- a/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
+++ b/docs/bir-spec/src/test/java/org/ballerinalang/birspec/BIRTestUtils.java
@@ -132,6 +132,14 @@ class BIRTestUtils {
             // assert markdown document
             assertMarkdownDocument(actualFunction.doc(), expectedFunction.markdownDocAttachment, constantPoolEntries);
 
+            // assert annotation attachments
+            assertAnnotationAttachments(actualFunction.annotationAttachmentsContent(),
+                                        expectedFunction.annotAttachments, constantPoolEntries);
+
+            // assert return type annotation attachments
+            assertAnnotationAttachments(actualFunction.returnTypeAnnotations(), expectedFunction.returnTypeAnnots,
+                                        constantPoolEntries);
+
             // assert required param count
             Assert.assertEquals(actualFunction.requiredParamCount(), expectedFunction.requiredParams.size());
 
@@ -707,6 +715,22 @@ class BIRTestUtils {
                 break;
             default:
                 Assert.fail(String.format("Unknown constant value type: %s", typeTag.name()));
+        }
+    }
+
+    private static void assertAnnotationAttachments(Bir.AnnotationAttachmentsContent actualAnnots,
+                                                    List<BIRNode.BIRAnnotationAttachment> expAnnots,
+                                                    ArrayList<Bir.ConstantPoolEntry> constantPoolEntries) {
+        Assert.assertEquals(actualAnnots.attachmentsCount(), expAnnots.size());
+
+        for (int i = 0; i < expAnnots.size(); i++) {
+            Bir.AnnotationAttachment actualAnnot = actualAnnots.annotationAttachments().get(i);
+            BIRNode.BIRAnnotationAttachment expAnnot = expAnnots.get(i);
+            Bir.ConstantPoolEntry annotTag = constantPoolEntries.get(actualAnnot.tagReferenceCpIndex());
+
+            assertConstantPoolEntry(annotTag, expAnnot.annotTagRef.value);
+
+            Assert.assertEquals(actualAnnot.attachValuesCount(), expAnnot.annotValues.size());
         }
     }
 

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/FunctionSymbolTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/symbols/FunctionSymbolTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.ballerina.semantic.api.test.symbols;
+
+import io.ballerina.compiler.api.SemanticModel;
+import io.ballerina.compiler.api.symbols.Annotatable;
+import io.ballerina.compiler.api.symbols.AnnotationSymbol;
+import io.ballerina.compiler.api.symbols.FunctionSymbol;
+import io.ballerina.compiler.api.symbols.FunctionTypeSymbol;
+import io.ballerina.compiler.api.symbols.Symbol;
+import io.ballerina.projects.Document;
+import io.ballerina.projects.Project;
+import io.ballerina.tools.text.LinePosition;
+import org.ballerinalang.test.BCompileUtil;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Optional;
+
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDefaultModulesSemanticModel;
+import static io.ballerina.semantic.api.test.util.SemanticAPITestUtils.getDocumentForSingleSource;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test cases for function and function type symbols.
+ *
+ * @since 2.0.0
+ */
+public class FunctionSymbolTest {
+
+    private SemanticModel model;
+    private Document srcFile;
+
+    @BeforeClass
+    public void setup() {
+        Project project = BCompileUtil.loadProject("test-src/symbols/function_symbols_test.bal");
+        model = getDefaultModulesSemanticModel(project);
+        srcFile = getDocumentForSingleSource(project);
+    }
+
+    @Test(dataProvider = "ReturnAnnotPosProvider")
+    public void testAnnotsOnReturnType(int line, int col, boolean hasAnnot, int annotSize, List<String> expAnnots) {
+        Optional<Symbol> symbol = model.symbol(srcFile, LinePosition.from(line, col));
+        FunctionTypeSymbol fnType = ((FunctionSymbol) symbol.get()).typeDescriptor();
+        Optional<Annotatable> annots = fnType.returnTypeAnnotations();
+
+        assertEquals(annots.isPresent(), hasAnnot);
+
+        if (!hasAnnot) {
+            return;
+        }
+
+        assertEquals(annots.get().annotations().size(), annotSize);
+
+        List<AnnotationSymbol> actualAnnots = annots.get().annotations();
+        for (int i = 0, expAnnotsSize = expAnnots.size(); i < expAnnotsSize; i++) {
+            assertEquals(actualAnnots.get(i).getName().get(), expAnnots.get(i));
+        }
+    }
+
+    @DataProvider(name = "ReturnAnnotPosProvider")
+    public Object[][] getReturnAnnotPos() {
+        return new Object[][]{
+                {16, 9, true, 1, List.of("a1")},
+                {18, 9, false, 0, null},
+//                TODO: following due to: https://github.com/ballerina-platform/ballerina-lang/issues/30219
+//                {21, 59, true, 1, List.of("a1")},
+        };
+    }
+}

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/function_symbols_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/symbols/function_symbols_test.bal
@@ -1,0 +1,29 @@
+// Copyright (c) 2021 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+//
+// WSO2 Inc. licenses this file to you under the Apache License,
+// Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+function foo(int x, float y = 12.3, string... z) returns @a1 {desc: "string"} string => "foo";
+
+function add(int x, int y) returns int => x + y;
+
+function testFnTypedesc() {
+    function () returns @a1 {desc: "In a typedesc"} string fn;
+}
+
+public annotation Annot a1 on function;
+
+type Annot record {
+    string desc;
+};

--- a/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
+++ b/tests/ballerina-compiler-api-test/src/test/resources/testng.xml
@@ -85,6 +85,9 @@
 
             <!--Statements-->
             <class name="io.ballerina.semantic.api.test.statements.SymbolsInMatchStmtTest" />
+
+            <!--Symbols-->
+            <class name="io.ballerina.semantic.api.test.symbols.FunctionSymbolTest" />
         </classes>
     </test>
 </suite>


### PR DESCRIPTION
## Purpose
This PR introduces a method to `FunctionTypeSymbol` to get the annotations attached to the return type of the function type.

Fix #27225

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [x] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
