### PR TITLE
Create user defined type for `distinct error`

### DIFF
--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/bir/codegen/JvmTypeGen.java
@@ -1971,7 +1971,9 @@ public class JvmTypeGen {
      * @return name of the field that holds the type instance
      */
     private static String getTypeFieldName(String typeName) {
-
+        if (typeName.isEmpty()) {
+            throw new AssertionError("Could not resolve the field for type");
+        }
         return String.format("$type$%s", typeName);
     }
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/parser/BLangNodeTransformer.java
@@ -965,13 +965,15 @@ public class BLangNodeTransformer extends NodeTransformer<BLangNode> {
             } else {
                 errorType.detailType = createTypeNode(typeNode);
             }
-            NonTerminalNode parent = errorTypeDescriptorNode.parent();
-            if (parent.kind() == SyntaxKind.DISTINCT_TYPE_DESC) {
-                parent = parent.parent();
-            }
-            if (parent.kind() != SyntaxKind.TYPE_DEFINITION) {
-                return deSugarTypeAsUserDefType(errorType);
-            }
+        }
+
+        NonTerminalNode parent = errorTypeDescriptorNode.parent();
+        boolean isDistinctError = parent.kind() == SyntaxKind.DISTINCT_TYPE_DESC;
+        if (isDistinctError) {
+            parent = parent.parent();
+        }
+        if ((typeParam.isPresent() || isDistinctError) && parent.kind() != SyntaxKind.TYPE_DEFINITION) {
+            return deSugarTypeAsUserDefType(errorType);
         }
 
         return errorType;

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/error/ErrorTest.java
@@ -45,10 +45,6 @@ public class ErrorTest {
     private CompileResult distinctErrorTestResult;
     private CompileResult negativeDistinctErrorRes;
 
-    private static final String ERROR1 = "error1";
-    private static final String ERROR2 = "error2";
-    private static final String ERROR3 = "error3";
-    private static final String EMPTY_CURLY_BRACE = "{}";
     private static final String CONST_ERROR_REASON = "reason one";
 
     @BeforeClass

--- a/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
+++ b/tests/jballerina-unit-test/src/test/java/org/ballerinalang/test/types/intersection/IntersectionTypeTest.java
@@ -112,6 +112,11 @@ public class IntersectionTypeTest {
     }
 
     @Test
+    public void testAnonDistinctError() {
+        BRunUtil.invoke(errorIntersectionResults, "testAnonDistinctError");
+    }
+
+    @Test
     public void testErrorIntersectionNegative() {
         CompileResult result = BCompileUtil.compile("test-src/types/intersection/error_intersection_type_negative.bal");
 

--- a/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type.bal
+++ b/tests/jballerina-unit-test/src/test/resources/test-src/types/intersection/error_intersection_type.bal
@@ -164,6 +164,19 @@ function getAnonymousRecord(IntersectionErrorThree err) returns record {Intersec
     return errRec;
 }
 
+type JsonParseDetail record {
+    string s;
+};
+
+type JsonParseError error<JsonParseDetail> & distinct error;
+
+function testAnonDistinctError() {
+    error e = error JsonParseError("msg", s = "the ling info");
+    if !(e is JsonParseError) {
+        panic error("Assertion error");
+    }
+}
+
 function assertEquality(any|error actual, any|error expected) {
     if expected is anydata && actual is anydata && expected == actual {
         return;


### PR DESCRIPTION
## Purpose
```
type T A & distinct error;
```
Convert the `distinct error` part into it's own type-def in the node transformer, similar to what we do when there is a type parameter in error def (`type A & distinct error<D>`).

Fixes #30117 

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
