### PR TITLE
Allow retrieving the intersection type from the effective type

### DIFF
--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaIntersectionTypeSymbol.java
@@ -71,7 +71,8 @@ public class BallerinaIntersectionTypeSymbol extends AbstractTypeSymbol implemen
         }
 
         TypesFactory typesFactory = TypesFactory.getInstance(this.context);
-        this.effectiveType = typesFactory.getTypeDescriptor(((BIntersectionType) this.getBType()).effectiveType);
+        this.effectiveType = typesFactory.getTypeDescriptor(((BIntersectionType) this.getBType()).effectiveType,
+                                                            false, false);
         return this.effectiveType;
     }
 

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/BallerinaUnionTypeSymbol.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
 
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INTERSECTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
 
 /**
@@ -119,13 +120,13 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
         List<TypeSymbol> memberTypes = this.memberTypeDescriptors();
         if (containsTwoElements(memberTypes) && containsNil(memberTypes)) {
             TypeSymbol member1 = memberTypes.get(0);
-            return member1.typeKind() == NIL ?
-                    memberTypes.get(1).signature() + "?" : member1.signature() + "?";
+            return member1.typeKind() == NIL ? getSignatureForIntersectionType(memberTypes.get(1)) + "?" :
+                    getSignatureForIntersectionType(member1) + "?";
         } else {
             StringJoiner joiner = new StringJoiner("|");
             unionType.resolvingToString = true;
             for (TypeSymbol typeDescriptor : memberTypes) {
-                joiner.add(typeDescriptor.signature());
+                joiner.add(getSignatureForIntersectionType(typeDescriptor));
             }
             unionType.resolvingToString = false;
             return joiner.toString();
@@ -139,6 +140,13 @@ public class BallerinaUnionTypeSymbol extends AbstractTypeSymbol implements Unio
             joiner.add(typeDescriptor.signature());
         }
         return joiner.toString();
+    }
+
+    private String getSignatureForIntersectionType(TypeSymbol typeSymbol) {
+        if (typeSymbol.typeKind() != INTERSECTION) {
+            return typeSymbol.signature();
+        }
+        return "(" + typeSymbol.signature() + ")";
     }
 
     private boolean containsNil(List<TypeSymbol> types) {

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -25,6 +25,7 @@ import io.ballerina.compiler.api.symbols.TypeDescKind;
 import io.ballerina.compiler.api.symbols.TypeSymbol;
 import io.ballerina.compiler.api.symbols.XMLTypeSymbol;
 import org.ballerinalang.model.symbols.SymbolKind;
+import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.SymbolTable;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.BClassSymbol;
@@ -64,6 +65,7 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import static org.ballerinalang.model.types.TypeKind.OBJECT;
@@ -128,6 +130,13 @@ public class TypesFactory {
     public TypeSymbol getTypeDescriptor(BType bType, boolean rawTypeOnly) {
         if (bType == null || bType.tag == NONE) {
             return null;
+        }
+
+        if (bType instanceof IntersectableReferenceType) {
+            Optional<BIntersectionType> intersectionType = ((IntersectableReferenceType) bType).getIntersectionType();
+            if (intersectionType.isPresent()) {
+                bType = intersectionType.get();
+            }
         }
 
         ModuleID moduleID = bType.tsymbol == null ? null : new BallerinaModuleID(bType.tsymbol.pkgID);

--- a/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
+++ b/compiler/ballerina-lang/src/main/java/io/ballerina/compiler/api/impl/symbols/TypesFactory.java
@@ -128,11 +128,15 @@ public class TypesFactory {
      * @return {@link TypeSymbol} generated
      */
     public TypeSymbol getTypeDescriptor(BType bType, boolean rawTypeOnly) {
+        return getTypeDescriptor(bType, rawTypeOnly, true);
+    }
+
+    TypeSymbol getTypeDescriptor(BType bType, boolean rawTypeOnly, boolean getOriginalType) {
         if (bType == null || bType.tag == NONE) {
             return null;
         }
 
-        if (bType instanceof IntersectableReferenceType) {
+        if (getOriginalType && bType instanceof IntersectableReferenceType) {
             Optional<BIntersectionType> intersectionType = ((IntersectableReferenceType) bType).getIntersectionType();
             if (intersectionType.isPresent()) {
                 bType = intersectionType.get();

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/ErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/ErrorType.java
@@ -22,7 +22,7 @@ package org.ballerinalang.model.types;
  *
  * @since 0.983.0
  */
-public interface ErrorType extends Type {
+public interface ErrorType extends IntersectableReferenceType {
 
     /**
      * Return error detail's type. Default type is a map.

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/IntersectableReferenceType.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/IntersectableReferenceType.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.ballerinalang.model.types;
+
+import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
+
+import java.util.Optional;
+
+/**
+ * {@code IntersectableReferenceType} represents reference types that can be used in intersection types, that result
+ * in the creation of effective types.
+ *
+ * @since 2.0.0
+ */
+public interface IntersectableReferenceType extends ReferenceType {
+
+    /**
+     * Retrieve the intersection type if this type was created as the effective type of a {@link IntersectionType}.
+     *
+     * @return the intersection type.
+     */
+    Optional<BIntersectionType> getIntersectionType();
+
+    /**
+     * Set the intersection type if this type was created as the effective type of a {@link IntersectionType}.
+     *
+     * @param intersectionType the intersection type.
+     */
+    void setIntersectionType(BIntersectionType intersectionType);
+}

--- a/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/SelectivelyImmutableReferenceType.java
+++ b/compiler/ballerina-lang/src/main/java/org/ballerinalang/model/types/SelectivelyImmutableReferenceType.java
@@ -25,7 +25,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.types.BIntersectionType;
  *
  * @since 1.3.0
  */
-public interface SelectivelyImmutableReferenceType extends ReferenceType {
+public interface SelectivelyImmutableReferenceType extends IntersectableReferenceType {
 
     BIntersectionType getImmutableType();
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/BIRPackageSymbolEnter.java
@@ -28,6 +28,7 @@ import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.symbols.SymbolOrigin;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.types.ConstrainedType;
+import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.model.types.SelectivelyImmutableReferenceType;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry;
 import org.wso2.ballerinalang.compiler.bir.writer.CPEntry.ByteCPEntry;
@@ -1324,7 +1325,7 @@ public class BIRPackageSymbolEnter {
                         constituentTypes.add(readTypeFromCp());
                     }
 
-                    BType effectiveType = readTypeFromCp();
+                    IntersectableReferenceType effectiveType = (IntersectableReferenceType) readTypeFromCp();
                     return new BIntersectionType(intersectionTypeSymbol, constituentTypes, effectiveType, flags);
                 case TypeTags.PACKAGE:
                     // TODO fix

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/analyzer/SymbolResolver.java
@@ -25,6 +25,7 @@ import org.ballerinalang.model.symbols.SymbolKind;
 import org.ballerinalang.model.tree.IdentifierNode;
 import org.ballerinalang.model.tree.NodeKind;
 import org.ballerinalang.model.tree.OperatorKind;
+import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.model.types.SelectivelyImmutableReferenceType;
 import org.ballerinalang.model.types.TypeKind;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
@@ -1974,7 +1975,7 @@ public class SymbolResolver extends BLangNodeVisitor {
         return detailRecordTypeDefinition;
     }
 
-    private BIntersectionType defineErrorIntersectionType(BErrorType effectiveType,
+    private BIntersectionType defineErrorIntersectionType(IntersectableReferenceType effectiveType,
                                                           LinkedHashSet<BType> constituentBTypes, PackageID pkgId,
                                                           BSymbol owner) {
 

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BAnyType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BAnyType.java
@@ -25,11 +25,14 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * @since 0.94
  */
 public class BAnyType extends BBuiltInRefType implements SelectivelyImmutableReferenceType {
 
+    private BIntersectionType intersectionType = null;
     private boolean nullable = true;
     public BIntersectionType immutableType;
 
@@ -85,5 +88,15 @@ public class BAnyType extends BBuiltInRefType implements SelectivelyImmutableRef
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BArrayType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BArrayType.java
@@ -26,6 +26,8 @@ import org.wso2.ballerinalang.compiler.util.BArrayState;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * @since 0.94
  */
@@ -39,6 +41,8 @@ public class BArrayType extends BType implements ArrayType {
     public int size = -1;
 
     public BArrayState state = BArrayState.OPEN;
+
+    private BIntersectionType intersectionType = null;
 
     public BArrayType(BType elementType) {
         super(TypeTags.ARRAY, null);
@@ -112,5 +116,15 @@ public class BArrayType extends BType implements ArrayType {
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BErrorType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BErrorType.java
@@ -23,6 +23,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.BTypeSymbol;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * Represents error type in Ballerina.
  *
@@ -33,6 +35,7 @@ public class BErrorType extends BType implements ErrorType {
     public BType detailType;
     public BTypeIdSet typeIdSet;
 
+    private BIntersectionType intersectionType = null;
     private static final String DOLLAR = "$";
     private static final String ERROR = "error<";
     private static final String CLOSE_ERROR = ">";
@@ -70,5 +73,15 @@ public class BErrorType extends BType implements ErrorType {
             return String.valueOf(tsymbol);
         }
         return ERROR +  detailType + CLOSE_ERROR;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntersectionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BIntersectionType.java
@@ -17,6 +17,7 @@
  */
 package org.wso2.ballerinalang.compiler.semantics.model.types;
 
+import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.model.types.IntersectionType;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
@@ -27,6 +28,7 @@ import org.wso2.ballerinalang.util.Flags;
 
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 
@@ -40,11 +42,13 @@ public class BIntersectionType extends BType implements IntersectionType {
     public BType effectiveType;
 
     private LinkedHashSet<BType> constituentTypes;
+    private BIntersectionType intersectionType;
 
-    public BIntersectionType(BTypeSymbol tsymbol, LinkedHashSet<BType> types, BType effectiveType) {
+    public BIntersectionType(BTypeSymbol tsymbol, LinkedHashSet<BType> types,
+                             IntersectableReferenceType effectiveType) {
         super(TypeTags.INTERSECTION, tsymbol);
         this.constituentTypes = toFlatTypeSet(types);
-        this.effectiveType = effectiveType;
+        this.effectiveType = (BType) effectiveType;
 
         for (BType constituentType : this.constituentTypes) {
             if (constituentType.tag == TypeTags.READONLY) {
@@ -52,12 +56,15 @@ public class BIntersectionType extends BType implements IntersectionType {
                 break;
             }
         }
+        effectiveType.setIntersectionType(this);
     }
 
-    public BIntersectionType(BTypeSymbol tsymbol, LinkedHashSet<BType> types, BType effectiveType, long flags) {
+    public BIntersectionType(BTypeSymbol tsymbol, LinkedHashSet<BType> types, IntersectableReferenceType effectiveType,
+                             long flags) {
         super(TypeTags.INTERSECTION, tsymbol, flags);
         this.constituentTypes = toFlatTypeSet(types);
-        this.effectiveType = effectiveType;
+        this.effectiveType = (BType) effectiveType;
+        effectiveType.setIntersectionType(this);
     }
 
     @Override
@@ -123,5 +130,15 @@ public class BIntersectionType extends BType implements IntersectionType {
     @Override
     public BIntersectionType getImmutableType() {
         return Symbols.isFlagOn(this.flags, Flags.READONLY) ? this : null;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BMapType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BMapType.java
@@ -25,6 +25,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * @since 0.94
  */
@@ -32,6 +34,8 @@ public class BMapType extends BBuiltInRefType implements ConstrainedType, Select
 
     public BType constraint;
     public BIntersectionType immutableType;
+
+    private BIntersectionType intersectionType = null;
 
     public BMapType(int tag, BType constraint, BTypeSymbol tsymbol) {
         super(tag, tsymbol);
@@ -74,5 +78,15 @@ public class BMapType extends BBuiltInRefType implements ConstrainedType, Select
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BObjectType.java
@@ -27,6 +27,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * {@code BObjectType} represents object type in Ballerina.
  *
@@ -42,6 +44,8 @@ public class BObjectType extends BStructureType implements ObjectType {
     private static final String RIGHT_CURL = "}";
     private static final String SEMI_COLON = ";";
     private static final String READONLY = "readonly";
+
+    private BIntersectionType intersectionType = null;
 
     public BIntersectionType immutableType;
     public BObjectType mutableType = null;
@@ -119,5 +123,15 @@ public class BObjectType extends BStructureType implements ObjectType {
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BRecordType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BRecordType.java
@@ -25,6 +25,8 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * {@code BRecordType} represents record type in Ballerina.
  *
@@ -47,6 +49,8 @@ public class BRecordType extends BStructureType implements RecordType {
 
     public BIntersectionType immutableType;
     public BRecordType mutableType;
+
+    private BIntersectionType intersectionType = null;
 
     public BRecordType(BTypeSymbol tSymbol) {
         super(TypeTags.RECORD, tSymbol);
@@ -102,5 +106,15 @@ public class BRecordType extends BStructureType implements RecordType {
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTableType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTableType.java
@@ -27,6 +27,7 @@ import org.wso2.ballerinalang.compiler.semantics.model.symbols.Symbols;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
+import java.util.Optional;
 
 /**
  * {@code BTableType} represents a table in Ballerina.
@@ -42,6 +43,8 @@ public class BTableType extends BType implements TableType {
     public boolean isTypeInlineDefined;
     public Location constraintPos;
     public BIntersectionType immutableType;
+
+    private BIntersectionType intersectionType = null;
 
     public BTableType(int tag, BType constraint, BTypeSymbol tSymbol) {
         super(tag, tSymbol);
@@ -100,5 +103,15 @@ public class BTableType extends BType implements TableType {
     @Override
     public BIntersectionType getImmutableType() {
         return immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTupleType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BTupleType.java
@@ -25,6 +25,7 @@ import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -39,6 +40,8 @@ public class BTupleType extends BType implements TupleType {
     public Boolean isAnyData = null;
 
     public BIntersectionType immutableType;
+
+    private BIntersectionType intersectionType = null;
 
     public BTupleType(List<BType> tupleTypes) {
         super(TypeTags.TUPLE, null);
@@ -87,5 +90,15 @@ public class BTupleType extends BType implements TupleType {
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BUnionType.java
@@ -29,6 +29,7 @@ import org.wso2.ballerinalang.util.Flags;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
 import java.util.regex.Pattern;
@@ -44,6 +45,8 @@ public class BUnionType extends BType implements UnionType {
 
     public BIntersectionType immutableType;
     public boolean resolvingToString = false;
+
+    private BIntersectionType intersectionType = null;
 
     private boolean nullable;
     private String cachedToString;
@@ -447,5 +450,15 @@ public class BUnionType extends BType implements UnionType {
         String typeStr = numberOfNotNilTypes > 1 ? "(" + joiner.toString() + ")" : joiner.toString();
         boolean hasNilType = uniqueTypes.size() > numberOfNotNilTypes;
         return (nullable && hasNilType && !hasNilableMember) ? (typeStr + Names.QUESTION_MARK.value) : typeStr;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLSubType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLSubType.java
@@ -23,6 +23,8 @@ import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.semantics.model.TypeVisitor;
 import org.wso2.ballerinalang.compiler.util.Names;
 
+import java.util.Optional;
+
 /**
  * Represents Builtin Subtype of integer.
  *
@@ -31,6 +33,7 @@ import org.wso2.ballerinalang.compiler.util.Names;
 public class BXMLSubType extends BType implements SelectivelyImmutableReferenceType {
 
     public BIntersectionType immutableType;
+    private BIntersectionType intersectionType = null;
 
     public BXMLSubType(int tag, Name name) {
 
@@ -83,5 +86,15 @@ public class BXMLSubType extends BType implements SelectivelyImmutableReferenceT
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLType.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/semantics/model/types/BXMLType.java
@@ -24,6 +24,8 @@ import org.wso2.ballerinalang.compiler.util.Names;
 import org.wso2.ballerinalang.compiler.util.TypeTags;
 import org.wso2.ballerinalang.util.Flags;
 
+import java.util.Optional;
+
 /**
  * Represents XML Type.
  *
@@ -33,6 +35,8 @@ public class BXMLType extends BBuiltInRefType implements SelectivelyImmutableRef
 
     public BType constraint;
     public BIntersectionType immutableType;
+
+    private BIntersectionType intersectionType = null;
 
     public BXMLType(BType constraint, BTypeSymbol tsymbol) {
         super(TypeTags.XML, tsymbol);
@@ -71,5 +75,15 @@ public class BXMLType extends BBuiltInRefType implements SelectivelyImmutableRef
     @Override
     public BIntersectionType getImmutableType() {
         return this.immutableType;
+    }
+
+    @Override
+    public Optional<BIntersectionType> getIntersectionType() {
+        return this.intersectionType ==  null ? Optional.empty() : Optional.of(this.intersectionType);
+    }
+
+    @Override
+    public void setIntersectionType(BIntersectionType intersectionType) {
+        this.intersectionType = intersectionType;
     }
 }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/ImmutableTypeCloner.java
@@ -21,6 +21,7 @@ import io.ballerina.tools.diagnostics.Location;
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.elements.Flag;
 import org.ballerinalang.model.elements.PackageID;
+import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.model.types.SelectivelyImmutableReferenceType;
 import org.ballerinalang.model.types.TypeKind;
 import org.wso2.ballerinalang.compiler.desugar.ASTBuilderUtil;
@@ -823,7 +824,8 @@ public class ImmutableTypeCloner {
         }};
 
         BIntersectionType intersectionType = new BIntersectionType(intersectionTypeSymbol, constituentTypes,
-                                                                   effectiveType, Flags.READONLY);
+                                                                   (IntersectableReferenceType) effectiveType,
+                                                                   Flags.READONLY);
         intersectionTypeSymbol.type = intersectionType;
         return intersectionType;
     }

--- a/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
+++ b/compiler/ballerina-lang/src/main/java/org/wso2/ballerinalang/compiler/util/Unifier.java
@@ -19,6 +19,7 @@ package org.wso2.ballerinalang.compiler.util;
 
 import org.ballerinalang.model.TreeBuilder;
 import org.ballerinalang.model.tree.NodeKind;
+import org.ballerinalang.model.types.IntersectableReferenceType;
 import org.ballerinalang.util.diagnostic.DiagnosticErrorCode;
 import org.wso2.ballerinalang.compiler.diagnostic.BLangDiagnosticLog;
 import org.wso2.ballerinalang.compiler.semantics.analyzer.Types;
@@ -472,7 +473,7 @@ public class Unifier implements BTypeVisitor<BType, BType> {
         }
 
         BIntersectionType type = new BIntersectionType(null, (LinkedHashSet<BType>) originalType.getConstituentTypes(),
-                                                       newEffectiveType);
+                                                       (IntersectableReferenceType) newEffectiveType);
         setFlags(type, originalType.flags);
         return originalType;
     }

--- a/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
+++ b/tests/ballerina-compiler-api-test/src/test/java/io/ballerina/semantic/api/test/ExpressionTypeTest.java
@@ -42,6 +42,7 @@ import static io.ballerina.compiler.api.symbols.TypeDescKind.DECIMAL;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FLOAT;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.FUTURE;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.INT;
+import static io.ballerina.compiler.api.symbols.TypeDescKind.INTERSECTION;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.JSON;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.MAP;
 import static io.ballerina.compiler.api.symbols.TypeDescKind.NIL;
@@ -323,6 +324,26 @@ public class ExpressionTypeTest {
                 {129, 12, 129, 37, INT},
                 {130, 4, 130, 36, BOOLEAN}
         };
+    }
+
+    @Test
+    public void testExpressionsOfIntersectionTypes() {
+        assertType(135, 4, 135, 21, INTERSECTION);
+        assertType(135, 4, 135, 22, INTERSECTION);
+        assertType(137, 4, 137, 24, INTERSECTION);
+        assertType(137, 4, 137, 23, INTERSECTION);
+        assertType(139, 4, 139, 26, UNION);
+        TypeSymbol t1 = getExprType(139, 4, 139, 27);
+        assertEquals(t1.typeKind(), UNION);
+        assertEquals(t1.signature(), "(Foo & readonly)|int|(string[] & readonly)");
+        assertType(141, 4, 141, 26, UNION);
+        TypeSymbol t2 = getExprType(141, 4, 141, 27);
+        assertEquals(t2.typeKind(), UNION);
+        assertEquals(t2.signature(), "(int[] & readonly)?");
+        assertType(143, 4, 143, 26, UNION);
+        TypeSymbol t3 = getExprType(143, 4, 143, 27);
+        assertEquals(t3.typeKind(), UNION);
+        assertEquals(t3.signature(), "(int[] & readonly)?");
     }
 
     @Test

--- a/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
+++ b/tests/ballerina-compiler-api-test/src/test/resources/test-src/expressions_test.bal
@@ -131,6 +131,35 @@ function testDependentlyTypedFunctionCall() {
     testParameterizedType2(boolean);
 }
 
+function testExpressionsOfIntersectionTypes() {
+    int[] x = [1, 2];
+    x.cloneReadOnly();
+
+    errorIntersection();
+
+    recordIntersection({});
+
+    nilableIntersection1();
+
+    nilableIntersection2();
+}
+
+type ErrorOne error<record { boolean fatal; }>;
+type ErrorTwo error<record { int code; }>;
+type ErrorIntersection ErrorOne & ErrorTwo;
+
+function errorIntersection() returns ErrorOne & ErrorTwo => error ErrorIntersection("error!", code = 1234, fatal = false);
+
+type Foo record {|
+    int i = 1;
+|};
+
+function recordIntersection(Foo foo) returns (readonly & Foo)|int|(string[] & readonly) => foo.cloneReadOnly();
+
+function nilableIntersection1() returns (int[] & readonly)? => ();
+
+function nilableIntersection2() returns ()|(int[] & readonly) => [1, 2];
+
 // utils
 
 class PersonObj {


### PR DESCRIPTION
## Purpose
$title.

Fixes https://github.com/ballerina-platform/ballerina-lang/issues/29984

## Approach
Each newly created effective type will have a reference to the intersection type that resulted in its initial creation.

## Check List 
- [x] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [x] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
