### PR TITLE
Improve the formatting behavior of blocks

### DIFF
--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -237,7 +237,6 @@ import io.ballerina.compiler.syntax.tree.XMLStepExpressionNode;
 import io.ballerina.compiler.syntax.tree.XMLTextNode;
 import io.ballerina.compiler.syntax.tree.XmlTypeDescriptorNode;
 import io.ballerina.tools.text.LineRange;
-import io.ballerina.tools.text.TextRange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1183,7 +1182,7 @@ public class FormattingTreeModifier extends TreeModifier {
             MappingConstructorExpressionNode mappingConstructorExpressionNode) {
         int fieldTrailingWS = 0;
         int fieldTrailingNL = 0;
-        if (shouldExpand(mappingConstructorExpressionNode.fields())) {
+        if (shouldExpand(mappingConstructorExpressionNode)) {
             fieldTrailingNL++;
         } else {
             fieldTrailingWS++;
@@ -4156,31 +4155,12 @@ public class FormattingTreeModifier extends TreeModifier {
     /**
      * Check whether a node list needs to be expanded into multiple lines.
      *
-     * @param nodeList node list
+     * @param node node to be expanded
      * @return <code>true</code> If the node list needs to be expanded into multiple lines.
      *         <code>false</code> otherwise
      */
-    private <T extends Node> boolean shouldExpand(NodeList<T> nodeList) {
-        int fieldCount = nodeList.size();
-        if (fieldCount <= 1) {
-            return false;
-        }
-
-        if (fieldCount > 3) {
-            return true;
-        }
-
-        for (Node field : nodeList) {
-            TextRange textRange = field.textRange();
-            if ((textRange.endOffset() - textRange.startOffset()) > 15) {
-                return true;
-            }
-
-            if (hasNonWSMinutiae(field.leadingMinutiae()) || hasNonWSMinutiae(field.trailingMinutiae())) {
-                return true;
-            }
-        }
-        return false;
+    private boolean shouldExpand(Node node) {
+        return node.toSourceCode().trim().contains(System.lineSeparator());
     }
 
     /**
@@ -4195,31 +4175,24 @@ public class FormattingTreeModifier extends TreeModifier {
             return true;
         }
 
+        if (hasNonWSMinutiae(objectTypeDesc.openBrace().trailingMinutiae())
+                || hasNonWSMinutiae(objectTypeDesc.closeBrace().leadingMinutiae())) {
+            return true;
+        }
+
         NodeList<Node> members = objectTypeDesc.members();
         return shouldExpandObjectMembers(members);
     }
 
     private boolean shouldExpandObjectMembers(NodeList<Node> members) {
-        int fieldCount = members.size();
-        if (fieldCount > 3) {
-            return true;
-        }
-
         for (Node member : members) {
-            if (member.kind() == SyntaxKind.METHOD_DECLARATION) {
-                return true;
-            }
-
-            TextRange textRange = member.textRange();
-            if ((textRange.endOffset() - textRange.startOffset()) > 15) {
-                return true;
-            }
-
-            if (hasNonWSMinutiae(member.leadingMinutiae()) || hasNonWSMinutiae(member.trailingMinutiae())) {
+            if (member.kind() == SyntaxKind.METHOD_DECLARATION
+                    || hasNonWSMinutiae(member.leadingMinutiae())
+                    || hasNonWSMinutiae(member.trailingMinutiae())
+                    || member.toSourceCode().contains(System.lineSeparator())) {
                 return true;
             }
         }
-
         return false;
     }
 
@@ -4235,19 +4208,14 @@ public class FormattingTreeModifier extends TreeModifier {
             return true;
         }
 
-        int fieldCount = recordTypeDesc.fields().size();
-        fieldCount += recordTypeDesc.recordRestDescriptor().isPresent() ? 1 : 0;
-        if (fieldCount > 3) {
+        if (hasNonWSMinutiae(recordTypeDesc.bodyStartDelimiter().trailingMinutiae())
+                || hasNonWSMinutiae(recordTypeDesc.bodyEndDelimiter().leadingMinutiae())) {
             return true;
         }
 
         for (Node field : recordTypeDesc.fields()) {
-            TextRange textRange = field.textRange();
-            if ((textRange.endOffset() - textRange.startOffset()) > 15) {
-                return true;
-            }
-
-            if (hasNonWSMinutiae(field.leadingMinutiae()) || hasNonWSMinutiae(field.trailingMinutiae())) {
+            if (hasNonWSMinutiae(field.leadingMinutiae()) || hasNonWSMinutiae(field.trailingMinutiae())
+                    || field.toSourceCode().contains(System.lineSeparator())) {
                 return true;
             }
         }

--- a/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
+++ b/misc/formatter/modules/formatter-core/src/main/java/org/ballerinalang/formatter/core/FormattingTreeModifier.java
@@ -2344,7 +2344,7 @@ public class FormattingTreeModifier extends TreeModifier {
 
         int fieldTrailingWS = 0;
         int fieldTrailingNL = 0;
-        if (shouldExpandObjectMembers(objectConstructorExpressionNode.members())) {
+        if (shouldExpand(objectConstructorExpressionNode)) {
             fieldTrailingNL++;
         } else {
             fieldTrailingWS++;
@@ -4181,6 +4181,23 @@ public class FormattingTreeModifier extends TreeModifier {
         }
 
         NodeList<Node> members = objectTypeDesc.members();
+        return shouldExpandObjectMembers(members);
+    }
+
+    /**
+     * Check whether an object constructor expression node needs to be expanded in to multiple lines.
+     *
+     * @param objectConstructor Object constructor expression node
+     * @return <code>true</code> If the object constructor expression node needs to be expanded in to multiple lines.
+     *         <code>false</code> otherwise
+     */
+    private boolean shouldExpand(ObjectConstructorExpressionNode objectConstructor) {
+        if (hasNonWSMinutiae(objectConstructor.openBraceToken().trailingMinutiae())
+                || hasNonWSMinutiae(objectConstructor.closeBraceToken().leadingMinutiae())) {
+            return true;
+        }
+
+        NodeList<Node> members = objectConstructor.members();
         return shouldExpandObjectMembers(members);
     }
 

--- a/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/misc/BlocksTest.java
+++ b/misc/formatter/modules/formatter-core/src/test/java/org/ballerinalang/formatter/core/misc/BlocksTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.ballerinalang.formatter.core.misc;
+
+import org.ballerinalang.formatter.core.FormatterTest;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+
+/**
+ * Test the line wrapping.
+ *
+ * @since 2.0.0
+ */
+public class BlocksTest extends FormatterTest {
+
+    @Test(dataProvider = "test-file-provider")
+    public void test(String source, String sourcePath) throws IOException {
+        super.test(source, sourcePath);
+    }
+
+    @DataProvider(name = "test-file-provider")
+    @Override
+    public Object[][] dataProvider() {
+        return this.getConfigsList();
+    }
+
+    @Override
+    public String getTestResourceDir() {
+        return Paths.get("misc", "blocks").toString();
+    }
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_1.bal
@@ -4,10 +4,7 @@ type Student record {
 };
 
 public function main() {
-    Student[] studentList = [{
-        firstName: "Michelle",
-        gpa: 3.5
-    }];
+    Student[] studentList = [{firstName: "Michelle", gpa: 3.5}];
     var result = from var student in studentList
                  do {
                      var name = {firstName: student.firstName};

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/query/assert/query_action_2.bal
@@ -7,10 +7,7 @@ public function main() {
     var result = from var student in studentList
                  // The block inside the `do` clause is executed in each iteration.
                  do {
-                     FullName fullName = {
-                         firstName: student.firstName,
-                         lastName: student.lastName
-                     };
+                     FullName fullName = {firstName: student.firstName, lastName: student.lastName};
                      nameList.push(fullName);
                  };
 

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/send-receive/source/send_receive_action_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/send-receive/source/send_receive_action_2.bal
@@ -1,11 +1,7 @@
 public function foo() {
 
 
-    @someAnnotate  {
-
-
-
-    }
+    @someAnnotate  {  }
 
 
 

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/send-receive/source/send_receive_action_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/send-receive/source/send_receive_action_3.bal
@@ -1,11 +1,7 @@
 public function foo() {
 
 
-    @someAnnotate  {
-
-
-
-    }
+    @someAnnotate  {    }
 
 
 

--- a/misc/formatter/modules/formatter-core/src/test/resources/actions/start/source/start_action_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/actions/start/source/start_action_2.bal
@@ -2,9 +2,8 @@ function foo()
 {
 future  < int  >
 f1   =
-@  strand
-  {  thread  : "any"
-}   start
+@  strand   {  thread  : "any"   }
+     start
  multiply  (  1  ,   2  )
  ;
  }

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/constant/assert/constant_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/constant/assert/constant_expression_1.bal
@@ -1,10 +1,7 @@
 const float PI = 3.14159;
 const SPEED_OF_LIGHT = 299792000;
 
-const map<string> data = {
-    "user": "Ballerina",
-    "ID": "1234"
-};
+const map<string> data = {"user": "Ballerina", "ID": "1234"};
 const map<map<string>> complexData = {
     "data": data,
     "data2": {"user": "WSO2"}

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/constant/source/constant_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/constant/source/constant_expression_1.bal
@@ -2,4 +2,5 @@
 const   SPEED_OF_LIGHT   = 299792000 ;
 
 const  map < string  >  data  =  {  "user"  :  "Ballerina"  ,   "ID": "1234"  } ;
-   const   map  <  map < string  >  > complexData = { "data": data, "data2": { "user"  : "WSO2"   } };
+   const   map  <  map < string  >  > complexData = { "data": data,
+   "data2": { "user"  : "WSO2"} };

--- a/misc/formatter/modules/formatter-core/src/test/resources/expressions/let/source/let_expression_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/expressions/let/source/let_expression_1.bal
@@ -2,9 +2,7 @@ type Person record {
    int age;
 };
 
-function getPerson() returns Person => {
-   age: 31
-};
+function getPerson() returns Person => {    age: 31   };
 
 public function foo() {
    int a =    let    int b = 1 in b * 2;

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_1.bal
@@ -1,0 +1,35 @@
+type Student record {
+    string name;
+    int age;
+    Grades grades;
+};
+
+type Address record {|
+    string city;
+    string country;
+|};
+
+function foo() {
+    Student john = {
+        name: "John Doe",
+        age,
+        grades: {
+            maths: 80,
+            chemistry: 65
+        }
+    };
+
+    Student john = {
+        name: "John Doe",
+        age,
+        grades: {maths: 80, chemistry: 65}
+    };
+
+    Student john = {name: "John Doe", age, grades: {maths: 80, chemistry: 65}};
+
+    Student john = {
+        name: "John Doe",
+        age,
+        grades: {maths: 80, chemistry: 65}
+    };
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_2.bal
@@ -1,0 +1,47 @@
+public type Address object {
+    public string city;
+    public string country;
+    public function value() returns string;
+};
+
+public type Address object {
+    public string city;
+    public string country;
+    public function value() returns string;
+};
+
+public type Address object {
+    public string city;
+    public string country;
+    public function value() returns string;
+};
+
+public type Address object {
+    public string city;
+    public string country;
+    public function value() returns string;
+};
+
+function foo() {
+    Address adr = object {
+                      public string city;
+                      public string country;
+                  };
+
+    Address adr = object {public string city; public string country;};
+
+    Address adr = object {
+                      public string city;
+                      public string country;
+                  };
+
+    Address adr = object {
+                      public string city;
+                      public string country;
+                  };
+
+    Address adr = object {
+                      public string city;
+                      public string country;
+                  };
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/assert/blocks_3.bal
@@ -1,0 +1,19 @@
+function foo() {
+    map<int> marks = {sam: 50, jon: 60, sam: 50, jon: 60, sam: 50, jon: 60};
+
+    Humanities humanitiesMarks = {
+        history: 80,
+        geography: 75
+    };
+
+    Humanities humanitiesMarks = {
+        history: 80,
+        geography: 75
+    };
+
+    map<int> allMarks = {
+        physics: 100,
+        ...humanitiesMarks,
+        chemistry: 75
+    };
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/source/blocks_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/source/blocks_1.bal
@@ -1,0 +1,26 @@
+type Student record {
+            string name;
+int age;    Grades grades;
+};
+
+type Address record {| string city;   string country;  |};
+
+function foo() {
+    Student john = {
+            name: "John Doe",
+            age,
+            grades: {
+                maths: 80,
+                chemistry: 65
+            }
+        };
+
+    Student john = {name: "John Doe",age,
+            grades: {maths: 80,chemistry: 65}
+            };
+
+    Student john = {name: "John Doe",age,grades: {maths: 80,chemistry: 65}};
+
+    Student john = {
+        name: "John Doe",age,grades: {maths: 80,chemistry: 65}};
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/source/blocks_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/source/blocks_2.bal
@@ -1,0 +1,31 @@
+public type Address object {
+    public string city;
+    public string country;
+    public function value() returns string;
+};
+
+public type Address object {public string city;public string country;public function value() returns string;};
+
+public type Address object {public string city;public string country;public function value() returns string;
+};
+
+public type Address object {
+    public string city;public string country;public function value() returns string;};
+
+function foo() {
+    Address adr = object {
+                          public string city;
+                          public string country;
+                      };
+
+    Address adr = object {public string city;  public string country;};
+
+    Address adr = object {
+public string city;public string country;};
+
+    Address adr = object {public string city;public string country;
+    };
+
+    Address adr = object {public string city;
+    public string country;};
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/source/blocks_3.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/blocks/source/blocks_3.bal
@@ -1,0 +1,12 @@
+function foo() {
+    map<int> marks = {sam: 50, jon: 60, sam: 50, jon: 60, sam: 50,    jon: 60};
+
+    Humanities humanitiesMarks = {
+        history: 80, geography: 75};
+
+    Humanities humanitiesMarks = {history: 80,
+geography: 75};
+
+    map<int> allMarks = {physics: 100, ...humanitiesMarks, chemistry: 75
+    };
+}

--- a/misc/formatter/modules/formatter-core/src/test/resources/misc/ranges/source/ranges_4.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/misc/ranges/source/ranges_4.bal
@@ -1,8 +1,7 @@
 import ballerina/io;
 
 public        function                 workerSendToWorker    (      )      returns     int   {
-      @strand  {      thread      :   "any"
-       }
+      @strand  {      thread      :   "any"}
     worker  w1   {
           int       i      =      40    ;
         i

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/behavioural/assert/handle_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/behavioural/assert/handle_type_1.bal
@@ -1,13 +1,17 @@
 import ballerina/jballerina.java;
 
-function newArrayDeque() returns handle = @java:Constructor {'class: "java.util.ArrayDeque"} external;
+function newArrayDeque() returns handle = @java:Constructor {
+    'class: "java.util.ArrayDeque"
+} external;
 
 function offer(handle receiver, handle e) returns boolean = @java:Method {
     'class: "java.util.ArrayDeque",
     paramTypes: ["short"]
 } external;
 
-function poll(handle receiver) returns handle = @java:Method {'class: "java.util.ArrayDeque"} external;
+function poll(handle receiver) returns handle = @java:Method {
+    'class: "java.util.ArrayDeque"
+} external;
 
 public function foo() {
     var arrayDeque = newArrayDeque();

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/other/source/json_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/other/source/json_type_1.bal
@@ -1,13 +1,14 @@
 public function foo() {json j1 = "Apple";json j2 = 5.36;
    json j3=true;
    json    j5    =   null  ;
-   json j6 = {  name  :     "apple",   color  : "red",   price   : j2  };
+   json j6 = {
+         name  :     "apple",   color  : "red",   price   : j2  };
 
    json   j8   =checkpanic   j5.mergeJson(j7)  ;
    json j9 = {
        name:          "Anne",       age: null, marks: {   math: 90, language: 95}  }  ;
-   json j10 = {  name: (  ), age:   20, marks: {
-       physics: 85     }};json   j11   =  checkpanic   j9.mergeJson(j10)  ;
+   json j10 = {  name: (  ), age:   20,
+   marks: {physics: 85     }};json   j11   =  checkpanic   j9.mergeJson(j10)  ;
    json   |    error   j12=   j2.mergeJson(j3);
    string s = j6.toJsonString();json j13   =
    checkpanic s.fromJsonString();

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/other/source/json_type_2.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/other/source/json_type_2.bal
@@ -1,8 +1,6 @@
 public function foo() {
 json j7 = [
    1,   false,   null,   "foo",
-   {
-       first: "John", last: "Pala"}
-       ];
+   {   first: "John", last: "Pala"}];
 
 }

--- a/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/table_type_1.bal
+++ b/misc/formatter/modules/formatter-core/src/test/resources/types/structured/assert/table_type_1.bal
@@ -5,10 +5,7 @@ type CustomerTable table<map<any>>;
 public function foo() {
     EmployeeTable employeeTab = table [{id: 1, name: "John"}];
     table<Person> personTab = employeeTab.'map(function(Employee employee) returns Person {
-                                                   return {
-                                                       id: employee.id,
-                                                       name: employee.name
-                                                   };
+                                                   return {id: employee.id, name: employee.name};
                                                });
 
     CustomerTable customerTab = table [{id: 13, fname: "Dan"}];


### PR DESCRIPTION
## Purpose
This PR improves the current behavior of formatting blocks.

**Previous Rule:** 
* expanding blocks based on the number of fields -> if the number of fields is greater than 2, then it would be expanded instead of formatting it as an inline-block

**Improved Rule:**
* expanding blocks based on the existing formatting of the user -> if a single newline is observed inside the block, the block will be expanded, else it would be formatted as an in-line block

The following block types are supported with this improvement.
* MappingConstructorExpressionNode
* ObjectTypeDescriptorNode
* RecordTypeDescriptorNode

Fixes #30095

## Approach
> Describe how you are implementing the solutions along with the design details.

## Samples
> Provide high-level details about the samples related to this feature.

## Remarks
> List any other known issues, related PRs, TODO items, or any other notes related to the PR.

## Check List 
- [ ] Read the [Contributing Guide](https://github.com/ballerina-platform/ballerina-lang/blob/master/CONTRIBUTING.md)
- [ ] Updated Change Log
- [ ] Checked Tooling Support (#<Issue Number>)
- [ ] Added necessary tests
  - [ ] Unit Tests
  - [ ] Spec Conformance Tests
  - [ ] Integration Tests
  - [ ] Ballerina By Example Tests
- [ ] Increased Test Coverage   
- [ ] Added necessary documentation  
  - [ ] API documentation 
  - [ ] Module documentation in Module.md files
  - [ ] Ballerina By Examples
