### PR TITLE
Add 10 sec percentile duration and remove 15 min

### DIFF
--- a/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/BallerinaMetricsObserver.java
+++ b/bvm/ballerina-runtime/src/main/java/io/ballerina/runtime/observability/metrics/BallerinaMetricsObserver.java
@@ -44,15 +44,15 @@ public class BallerinaMetricsObserver implements BallerinaObserver {
 
     private static final StatisticConfig[] responseTimeStatisticConfigs = new StatisticConfig[]{
             StatisticConfig.builder()
+                    .expiry(Duration.ofSeconds(10))
+                    .percentiles(StatisticConfig.DEFAULT.getPercentiles())
+                    .build(),
+            StatisticConfig.builder()
                     .expiry(Duration.ofMinutes(1))
                     .percentiles(StatisticConfig.DEFAULT.getPercentiles())
                     .build(),
             StatisticConfig.builder()
                     .expiry(Duration.ofMinutes(5))
-                    .percentiles(StatisticConfig.DEFAULT.getPercentiles())
-                    .build(),
-            StatisticConfig.builder()
-                    .expiry(Duration.ofMinutes(15))
                     .percentiles(StatisticConfig.DEFAULT.getPercentiles())
                     .build()
     };

--- a/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
+++ b/tests/jballerina-integration-test/src/test/java/org/ballerinalang/test/observability/metrics/MetricsTestCase.java
@@ -264,8 +264,8 @@ public class MetricsTestCase extends ObservabilityBaseTest {
      * @param snapshot The snapshot to test
      */
     private void testFunctionResponseTimeGaugeSnapshot(long invocationCount, Snapshot snapshot) {
-        List<Duration> durations = Arrays.asList(Duration.ofMinutes(1), Duration.ofMinutes(5),
-                Duration.ofMinutes(15));
+        List<Duration> durations = Arrays.asList(Duration.ofSeconds(10), Duration.ofMinutes(1),
+                Duration.ofMinutes(5));
         Assert.assertTrue(durations.contains(snapshot.getTimeWindow()), "time window "
                 + snapshot.getTimeWindow() + " of snapshot not equal to either one of "
                 + durations.toString());


### PR DESCRIPTION
## Purpose
We need to add 10 second duration to response time percentiles. To avoid performance degradation we are removing the 15 minutes duration.
More information on this was communicated with the email: "Adding 10 seconds duration for response time percentiles"