### PR TITLE
Add sample toml generation based on default values in schema

### DIFF
--- a/misc/toml-parser/spotbugs-exclude.xml
+++ b/misc/toml-parser/spotbugs-exclude.xml
@@ -26,4 +26,8 @@
         <Class name="io.ballerina.toml.semantic.diagnostics.DiagnosticComparator"/>
         <Bug pattern="SE_COMPARATOR_SHOULD_BE_SERIALIZABLE"/>
     </Match>
+    <Match>
+        <Class name="io.ballerina.toml.validator.BoilerplateGenerator"/>
+        <Bug pattern="FE_FLOATING_POINT_EQUALITY"/>
+    </Match>
 </FindBugsFilter>

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/BoilerplateGenerator.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/BoilerplateGenerator.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package io.ballerina.toml.validator;
+
+import io.ballerina.toml.validator.schema.AbstractSchema;
+import io.ballerina.toml.validator.schema.ArraySchema;
+import io.ballerina.toml.validator.schema.BooleanSchema;
+import io.ballerina.toml.validator.schema.NumericSchema;
+import io.ballerina.toml.validator.schema.Schema;
+import io.ballerina.toml.validator.schema.SchemaVisitor;
+import io.ballerina.toml.validator.schema.StringSchema;
+import io.ballerina.toml.validator.schema.Type;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Generates a Toml string with the default values supported.
+ *
+ * @since 2.0.0
+ */
+public class BoilerplateGenerator extends SchemaVisitor {
+
+    private String parentTableKey;
+    private final List<String> output;
+    private String key;
+    
+    private static final String NEW_LINE = System.lineSeparator();
+
+    public BoilerplateGenerator(Schema rootSchema) {
+        this.output = new ArrayList<>();
+        Map<String, AbstractSchema> children = rootSchema.properties();
+        for (Map.Entry<String, AbstractSchema> entry : children.entrySet()) {
+            String key = entry.getKey();
+            AbstractSchema value = entry.getValue();
+            this.parentTableKey = key;
+            value.accept(this);
+        }
+    }
+
+    @Override
+    public void visit(Schema objectSchema) {
+        Map<String, AbstractSchema> children = objectSchema.properties();
+        if (!isTableHeaderSkippable(children)) {
+            output.add("[" + this.parentTableKey + "]" + NEW_LINE);
+        }
+        String parentKey = this.parentTableKey;
+        for (Map.Entry<String, AbstractSchema> entry : children.entrySet()) {
+            String key = entry.getKey();
+            AbstractSchema value = entry.getValue();
+            if (value.type() == Type.OBJECT) {
+                this.parentTableKey = this.parentTableKey + "." + key;
+            }
+            if (value.type() == Type.ARRAY) {
+                this.parentTableKey = this.parentTableKey + "." + key;
+            } else {
+                this.key = key;
+            }
+            value.accept(this);
+            this.parentTableKey = parentKey;
+        }
+    }
+
+    @Override
+    public void visit(ArraySchema arraySchema) {
+        AbstractSchema items = arraySchema.items();
+        if (items.type() == Type.OBJECT) {
+            output.add("[[" + this.parentTableKey + "]]" + NEW_LINE);
+            Map<String, AbstractSchema> children = ((Schema) items).properties();
+            for (Map.Entry<String, AbstractSchema> entry : children.entrySet()) {
+                String key = entry.getKey();
+                AbstractSchema value = entry.getValue();
+                if (value.type() == Type.OBJECT) {
+                    this.parentTableKey = this.parentTableKey + "." + key;
+                } else {
+                    this.key = key;
+                    value.accept(this);
+                }
+            }
+        } else {
+            items.accept(this);
+        }
+    }
+
+    @Override
+    public void visit(BooleanSchema booleanSchema) {
+        Optional<Boolean> defaultValue = booleanSchema.defaultValue();
+        if (defaultValue.isEmpty()) {
+            throw new RuntimeException(this.parentTableKey + " Default value is not set");
+        }
+        Boolean val = defaultValue.get();
+        output.add(this.key + " = " + val + NEW_LINE);
+    }
+
+    @Override
+    public void visit(NumericSchema numericSchema) {
+        Optional<Double> defaultValue = numericSchema.defaultValue();
+        if (defaultValue.isEmpty()) {
+            throw new RuntimeException(this.parentTableKey + " Default value is not set");
+        }
+        Double val = defaultValue.get();
+        output.add(this.key + " = " + numericPrettyPrint(val) + NEW_LINE);
+    }
+
+    @Override
+    public void visit(StringSchema stringSchema) {
+        Optional<String> defaultValue = stringSchema.defaultValue();
+        if (defaultValue.isEmpty()) {
+            throw new RuntimeException(this.parentTableKey + " Default value is not set");
+        }
+        String val = defaultValue.get();
+        output.add(this.key + " = " + "\"" + val + "\"" + NEW_LINE);
+    }
+
+    public List<String> getOutput() {
+        return output;
+    }
+
+    private static String numericPrettyPrint(double d) {
+        if (d == (long) d) {
+            return String.format("%d", (long) d);
+        } else {
+            return String.format("%s", d);
+        }
+    }
+
+    private static boolean isTableHeaderSkippable(Map<String, AbstractSchema> children) {
+        for (AbstractSchema value : children.values()) {
+            if (!(value.type() == Type.OBJECT || value.type() == Type.ARRAY)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+}

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/AbstractSchema.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/AbstractSchema.java
@@ -19,7 +19,6 @@
 package io.ballerina.toml.validator.schema;
 
 import java.util.Map;
-
 /**
  * Represents the base class for all the sub schemas in json schema.
  *

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/NumericSchema.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/NumericSchema.java
@@ -26,12 +26,12 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class NumericSchema extends AbstractSchema {
+public class NumericSchema extends PrimitiveValueSchema<Double> {
     private final Double minimum;
     private final Double maximum;
 
-    public NumericSchema(Type type, Map<String, String> message, Double minimum, Double maximum) {
-        super(type, message);
+    public NumericSchema(Type type, Map<String, String> message, Double minimum, Double maximum, Double defaultValue) {
+        super(type, message, defaultValue);
         this.minimum = minimum;
         this.maximum = maximum;
     }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/PrimitiveValueSchema.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/PrimitiveValueSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except
@@ -19,20 +19,23 @@
 package io.ballerina.toml.validator.schema;
 
 import java.util.Map;
+import java.util.Optional;
 
 /**
- * Represents boolean schema in JSON schema.
+ * Represents primitive value schema in JSON schema.
  *
+ * @param <T> Type of the primitive value.
  * @since 2.0.0
  */
-public class BooleanSchema extends PrimitiveValueSchema<Boolean> {
-
-    public BooleanSchema(Type type, Map<String, String> message, Boolean defaultValue) {
-        super(type, message, defaultValue);
+public abstract class PrimitiveValueSchema<T> extends AbstractSchema {
+    private final T defaultValue;
+    
+    public PrimitiveValueSchema(Type type, Map<String, String> message, T defaultValue) {
+        super(type, message);
+        this.defaultValue = defaultValue;
     }
 
-    @Override
-    public void accept(SchemaVisitor visitor) {
-        visitor.visit(this);
+    public Optional<T> defaultValue() {
+        return Optional.ofNullable(this.defaultValue);
     }
 }

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/SchemaDeserializer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/SchemaDeserializer.java
@@ -25,7 +25,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -92,7 +92,7 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
         boolean additionalProperties = parseOptionalBooleanFromJson(jsonObj, ADDITIONAL_PROPERTIES);
         JsonObject properties = jsonObj.get(PROPERTIES).getAsJsonObject();
         Set<Map.Entry<String, JsonElement>> entries = properties.entrySet();
-        Map<String, AbstractSchema> propertiesList = new HashMap<>();
+        Map<String, AbstractSchema> propertiesList = new LinkedHashMap<>();
         for (Map.Entry<String, JsonElement> entry : entries) {
             String key = entry.getKey();
             AbstractSchema
@@ -181,10 +181,10 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
     }
 
     private Map<String, String> parseOptionalMapFromMessageJson(JsonObject jsonObject) {
-        Map<String, String> customMessages = new HashMap<>();
+        Map<String, String> customMessages = new LinkedHashMap<>();
         JsonObject customMessageJson = jsonObject.getAsJsonObject(SchemaDeserializer.MESSAGE);
         if (customMessageJson == null) {
-            return new HashMap<>();
+            return new LinkedHashMap<>();
         }
 
         addFieldToCustomMessagesMap(customMessages, customMessageJson, TYPE);

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/SchemaDeserializer.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/SchemaDeserializer.java
@@ -55,6 +55,7 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
     public static final String MINIMUM = "minimum";
     public static final String MAXIMUM = "maximum";
     public static final String MESSAGE = "message";
+    public static final String DEFAULT_VALUE = "default";
 
     @Override
     public AbstractSchema deserialize(JsonElement jsonElement, java.lang.reflect.Type refType,
@@ -74,7 +75,8 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
                 return getStringSchema(jsonObj);
             case BOOLEAN:
                 Map<String, String> customMessages = parseOptionalMapFromMessageJson(jsonObj);
-                return new BooleanSchema(Type.BOOLEAN, customMessages);
+                Boolean defaultValue = parseOptionalBooleanFromJson(jsonObj, DEFAULT_VALUE);
+                return new BooleanSchema(Type.BOOLEAN, customMessages, defaultValue);
             default:
                 throw new JsonSchemaException(type + " is not supported type in json schema");
         }
@@ -112,15 +114,17 @@ public class SchemaDeserializer implements JsonDeserializer<AbstractSchema> {
 
     private StringSchema getStringSchema(JsonObject jsonObj) {
         String pattern = parseOptionalStringFromJson(jsonObj, PATTERN);
+        String defaultValue = parseOptionalStringFromJson(jsonObj, DEFAULT_VALUE);
         Map<String, String> customMessages = parseOptionalMapFromMessageJson(jsonObj);
-        return new StringSchema(Type.STRING, customMessages, pattern);
+        return new StringSchema(Type.STRING, customMessages, pattern, defaultValue);
     }
 
     private NumericSchema getNumericSchema(JsonObject jsonObj, Type type) {
         Double minimum = parseOptionalDoubleFromJson(jsonObj, MINIMUM);
         Double maximum = parseOptionalDoubleFromJson(jsonObj, MAXIMUM);
+        Double defaultValue = parseOptionalDoubleFromJson(jsonObj, DEFAULT_VALUE);
         Map<String, String> customMessages = parseOptionalMapFromMessageJson(jsonObj);
-        return new NumericSchema(type, customMessages, minimum, maximum);
+        return new NumericSchema(type, customMessages, minimum, maximum, defaultValue);
     }
 
     private Double parseOptionalDoubleFromJson(JsonObject jsonObject, String key) {

--- a/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/StringSchema.java
+++ b/misc/toml-parser/src/main/java/io/ballerina/toml/validator/schema/StringSchema.java
@@ -26,11 +26,11 @@ import java.util.Optional;
  *
  * @since 2.0.0
  */
-public class StringSchema extends AbstractSchema {
+public class StringSchema extends PrimitiveValueSchema<String> {
     private final String pattern;
 
-    public StringSchema(Type type, Map<String, String> message, String pattern) {
-        super(type, message);
+    public StringSchema(Type type, Map<String, String> message, String pattern, String defaultValue) {
+        super(type, message, defaultValue);
         this.pattern = pattern;
     }
 

--- a/misc/toml-parser/src/test/java/toml/parser/test/TestTomlValidator.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/TestTomlValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
  * WSO2 Inc. licenses this file to you under the Apache License,
  * Version 2.0 (the "License"); you may not use this file except

--- a/misc/toml-parser/src/test/java/toml/parser/test/validator/BoilerplateGeneratorTest.java
+++ b/misc/toml-parser/src/test/java/toml/parser/test/validator/BoilerplateGeneratorTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package toml.parser.test.validator;
+
+import io.ballerina.toml.validator.BoilerplateGenerator;
+import io.ballerina.toml.validator.schema.Schema;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * Contains test cases to to boilerplate toml generation functionality.
+ *
+ * @since 2.0.0
+ */
+public class BoilerplateGeneratorTest {
+    @Test
+    public void testGen() throws IOException {
+        Path schemaPath = Paths.get("src", "test", "resources", "validator", "boilerplate", "schema.json");
+        Path expectedToml = Paths.get("src", "test", "resources", "validator", "boilerplate", "expected.toml");
+        Schema rootSchema = Schema.from(schemaPath);
+        BoilerplateGenerator generator = new BoilerplateGenerator(rootSchema);
+        StringBuilder actual = new StringBuilder();
+        for (String s : generator.getOutput()) {
+            actual.append(s);
+        }
+        String expected = Files.readString(expectedToml);
+        Assert.assertEquals(actual.toString(), expected);
+    }
+}

--- a/misc/toml-parser/src/test/resources/validator/boilerplate/expected.toml
+++ b/misc/toml-parser/src/test/resources/validator/boilerplate/expected.toml
@@ -1,0 +1,45 @@
+[container.image]
+name = "hello"
+repository = "local"
+tag = "v1.0.0"
+base = "ballerina/jre11:v1"
+cmd = ""
+[container.image.user]
+run_as = "ballerina"
+[[container.copy.files]]
+sourceFile = "./data/data.txt"
+target = "/home/ballerina/data/data.txt"
+[[cloud.config.envs]]
+key_ref = "FOO"
+name = "foo"
+config_name = "module-foo"
+[[cloud.config.secrets]]
+key_ref = "MYSQL_ROOT_PASSWORD"
+name = "ROOT_PASSWORD"
+secret_name = "db-crdential-secret"
+[[cloud.config.files]]
+file = "resource/file.text"
+mount_path = "/home/ballerina/foo/file.conf"
+[cloud.deployment]
+internal_domain_name = "module_svc"
+external_accessible = true
+min_memory = "100Mi"
+max_memory = "256Mi"
+min_cpu = "1000m"
+max_cpu = "1500m"
+[cloud.deployment.autoscaling]
+enable = true
+min_replicas = 2
+max_replicas = 3
+cpu = 50
+memory = 80
+[cloud.deployment.probes.readiness]
+port = 9091
+path = "/readyz"
+[cloud.deployment.probes.liveness]
+port = 9091
+path = "/healthz"
+[cloud.deployment.storage.volumes]
+name = "volume1"
+local_path = "files"
+size = "2Gi"

--- a/misc/toml-parser/src/test/resources/validator/boilerplate/schema.json
+++ b/misc/toml-parser/src/test/resources/validator/boilerplate/schema.json
@@ -1,0 +1,294 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "C2C Spec",
+    "description": "Schema for C2C Cloud file",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "container": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "image": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "name": {
+                            "type": "string",
+                            "pattern": "[a-zA-Z0-9][a-zA-Z0-9_.-]+",
+                            "default": "hello"
+                        },
+                        "repository": {
+                            "type": "string",
+                            "pattern": "^(?!\\s*$).+",
+                            "default": "local"
+                        },
+                        "tag": {
+                            "type": "string",
+                            "pattern": "^[\\w][\\w.-]{0,127}$",
+                            "default": "v1.0.0"
+                        },
+                        "base": {
+                            "type": "string",
+                            "pattern": "^(?!\\s*$).+",
+                            "default": "ballerina/jre11:v1"
+                        },
+                        "cmd": {
+                            "type": "string",
+                            "pattern": ".*",
+                            "default": ""
+                        },
+                        "user": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "run_as": {
+                                    "type": "string",
+                                    "pattern": "^(?!\\s*$).+",
+                                    "default": "ballerina"
+                                }
+                            }
+                        }
+                    }
+                },
+                "copy": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "files": {
+                            "type": "array",
+                            "additionalProperties": false,
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "sourceFile": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "./data/data.txt"
+                                    },
+                                    "target": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "/home/ballerina/data/data.txt"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "cloud": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "envs": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "key_ref": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "FOO"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "foo"
+                                    },
+                                    "config_name": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "module-foo"
+                                    }
+                                }
+                            }
+                        },
+                        "secrets": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "key_ref": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "MYSQL_ROOT_PASSWORD"
+                                    },
+                                    "name": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "ROOT_PASSWORD"
+                                    },
+                                    "secret_name": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "db-crdential-secret"
+                                    }
+                                }
+                            }
+                        },
+                        "files": {
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "file": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "resource/file.text"
+                                    },
+                                    "mount_path": {
+                                        "type": "string",
+                                        "pattern": "^(?!\\s*$).+",
+                                        "default": "/home/ballerina/foo/file.conf"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "deployment": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                        "internal_domain_name": {
+                            "type": "string",
+                            "pattern": "[a-z0-9]([-a-z0-9]*[a-z0-9])?",
+                            "default": "module_svc"
+                        },
+                        "external_accessible": {
+                            "type": "boolean",
+                            "default": true
+                        },
+                        "min_memory": {
+                            "type": "string",
+                            "pattern": "^(?:0?[1-9]?|[1-9][0-9]*?)\\.?\\d*?(?:[EPTGMK]i?b?)?$",
+                            "default": "100Mi"
+                        },
+                        "max_memory": {
+                            "type": "string",
+                            "pattern": "^(?:0?[1-9]?|[1-9][0-9]*?)\\.?\\d*?(?:[EPTGMK]i?b?)?$",
+                            "default": "256Mi"
+                        },
+                        "min_cpu": {
+                            "type": "string",
+                            "pattern": "^(?:0?[1-9]?|[1-9][0-9]*?)\\.?\\d*?(m)?$",
+                            "default": "1000m"
+                        },
+                        "max_cpu": {
+                            "type": "string",
+                            "pattern": "^(?:0?[1-9]?|[1-9][0-9]*?)\\.?\\d*?(m)?$",
+                            "default": "1500m"
+                        },
+                        "autoscaling": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "enable": {
+                                    "type": "boolean",
+                                    "default": true
+                                },
+                                "min_replicas": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "default": 2
+                                },
+                                "max_replicas": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "default": 3
+                                },
+                                "cpu": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 100,
+                                    "default": 50
+                                },
+                                "memory": {
+                                    "type": "integer",
+                                    "minimum": 1,
+                                    "maximum": 100,
+                                    "default": 80
+                                }
+                            }
+                        },
+                        "probes": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "readiness": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "default": 9091
+                                        },
+                                        "path": {
+                                            "type": "string",
+                                            "pattern": "^(?!\\s*$).+",
+                                            "default": "/readyz"
+                                        }
+                                    }
+                                },
+                                "liveness": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "port": {
+                                            "type": "integer",
+                                            "minimum": 0,
+                                            "default": 9091
+                                        },
+                                        "path": {
+                                            "type": "string",
+                                            "pattern": "^(?!\\s*$).+",
+                                            "default": "/healthz"
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        "storage": {
+                            "type": "object",
+                            "additionalProperties": false,
+                            "properties": {
+                                "volumes": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "name": {
+                                            "type": "string",
+                                            "pattern": "^(?!\\s*$).+",
+                                            "default": "volume1"
+                                        },
+                                        "local_path": {
+                                            "type": "string",
+                                            "pattern": "^(?!\\s*$).+",
+                                            "default": "files"
+                                        },
+                                        "size": {
+                                            "type": "string",
+                                            "pattern": "^(?!\\s*$).+",
+                                            "default": "2Gi"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Purpose
Adds default value support for toml schema.  
Adds boilerplate generator which allows generating toml document from a schema with default values.

This will be used by c2c to generate a boilerplate with default values.

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
